### PR TITLE
Update description  for "`find` default action test"

### DIFF
--- a/tests/unit/requestable_test.js
+++ b/tests/unit/requestable_test.js
@@ -290,7 +290,7 @@ test("it should mixin Evented", function() {
   });
 });
 
-test("it defines `findRecord` as an action by default", function() {
+test("it defines `find` as an action by default", function() {
   verifyActionExists(source, 'find');
 });
 


### PR DESCRIPTION
In a08f53fc6af05a97c9e91f862467cb03f7dab835 the `findRecord` action has been
renamed to `find` but this hasn't been updated in the test description.
