### PR TITLE
Add `grunt-cli` to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "grunt": "~0.4.1",
+    "grunt-cli": "~0.1.11",
     "glob": "~3.2.1",
     "grunt-contrib-clean": "~0.4.1",
     "grunt-contrib-concat": "~0.3.0",


### PR DESCRIPTION
This is needed so Travis can execute `grunt`. Inspired by
https://github.com/tildeio/rsvp.js/commit/44ab76930c2bc6cd323bd846d385e46633612b7b
