### PR TITLE
Ignore `grunt-cli` dependency when loading all grunt tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,7 @@ module.exports = function(grunt) {
 
   grunt.initConfig(config);
 
-  require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+  require('matchdep').filterDev(['grunt-*', '!grunt-cli']).forEach(grunt.loadNpmTasks);
   grunt.loadTasks('tasks');
 
   grunt.registerTask('default', "Build (in debug mode) & test your application.", ['build:debug', 'test']);

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "karma-coverage": "~0.0.3",
     "karma-chrome-launcher": "~0.1.0",
     "karma-phantomjs-launcher": "~0.0.2",
-    "matchdep": "~0.1.2",
+    "matchdep": "~0.3.0",
     "string": "~1.4.0"
   }
 }


### PR DESCRIPTION
This removes the `Local Npm module "grunt-cli" not found. Is it installed?` [message](https://travis-ci.org/cerebris/orbit.js/builds/16777892#L770) when executing `npm test` on Travis.

This is inspired by http://git.io/SVuF9w
