### PR TITLE
Issue 18: Test case for doubling data

### DIFF
--- a/test/tests/integration/rest_memory_local_blocking_transforms_test.js
+++ b/test/tests/integration/rest_memory_local_blocking_transforms_test.js
@@ -93,6 +93,29 @@ test("multiple records found with rest should be inserted into memory and local 
   });
 });
 
+test("if find is called mutiple times, the count of synced objects in the dbs should remain the same", function() {
+  expect(5);
+  server.respondWith('GET', '/planets', function(xhr) {
+      ok(true, 'GET request');
+      xhr.respond(200,
+                  {'Content-Type': 'application/json'},
+                  JSON.stringify([
+                    {id: 12345, name: 'Jupiter', classification: 'gas giant'},
+                    {id: 12346, name: 'Earth', classification: 'terrestrial'}
+                  ]));
+  });
+  stop();
+  restSource.find('planet').then(function(planets) {
+    start();
+    equal(memorySource.length('planet'), 2, 'memory source cache size should == 2'); //fails because size == 4
+    equal(restSource.length('planet'), 2, 'rest source cache size should == 2'); //fails because size == 4
+    equal(localSource.length('planet'), 2, 'local source cache size should == 2'); //fails because size == 4
+  }).then(restSource.find('planet').then(function(planets) {
+    console.log(planets); // 2 planets returned
+    console.log(localSource.length('planet')); // size == 4
+  }));
+});
+
 test("records inserted into memory should be posted with rest", function() {
   expect(8);
 


### PR DESCRIPTION
ref https://github.com/orbitjs/orbit.js/issues/18

This test case acts a bit weird. I tried to simulate 2 calls of find. So I waited for the first one to finish, to call it again (with a different callback). Interestingly, the tests for the first call already fail, because the size == 4. However, this only happens because of the second find. If I remove the second call to find, the test passes. Did i missed something?
