### PR TITLE
Support false for defaultValues

### DIFF
--- a/lib/orbit_common/schema.js
+++ b/lib/orbit_common/schema.js
@@ -133,7 +133,7 @@ Schema.prototype = {
     if (attributes) {
       for (var attribute in attributes) {
         if (record[attribute] === undefined) {
-          if (attributes[attribute].defaultValue) {
+          if (attributes[attribute].defaultValue !== undefined) {
             if (typeof attributes[attribute].defaultValue === 'function') {
               record[attribute] = attributes[attribute].defaultValue.call(record);
             } else {

--- a/test/tests/orbit_common/unit/schema_test.js
+++ b/test/tests/orbit_common/unit/schema_test.js
@@ -62,7 +62,8 @@ test("#normalize initializes a record's attributes with any defaults that are sp
           shape: {type: 'string'},
           classification: {type: 'string', defaultValue: function() {
             return 'terrestrial';
-          }}
+          }},
+          hasWater: {type: 'boolean', defaultValue: false}
         }
       }
     }
@@ -73,6 +74,7 @@ test("#normalize initializes a record's attributes with any defaults that are sp
   strictEqual(earth.name, 'Earth', 'default has been set by value');
   strictEqual(earth.shape, null, 'default has not been set - should be null');
   strictEqual(earth.classification, 'terrestrial', 'default has been set by function');
+  strictEqual(earth.hasWater, false, 'default has not been set - should be false');
 });
 
 test("#normalize initializes a record's links", function() {


### PR DESCRIPTION
I spotted this adding defaultValues to ember-orbit, the test I was using had a defaultValue of false and I couldn't understand why the test was failing. This adds a check for undefined instead of a truthy value.
