### PR TITLE
Changed variable name to better reflect value

### DIFF
--- a/lib/orbit-common/jsonapi-source.js
+++ b/lib/orbit-common/jsonapi-source.js
@@ -338,14 +338,14 @@ var JSONAPISource = Source.extend({
   },
 
   deserialize: function(type, data) {
-    var deserialized = this.serializerForType(type).deserialize(type, data);
-    var primary = deserialized[type];
+    var deserialized = this.serializerForType(type).deserialize(type, data),
+        records = deserialized[type];
 
     if (this._cache) {
-      if (isArray(primary)) {
-        this._addRecordsToCache(type, primary);
+      if (isArray(records)) {
+        this._addRecordsToCache(type, records);
       } else {
-        this._addRecordToCache(type, primary);
+        this._addRecordToCache(type, records);
       }
 
       if (deserialized.linked) {
@@ -355,7 +355,7 @@ var JSONAPISource = Source.extend({
       }
     }
 
-    return primary;
+    return records;
   }
 });
 


### PR DESCRIPTION
Calling the variable that holds the deserialized record or array of records `primary` is confusing because it's suggestive (in the case of DB records or JSON representations thereof) of primary keys.

The method signatures for `_addRecordsToCache` and `_addRecordToCache` use `records` and `record`, respectively, so this is consistent with their use.
