### PR TITLE
`null` relation raises exception

### DIFF
--- a/lib/orbit-common/jsonapi-serializer.js
+++ b/lib/orbit-common/jsonapi-serializer.js
@@ -21,7 +21,7 @@ var JSONAPISerializer = Serializer.extend({
 
         relKeys.forEach(function(key) {
           var link = serialized.__rel[key];
-          if (typeof link === 'object') {
+          if (link !== null && typeof link === 'object') {
             links[key] = Object.keys(link);
           } else {
             links[key] = link;


### PR DESCRIPTION
I've got a relation that sometimes is set to `null`. In JS, `typeof null === 'object'`, and then this line of code was calling `Object.keys` on `null` (non object).

If this bugfix is correct I'll add regression tests, else, happy to improve the patch.

Thanks for your work!
