### PR TITLE
null is an object bugfixes

### DIFF
--- a/lib/orbit-common/jsonapi-source.js
+++ b/lib/orbit-common/jsonapi-source.js
@@ -147,7 +147,7 @@ var JSONAPISource = Source.extend({
 
       for (var i = 0, l = id.length; i < l; i++) {
         localId =  id[i];
-        if (typeof localId === 'object' && localId[this.schema.remoteIdField]) {
+        if (localId !== null && typeof localId === 'object' && localId[this.schema.remoteIdField]) {
           remoteId = localId[this.schema.remoteIdField];
         } else {
           remoteId = this.schema.localToRemoteId(type, localId);
@@ -190,7 +190,7 @@ var JSONAPISource = Source.extend({
       path: [type, this.getId(record)],
       value: record
     });
-  },  
+  },
 
   _findOne: function(type, remoteId) {
     var _this = this;

--- a/lib/orbit-common/memory-source.js
+++ b/lib/orbit-common/memory-source.js
@@ -53,7 +53,7 @@ var MemorySource = Source.extend({
         for (var i = 0, l = id.length; i < l; i++) {
           resId =  id[i];
 
-          if (typeof resId === 'object' && resId[remoteIdField]) {
+          if (resId !== null && typeof resId === 'object' && resId[remoteIdField]) {
             res = _this._filterOne.call(_this, type, remoteIdField, resId[remoteIdField]);
           } else {
             res =  _this.retrieve([type, resId]);
@@ -71,7 +71,7 @@ var MemorySource = Source.extend({
           id = notFound;
         }
 
-      } else if (typeof id === 'object') {
+      } else if (id !== null && typeof id === 'object') {
         if (id[idField]) {
           result = _this.retrieve([type, id[idField]]);
 
@@ -100,7 +100,7 @@ var MemorySource = Source.extend({
         record;
 
     return new Orbit.Promise(function(resolve, reject) {
-      if (typeof id === 'object') {
+      if (id !== null && typeof id === 'object') {
         record = _this.retrieve([type, id[idField]]);
 
       } else {

--- a/lib/orbit-common/source.js
+++ b/lib/orbit-common/source.js
@@ -86,7 +86,7 @@ var Source = Class.extend({
   },
 
   _patch: function(type, id, property, value) {
-    if (typeof id === 'object') {
+    if (id !== null && typeof id === 'object') {
       var record = this.normalize(type, id);
       id = this.getId(record);
     }
@@ -99,7 +99,7 @@ var Source = Class.extend({
   },
 
   _remove: function(type, id) {
-    if (typeof id === 'object') {
+    if (id !== null && typeof id === 'object') {
       var record = this.normalize(type, id);
       id = this.getId(record);
     }
@@ -126,11 +126,11 @@ var Source = Class.extend({
         _this = this;
 
     // Normalize ids
-    if (typeof id === 'object') {
+    if (id !== null && typeof id === 'object') {
       var record = this.normalize(type, id);
       id = this.getId(record);
     }
-    if (typeof value === 'object') {
+    if (value !== null && typeof value === 'object') {
       var relatedRecord = this.normalize(linkDef.model, value);
       value = this.getId(relatedRecord);
     }
@@ -165,11 +165,11 @@ var Source = Class.extend({
         _this = this;
 
     // Normalize ids
-    if (typeof id === 'object') {
+    if (id !== null && typeof id === 'object') {
       record = this.normalize(type, id);
       id = this.getId(record);
     }
-    if (typeof value === 'object') {
+    if (value !== null && typeof value === 'object') {
       var relatedRecord = this.normalize(linkDef.model, value);
       value = this.getId(relatedRecord);
     }

--- a/lib/orbit/lib/diffs.js
+++ b/lib/orbit/lib/diffs.js
@@ -44,7 +44,7 @@ var diffs = function(a, b, options) {
 
     var type = Object.prototype.toString.call(a);
     if (type === Object.prototype.toString.call(b)) {
-      if (typeof a === 'object') {
+      if (a !== null && typeof a === 'object') {
         var i,
             d;
 


### PR DESCRIPTION
A relation can sometimes be set to null. In JS, `typeof null === 'object'`, and
a condition wasn't taking that case into account, allowing `Object.keys` to be
called on `null` (non object).

Continues work over 300cae4c7845c6e29d35d33f7a6c811451541f35.
See: https://github.com/orbitjs/orbit.js/pull/41
