### PR TITLE
Add JSONPatch header to JSONAPISource application/json-patch+json

### DIFF
--- a/lib/orbit-common/jsonapi-source.js
+++ b/lib/orbit-common/jsonapi-source.js
@@ -270,7 +270,11 @@ var JSONAPISource = Source.extend({
 //TODO-log      console.log('ajax start', method);
 
       if (hash.data && method !== 'GET') {
-        hash.contentType = 'application/json; charset=utf-8';
+        if (method === 'PATCH') {
+          hash.contentType = 'application/json-patch+json; charset=utf-8';
+        } else {
+          hash.contentType = 'application/json; charset=utf-8';
+        }
         hash.data = JSON.stringify(hash.data);
       }
 


### PR DESCRIPTION
## Adds AJAX header for PATCH requests

Per the JSON Patch spec in section-1 the content type for PATCH is `application/json-patch+json`

http://tools.ietf.org/html/rfc6902#section-1

```
JSON Patch is a format (identified by the media type "application/
json-patch+json") for expressing a sequence of operations to apply to
a target JSON document; it is suitable for use with the HTTP PATCH
method.
```

**Express middleware example:**

https://github.com/expressjs/body-parser

``` js
// parse application/json-patch+json as json
app.use(bodyParser.json({ type: 'application/json-patch+json' });
```

**Rails example:**

http://guides.rubyonrails.org/upgrading_ruby_on_rails.html#a-note-about-media-types
- In your controller

``` ruby
def update
  respond_to do |format|
    format.json do
      # perform a partial update
      @post.update params[:post]
    end

    format.json_patch do
      # perform sophisticated change
    end
  end
end
```
- In config/initializers/json_patch.rb:

``` ruby
Mime::Type.register 'application/json-patch+json', :json_patch
```
