### PR TITLE
Makes sure that it returns an array when you try to perform a findMany.

### DIFF
--- a/lib/orbit-common/jsonapi-source.js
+++ b/lib/orbit-common/jsonapi-source.js
@@ -467,6 +467,7 @@ var JSONAPISource = Source.extend({
       function(raw) {
         var records = _this.deserialize(type, null, raw);
         return _this.settleTransforms().then(function() {
+          if(!isArray(records))records=[records];
           return records;
         });
       }


### PR DESCRIPTION
This solve a problem I run into with this situation :  
I have a Project model linked to tasks and I want to be sure that when I do 

``` javascript
project.get("tasks").find().then(function(tasks){})
```

tasks is an array even if just one task is linked to this project.
