### PR TITLE
findLinked should return nothing when nothing is linked instead of every models of the linked type.

### DIFF
--- a/lib/orbit-common/source.js
+++ b/lib/orbit-common/source.js
@@ -1,3 +1,4 @@
+import Orbit from 'orbit/main';
 import Document from 'orbit/document';
 import Transformable from 'orbit/transformable';
 import Requestable from 'orbit/requestable';
@@ -73,11 +74,17 @@ var Source = Class.extend({
       relId = this.retrieveLink(type, id, link);
     }
 
-    if (relId) {
+    if (relId && relId.length) {
       return this.find(relType, relId);
-
     } else {
       return this.findLink(type, id, link).then(function(relId) {
+        if (!relId || !relId.length) {
+          if(linkDef.type==="hasMany"){
+            relId = ["fakeid","wrongid"];
+          }else{
+            relId = "fakeid";
+          }
+        }
         return _this.find(relType, relId);
       });
     }


### PR DESCRIPTION
If I have a DB with several moons and a planet "earth" that has no moon linked to it , when I do: 

``` javascript
 earth.get("moon").find().then(function(moons){
  console.log(moons.length);
  //it should print 0, instead it prints the total number of moons in the database
  //because moons is equal to the full list of moons
});
```

This is simply because findLinked use find underneath with an id for hasOne or a list of ids for hasMany and when id is nothing or ids is an empty list, using find is like querying everything.

**This is a real show stopper.**

So this PR is a messy trick to make sure that it will perform a request with an empty result. I know this is not the right way to do it, but this is a starting point. What do you think ?
