### PR TITLE
Post value of association as an array

### DIFF
--- a/lib/orbit-common/jsonapi-source.js
+++ b/lib/orbit-common/jsonapi-source.js
@@ -296,7 +296,7 @@ var JSONAPISource = Source.extend({
 
     var method = 'POST';
     var json = {};
-    json[relResourceType] = relResourceId;
+    json[relResourceType] = linkDef.type === 'hasMany' ? [relResourceId] : relResourceId;
 
     return this.ajax(this.resourceLinkURL(type, id, link), method, {data: json}).then(
       function() {

--- a/test/tests/orbit_common/unit/jsonapi-source-test.js
+++ b/test/tests/orbit_common/unit/jsonapi-source-test.js
@@ -257,7 +257,7 @@ test("#addLink - can add a hasMany relationship with POST", function() {
   expect(2);
 
   server.respondWith('POST', '/planets/12345/links/moons', function(xhr) {
-    deepEqual(JSON.parse(xhr.requestBody), {moons: '987'},
+    deepEqual(JSON.parse(xhr.requestBody), {moons: ['987']},
               'POST request to add link to primary record');
     xhr.respond(200,
                 {'Content-Type': 'application/json'},


### PR DESCRIPTION
This isn't finished, just somewhere to clarify a few things.

When a link is added to a hasMany assocation it's currently posted as a single item, [according to the spec](http://jsonapi.org/format/#crud-updating-to-many-relationships) it should be an array. 

> POST /articles/1/links/comments
> Content-Type: application/vnd.api+json
> Accept: application/vnd.api+json
> 
> {
>   "comments": ["1", "2"]
> }

In this PR I've updated the test to expect the POSTed link to be an array. 

A case that I'm really not clear on is how you add multiple items to a hasMany link. I presume from the orbit API this would be done with:

```
source.addLink('planet', {id: '12345'}, 'moons', {id: '987'})
source.addLink('planet', {id: '12345'}, 'moons', {id: '988'})
```

With regards to the implementation I suspect it should be something like

```
_transformAddLinkStd: function(operation) {
  var _this = this;

  var type = operation.path[0];
  var id = operation.path[1];
  var link = operation.path[3];
  var relId = operation.path[4] || operation.value;

  var linkDef = this.schema.models[type].links[link];
  var relType = linkDef.model;
  var relResourceType = this.resourceType(relType);
  var relResourceId = this.resourceId(relType, relId);

  var method = 'POST';
  var json = {};

  // ****** change here *******
  json[relResourceType] = linkDef.type === 'hasMany' ? existingAssocationIds.concat(relResourceId) : relResourceId;

  return this.ajax(this.resourceLinkURL(type, id, link), method, {data: json}).then(
    function() {
      _this._transformCache(operation);
    }
  );
},
```

if this is correct the main issue is getting hold of the existingAssociationIds. The operation doesn't seem to include the model or the association so I'm not sure how to approach this.

Hopefully I'm not way off track here...
