### PR TITLE
Remove hasOne links when object is removed.

### DIFF
--- a/lib/orbit-common/cache.js
+++ b/lib/orbit-common/cache.js
@@ -230,18 +230,10 @@ var Cache = Class.extend({
           Object.keys(value.__rev).forEach(function(path) {
             path = _this._doc.deserializePath(path);
 
-            if (path.length === 4) {
-              operation = {
-                op: 'replace',
-                path: path,
-                value: null
-              };
-            } else {
-              operation = {
-                op: 'remove',
-                path: path
-              };
-            }
+            operation = {
+              op: 'remove',
+              path: path
+            };
 
             try {
               _this._transform(operation, _this.trackChanges);


### PR DESCRIPTION
Replacing a hasOne link when an object is removed appears to create a infinite
loop between sources of trying to replace that link with null.
