### PR TITLE
Modifying jsonapi-serializer to ignore links that are not defined in the schema

### DIFF
--- a/lib/orbit-common/jsonapi-serializer.js
+++ b/lib/orbit-common/jsonapi-serializer.js
@@ -234,6 +234,8 @@ var JSONAPISerializer = Serializer.extend({
       Object.keys(record.links).forEach(function(link) {
         linkValue = record.links[link];
         linkSchema = schema.models[model].links[link];
+        
+        if (!linkSchema) return;
 
         if (linkSchema.type === 'hasMany' && isArray(linkValue)) {
           record.__rel[link] = record.__rel[link] || [];


### PR DESCRIPTION
In method `assignLinksToRecord`

https://github.com/orbitjs/orbit.js/issues/63
