### PR TITLE
Update transformable.js

### DIFF
--- a/lib/orbit/transformable.js
+++ b/lib/orbit/transformable.js
@@ -80,9 +80,11 @@ var Transformable = {
 
         // console.log('settleTransforms', this.id, ops);
 
-        _this.settlingTransforms = true;
+        if (_this.settlingTransforms) {
+          return _this.settlingTransforms;
+        }
 
-        return new Orbit.Promise(function(resolve) {
+        _this.settlingTransforms = new Orbit.Promise(function(resolve) {
           var settleEach = function() {
             if (ops.length === 0) {
               _this.settlingTransforms = false;


### PR DESCRIPTION
Ensures you can't ever kick off two `settleTransform` operations at the same time.
