### PR TITLE
Don't 'replace' isNone value with isNone value

### DIFF
--- a/lib/orbit/transform-connector.js
+++ b/lib/orbit/transform-connector.js
@@ -86,6 +86,8 @@ var TransformConnector = Class.extend({
 
       } else if (isNone(currentValue) && operation.op === 'remove') {
         return;
+      } else if (isNone(currentValue) && isNone(operation.value) && operation.op === 'replace') {
+        return;
       }
     }
 


### PR DESCRIPTION
In an environment with two sources connected with bi-directional transform-connectors, if you replace a value with a 'null', it creates an infinite loop. See this for an example: http://jsfiddle.net/chrisyunker/0neso67b/. It also does the same if you replace value with 'undefined'.

Adding another check for this situation in 'transform-connector.transform' is one way to fix this. However, there may be a better way.
