### PR TITLE
fix "this" bug in request-connector

### DIFF
--- a/lib/orbit/request-connector.js
+++ b/lib/orbit/request-connector.js
@@ -83,7 +83,7 @@ var RequestConnector = Class.extend({
     var _this = this;
 
     this.actions.forEach(function(action) {
-      this.primarySource.off(_this.mode + capitalize(action),
+      _this.primarySource.off(_this.mode + capitalize(action),
         _this.handlers[action],
         _this.secondarySource
       );

--- a/test/tests/orbit/unit/request-connector-test.js
+++ b/test/tests/orbit/unit/request-connector-test.js
@@ -266,6 +266,9 @@ module("Orbit - RequestConnector", {
   },
 
   teardown: function() {
+    if (requestConnector) {
+      requestConnector.deactivate();
+    }
     primarySource = null;
     secondarySource = null;
     requestConnector = null;


### PR DESCRIPTION
Also adds a `.deactivate()` call to the teardown for the module (which fails without the corresponding change in code)
