### PR TITLE
Remove default values and normalization from Schema

### DIFF
--- a/packages/@orbit/core/src/index.ts
+++ b/packages/@orbit/core/src/index.ts
@@ -14,7 +14,7 @@ export * from './query-expression';
 export { QueryTerm } from './query-term';
 export { default as Query, QueryOrExpression } from './query';
 export * from './record';
-export { default as Schema, AttributeDefinition, RelationshipDefinition, KeyDefinition, IdDefinition, ModelDefinition, SchemaSettings, isRecordNormalized } from './schema';
+export { default as Schema, AttributeDefinition, RelationshipDefinition, KeyDefinition, ModelDefinition, SchemaSettings } from './schema';
 export { Source, SourceSettings } from './source';
 export { default as TransformLog, TransformLogOptions } from './transform-log';
 export { default as Transform, TransformOrOperations } from './transform';

--- a/packages/@orbit/core/test/schema-test.js
+++ b/packages/@orbit/core/test/schema-test.js
@@ -52,15 +52,8 @@ module('Schema', function() {
     });
 
     assert.ok(schema.modelDefaults, 'modelDefaults has been set');
-    assert.ok(schema.modelDefaults.id, 'modelDefaults.id has been set');
-    assert.strictEqual(schema.modelDefaults.id.defaultValue, uuid, 'modelDefaults.id.defaultValue has been set');
-
     assert.ok(schema.models, 'schema.models has been set');
-
-    const model = schema.models.planet;
-    assert.ok(model, 'model definition has been set');
-    assert.ok(model.id, 'model.id has been set');
-    assert.strictEqual(model.id.defaultValue, uuid, 'model.id.defaultValue has been set');
+    assert.ok(schema.models.planet, 'model definition has been set');
   });
 
   test('#modelDefaults can be overridden', function(assert) {
@@ -69,10 +62,8 @@ module('Schema', function() {
     };
 
     const schema = new Schema({
+      generateId: customIdGenerator,
       modelDefaults: {
-        id: {
-          defaultValue: customIdGenerator
-        },
         keys: {
           remoteId: {}
         },
@@ -99,9 +90,8 @@ module('Schema', function() {
       }
     });
 
+    assert.strictEqual(schema.generateId, customIdGenerator, 'custom id generator has been set');
     assert.ok(schema.modelDefaults, 'modelDefaults has been set');
-    assert.ok(schema.modelDefaults.id, 'modelDefaults.id has been set');
-    assert.strictEqual(schema.modelDefaults.id.defaultValue, customIdGenerator, 'custom id generator has been set');
     assert.ok(schema.modelDefaults.keys.remoteId, 'custom remoteId key has been set');
     assert.ok(schema.modelDefaults.attributes.someAttr, 'default model schema attribute has been set');
     assert.ok(schema.modelDefaults.relationships.someLink, 'default model link schema has been set');
@@ -109,21 +99,17 @@ module('Schema', function() {
     assert.ok(schema.models, 'schema.models has been set');
     let model = schema.models.planet;
     assert.ok(model, 'model definition has been set');
-    assert.ok(model.id, 'model.id has been set');
     assert.ok(model.keys, 'model.keys has been set');
     assert.ok(model.attributes, 'model.attributes has been set');
     assert.ok(model.relationships, 'model.relationships has been set');
-    assert.strictEqual(model.id.defaultValue, customIdGenerator, 'model.id.defaultValue has been set');
     assert.ok(model.attributes['someAttr'], 'model.attributes match defaults');
     assert.ok(model.relationships['someLink'], 'model.relationships match defaults');
 
     model = schema.models.moon;
     assert.ok(model, 'model definition has been set');
-    assert.ok(model.id, 'model.id has been set');
     assert.ok(model.keys, 'model.keys has been set');
     assert.ok(model.attributes, 'model.attributes has been set');
     assert.ok(model.relationships, 'model.relationships has been set');
-    assert.strictEqual(model.id.defaultValue, customIdGenerator, 'model.id.defaultValue has been set');
     assert.equal(Object.keys(model.keys).length, 0, 'model has no keys');
     assert.equal(Object.keys(model.attributes).length, 0, 'model has no attributes');
     assert.equal(Object.keys(model.relationships).length, 0, 'model has no relationships');
@@ -145,120 +131,6 @@ module('Schema', function() {
     assert.deepEqual(schema.modelDefinition('planet').attributes, planetDefinition.attributes);
   });
 
-  test('#normalize initializes a record with a unique primary key', function(assert) {
-    const schema = new Schema({
-      models: {
-        planet: {}
-      }
-    });
-
-    const earth = schema.normalize({ type: 'planet' });
-    const mars = schema.normalize({ type: 'planet' });
-
-    assert.ok(earth.id, 'id has been set');
-    assert.ok(mars.id, 'id has been set');
-    assert.notEqual(earth.id, mars.id, 'ids are unique');
-  });
-
-  test('#normalize initializes a record\'s attributes with any defaults that are specified with a value or function', function(assert) {
-    const schema = new Schema({
-      models: {
-        planet: {
-          attributes: {
-            name: { type: 'string', defaultValue: 'Earth' },
-            shape: { type: 'string' },
-            classification: { type: 'string', defaultValue: function() {
-              return 'terrestrial';
-            } },
-            hasWater: { type: 'boolean', defaultValue: false }
-          }
-        }
-      }
-    });
-
-    const earth = schema.normalize({ type: 'planet' });
-
-    assert.strictEqual(earth.attributes.name, 'Earth', 'default has been set by value');
-    assert.strictEqual(earth.attributes.shape, undefined, 'default has not been set - should be undefined');
-    assert.strictEqual(earth.attributes.classification, 'terrestrial', 'default has been set by function');
-    assert.strictEqual(earth.attributes.hasWater, false, 'default has not been set - should be false');
-  });
-
-  test('#normalize initializes a record\'s relationships', function(assert) {
-    const schema = new Schema({
-      models: {
-        planet: {
-          relationships: {
-            moons: { type: 'hasMany', model: 'moon', inverse: 'planet' }
-          }
-        },
-        moon: {
-          relationships: {
-            planet: { type: 'hasOne', model: 'planet', inverse: 'moons' }
-          }
-        }
-      }
-    });
-
-    const earth = schema.normalize({ type: 'planet' });
-    const moon = schema.normalize({ type: 'moon' });
-
-    assert.deepEqual(earth.relationships.moons.data, {}, 'default has not been set - should be undefined');
-    assert.strictEqual(moon.relationships.planet.data, null, 'default has not been set - should be undefined');
-  });
-
-  test('#normalize will not overwrite data set as attributes', function(assert) {
-    const schema = new Schema({
-      models: {
-        planet: {
-          attributes: {
-            name: { type: 'string', defaultValue: 'Jupiter' },
-            classification: { type: 'string', defaultValue: function() {
-              return 'gas giant';
-            } }
-          },
-          relationships: {
-            moons: { type: 'hasMany', model: 'moon', inverse: 'planet' }
-          }
-        },
-        moon: {
-          attributes: {
-            name: { type: 'string' }
-          },
-          relationships: {
-            planet: { type: 'hasOne', model: 'planet', inverse: 'moons' }
-          }
-        }
-      }
-    });
-
-    const earth = schema.normalize({ type: 'planet', attributes: { name: 'Earth', classification: 'terrestrial' } });
-
-    const moon = schema.normalize({ type: 'moon', attributes: { name: '*The Moon*' }, relationships: { planet: { data: 'planet:' + earth.id } } });
-
-    assert.strictEqual(earth.attributes.name, 'Earth', 'name has been specified');
-    assert.strictEqual(earth.attributes.classification, 'terrestrial', 'classification has been specified');
-
-    assert.deepEqual(earth.relationships.moons.data, {}, 'hasMany relationship was not initialized');
-    assert.strictEqual(moon.relationships.planet.data, 'planet:' + earth.id, 'hasOne relationship was specified in data');
-
-    const io = schema.normalize({ type: 'moon' });
-
-    const europa = schema.normalize({ type: 'moon' });
-
-    const jupitersMoons = {};
-    jupitersMoons[io.id] = true;
-    jupitersMoons[europa.id] = true;
-
-    const jupiter = schema.normalize({
-      type: 'planet',
-      attributes: { name: 'Jupiter' },
-      relationships: { moons: jupitersMoons }
-    });
-
-    assert.deepEqual(jupiter.relationships.moons, jupitersMoons, 'hasMany relationship was specified in data');
-  });
-
   test('#pluralize simply adds an `s` to the end of words', function(assert) {
     const schema = new Schema();
     assert.equal(schema.pluralize('cow'), 'cows', 'no kine here');
@@ -270,19 +142,15 @@ module('Schema', function() {
     assert.equal(schema.singularize('data'), 'data', 'no Latin knowledge here');
   });
 
-  test('#generateDefaultId', function(assert) {
+  test('#generateId', function(assert) {
     const schema = new Schema({
-      modelDefaults: {
-        id: {
-          defaultValue: () => 'generated-id'
-        }
-      },
+      generateId: (modelName) => `${modelName}-123`,
 
       models: {
         moon: {}
       }
     });
 
-    assert.equal(schema.generateDefaultId('moon'), 'generated-id', 'provides the default value for the ID');
+    assert.equal(schema.generateId('moon'), 'moon-123', 'provides the default value for the ID');
   });
 });

--- a/packages/@orbit/indexeddb/test/source-test.js
+++ b/packages/@orbit/indexeddb/test/source-test.js
@@ -88,14 +88,14 @@ module('IndexedDBSource', function(hooks) {
   test('#push - addRecord', function(assert) {
     assert.expect(1);
 
-    let planet = schema.normalize({
+    let planet = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
         name: 'Jupiter',
         classification: 'gas giant'
       }
-    });
+    };
 
     return source.push(Transform.from(addRecord(planet)))
       .then(() => verifyIndexedDBContainsRecord(assert, source, planet));
@@ -104,16 +104,16 @@ module('IndexedDBSource', function(hooks) {
   test('#push - replaceRecord', function(assert) {
     assert.expect(1);
 
-    let original = schema.normalize({
+    let original = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
         name: 'Jupiter',
         classification: 'gas giant'
       }
-    });
+    };
 
-    let revised = schema.normalize({
+    let revised = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -121,7 +121,7 @@ module('IndexedDBSource', function(hooks) {
         classification: 'gas giant',
         revised: true
       }
-    });
+    };
 
     return source.push(Transform.from(addRecord(original)))
       .then(() => source.push(Transform.from(replaceRecord(revised))))
@@ -131,14 +131,14 @@ module('IndexedDBSource', function(hooks) {
   test('#push - removeRecord', function(assert) {
     assert.expect(1);
 
-    let planet = schema.normalize({
+    let planet = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
         name: 'Jupiter',
         classification: 'gas giant'
       }
-    });
+    };
 
     return source.push(Transform.from(addRecord(planet)))
       .then(() => source.push(Transform.from(removeRecord(planet))))
@@ -148,16 +148,16 @@ module('IndexedDBSource', function(hooks) {
   test('#push - replaceKey', function(assert) {
     assert.expect(1);
 
-    let original = schema.normalize({
+    let original = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
         name: 'Jupiter',
         classification: 'gas giant'
       }
-    });
+    };
 
-    let revised = schema.normalize({
+    let revised = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -167,7 +167,7 @@ module('IndexedDBSource', function(hooks) {
       keys: {
         remoteId: '123'
       }
-    });
+    };
 
     return source.push(Transform.from(addRecord(original)))
       .then(() => source.push(Transform.from(replaceKey(original, 'remoteId', '123'))))
@@ -177,16 +177,16 @@ module('IndexedDBSource', function(hooks) {
   test('#push - replaceAttribute', function(assert) {
     assert.expect(1);
 
-    let original = schema.normalize({
+    let original = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
         name: 'Jupiter',
         classification: 'gas giant'
       }
-    });
+    };
 
-    let revised = schema.normalize({
+    let revised = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -194,7 +194,7 @@ module('IndexedDBSource', function(hooks) {
         classification: 'gas giant',
         order: 5
       }
-    });
+    };
 
     return source.push(Transform.from(addRecord(original)))
       .then(() => source.push(Transform.from(replaceAttribute(original, 'order', 5))))
@@ -204,7 +204,7 @@ module('IndexedDBSource', function(hooks) {
   test('#push - addToHasMany', function(assert) {
     assert.expect(1);
 
-    let original = schema.normalize({
+    let original = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -216,9 +216,9 @@ module('IndexedDBSource', function(hooks) {
           data: {}
         }
       }
-    });
+    };
 
-    let revised = schema.normalize({
+    let revised = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -232,7 +232,7 @@ module('IndexedDBSource', function(hooks) {
           }
         }
       }
-    });
+    };
 
     return source.push(Transform.from(addRecord(original)))
       .then(() => source.push(Transform.from(addToHasMany(original, 'moons', { type: 'moon', id: 'moon1' }))))
@@ -242,7 +242,7 @@ module('IndexedDBSource', function(hooks) {
   test('#push - removeFromHasMany', function(assert) {
     assert.expect(1);
 
-    let original = schema.normalize({
+    let original = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -257,9 +257,9 @@ module('IndexedDBSource', function(hooks) {
           }
         }
       }
-    });
+    };
 
-    let revised = schema.normalize({
+    let revised = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -273,7 +273,7 @@ module('IndexedDBSource', function(hooks) {
           }
         }
       }
-    });
+    };
 
     return source.push(Transform.from(addRecord(original)))
       .then(() => source.push(Transform.from(removeFromHasMany(original, 'moons', { type: 'moon', id: 'moon2' }))))
@@ -283,7 +283,7 @@ module('IndexedDBSource', function(hooks) {
   test('#push - replaceHasMany', function(assert) {
     assert.expect(1);
 
-    let original = schema.normalize({
+    let original = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -297,9 +297,9 @@ module('IndexedDBSource', function(hooks) {
           }
         }
       }
-    });
+    };
 
-    let revised = schema.normalize({
+    let revised = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -314,7 +314,7 @@ module('IndexedDBSource', function(hooks) {
           }
         }
       }
-    });
+    };
 
     return source.push(Transform.from(addRecord(original)))
       .then(() => source.push(Transform.from(replaceHasMany(original, 'moons', [{ type: 'moon', id: 'moon2' }, { type: 'moon', id: 'moon3' }]))))
@@ -324,7 +324,7 @@ module('IndexedDBSource', function(hooks) {
   test('#push - replaceHasOne - record', function(assert) {
     assert.expect(1);
 
-    let original = schema.normalize({
+    let original = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -336,9 +336,9 @@ module('IndexedDBSource', function(hooks) {
           data: null
         }
       }
-    });
+    };
 
-    let revised = schema.normalize({
+    let revised = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -350,7 +350,7 @@ module('IndexedDBSource', function(hooks) {
           data: 'solarSystem:ss1'
         }
       }
-    });
+    };
 
     return source.push(Transform.from(addRecord(original)))
       .then(() => source.push(Transform.from(replaceHasOne(original, 'solarSystem', { type: 'solarSystem', id: 'ss1' }))))
@@ -360,7 +360,7 @@ module('IndexedDBSource', function(hooks) {
   test('#push - replaceHasOne - null', function(assert) {
     assert.expect(1);
 
-    let original = schema.normalize({
+    let original = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -372,9 +372,9 @@ module('IndexedDBSource', function(hooks) {
           data: 'solarSystem:ss1'
         }
       }
-    });
+    };
 
-    let revised = schema.normalize({
+    let revised = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -386,7 +386,7 @@ module('IndexedDBSource', function(hooks) {
           data: null
         }
       }
-    });
+    };
 
     return source.push(Transform.from(addRecord(original)))
       .then(() => source.push(Transform.from(replaceHasOne(original, 'solarSystem', null))))
@@ -396,31 +396,31 @@ module('IndexedDBSource', function(hooks) {
   test('#pull - all records', function(assert) {
     assert.expect(2);
 
-    let earth = schema.normalize({
+    let earth = {
       type: 'planet',
       id: 'earth',
       attributes: {
         name: 'Earth',
         classification: 'terrestrial'
       }
-    });
+    };
 
-    let jupiter = schema.normalize({
+    let jupiter = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
         name: 'Jupiter',
         classification: 'gas giant'
       }
-    });
+    };
 
-    let io = schema.normalize({
+    let io = {
       type: 'moon',
       id: 'io',
       attributes: {
         name: 'Io'
       }
-    });
+    };
 
     return source.push(Transform.from([
       addRecord(earth),
@@ -441,31 +441,31 @@ module('IndexedDBSource', function(hooks) {
   test('#pull - records of one type', function(assert) {
     assert.expect(2);
 
-    let earth = schema.normalize({
+    let earth = {
       type: 'planet',
       id: 'earth',
       attributes: {
         name: 'Earth',
         classification: 'terrestrial'
       }
-    });
+    };
 
-    let jupiter = schema.normalize({
+    let jupiter = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
         name: 'Jupiter',
         classification: 'gas giant'
       }
-    });
+    };
 
-    let io = schema.normalize({
+    let io = {
       type: 'moon',
       id: 'io',
       attributes: {
         name: 'Io'
       }
-    });
+    };
 
     return source.push(Transform.from([
       addRecord(earth),
@@ -486,31 +486,31 @@ module('IndexedDBSource', function(hooks) {
   test('#pull - a specific record', function(assert) {
     assert.expect(2);
 
-    let earth = schema.normalize({
+    let earth = {
       type: 'planet',
       id: 'earth',
       attributes: {
         name: 'Earth',
         classification: 'terrestrial'
       }
-    });
+    };
 
-    let jupiter = schema.normalize({
+    let jupiter = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
         name: 'Jupiter',
         classification: 'gas giant'
       }
-    });
+    };
 
-    let io = schema.normalize({
+    let io = {
       type: 'moon',
       id: 'io',
       attributes: {
         name: 'Io'
       }
-    });
+    };
 
     return source.clearRecords('planet')
       .then(() => source.clearRecords('moon'))

--- a/packages/@orbit/jsonapi/src/jsonapi-serializer.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-serializer.ts
@@ -225,9 +225,9 @@ export default class JSONAPISerializer {
         };
 
         id = this.keyMap.idFromKeys(type, keys) ||
-             this.schema.generateDefaultId(type);
+             this.schema.generateId(type);
       } else {
-        id = this.schema.generateDefaultId(type);
+        id = this.schema.generateId(type);
       }
 
       record = { type, id };
@@ -299,7 +299,7 @@ export default class JSONAPISerializer {
   }
 
   protected _generateNewId(type: string, keyName: string, keyValue: string) {
-    let id = this.schema.generateDefaultId(type);
+    let id = this.schema.generateId(type);
 
     this.keyMap.pushRecord({
       type,

--- a/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
@@ -1,4 +1,3 @@
-import { uuid } from '@orbit/utils';
 import Orbit, {
   addRecord,
   replaceRecord,
@@ -40,9 +39,6 @@ module('JSONAPISource', function(hooks) {
 
       let schema = new Schema({
         modelDefaults: {
-          id: {
-            defaultValue: uuid
-          },
           keys: {
             remoteId: {}
           }
@@ -867,11 +863,6 @@ module('JSONAPISource', function(hooks) {
       fetchStub = sinon.stub(Orbit, 'fetch');
 
       let schema = new Schema({
-        modelDefaults: {
-          id: {
-            defaultValue: uuid
-          }
-        },
         models: {
           planet: {
             attributes: {

--- a/packages/@orbit/local-storage/test/source-test.js
+++ b/packages/@orbit/local-storage/test/source-test.js
@@ -64,14 +64,14 @@ module('LocalStorageSource', function(hooks) {
   test('#push - addRecord', function(assert) {
     assert.expect(1);
 
-    let planet = schema.normalize({
+    let planet = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
         name: 'Jupiter',
         classification: 'gas giant'
       }
-    });
+    };
 
     return source.push(Transform.from(addRecord(planet)))
       .then(() => verifyLocalStorageContainsRecord(assert, source, planet));
@@ -80,16 +80,16 @@ module('LocalStorageSource', function(hooks) {
   test('#push - replaceRecord', function(assert) {
     assert.expect(1);
 
-    let original = schema.normalize({
+    let original = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
         name: 'Jupiter',
         classification: 'gas giant'
       }
-    });
+    };
 
-    let revised = schema.normalize({
+    let revised = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -97,7 +97,7 @@ module('LocalStorageSource', function(hooks) {
         classification: 'gas giant',
         revised: true
       }
-    });
+    };
 
     return source.push(Transform.from(addRecord(original)))
       .then(() => source.push(Transform.from(replaceRecord(revised))))
@@ -107,14 +107,14 @@ module('LocalStorageSource', function(hooks) {
   test('#push - removeRecord', function(assert) {
     assert.expect(1);
 
-    let planet = schema.normalize({
+    let planet = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
         name: 'Jupiter',
         classification: 'gas giant'
       }
-    });
+    };
 
     return source.push(Transform.from(addRecord(planet)))
       .then(() => source.push(Transform.from(removeRecord(planet))))
@@ -124,16 +124,16 @@ module('LocalStorageSource', function(hooks) {
   test('#push - replaceKey', function(assert) {
     assert.expect(1);
 
-    let original = schema.normalize({
+    let original = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
         name: 'Jupiter',
         classification: 'gas giant'
       }
-    });
+    };
 
-    let revised = schema.normalize({
+    let revised = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -143,7 +143,7 @@ module('LocalStorageSource', function(hooks) {
       keys: {
         remoteId: '123'
       }
-    });
+    };
 
     return source.push(Transform.from(addRecord(original)))
       .then(() => source.push(Transform.from(replaceKey(original, 'remoteId', '123'))))
@@ -153,16 +153,16 @@ module('LocalStorageSource', function(hooks) {
   test('#push - replaceAttribute', function(assert) {
     assert.expect(1);
 
-    let original = schema.normalize({
+    let original = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
         name: 'Jupiter',
         classification: 'gas giant'
       }
-    });
+    };
 
-    let revised = schema.normalize({
+    let revised = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -170,7 +170,7 @@ module('LocalStorageSource', function(hooks) {
         classification: 'gas giant',
         order: 5
       }
-    });
+    };
 
     return source.push(Transform.from(addRecord(original)))
       .then(() => source.push(Transform.from(replaceAttribute(original, 'order', 5))))
@@ -180,7 +180,7 @@ module('LocalStorageSource', function(hooks) {
   test('#push - addToHasMany', function(assert) {
     assert.expect(1);
 
-    let original = schema.normalize({
+    let original = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -192,9 +192,9 @@ module('LocalStorageSource', function(hooks) {
           data: {}
         }
       }
-    });
+    };
 
-    let revised = schema.normalize({
+    let revised = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -208,7 +208,7 @@ module('LocalStorageSource', function(hooks) {
           }
         }
       }
-    });
+    };
 
     return source.push(Transform.from(addRecord(original)))
       .then(() => source.push(Transform.from(addToHasMany(original, 'moons', { type: 'moon', id: 'moon1' }))))
@@ -218,7 +218,7 @@ module('LocalStorageSource', function(hooks) {
   test('#push - removeFromHasMany', function(assert) {
     assert.expect(1);
 
-    let original = schema.normalize({
+    let original = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -233,9 +233,9 @@ module('LocalStorageSource', function(hooks) {
           }
         }
       }
-    });
+    };
 
-    let revised = schema.normalize({
+    let revised = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -249,7 +249,7 @@ module('LocalStorageSource', function(hooks) {
           }
         }
       }
-    });
+    };
 
     return source.push(Transform.from(addRecord(original)))
       .then(() => source.push(Transform.from(removeFromHasMany(original, 'moons', { type: 'moon', id: 'moon2' }))))
@@ -259,7 +259,7 @@ module('LocalStorageSource', function(hooks) {
   test('#push - replaceHasMany', function(assert) {
     assert.expect(1);
 
-    let original = schema.normalize({
+    let original = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -273,9 +273,9 @@ module('LocalStorageSource', function(hooks) {
           }
         }
       }
-    });
+    };
 
-    let revised = schema.normalize({
+    let revised = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -290,7 +290,7 @@ module('LocalStorageSource', function(hooks) {
           }
         }
       }
-    });
+    };
 
     return source.push(Transform.from(addRecord(original)))
       .then(() => source.push(Transform.from(replaceHasMany(original, 'moons', [{ type: 'moon', id: 'moon2' }, { type: 'moon', id: 'moon3' }]))))
@@ -300,7 +300,7 @@ module('LocalStorageSource', function(hooks) {
   test('#push - replaceHasOne - record', function(assert) {
     assert.expect(1);
 
-    let original = schema.normalize({
+    let original = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -312,9 +312,9 @@ module('LocalStorageSource', function(hooks) {
           data: null
         }
       }
-    });
+    };
 
-    let revised = schema.normalize({
+    let revised = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -326,7 +326,7 @@ module('LocalStorageSource', function(hooks) {
           data: 'solarSystem:ss1'
         }
       }
-    });
+    };
 
     return source.push(Transform.from(addRecord(original)))
       .then(() => source.push(Transform.from(replaceHasOne(original, 'solarSystem', { type: 'solarSystem', id: 'ss1' }))))
@@ -336,7 +336,7 @@ module('LocalStorageSource', function(hooks) {
   test('#push - replaceHasOne - null', function(assert) {
     assert.expect(1);
 
-    let original = schema.normalize({
+    let original = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -348,9 +348,9 @@ module('LocalStorageSource', function(hooks) {
           data: 'solarSystem:ss1'
         }
       }
-    });
+    };
 
-    let revised = schema.normalize({
+    let revised = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -362,7 +362,7 @@ module('LocalStorageSource', function(hooks) {
           data: null
         }
       }
-    });
+    };
 
     return source.push(Transform.from(addRecord(original)))
       .then(() => source.push(Transform.from(replaceHasOne(original, 'solarSystem', null))))
@@ -372,10 +372,10 @@ module('LocalStorageSource', function(hooks) {
   test('#reset - clears records for source', function(assert) {
     assert.expect(2);
 
-    let planet = schema.normalize({
+    let planet = {
       type: 'planet',
       id: 'jupiter'
-    });
+    };
 
     return source.push(Transform.from(addRecord(planet)))
       .then(() => {
@@ -388,31 +388,31 @@ module('LocalStorageSource', function(hooks) {
   test('#pull - all records', function(assert) {
     assert.expect(2);
 
-    let earth = schema.normalize({
+    let earth = {
       type: 'planet',
       id: 'earth',
       attributes: {
         name: 'Earth',
         classification: 'terrestrial'
       }
-    });
+    };
 
-    let jupiter = schema.normalize({
+    let jupiter = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
         name: 'Jupiter',
         classification: 'gas giant'
       }
-    });
+    };
 
-    let io = schema.normalize({
+    let io = {
       type: 'moon',
       id: 'io',
       attributes: {
         name: 'Io'
       }
-    });
+    };
 
     source.reset();
 
@@ -435,31 +435,31 @@ module('LocalStorageSource', function(hooks) {
   test('#pull - records of one type', function(assert) {
     assert.expect(2);
 
-    let earth = schema.normalize({
+    let earth = {
       type: 'planet',
       id: 'earth',
       attributes: {
         name: 'Earth',
         classification: 'terrestrial'
       }
-    });
+    };
 
-    let jupiter = schema.normalize({
+    let jupiter = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
         name: 'Jupiter',
         classification: 'gas giant'
       }
-    });
+    };
 
-    let io = schema.normalize({
+    let io = {
       type: 'moon',
       id: 'io',
       attributes: {
         name: 'Io'
       }
-    });
+    };
 
     source.reset();
 
@@ -482,31 +482,31 @@ module('LocalStorageSource', function(hooks) {
   test('#pull - a specific record', function(assert) {
     assert.expect(2);
 
-    let earth = schema.normalize({
+    let earth = {
       type: 'planet',
       id: 'earth',
       attributes: {
         name: 'Earth',
         classification: 'terrestrial'
       }
-    });
+    };
 
-    let jupiter = schema.normalize({
+    let jupiter = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
         name: 'Jupiter',
         classification: 'gas giant'
       }
-    });
+    };
 
-    let io = schema.normalize({
+    let io = {
       type: 'moon',
       id: 'io',
       attributes: {
         name: 'Io'
       }
-    });
+    };
 
     source.reset();
 


### PR DESCRIPTION
Records should work everywhere in their sparse form, requiring only a
type and id. In the sparse form, it becomes ambiguous when to assign
default values. The concept of default values is probably best left
as a source-specific concern.