### PR TITLE
Simplify Schema

### DIFF
--- a/packages/@orbit/data/test/schema-test.ts
+++ b/packages/@orbit/data/test/schema-test.ts
@@ -44,78 +44,7 @@ module('Schema', function() {
     });
   });
 
-  test('#modelDefaults is assigned by default', function(assert) {
-    const schema = new Schema({
-      models: {
-        planet: {}
-      }
-    });
-
-    assert.ok(schema.modelDefaults, 'modelDefaults has been set');
-    assert.ok(schema.models, 'schema.models has been set');
-    assert.ok(schema.models.planet, 'model definition has been set');
-  });
-
-  test('#modelDefaults can be overridden', function(assert) {
-    const customIdGenerator = function() {
-      return Math.random().toString(); // don't do this ;)
-    };
-
-    const schema = new Schema({
-      generateId: customIdGenerator,
-      modelDefaults: {
-        keys: {
-          remoteId: {}
-        },
-        attributes: {
-          someAttr: {}
-        },
-        relationships: {
-          someLink: {}
-        }
-      },
-      models: {
-        planet: {},
-        moon: {
-          keys: {
-            remoteId: undefined
-          },
-          attributes: {
-            someAttr: undefined
-          },
-          relationships: {
-            someLink: undefined
-          }
-        }
-      }
-    });
-
-    assert.strictEqual(schema.generateId, customIdGenerator, 'custom id generator has been set');
-    assert.ok(schema.modelDefaults, 'modelDefaults has been set');
-    assert.ok(schema.modelDefaults.keys.remoteId, 'custom remoteId key has been set');
-    assert.ok(schema.modelDefaults.attributes.someAttr, 'default model schema attribute has been set');
-    assert.ok(schema.modelDefaults.relationships.someLink, 'default model link schema has been set');
-
-    assert.ok(schema.models, 'schema.models has been set');
-    let model = schema.models.planet;
-    assert.ok(model, 'model definition has been set');
-    assert.ok(model.keys, 'model.keys has been set');
-    assert.ok(model.attributes, 'model.attributes has been set');
-    assert.ok(model.relationships, 'model.relationships has been set');
-    assert.ok(model.attributes['someAttr'], 'model.attributes match defaults');
-    assert.ok(model.relationships['someLink'], 'model.relationships match defaults');
-
-    model = schema.models.moon;
-    assert.ok(model, 'model definition has been set');
-    assert.ok(model.keys, 'model.keys has been set');
-    assert.ok(model.attributes, 'model.attributes has been set');
-    assert.ok(model.relationships, 'model.relationships has been set');
-    assert.equal(Object.keys(model.keys).length, 0, 'model has no keys');
-    assert.equal(Object.keys(model.attributes).length, 0, 'model has no attributes');
-    assert.equal(Object.keys(model.relationships).length, 0, 'model has no relationships');
-  });
-
-  test('#modelDefinition returns a registered model definition', function(assert) {
+  test('#models provides access to model definitions', function(assert) {
     const planetDefinition = {
       attributes: {
         name: { type: 'string', defaultValue: 'Earth' }
@@ -128,7 +57,7 @@ module('Schema', function() {
       }
     });
 
-    assert.deepEqual(schema.modelDefinition('planet').attributes, planetDefinition.attributes);
+    assert.deepEqual(schema.models.planet.attributes, planetDefinition.attributes);
   });
 
   test('#pluralize simply adds an `s` to the end of words', function(assert) {

--- a/packages/@orbit/store/src/cache/operation-processors/cache-integrity-processor.ts
+++ b/packages/@orbit/store/src/cache/operation-processors/cache-integrity-processor.ts
@@ -85,7 +85,7 @@ export default class CacheIntegrityProcessor extends OperationProcessor {
 
   private _relatedRecordAdded(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): RecordOperation[] {
     if (relatedRecord) {
-      const relationshipDef = this.cache.schema.relationshipDefinition(record.type, relationship);
+      const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
       if (relationshipDef.inverse) {
         this._addRevLink(record, relationship, relatedRecord);
       }
@@ -95,7 +95,7 @@ export default class CacheIntegrityProcessor extends OperationProcessor {
 
   private _relatedRecordsAdded(record: RecordIdentity, relationship: string, relatedRecords: RecordIdentity[]): RecordOperation[] {
     if (relatedRecords && relatedRecords.length > 0) {
-      const relationshipDef = this.cache.schema.relationshipDefinition(record.type, relationship);
+      const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
       if (relationshipDef.inverse) {
         relatedRecords.forEach(relatedRecord => this._addRevLink(record, relationship, relatedRecord));
       }
@@ -104,7 +104,7 @@ export default class CacheIntegrityProcessor extends OperationProcessor {
   }
 
   private _relatedRecordRemoved(record: RecordIdentity, relationship: string, relatedRecord?: RecordIdentity): RecordOperation[] {
-    const relationshipDef = this.cache.schema.relationshipDefinition(record.type, relationship);
+    const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
 
     if (relationshipDef.inverse) {
       if (relatedRecord === undefined) {
@@ -124,7 +124,7 @@ export default class CacheIntegrityProcessor extends OperationProcessor {
   }
 
   private _relatedRecordsRemoved(record: RecordIdentity, relationship: string, relatedRecords?: RecordIdentity[]): RecordOperation[] {
-    const relationshipDef = this.cache.schema.relationshipDefinition(record.type, relationship);
+    const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
 
     if (relationshipDef.inverse) {
       if (relatedRecords === undefined) {
@@ -243,7 +243,7 @@ export default class CacheIntegrityProcessor extends OperationProcessor {
 
   _addRevLink(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): void {
     if (relatedRecord) {
-      const relationshipDef = this.cache.schema.relationshipDefinition(record.type, relationship);
+      const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
       const relationshipPath = [record.type, record.id, 'relationships', relationship, 'data'];
 
       if (relationshipDef.type === 'hasMany') {
@@ -257,7 +257,7 @@ export default class CacheIntegrityProcessor extends OperationProcessor {
 
   _removeRevLink(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): void {
     if (relatedRecord) {
-      const relationshipDef = this.cache.schema.relationshipDefinition(record.type, relationship);
+      const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
       const relationshipPath = [record.type, record.id, 'relationships', relationship, 'data'];
 
       if (relationshipDef.type === 'hasMany') {

--- a/packages/@orbit/store/src/cache/operation-processors/schema-consistency-processor.ts
+++ b/packages/@orbit/store/src/cache/operation-processors/schema-consistency-processor.ts
@@ -58,7 +58,7 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
 
   _relatedRecordAdded(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): RecordOperation[] {
     const ops: RecordOperation[] = [];
-    const relationshipDef = this.cache.schema.relationshipDefinition(record.type, relationship);
+    const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
     const inverseRelationship = relationshipDef.inverse;
 
     if (inverseRelationship && relatedRecord) {
@@ -70,7 +70,7 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
 
   _relatedRecordsAdded(record: RecordIdentity, relationship: string, relatedRecords: RecordIdentity[]): RecordOperation[] {
     const ops: RecordOperation[] = [];
-    const relationshipDef = this.cache.schema.relationshipDefinition(record.type, relationship);
+    const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
     const inverseRelationship = relationshipDef.inverse;
 
     if (inverseRelationship && relatedRecords && relatedRecords.length > 0) {
@@ -82,7 +82,7 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
 
   _relatedRecordRemoved(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): RecordOperation[] {
     const ops: RecordOperation[] = [];
-    const relationshipDef = this.cache.schema.relationshipDefinition(record.type, relationship);
+    const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
     const inverseRelationship = relationshipDef.inverse;
 
     if (inverseRelationship) {
@@ -104,7 +104,7 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
 
   _relatedRecordReplaced(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): RecordOperation[] {
     const ops: RecordOperation[] = [];
-    const relationshipDef = this.cache.schema.relationshipDefinition(record.type, relationship);
+    const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
     const inverseRelationship = relationshipDef.inverse;
 
     if (inverseRelationship) {
@@ -133,7 +133,7 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
 
   _relatedRecordsRemoved(record: RecordIdentity, relationship: string, relatedRecords: RecordIdentity[]): RecordOperation[] {
     const ops: RecordOperation[] = [];
-    const relationshipDef = this.cache.schema.relationshipDefinition(record.type, relationship);
+    const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
     const inverseRelationship = relationshipDef.inverse;
 
     if (inverseRelationship) {
@@ -155,7 +155,7 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
 
   _relatedRecordsReplaced(record: RecordIdentity, relationship: string, relatedRecords: RecordIdentity[]): RecordOperation[] {
     const ops: RecordOperation[] = [];
-    const relationshipDef = this.cache.schema.relationshipDefinition(record.type, relationship);
+    const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
     const currentRecord = this.cache.records(record.type).get(record.id);
     const prevRelationshipData = currentRecord && deepGet(currentRecord, ['relationships', relationship, 'data']);
     const prevRelatedRecordMap = recordMapFromData(prevRelationshipData);
@@ -181,7 +181,7 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
     const relationships = record.relationships;
 
     if (relationships) {
-      const modelDef = this.cache.schema.modelDefinition(record.type);
+      const modelDef = this.cache.schema.models[record.type];
       const recordIdentity = cloneRecordIdentity(record);
 
       Object.keys(relationships).forEach(relationship => {
@@ -205,7 +205,7 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
     const relationships = currentRecord && deepGet(currentRecord, ['relationships']);
 
     if (relationships) {
-      const modelDef = this.cache.schema.modelDefinition(record.type);
+      const modelDef = this.cache.schema.models[record.type];
       const recordIdentity = cloneRecordIdentity(record);
 
       Object.keys(relationships).forEach(relationship => {
@@ -223,7 +223,7 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
 
   _recordReplaced(record: Record): RecordOperation[] {
     const ops: RecordOperation[] = [];
-    const modelDef = this.cache.schema.modelDefinition(record.type);
+    const modelDef = this.cache.schema.models[record.type];
     const recordIdentity = cloneRecordIdentity(record);
 
     for (let relationship in modelDef.relationships) {
@@ -272,7 +272,7 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
   }
 
   _addRelationshipOp(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): RecordOperation {
-    const relationshipDef = this.cache.schema.relationshipDefinition(record.type, relationship);
+    const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
     const isHasMany = relationshipDef.type === 'hasMany';
 
     return <RecordOperation>{
@@ -284,7 +284,7 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
   }
 
   _removeRelationshipOp(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): RecordOperation {
-    const relationshipDef = this.cache.schema.relationshipDefinition(record.type, relationship);
+    const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
     const isHasMany = relationshipDef.type === 'hasMany';
 
     return <RecordOperation>{


### PR DESCRIPTION
Removes modelDefaults to discourage dynamic schema creation. It will be
more performant for schemas to be defined fully at build time.

Also, removes methods `modelDefinition`, `keyDefinition`, and
`relationshipDefinition` in favor of direct access to the `models`
dictionary.