### PR TITLE
Allow coordinator to be deactivated when inactive

### DIFF
--- a/packages/@orbit/coordinator/src/coordinator.ts
+++ b/packages/@orbit/coordinator/src/coordinator.ts
@@ -138,11 +138,19 @@ export default class Coordinator {
   }
 
   deactivate(): Promise<void> {
-    this._activated = null;
-
-    return this.strategies.reverse().reduce((chain, strategy) => {
-      return chain
-        .then(() => strategy.deactivate());
-    }, Orbit.Promise.resolve());
+    if (this._activated) {
+      return this._activated
+        .then(() => {
+          return this.strategies.reverse().reduce((chain, strategy) => {
+            return chain
+              .then(() => strategy.deactivate());
+          }, Orbit.Promise.resolve());
+        })
+        .then(() => {
+          this._activated = null;
+        });
+    } else {
+      return Orbit.Promise.resolve();
+    }
   }
 }

--- a/packages/@orbit/coordinator/test/coordinator-test.ts
+++ b/packages/@orbit/coordinator/test/coordinator-test.ts
@@ -265,4 +265,39 @@ module('Coordinator', function(hooks) {
         assert.equal(deactivatedCount, 3, 'both strategies have been deactivated');
       });
   });
+
+  test('can be deactivated multiple times, without being activated', function(assert) {
+    assert.expect(2);
+
+    let activatedCount = 0;
+    let deactivatedCount = 0;
+
+    class CustomStrategy extends Strategy {
+      activate(coordinator, options): Promise<any> {
+        assert.ok(false, 'strategies should not be activated');
+        return Orbit.Promise.resolve();
+      }
+
+      deactivate(): Promise<any> {
+        assert.ok(false, 'strategies should not be deactivated');
+        return Orbit.Promise.resolve();
+      }
+    }
+
+    let s1 = new CustomStrategy({ name: 's1' });
+    let s2 = new CustomStrategy({ name: 's2' });
+    let s3 = new CustomStrategy({ name: 's3' });
+
+    coordinator = new Coordinator({ strategies: [s2, s1] });
+    coordinator.addStrategy(s3);
+
+    return coordinator.deactivate()
+      .then(() => {
+        assert.ok(true, 'deactivate completes despite not being active');
+        return coordinator.deactivate();
+      })
+      .then(() => {
+        assert.ok(true, 'deactivate can continue to be called');
+      });
+  });
 });


### PR DESCRIPTION
Make `coordinator.deactivate()` safe to call regardless of the state of 
the coordinator.