### PR TITLE
BREAKING: Rename transform operators that deal with relationships

### DIFF
--- a/packages/@orbit/data/src/operation.ts
+++ b/packages/@orbit/data/src/operation.ts
@@ -79,11 +79,11 @@ export interface ReplaceAttributeOperation extends Operation {
  * Add to has-many relationship operation.
  *
  * @export
- * @interface AddToHasManyOperation
+ * @interface AddToRelatedRecordsOperation
  * @extends {Operation}
  */
-export interface AddToHasManyOperation extends Operation {
-  op: 'addToHasMany';
+export interface AddToRelatedRecordsOperation extends Operation {
+  op: 'addToRelatedRecords';
   record: RecordIdentity;
   relationship: string;
   relatedRecord: RecordIdentity;
@@ -93,11 +93,11 @@ export interface AddToHasManyOperation extends Operation {
  * Remove from has-many relationship operation.
  *
  * @export
- * @interface RemoveFromHasManyOperation
+ * @interface RemoveFromRelatedRecordsOperation
  * @extends {Operation}
  */
-export interface RemoveFromHasManyOperation extends Operation {
-  op: 'removeFromHasMany';
+export interface RemoveFromRelatedRecordsOperation extends Operation {
+  op: 'removeFromRelatedRecords';
   record: RecordIdentity;
   relationship: string;
   relatedRecord: RecordIdentity;
@@ -107,11 +107,11 @@ export interface RemoveFromHasManyOperation extends Operation {
  * Replace has-many relationship operation.
  *
  * @export
- * @interface ReplaceHasManyOperation
+ * @interface ReplaceRelatedRecordsOperation
  * @extends {Operation}
  */
-export interface ReplaceHasManyOperation extends Operation {
-  op: 'replaceHasMany';
+export interface ReplaceRelatedRecordsOperation extends Operation {
+  op: 'replaceRelatedRecords';
   record: RecordIdentity;
   relationship: string;
   relatedRecords: RecordIdentity[];
@@ -121,11 +121,11 @@ export interface ReplaceHasManyOperation extends Operation {
  * Replace has-one relationship operation.
  *
  * @export
- * @interface ReplaceHasOneOperation
+ * @interface ReplaceRelatedRecordOperation
  * @extends {Operation}
  */
-export interface ReplaceHasOneOperation extends Operation {
-  op: 'replaceHasOne';
+export interface ReplaceRelatedRecordOperation extends Operation {
+  op: 'replaceRelatedRecord';
   record: RecordIdentity;
   relationship: string;
   relatedRecord: RecordIdentity;
@@ -141,10 +141,10 @@ export type RecordOperation = AddRecordOperation |
   RemoveRecordOperation |
   ReplaceKeyOperation |
   ReplaceAttributeOperation |
-  AddToHasManyOperation |
-  RemoveFromHasManyOperation |
-  ReplaceHasManyOperation |
-  ReplaceHasOneOperation;
+  AddToRelatedRecordsOperation |
+  RemoveFromRelatedRecordsOperation |
+  ReplaceRelatedRecordsOperation |
+  ReplaceRelatedRecordOperation;
 
 function markOperationToDelete(operation: Operation): void {
   const o: any = operation;
@@ -169,12 +169,12 @@ function mergeOperations(superceded: RecordOperation, superceding: RecordOperati
             superceding.op === 'replaceAttribute' &&
             superceded.attribute === superceding.attribute) {
           markOperationToDelete(superceded);
-        } else if (superceded.op === 'replaceHasOne' &&
-            superceding.op === 'replaceHasOne' &&
+        } else if (superceded.op === 'replaceRelatedRecord' &&
+            superceding.op === 'replaceRelatedRecord' &&
             superceded.relationship === superceding.relationship) {
           markOperationToDelete(superceded);
-        } else if (superceded.op === 'replaceHasMany' &&
-            superceding.op === 'replaceHasMany' &&
+        } else if (superceded.op === 'replaceRelatedRecords' &&
+            superceding.op === 'replaceRelatedRecords' &&
             superceded.relationship === superceding.relationship) {
           markOperationToDelete(superceded);
         } else {
@@ -182,20 +182,20 @@ function mergeOperations(superceded: RecordOperation, superceding: RecordOperati
             updateRecordReplaceAttribute(superceded.record, superceded.attribute, superceded.value);
             delete superceded.attribute;
             delete superceded.value;
-          } else if (superceded.op === 'replaceHasOne') {
+          } else if (superceded.op === 'replaceRelatedRecord') {
             updateRecordReplaceHasOne(superceded.record, superceded.relationship, superceded.relatedRecord);
             delete superceded.relationship;
             delete superceded.relatedRecord;
-          } else if (superceded.op === 'replaceHasMany') {
+          } else if (superceded.op === 'replaceRelatedRecords') {
             updateRecordReplaceHasMany(superceded.record, superceded.relationship, superceded.relatedRecords);
             delete superceded.relationship;
             delete superceded.relatedRecords;
           }
           if (superceding.op === 'replaceAttribute') {
             updateRecordReplaceAttribute(superceded.record, superceding.attribute, superceding.value);
-          } else if (superceding.op === 'replaceHasOne') {
+          } else if (superceding.op === 'replaceRelatedRecord') {
             updateRecordReplaceHasOne(superceded.record, superceding.relationship, superceding.relatedRecord);
-          } else if (superceding.op === 'replaceHasMany') {
+          } else if (superceding.op === 'replaceRelatedRecords') {
             updateRecordReplaceHasMany(superceded.record, superceding.relationship, superceding.relatedRecords);
           }
           superceded.op = 'replaceRecord';
@@ -205,13 +205,13 @@ function mergeOperations(superceded: RecordOperation, superceding: RecordOperati
                  isReplaceFieldOp(superceding.op)) {
         if (superceding.op === 'replaceAttribute') {
           updateRecordReplaceAttribute(superceded.record, superceding.attribute, superceding.value);
-        } else if (superceding.op === 'replaceHasOne') {
+        } else if (superceding.op === 'replaceRelatedRecord') {
           updateRecordReplaceHasOne(superceded.record, superceding.relationship, superceding.relatedRecord);
-        } else if (superceding.op === 'replaceHasMany') {
+        } else if (superceding.op === 'replaceRelatedRecords') {
           updateRecordReplaceHasMany(superceded.record, superceding.relationship, superceding.relatedRecords);
         }
         markOperationToDelete(superceding);
-      } else if (superceding.op === 'addToHasMany') {
+      } else if (superceding.op === 'addToRelatedRecords') {
         if (superceded.op === 'addRecord') {
           updateRecordAddToHasMany(superceded.record, superceding.relationship, superceding.relatedRecord);
           markOperationToDelete(superceding);
@@ -223,8 +223,8 @@ function mergeOperations(superceded: RecordOperation, superceding: RecordOperati
             markOperationToDelete(superceding);
           }
         }
-      } else if (superceding.op === 'removeFromHasMany') {
-        if (superceded.op === 'addToHasMany' &&
+      } else if (superceding.op === 'removeFromRelatedRecords') {
+        if (superceded.op === 'addToRelatedRecords' &&
             superceded.relationship === superceding.relationship &&
             equalRecordIdentities(superceded.relatedRecord, superceding.relatedRecord)) {
           markOperationToDelete(superceded);
@@ -245,8 +245,8 @@ function mergeOperations(superceded: RecordOperation, superceding: RecordOperati
 
 function isReplaceFieldOp(op: string): boolean {
   return (op === 'replaceAttribute' ||
-          op === 'replaceHasOne' ||
-          op === 'replaceHasMany');
+          op === 'replaceRelatedRecord' ||
+          op === 'replaceRelatedRecords');
 }
 
 function updateRecordReplaceAttribute(record: Record, attribute: string, value: any) {

--- a/packages/@orbit/data/src/transform-builder.ts
+++ b/packages/@orbit/data/src/transform-builder.ts
@@ -8,10 +8,10 @@ import {
   RemoveRecordOperation,
   ReplaceKeyOperation,
   ReplaceAttributeOperation,
-  AddToHasManyOperation,
-  RemoveFromHasManyOperation,
-  ReplaceHasManyOperation,
-  ReplaceHasOneOperation
+  AddToRelatedRecordsOperation,
+  RemoveFromRelatedRecordsOperation,
+  ReplaceRelatedRecordsOperation,
+  ReplaceRelatedRecordOperation
 } from './operation';
 import { eq } from '@orbit/utils';
 
@@ -71,50 +71,50 @@ export default class TransformBuilder {
   }
 
   /**
-   * Instantiate a new `addToHasMany` operation.
+   * Instantiate a new `addToRelatedRecords` operation.
    *
    * @param {RecordIdentity} record
    * @param {string} relationship
    * @param {RecordIdentity} relatedRecord
-   * @returns {AddToHasManyOperation}
+   * @returns {AddToRelatedRecordsOperation}
    */
-  addToHasMany(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): AddToHasManyOperation {
-    return { op: 'addToHasMany', record, relationship, relatedRecord };
+  addToRelatedRecords(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): AddToRelatedRecordsOperation {
+    return { op: 'addToRelatedRecords', record, relationship, relatedRecord };
   }
 
   /**
-   * Instantiate a new `removeFromHasMany` operation.
+   * Instantiate a new `removeFromRelatedRecords` operation.
    *
    * @param {RecordIdentity} record
    * @param {string} relationship
    * @param {RecordIdentity} relatedRecord
-   * @returns {RemoveFromHasManyOperation}
+   * @returns {RemoveFromRelatedRecordsOperation}
    */
-  removeFromHasMany(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): RemoveFromHasManyOperation {
-    return { op: 'removeFromHasMany', record, relationship, relatedRecord };
+  removeFromRelatedRecords(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): RemoveFromRelatedRecordsOperation {
+    return { op: 'removeFromRelatedRecords', record, relationship, relatedRecord };
   }
 
   /**
-   * Instantiate a new `replaceHasMany` operation.
+   * Instantiate a new `replaceRelatedRecords` operation.
    *
    * @param {RecordIdentity} record
    * @param {string} relationship
    * @param {RecordIdentity[]} relatedRecords
-   * @returns {ReplaceHasManyOperation}
+   * @returns {ReplaceRelatedRecordsOperation}
    */
-  replaceHasMany(record: RecordIdentity, relationship: string, relatedRecords: RecordIdentity[]): ReplaceHasManyOperation {
-    return { op: 'replaceHasMany', record, relationship, relatedRecords };
+  replaceRelatedRecords(record: RecordIdentity, relationship: string, relatedRecords: RecordIdentity[]): ReplaceRelatedRecordsOperation {
+    return { op: 'replaceRelatedRecords', record, relationship, relatedRecords };
   }
 
   /**
-   * Instantiate a new `replaceHasOne` operation.
+   * Instantiate a new `replaceRelatedRecord` operation.
    *
    * @param {RecordIdentity} record
    * @param {string} relationship
    * @param {RecordIdentity} relatedRecord
-   * @returns {ReplaceHasOneOperation}
+   * @returns {ReplaceRelatedRecordOperation}
    */
-  replaceHasOne(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): ReplaceHasOneOperation {
-    return { op: 'replaceHasOne', record, relationship, relatedRecord };
+  replaceRelatedRecord(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): ReplaceRelatedRecordOperation {
+    return { op: 'replaceRelatedRecord', record, relationship, relatedRecord };
   }
 }

--- a/packages/@orbit/data/test/operation-test.ts
+++ b/packages/@orbit/data/test/operation-test.ts
@@ -127,7 +127,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce addRecord + replaceHasMany for the same record', function(assert) {
+    test('can coalesce addRecord + replaceRelatedRecords for the same record', function(assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -135,7 +135,7 @@ module('Operation', function() {
             record: { type: 'contact', id: '1234', attributes: { name: 'Joe' } }
           },
           {
-            op: 'replaceHasMany',
+            op: 'replaceRelatedRecords',
             record: { type: 'contact', id: '1234' },
             relationship: 'phoneNumbers',
             relatedRecords: [{ type: 'phoneNumber', id: 'abc' }]
@@ -158,7 +158,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce addRecord + replaceHasOne for the same record', function(assert) {
+    test('can coalesce addRecord + replaceRelatedRecord for the same record', function(assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -166,7 +166,7 @@ module('Operation', function() {
             record: { type: 'contact', id: '1234', attributes: { name: 'Joe' } }
           },
           {
-            op: 'replaceHasOne',
+            op: 'replaceRelatedRecord',
             record: { type: 'contact', id: '1234' },
             relationship: 'address',
             relatedRecord: { type: 'address', id: 'abc' }
@@ -189,7 +189,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce addRecord + addToHasMany for the same record', function(assert) {
+    test('can coalesce addRecord + addToRelatedRecords for the same record', function(assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -197,7 +197,7 @@ module('Operation', function() {
             record: { type: 'contact', id: '1234', attributes: { name: 'Joe' } }
           },
           {
-            op: 'addToHasMany',
+            op: 'addToRelatedRecords',
             record: { type: 'contact', id: '1234' },
             relationship: 'phoneNumbers',
             relatedRecord: { type: 'phoneNumber', id: 'abc' }
@@ -220,7 +220,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce addRecord + replaceHasOne for the same record', function(assert) {
+    test('can coalesce addRecord + replaceRelatedRecord for the same record', function(assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -228,7 +228,7 @@ module('Operation', function() {
             record: { type: 'contact', id: '1234', attributes: { name: 'Joe' } }
           },
           {
-            op: 'replaceHasOne',
+            op: 'replaceRelatedRecord',
             record: { type: 'contact', id: '1234' },
             relationship: 'address',
             relatedRecord: { type: 'address', id: 'abc' }
@@ -251,7 +251,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce addRecord + replaceHasOne for the same record + relationship', function(assert) {
+    test('can coalesce addRecord + replaceRelatedRecord for the same record + relationship', function(assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -265,7 +265,7 @@ module('Operation', function() {
             }
           },
           {
-            op: 'replaceHasOne',
+            op: 'replaceRelatedRecord',
             record: { type: 'contact', id: '1234' },
             relationship: 'address',
             relatedRecord: { type: 'address', id: 'abc' }
@@ -288,17 +288,17 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce replaceHasOne + replaceHasOne for the same record + relationship', function(assert) {
+    test('can coalesce replaceRelatedRecord + replaceRelatedRecord for the same record + relationship', function(assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
-            op: 'replaceHasOne',
+            op: 'replaceRelatedRecord',
             record: { type: 'contact', id: '1234' },
             relationship: 'address',
             relatedRecord: { type: 'address', id: 'abc' }
           },
           {
-            op: 'replaceHasOne',
+            op: 'replaceRelatedRecord',
             record: { type: 'contact', id: '1234' },
             relationship: 'address',
             relatedRecord: { type: 'address', id: 'def' }
@@ -306,7 +306,7 @@ module('Operation', function() {
         ]),
         [
           {
-            op: 'replaceHasOne',
+            op: 'replaceRelatedRecord',
             record: { type: 'contact', id: '1234' },
             relationship: 'address',
             relatedRecord: { type: 'address', id: 'def' }
@@ -332,7 +332,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce addRecord + replaceHasOne + removeRecord for the same record', function(assert) {
+    test('can coalesce addRecord + replaceRelatedRecord + removeRecord for the same record', function(assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -346,7 +346,7 @@ module('Operation', function() {
             }
           },
           {
-            op: 'replaceHasOne',
+            op: 'replaceRelatedRecord',
             record: { type: 'contact', id: '1234' },
             relationship: 'address',
             relatedRecord: { type: 'address', id: 'abc' }
@@ -361,7 +361,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce addRecord + replaceHasOne + removeRecord for the same record in non-contiguous ops', function(assert) {
+    test('can coalesce addRecord + replaceRelatedRecord + removeRecord for the same record in non-contiguous ops', function(assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -379,7 +379,7 @@ module('Operation', function() {
             record: { type: 'contact', id: '5678', attributes: { name: 'Jim' } }
           },
           {
-            op: 'replaceHasOne',
+            op: 'replaceRelatedRecord',
             record: { type: 'contact', id: '1234' },
             relationship: 'address',
             relatedRecord: { type: 'address', id: 'abc' }
@@ -433,13 +433,13 @@ module('Operation', function() {
             value: 'a'
           },
           {
-            op: 'replaceHasOne',
+            op: 'replaceRelatedRecord',
             record: { type: 'contact', id: '1234' },
             relationship: 'address',
             relatedRecord: { type: 'address', id: 'def789' }
           },
           {
-            op: 'replaceHasOne',
+            op: 'replaceRelatedRecord',
             record: { type: 'address', id: 'def789' },
             relationship: 'contact',
             relatedRecord: { type: 'contact', id: '1234' }
@@ -463,13 +463,13 @@ module('Operation', function() {
             record: { type: 'address', id: 'def789', attributes: { street: 'abc' } }
           },
           {
-            op: 'replaceHasOne',
+            op: 'replaceRelatedRecord',
             record: { type: 'contact', id: '1234' },
             relationship: 'address',
             relatedRecord: { type: 'address', id: 'def789' }
           },
           {
-            op: 'replaceHasOne',
+            op: 'replaceRelatedRecord',
             record: { type: 'address', id: 'def789' },
             relationship: 'contact',
             relatedRecord: { type: 'contact', id: '1234' }
@@ -478,17 +478,17 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce addToHasMany + removeFromHasMany for the same record + relationship', function(assert) {
+    test('can coalesce addToRelatedRecords + removeFromRelatedRecords for the same record + relationship', function(assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
-            op: 'addToHasMany',
+            op: 'addToRelatedRecords',
             record: { type: 'contact', id: '1234' },
             relationship: 'phoneNumbers',
             relatedRecord: { type: 'phoneNumber', id: 'abc' }
           },
           {
-            op: 'removeFromHasMany',
+            op: 'removeFromRelatedRecords',
             record: { type: 'contact', id: '1234' },
             relationship: 'phoneNumbers',
             relatedRecord: { type: 'phoneNumber', id: 'abc' }
@@ -499,7 +499,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce addRecord + addToHasMany for the same record', function(assert) {
+    test('can coalesce addRecord + addToRelatedRecords for the same record', function(assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -516,7 +516,7 @@ module('Operation', function() {
             }
           },
           {
-            op: 'addToHasMany',
+            op: 'addToRelatedRecords',
             record: { type: 'address', id: 'def789' },
             relationship: 'phoneNumbers',
             relatedRecord: { type: 'phoneNumber', id: 'def' }
@@ -543,7 +543,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce replaceRecord + addToHasMany for the same record', function(assert) {
+    test('can coalesce replaceRecord + addToRelatedRecords for the same record', function(assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -560,7 +560,7 @@ module('Operation', function() {
             }
           },
           {
-            op: 'addToHasMany',
+            op: 'addToRelatedRecords',
             record: { type: 'address', id: 'def789' },
             relationship: 'phoneNumbers',
             relatedRecord: { type: 'phoneNumber', id: 'def' }
@@ -587,17 +587,17 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce removeFromHasMany + addToHasMany for the same record + relationship', function(assert) {
+    test('can coalesce removeFromRelatedRecords + addToRelatedRecords for the same record + relationship', function(assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
-            op: 'addToHasMany',
+            op: 'addToRelatedRecords',
             record: { type: 'address', id: 'def789' },
             relationship: 'phoneNumbers',
             relatedRecord: { type: 'phoneNumber', id: 'abc' }
           },
           {
-            op: 'removeFromHasMany',
+            op: 'removeFromRelatedRecords',
             record: { type: 'address', id: 'def789' },
             relationship: 'phoneNumbers',
             relatedRecord: { type: 'phoneNumber', id: 'abc' }
@@ -608,7 +608,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce addRecord + removeFromHasMany for the same record', function(assert) {
+    test('can coalesce addRecord + removeFromRelatedRecords for the same record', function(assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -625,7 +625,7 @@ module('Operation', function() {
             }
           },
           {
-            op: 'removeFromHasMany',
+            op: 'removeFromRelatedRecords',
             record: { type: 'address', id: 'def789' },
             relationship: 'phoneNumbers',
             relatedRecord: { type: 'phoneNumber', id: 'abc' }

--- a/packages/@orbit/data/test/transform-builder-test.ts
+++ b/packages/@orbit/data/test/transform-builder-test.ts
@@ -55,43 +55,43 @@ module('TransformBuilder', function(hooks) {
     );
   });
 
-  test('#addToHasMany', function(assert) {
+  test('#addToRelatedRecords', function(assert) {
     let record = { type: 'planet', id: 'jupiter' };
     let relatedRecord = { type: 'moon', id: 'Io' };
 
     assert.deepEqual(
-      tb.addToHasMany(record, 'moons', relatedRecord),
-      { op: 'addToHasMany', record, relationship: 'moons', relatedRecord }
+      tb.addToRelatedRecords(record, 'moons', relatedRecord),
+      { op: 'addToRelatedRecords', record, relationship: 'moons', relatedRecord }
     );
   });
 
-  test('#removeFromHasMany', function(assert) {
+  test('#removeFromRelatedRecords', function(assert) {
     let record = { type: 'planet', id: 'jupiter' };
     let relatedRecord = { type: 'moon', id: 'Io' };
 
     assert.deepEqual(
-      tb.removeFromHasMany(record, 'moons', relatedRecord),
-      { op: 'removeFromHasMany', record, relationship: 'moons', relatedRecord }
+      tb.removeFromRelatedRecords(record, 'moons', relatedRecord),
+      { op: 'removeFromRelatedRecords', record, relationship: 'moons', relatedRecord }
     );
   });
 
-  test('#replaceHasMany', function(assert) {
+  test('#replaceRelatedRecords', function(assert) {
     let record = { type: 'planet', id: 'jupiter' };
     let relatedRecords = [{ type: 'moon', id: 'Io' }];
 
     assert.deepEqual(
-      tb.replaceHasMany(record, 'moons', relatedRecords),
-      { op: 'replaceHasMany', record, relationship: 'moons', relatedRecords }
+      tb.replaceRelatedRecords(record, 'moons', relatedRecords),
+      { op: 'replaceRelatedRecords', record, relationship: 'moons', relatedRecords }
     );
   });
 
-  test('#replaceHasOne', function(assert) {
+  test('#replaceRelatedRecord', function(assert) {
     let record = { type: 'moon', id: 'Io' };
     let relatedRecord = { type: 'planet', id: 'Jupiter' };
 
     assert.deepEqual(
-      tb.replaceHasOne(record, 'planet', relatedRecord),
-      { op: 'replaceHasOne', record, relationship: 'planet', relatedRecord }
+      tb.replaceRelatedRecord(record, 'planet', relatedRecord),
+      { op: 'replaceRelatedRecord', record, relationship: 'planet', relatedRecord }
     );
   });
 });

--- a/packages/@orbit/indexeddb/src/lib/transform-operators.ts
+++ b/packages/@orbit/indexeddb/src/lib/transform-operators.ts
@@ -3,12 +3,12 @@ import {
   serializeRecordIdentity,
   Record, RecordIdentity,
   AddRecordOperation,
-  AddToHasManyOperation,
+  AddToRelatedRecordsOperation,
   ReplaceAttributeOperation,
-  RemoveFromHasManyOperation,
+  RemoveFromRelatedRecordsOperation,
   RemoveRecordOperation,
-  ReplaceHasManyOperation,
-  ReplaceHasOneOperation,
+  ReplaceRelatedRecordsOperation,
+  ReplaceRelatedRecordOperation,
   ReplaceKeyOperation,
   ReplaceRecordOperation
 } from '@orbit/data';
@@ -55,7 +55,7 @@ export default {
       });
   },
 
-  addToHasMany(source: Source, operation: AddToHasManyOperation) {
+  addToRelatedRecords(source: Source, operation: AddToRelatedRecordsOperation) {
     return getRecord(source, operation.record)
       .then(record => {
         deepSet(record, ['relationships', operation.relationship, 'data', serializeRecordIdentity(operation.relatedRecord)], true);
@@ -63,7 +63,7 @@ export default {
       });
   },
 
-  removeFromHasMany(source: Source, operation: RemoveFromHasManyOperation) {
+  removeFromRelatedRecords(source: Source, operation: RemoveFromRelatedRecordsOperation) {
     return getRecord(source, operation.record)
       .then(record => {
         if (record &&
@@ -78,7 +78,7 @@ export default {
       });
   },
 
-  replaceHasMany(source: Source, operation: ReplaceHasManyOperation) {
+  replaceRelatedRecords(source: Source, operation: ReplaceRelatedRecordsOperation) {
     return getRecord(source, operation.record)
       .then(record => {
         let data = {};
@@ -90,7 +90,7 @@ export default {
       });
   },
 
-  replaceHasOne(source: Source, operation: ReplaceHasOneOperation) {
+  replaceRelatedRecord(source: Source, operation: ReplaceRelatedRecordOperation) {
     return getRecord(source, operation.record)
       .then(record => {
         let data = operation.relatedRecord ? serializeRecordIdentity(operation.relatedRecord) : null;

--- a/packages/@orbit/indexeddb/test/source-test.ts
+++ b/packages/@orbit/indexeddb/test/source-test.ts
@@ -201,7 +201,7 @@ module('IndexedDBSource', function(hooks) {
       .then(() => verifyIndexedDBContainsRecord(assert, source, revised));
   });
 
-  test('#push - addToHasMany', function(assert) {
+  test('#push - addToRelatedRecords', function(assert) {
     assert.expect(1);
 
     let original = {
@@ -235,11 +235,11 @@ module('IndexedDBSource', function(hooks) {
     };
 
     return source.push(t => t.addRecord(original))
-      .then(() => source.push(t => t.addToHasMany(original, 'moons', { type: 'moon', id: 'moon1' })))
+      .then(() => source.push(t => t.addToRelatedRecords(original, 'moons', { type: 'moon', id: 'moon1' })))
       .then(() => verifyIndexedDBContainsRecord(assert, source, revised));
   });
 
-  test('#push - removeFromHasMany', function(assert) {
+  test('#push - removeFromRelatedRecords', function(assert) {
     assert.expect(1);
 
     let original = {
@@ -276,11 +276,11 @@ module('IndexedDBSource', function(hooks) {
     };
 
     return source.push(t => t.addRecord(original))
-      .then(() => source.push(t => t.removeFromHasMany(original, 'moons', { type: 'moon', id: 'moon2' })))
+      .then(() => source.push(t => t.removeFromRelatedRecords(original, 'moons', { type: 'moon', id: 'moon2' })))
       .then(() => verifyIndexedDBContainsRecord(assert, source, revised));
   });
 
-  test('#push - replaceHasMany', function(assert) {
+  test('#push - replaceRelatedRecords', function(assert) {
     assert.expect(1);
 
     let original = {
@@ -317,11 +317,11 @@ module('IndexedDBSource', function(hooks) {
     };
 
     return source.push(t => t.addRecord(original))
-      .then(() => source.push(t => t.replaceHasMany(original, 'moons', [{ type: 'moon', id: 'moon2' }, { type: 'moon', id: 'moon3' }])))
+      .then(() => source.push(t => t.replaceRelatedRecords(original, 'moons', [{ type: 'moon', id: 'moon2' }, { type: 'moon', id: 'moon3' }])))
       .then(() => verifyIndexedDBContainsRecord(assert, source, revised));
   });
 
-  test('#push - replaceHasOne - record', function(assert) {
+  test('#push - replaceRelatedRecord - record', function(assert) {
     assert.expect(1);
 
     let original = {
@@ -353,11 +353,11 @@ module('IndexedDBSource', function(hooks) {
     };
 
     return source.push(t => t.addRecord(original))
-      .then(() => source.push(t => t.replaceHasOne(original, 'solarSystem', { type: 'solarSystem', id: 'ss1' })))
+      .then(() => source.push(t => t.replaceRelatedRecord(original, 'solarSystem', { type: 'solarSystem', id: 'ss1' })))
       .then(() => verifyIndexedDBContainsRecord(assert, source, revised));
   });
 
-  test('#push - replaceHasOne - null', function(assert) {
+  test('#push - replaceRelatedRecord - null', function(assert) {
     assert.expect(1);
 
     let original = {
@@ -389,7 +389,7 @@ module('IndexedDBSource', function(hooks) {
     };
 
     return source.push(t => t.addRecord(original))
-      .then(() => source.push(t => t.replaceHasOne(original, 'solarSystem', null)))
+      .then(() => source.push(t => t.replaceRelatedRecord(original, 'solarSystem', null)))
       .then(() => verifyIndexedDBContainsRecord(assert, source, revised));
   });
 

--- a/packages/@orbit/jsonapi/src/lib/transform-requests.ts
+++ b/packages/@orbit/jsonapi/src/lib/transform-requests.ts
@@ -11,10 +11,10 @@ import {
   RemoveRecordOperation,
   ReplaceAttributeOperation,
   ReplaceRecordOperation,
-  AddToHasManyOperation,
-  RemoveFromHasManyOperation,
-  ReplaceHasOneOperation,
-  ReplaceHasManyOperation
+  AddToRelatedRecordsOperation,
+  RemoveFromRelatedRecordsOperation,
+  ReplaceRelatedRecordOperation,
+  ReplaceRelatedRecordsOperation
 } from '@orbit/data';
 import { clone, deepSet } from '@orbit/utils';
 import JSONAPISource from '../jsonapi-source';
@@ -59,7 +59,7 @@ export const TransformRequestProcessors = {
       .then(() => []);
   },
 
-  addToHasMany(source: JSONAPISource, request) {
+  addToRelatedRecords(source: JSONAPISource, request) {
     const { type, id } = request.record;
     const { relationship } = request;
     const json = {
@@ -71,7 +71,7 @@ export const TransformRequestProcessors = {
       .then(() => []);
   },
 
-  removeFromHasMany(source: JSONAPISource, request) {
+  removeFromRelatedRecords(source: JSONAPISource, request) {
     const { type, id } = request.record;
     const { relationship } = request;
     const json = {
@@ -83,7 +83,7 @@ export const TransformRequestProcessors = {
       .then(() => []);
   },
 
-  replaceHasOne(source: JSONAPISource, request) {
+  replaceRelatedRecord(source: JSONAPISource, request) {
     const { type, id } = request.record;
     const { relationship, relatedRecord } = request;
     const json = {
@@ -95,7 +95,7 @@ export const TransformRequestProcessors = {
       .then(() => []);
   },
 
-  replaceHasMany(source: JSONAPISource, request) {
+  replaceRelatedRecords(source: JSONAPISource, request) {
     const { type, id } = request.record;
     const { relationship, relatedRecords } = request;
     const json = {
@@ -131,15 +131,15 @@ export function getTransformRequests(source: JSONAPISource, transform: Transform
         if (operation.op === 'replaceAttribute') {
           newRequestNeeded = false;
           replaceRecordAttribute(prevRequest.record, operation.attribute, operation.value);
-        } else if (operation.op === 'replaceHasOne') {
+        } else if (operation.op === 'replaceRelatedRecord') {
           newRequestNeeded = false;
           replaceRecordHasOne(prevRequest.record, operation.relationship, operation.relatedRecord);
-        } else if (operation.op === 'replaceHasMany') {
+        } else if (operation.op === 'replaceRelatedRecords') {
           newRequestNeeded = false;
           replaceRecordHasMany(prevRequest.record, operation.relationship, operation.relatedRecords);
         }
-      } else if (prevRequest.op === 'addToHasMany' &&
-                 operation.op === 'addToHasMany' &&
+      } else if (prevRequest.op === 'addToRelatedRecords' &&
+                 operation.op === 'addToRelatedRecords' &&
                  prevRequest.relationship === operation.relationship) {
         newRequestNeeded = false;
         prevRequest.relatedRecords.push(cloneRecordIdentity(operation.relatedRecord));
@@ -200,25 +200,25 @@ const OperationToRequestMap = {
     };
   },
 
-  addToHasMany(operation: AddToHasManyOperation) {
+  addToRelatedRecords(operation: AddToRelatedRecordsOperation) {
     return {
-      op: 'addToHasMany',
+      op: 'addToRelatedRecords',
       record: cloneRecordIdentity(operation.record),
       relationship: operation.relationship,
       relatedRecords: [cloneRecordIdentity(operation.relatedRecord)]
     };
   },
 
-  removeFromHasMany(operation: RemoveFromHasManyOperation) {
+  removeFromRelatedRecords(operation: RemoveFromRelatedRecordsOperation) {
     return {
-      op: 'removeFromHasMany',
+      op: 'removeFromRelatedRecords',
       record: cloneRecordIdentity(operation.record),
       relationship: operation.relationship,
       relatedRecords: [cloneRecordIdentity(operation.relatedRecord)]
     };
   },
 
-  replaceHasOne(operation: ReplaceHasOneOperation) {
+  replaceRelatedRecord(operation: ReplaceRelatedRecordOperation) {
     const record: Record = {
       type: operation.record.type,
       id: operation.record.id
@@ -232,7 +232,7 @@ const OperationToRequestMap = {
     };
   },
 
-  replaceHasMany(operation: ReplaceHasManyOperation) {
+  replaceRelatedRecords(operation: ReplaceRelatedRecordsOperation) {
     const record = cloneRecordIdentity(operation.record);
     const relationshipData = {};
     operation.relatedRecords.forEach(r => {

--- a/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
@@ -369,7 +369,7 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/12345/relationships/moons')
         .returns(jsonapiResponse(204));
 
-      return source.push(t => t.addToHasMany(planet, 'moons', moon))
+      return source.push(t => t.addToRelatedRecords(planet, 'moons', moon))
         .then(() => {
           assert.ok(true, 'records linked');
 
@@ -400,7 +400,7 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/12345/relationships/moons')
         .returns(jsonapiResponse(200));
 
-      return source.push(t => t.removeFromHasMany(planet, 'moons', moon))
+      return source.push(t => t.removeFromRelatedRecords(planet, 'moons', moon))
         .then(function() {
           assert.ok(true, 'records unlinked');
 
@@ -431,7 +431,7 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/moons/987')
         .returns(jsonapiResponse(200));
 
-      return source.push(t => t.replaceHasOne(moon, 'planet', planet))
+      return source.push(t => t.replaceRelatedRecord(moon, 'planet', planet))
         .then(function() {
           assert.ok(true, 'relationship replaced');
 
@@ -457,7 +457,7 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/moons/987')
         .returns(jsonapiResponse(200));
 
-      return source.push(t => t.replaceHasOne(moon, 'planet', null))
+      return source.push(t => t.replaceRelatedRecord(moon, 'planet', null))
         .then(function() {
           assert.ok(true, 'relationship replaced');
 
@@ -488,7 +488,7 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/12345')
         .returns(jsonapiResponse(200));
 
-      return source.push(t => t.replaceHasMany(planet, 'moons', [moon]))
+      return source.push(t => t.replaceRelatedRecords(planet, 'moons', [moon]))
         .then(function() {
           assert.ok(true, 'relationship replaced');
 

--- a/packages/@orbit/jsonapi/test/lib/transform-requests-test.ts
+++ b/packages/@orbit/jsonapi/test/lib/transform-requests-test.ts
@@ -107,39 +107,39 @@ module('TransformRequests', function(hooks) {
       }]);
     });
 
-    test('addToHasMany', function(assert) {
+    test('addToRelatedRecords', function(assert) {
       const jupiter = { type: 'planet', id: 'jupiter' };
       const io = { type: 'moon', id: 'io' };
 
-      const t = Transform.from(tb.addToHasMany(jupiter, 'moons', io));
+      const t = Transform.from(tb.addToRelatedRecords(jupiter, 'moons', io));
 
       assert.deepEqual(getTransformRequests(source, t), [{
-        op: 'addToHasMany',
+        op: 'addToRelatedRecords',
         record: jupiter,
         relationship: 'moons',
         relatedRecords: [io]
       }]);
     });
 
-    test('removeFromHasMany', function(assert) {
+    test('removeFromRelatedRecords', function(assert) {
       const jupiter = { type: 'planet', id: 'jupiter' };
       const io = { type: 'moon', id: 'io' };
 
-      const t = Transform.from(tb.removeFromHasMany(jupiter, 'moons', io));
+      const t = Transform.from(tb.removeFromRelatedRecords(jupiter, 'moons', io));
 
       assert.deepEqual(getTransformRequests(source, t), [{
-        op: 'removeFromHasMany',
+        op: 'removeFromRelatedRecords',
         record: jupiter,
         relationship: 'moons',
         relatedRecords: [io]
       }]);
     });
 
-    test('replaceHasOne => replaceRecord', function(assert) {
+    test('replaceRelatedRecord => replaceRecord', function(assert) {
       const jupiter = { type: 'planet', id: 'jupiter' };
       const io = { type: 'moon', id: 'io' };
 
-      const t = Transform.from(tb.replaceHasOne(io, 'planet', jupiter));
+      const t = Transform.from(tb.replaceRelatedRecord(io, 'planet', jupiter));
 
       assert.deepEqual(getTransformRequests(source, t), [{
         op: 'replaceRecord',
@@ -155,10 +155,10 @@ module('TransformRequests', function(hooks) {
       }]);
     });
 
-    test('replaceHasOne (with null) => replaceRecord', function(assert) {
+    test('replaceRelatedRecord (with null) => replaceRecord', function(assert) {
       const io = { type: 'moon', id: 'io' };
 
-      const t = Transform.from(tb.replaceHasOne(io, 'planet', null));
+      const t = Transform.from(tb.replaceRelatedRecord(io, 'planet', null));
 
       assert.deepEqual(getTransformRequests(source, t), [{
         op: 'replaceRecord',
@@ -174,12 +174,12 @@ module('TransformRequests', function(hooks) {
       }]);
     });
 
-    test('replaceHasMany => replaceRecord', function(assert) {
+    test('replaceRelatedRecords => replaceRecord', function(assert) {
       const jupiter = { type: 'planet', id: 'jupiter' };
       const io = { type: 'moon', id: 'io' };
       const europa = { type: 'moon', id: 'europa' };
 
-      const t = Transform.from(tb.replaceHasMany(jupiter, 'moons', [io, europa]));
+      const t = Transform.from(tb.replaceRelatedRecords(jupiter, 'moons', [io, europa]));
 
       assert.deepEqual(getTransformRequests(source, t), [{
         op: 'replaceRecord',
@@ -243,18 +243,18 @@ module('TransformRequests', function(hooks) {
       }]);
     });
 
-    test('addToHasMany + addToHasMany => [addToHasMany]', function(assert) {
+    test('addToRelatedRecords + addToRelatedRecords => [addToRelatedRecords]', function(assert) {
       const jupiter = { type: 'planet', id: 'jupiter' };
       const io = { type: 'moon', id: 'io' };
       const europa = { type: 'moon', id: 'europa' };
 
       const t = Transform.from([
-        tb.addToHasMany(jupiter, 'moons', io),
-        tb.addToHasMany(jupiter, 'moons', europa)
+        tb.addToRelatedRecords(jupiter, 'moons', io),
+        tb.addToRelatedRecords(jupiter, 'moons', europa)
       ]);
 
       assert.deepEqual(getTransformRequests(source, t), [{
-        op: 'addToHasMany',
+        op: 'addToRelatedRecords',
         record: jupiter,
         relationship: 'moons',
         relatedRecords: [io, europa]

--- a/packages/@orbit/local-storage/src/lib/transform-operators.ts
+++ b/packages/@orbit/local-storage/src/lib/transform-operators.ts
@@ -1,14 +1,14 @@
-import { 
+import {
   cloneRecordIdentity,
   serializeRecordIdentity,
   Record, RecordIdentity,
   AddRecordOperation,
-  AddToHasManyOperation,
+  AddToRelatedRecordsOperation,
   ReplaceAttributeOperation,
-  RemoveFromHasManyOperation,
+  RemoveFromRelatedRecordsOperation,
   RemoveRecordOperation,
-  ReplaceHasManyOperation,
-  ReplaceHasOneOperation,
+  ReplaceRelatedRecordsOperation,
+  ReplaceRelatedRecordOperation,
   ReplaceKeyOperation,
   ReplaceRecordOperation
 } from '@orbit/data';
@@ -44,13 +44,13 @@ export default {
     source.putRecord(record);
   },
 
-  addToHasMany(source: Source, operation: AddToHasManyOperation) {
+  addToRelatedRecords(source: Source, operation: AddToRelatedRecordsOperation) {
     let record: Record = source.getRecord(operation.record) || cloneRecordIdentity(operation.record);
     deepSet(record, ['relationships', operation.relationship, 'data', serializeRecordIdentity(operation.relatedRecord)], true);
     source.putRecord(record);
   },
 
-  removeFromHasMany(source: Source, operation: RemoveFromHasManyOperation) {
+  removeFromRelatedRecords(source: Source, operation: RemoveFromRelatedRecordsOperation) {
     let record: Record = source.getRecord(operation.record);
     if (record &&
         record.relationships &&
@@ -63,7 +63,7 @@ export default {
     }
   },
 
-  replaceHasMany(source: Source, operation: ReplaceHasManyOperation) {
+  replaceRelatedRecords(source: Source, operation: ReplaceRelatedRecordsOperation) {
     let record: Record = source.getRecord(operation.record) || cloneRecordIdentity(operation.record);
     let data = {};
     operation.relatedRecords.forEach(relatedRecord => {
@@ -73,7 +73,7 @@ export default {
     source.putRecord(record);
   },
 
-  replaceHasOne(source: Source, operation: ReplaceHasOneOperation) {
+  replaceRelatedRecord(source: Source, operation: ReplaceRelatedRecordOperation) {
     let record: Record = source.getRecord(operation.record) || cloneRecordIdentity(operation.record);
     let data = operation.relatedRecord ? serializeRecordIdentity(operation.relatedRecord) : null;
     deepSet(record, ['relationships', operation.relationship, 'data'], data);

--- a/packages/@orbit/local-storage/test/source-test.ts
+++ b/packages/@orbit/local-storage/test/source-test.ts
@@ -167,7 +167,7 @@ module('LocalStorageSource', function(hooks) {
       .then(() => verifyLocalStorageContainsRecord(assert, source, revised));
   });
 
-  test('#push - addToHasMany', function(assert) {
+  test('#push - addToRelatedRecords', function(assert) {
     assert.expect(1);
 
     let original = {
@@ -201,11 +201,11 @@ module('LocalStorageSource', function(hooks) {
     };
 
     return source.push(t => t.addRecord(original))
-      .then(() => source.push(t => t.addToHasMany(original, 'moons', { type: 'moon', id: 'moon1' })))
+      .then(() => source.push(t => t.addToRelatedRecords(original, 'moons', { type: 'moon', id: 'moon1' })))
       .then(() => verifyLocalStorageContainsRecord(assert, source, revised));
   });
 
-  test('#push - removeFromHasMany', function(assert) {
+  test('#push - removeFromRelatedRecords', function(assert) {
     assert.expect(1);
 
     let original = {
@@ -242,11 +242,11 @@ module('LocalStorageSource', function(hooks) {
     };
 
     return source.push(t => t.addRecord(original))
-      .then(() => source.push(t => t.removeFromHasMany(original, 'moons', { type: 'moon', id: 'moon2' })))
+      .then(() => source.push(t => t.removeFromRelatedRecords(original, 'moons', { type: 'moon', id: 'moon2' })))
       .then(() => verifyLocalStorageContainsRecord(assert, source, revised));
   });
 
-  test('#push - replaceHasMany', function(assert) {
+  test('#push - replaceRelatedRecords', function(assert) {
     assert.expect(1);
 
     let original = {
@@ -283,11 +283,11 @@ module('LocalStorageSource', function(hooks) {
     };
 
     return source.push(t => t.addRecord(original))
-      .then(() => source.push(t => t.replaceHasMany(original, 'moons', [{ type: 'moon', id: 'moon2' }, { type: 'moon', id: 'moon3' }])))
+      .then(() => source.push(t => t.replaceRelatedRecords(original, 'moons', [{ type: 'moon', id: 'moon2' }, { type: 'moon', id: 'moon3' }])))
       .then(() => verifyLocalStorageContainsRecord(assert, source, revised));
   });
 
-  test('#push - replaceHasOne - record', function(assert) {
+  test('#push - replaceRelatedRecord - record', function(assert) {
     assert.expect(1);
 
     let original = {
@@ -319,11 +319,11 @@ module('LocalStorageSource', function(hooks) {
     };
 
     return source.push(t => t.addRecord(original))
-      .then(() => source.push(t => t.replaceHasOne(original, 'solarSystem', { type: 'solarSystem', id: 'ss1' })))
+      .then(() => source.push(t => t.replaceRelatedRecord(original, 'solarSystem', { type: 'solarSystem', id: 'ss1' })))
       .then(() => verifyLocalStorageContainsRecord(assert, source, revised));
   });
 
-  test('#push - replaceHasOne - null', function(assert) {
+  test('#push - replaceRelatedRecord - null', function(assert) {
     assert.expect(1);
 
     let original = {
@@ -355,7 +355,7 @@ module('LocalStorageSource', function(hooks) {
     };
 
     return source.push(t => t.addRecord(original))
-      .then(() => source.push(t => t.replaceHasOne(original, 'solarSystem', null)))
+      .then(() => source.push(t => t.replaceRelatedRecord(original, 'solarSystem', null)))
       .then(() => verifyLocalStorageContainsRecord(assert, source, revised));
   });
 

--- a/packages/@orbit/store/src/cache/inverse-transforms.ts
+++ b/packages/@orbit/store/src/cache/inverse-transforms.ts
@@ -5,12 +5,12 @@ import {
   RecordIdentity,
   RecordOperation,
   AddRecordOperation,
-  AddToHasManyOperation,
+  AddToRelatedRecordsOperation,
   ReplaceAttributeOperation,
-  RemoveFromHasManyOperation,
+  RemoveFromRelatedRecordsOperation,
   RemoveRecordOperation,
-  ReplaceHasManyOperation,
-  ReplaceHasOneOperation,
+  ReplaceRelatedRecordsOperation,
+  ReplaceRelatedRecordOperation,
   ReplaceKeyOperation,
   ReplaceRecordOperation
 } from '@orbit/data';
@@ -120,7 +120,7 @@ const InverseTransforms = {
     }
   },
 
-  addToHasMany(cache: Cache, op: AddToHasManyOperation): RecordOperation {
+  addToRelatedRecords(cache: Cache, op: AddToRelatedRecordsOperation): RecordOperation {
     const { type, id } = op.record;
     const { relationship, relatedRecord } = op;
     const record = cache.records(type).get(id);
@@ -128,7 +128,7 @@ const InverseTransforms = {
 
     if (current === undefined) {
       return {
-        op: 'removeFromHasMany',
+        op: 'removeFromRelatedRecords',
         record: { type, id },
         relationship,
         relatedRecord
@@ -136,7 +136,7 @@ const InverseTransforms = {
     }
   },
 
-  removeFromHasMany(cache: Cache, op: RemoveFromHasManyOperation): RecordOperation {
+  removeFromRelatedRecords(cache: Cache, op: RemoveFromRelatedRecordsOperation): RecordOperation {
     const { type, id } = op.record;
     const { relationship, relatedRecord } = op;
     const record = cache.records(type).get(id);
@@ -144,7 +144,7 @@ const InverseTransforms = {
 
     if (current) {
       return {
-        op: 'addToHasMany',
+        op: 'addToRelatedRecords',
         record: { type, id },
         relationship,
         relatedRecord
@@ -152,7 +152,7 @@ const InverseTransforms = {
     }
   },
 
-  replaceHasMany(cache: Cache, op: ReplaceHasManyOperation): RecordOperation {
+  replaceRelatedRecords(cache: Cache, op: ReplaceRelatedRecordsOperation): RecordOperation {
     const { type, id } = op.record;
     const { relationship } = op;
     const record = cache.records(type).get(id);
@@ -166,7 +166,7 @@ const InverseTransforms = {
 
     if (!eq(currentRecords, op.relatedRecords)) {
       return {
-        op: 'replaceHasMany',
+        op: 'replaceRelatedRecords',
         record: { type, id },
         relationship,
         relatedRecords: currentRecords
@@ -174,7 +174,7 @@ const InverseTransforms = {
     }
   },
 
-  replaceHasOne(cache: Cache, op: ReplaceHasOneOperation): RecordOperation {
+  replaceRelatedRecord(cache: Cache, op: ReplaceRelatedRecordOperation): RecordOperation {
     const { type, id } = op.record;
     const { relationship } = op;
     const record = cache.records(type).get(id);
@@ -183,7 +183,7 @@ const InverseTransforms = {
 
     if (!eq(currentRecord, op.relatedRecord)) {
       return {
-        op: 'replaceHasOne',
+        op: 'replaceRelatedRecord',
         record: { type, id },
         relationship: relationship,
         relatedRecord: currentRecord

--- a/packages/@orbit/store/src/cache/operation-processors/cache-integrity-processor.ts
+++ b/packages/@orbit/store/src/cache/operation-processors/cache-integrity-processor.ts
@@ -41,13 +41,13 @@ export default class CacheIntegrityProcessor extends OperationProcessor {
 
   after(operation: RecordOperation): RecordOperation[] {
     switch (operation.op) {
-      case 'replaceHasOne':
+      case 'replaceRelatedRecord':
         return this._relatedRecordRemoved(operation.record, operation.relationship);
 
-      case 'replaceHasMany':
+      case 'replaceRelatedRecords':
         return this._relatedRecordsRemoved(operation.record, operation.relationship);
 
-      case 'removeFromHasMany':
+      case 'removeFromRelatedRecords':
         return this._relatedRecordRemoved(operation.record, operation.relationship, operation.relatedRecord);
 
       case 'removeRecord':
@@ -63,13 +63,13 @@ export default class CacheIntegrityProcessor extends OperationProcessor {
 
   finally(operation): RecordOperation[] {
     switch (operation.op) {
-      case 'replaceHasOne':
+      case 'replaceRelatedRecord':
         return this._relatedRecordAdded(operation.record, operation.relationship, operation.relatedRecord);
 
-      case 'replaceHasMany':
+      case 'replaceRelatedRecords':
         return this._relatedRecordsAdded(operation.record, operation.relationship, operation.relatedRecords);
 
-      case 'addToHasMany':
+      case 'addToRelatedRecords':
         return this._relatedRecordAdded(operation.record, operation.relationship, operation.relatedRecord);
 
       case 'addRecord':
@@ -162,14 +162,14 @@ export default class CacheIntegrityProcessor extends OperationProcessor {
 
           if (isHasMany) {
             ops.push({
-              op: 'removeFromHasMany',
+              op: 'removeFromRelatedRecords',
               record: { type: path[0], id: path[1] },
               relationship: path[3],
               relatedRecord: deserializeRecordIdentity(path[5])
             });
           } else {
             ops.push({
-              op: 'replaceHasOne',
+              op: 'replaceRelatedRecord',
               record: { type: path[0], id: path[1] },
               relationship: path[3],
               relatedRecord: null

--- a/packages/@orbit/store/src/cache/operation-processors/schema-consistency-processor.ts
+++ b/packages/@orbit/store/src/cache/operation-processors/schema-consistency-processor.ts
@@ -33,16 +33,16 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
       case 'addRecord':
         return this._recordAdded(operation.record);
 
-      case 'addToHasMany':
+      case 'addToRelatedRecords':
         return this._relatedRecordAdded(operation.record, operation.relationship, operation.relatedRecord);
 
-      case 'replaceHasOne':
+      case 'replaceRelatedRecord':
         return this._relatedRecordReplaced(operation.record, operation.relationship, operation.relatedRecord);
 
-      case 'replaceHasMany':
+      case 'replaceRelatedRecords':
         return this._relatedRecordsReplaced(operation.record, operation.relationship, operation.relatedRecords);
 
-      case 'removeFromHasMany':
+      case 'removeFromRelatedRecords':
         return this._relatedRecordRemoved(operation.record, operation.relationship, operation.relatedRecord);
 
       case 'removeRecord':
@@ -279,7 +279,7 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
     const isHasMany = relationshipDef.type === 'hasMany';
 
     return <RecordOperation>{
-      op: isHasMany ? 'addToHasMany' : 'replaceHasOne',
+      op: isHasMany ? 'addToRelatedRecords' : 'replaceRelatedRecord',
       record,
       relationship,
       relatedRecord
@@ -291,7 +291,7 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
     const isHasMany = relationshipDef.type === 'hasMany';
 
     return <RecordOperation>{
-      op: isHasMany ? 'removeFromHasMany' : 'replaceHasOne',
+      op: isHasMany ? 'removeFromRelatedRecords' : 'replaceRelatedRecord',
       record,
       relationship,
       relatedRecord: isHasMany ? relatedRecord : null

--- a/packages/@orbit/store/src/cache/patch-transforms.ts
+++ b/packages/@orbit/store/src/cache/patch-transforms.ts
@@ -4,12 +4,12 @@ import {
   RecordIdentity,
   RecordOperation,
   AddRecordOperation,
-  AddToHasManyOperation,
+  AddToRelatedRecordsOperation,
   ReplaceAttributeOperation,
-  RemoveFromHasManyOperation,
+  RemoveFromRelatedRecordsOperation,
   RemoveRecordOperation,
-  ReplaceHasManyOperation,
-  ReplaceHasOneOperation,
+  ReplaceRelatedRecordsOperation,
+  ReplaceRelatedRecordOperation,
   ReplaceKeyOperation,
   ReplaceRecordOperation
 } from '@orbit/data';
@@ -107,7 +107,7 @@ export default {
     }
   },
 
-  addToHasMany(cache: Cache, op: AddToHasManyOperation): boolean {
+  addToRelatedRecords(cache: Cache, op: AddToRelatedRecordsOperation): boolean {
     const { type, id } = op.record;
     const records = cache.records(type);
     const relatedIdentifier = serializeRecordIdentity(op.relatedRecord);
@@ -127,7 +127,7 @@ export default {
     }
   },
 
-  removeFromHasMany(cache: Cache, op: RemoveFromHasManyOperation): boolean {
+  removeFromRelatedRecords(cache: Cache, op: RemoveFromRelatedRecordsOperation): boolean {
     const { type, id } = op.record;
     const records = cache.records(type);
     let record = records.get(id);
@@ -144,7 +144,7 @@ export default {
     return false;
   },
 
-  replaceHasMany(cache: Cache, op: ReplaceHasManyOperation): boolean {
+  replaceRelatedRecords(cache: Cache, op: ReplaceRelatedRecordsOperation): boolean {
     const { type, id } = op.record;
     const records = cache.records(type);
     let record = records.get(id);
@@ -164,7 +164,7 @@ export default {
     }
   },
 
-  replaceHasOne(cache: Cache, op: ReplaceHasOneOperation): boolean {
+  replaceRelatedRecord(cache: Cache, op: ReplaceRelatedRecordOperation): boolean {
     let relatedData;
     if (op.relatedRecord) {
       relatedData = serializeRecordIdentity(op.relatedRecord);

--- a/packages/@orbit/store/test/cache-test.ts
+++ b/packages/@orbit/store/test/cache-test.ts
@@ -153,7 +153,7 @@ module('Cache', function(hooks) {
   test('#patch adds link to hasMany if record doesn\'t exist', function(assert) {
     let cache = new Cache({ schema, keyMap });
 
-    cache.patch(t => t.addToHasMany({ type: 'planet', id: 'p1' }, 'moons', { type: 'moon', id: 'm1' }));
+    cache.patch(t => t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', { type: 'moon', id: 'm1' }));
 
     assert.equal(cache.records('planet').get('p1').relationships.moons.data['moon:m1'], true, 'relationship was added');
   });
@@ -167,7 +167,7 @@ module('Cache', function(hooks) {
       assert.ok(false, 'no operations were applied');
     });
 
-    cache.patch(t => t.removeFromHasMany({ type: 'planet', id: 'p1' }, 'moons', { type: 'moon', id: 'moon1' }));
+    cache.patch(t => t.removeFromRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', { type: 'moon', id: 'moon1' }));
 
     assert.equal(cache.records('planet').get('p1'), undefined, 'planet does not exist');
   });
@@ -178,7 +178,7 @@ module('Cache', function(hooks) {
     let cache = new Cache({ schema, keyMap });
 
     const tb = new TransformBuilder();
-    const operation = tb.replaceHasOne(
+    const operation = tb.replaceRelatedRecord(
       { type: 'moon', id: 'moon1' },
       'planet',
       { type: 'planet', id: 'p1' });
@@ -196,7 +196,7 @@ module('Cache', function(hooks) {
     let cache = new Cache({ schema, keyMap });
 
     const tb = new TransformBuilder();
-    const operation = tb.replaceHasOne(
+    const operation = tb.replaceRelatedRecord(
       { type: 'moon', id: 'moon1' },
       'planet',
       null);
@@ -221,7 +221,7 @@ module('Cache', function(hooks) {
       assert.ok(false, 'no operations were applied');
     });
 
-    cache.patch(t => t.addToHasMany(jupiter, 'moons', { type: 'moon', id: 'm1' }));
+    cache.patch(t => t.addToRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'm1' }));
 
     assert.ok(true, 'patch completed');
   });
@@ -239,7 +239,7 @@ module('Cache', function(hooks) {
       assert.ok(false, 'no operations were applied');
     });
 
-    cache.patch(t => t.removeFromHasMany(jupiter, 'moons', { type: 'moon', id: 'm1' }));
+    cache.patch(t => t.removeFromRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'm1' }));
 
     assert.ok(true, 'patch completed');
   });
@@ -257,7 +257,7 @@ module('Cache', function(hooks) {
       assert.ok(false, 'no operations were applied');
     });
 
-    cache.patch(t => t.replaceHasOne(europa, 'planet', { type: 'planet', id: 'p1' }));
+    cache.patch(t => t.replaceRelatedRecord(europa, 'planet', { type: 'planet', id: 'p1' }));
 
     assert.ok(true, 'patch completed');
   });
@@ -275,7 +275,7 @@ module('Cache', function(hooks) {
       assert.ok(false, 'no operations were applied');
     });
 
-    cache.patch(t => t.replaceHasOne(europa, 'planet', null));
+    cache.patch(t => t.replaceRelatedRecord(europa, 'planet', null));
 
     assert.ok(true, 'patch completed');
   });
@@ -357,8 +357,8 @@ module('Cache', function(hooks) {
       t.addRecord(jupiter),
       t.addRecord(io),
       t.addRecord(europa),
-      t.addToHasMany(jupiter, 'moons', io),
-      t.addToHasMany(jupiter, 'moons', europa)
+      t.addToRelatedRecords(jupiter, 'moons', io),
+      t.addToRelatedRecords(jupiter, 'moons', europa)
     ]);
 
     // Removing the moon should remove the planet should remove the other moon
@@ -395,8 +395,8 @@ module('Cache', function(hooks) {
       t.addRecord(jupiter),
       t.addRecord(io),
       t.addRecord(europa),
-      t.addToHasMany(jupiter, 'moons', io),
-      t.addToHasMany(jupiter, 'moons', europa)
+      t.addToRelatedRecords(jupiter, 'moons', io),
+      t.addToRelatedRecords(jupiter, 'moons', europa)
     ]);
 
     // Since there are no dependent relationships, no other records will be

--- a/packages/@orbit/store/test/cache/operation-processors/cache-integrity-processor-test.ts
+++ b/packages/@orbit/store/test/cache/operation-processors/cache-integrity-processor-test.ts
@@ -147,7 +147,7 @@ module('CacheIntegrityProcessor', function(hooks) {
     }, 'rev links match');
 
     const addPlanetOp = {
-      op: 'addToHasMany',
+      op: 'addToRelatedRecords',
       record: { type: 'moon', id: europa.id },
       relationship: 'planet',
       relatedRecord: { type: 'planet', id: saturn.id }
@@ -233,7 +233,7 @@ module('CacheIntegrityProcessor', function(hooks) {
     }, 'rev links match');
 
     const replacePlanetOp = {
-      op: 'replaceHasOne',
+      op: 'replaceRelatedRecord',
       record: europa,
       relationship: 'planet',
       relatedRecord: saturn
@@ -304,7 +304,7 @@ module('CacheIntegrityProcessor', function(hooks) {
     }, 'rev links match');
 
     const clearMoonsOp = {
-      op: 'replaceHasMany',
+      op: 'replaceRelatedRecords',
       record: saturn,
       relationship: 'moons',
       relatedRecords: []
@@ -370,7 +370,7 @@ module('CacheIntegrityProcessor', function(hooks) {
     }, 'rev links match');
 
     const replaceMoonsOp = {
-      op: 'replaceHasMany',
+      op: 'replaceRelatedRecords',
       record: saturn,
       relationship: 'moons',
       relatedRecords: [{ type: 'moon', id: 'titan' }]
@@ -449,7 +449,7 @@ module('CacheIntegrityProcessor', function(hooks) {
     }, 'rev links match');
 
     const replaceMoonsOp = {
-      op: 'replaceHasMany',
+      op: 'replaceRelatedRecords',
       record: saturn,
       relationship: 'moons',
       relatedRecords: [{ type: 'moon', id: 'europa' }]
@@ -512,7 +512,7 @@ module('CacheIntegrityProcessor', function(hooks) {
     }, 'rev links match');
 
     const clearInhabitantsOp = {
-      op: 'replaceHasMany',
+      op: 'replaceRelatedRecords',
       record: earth,
       relationship: 'inhabitants',
       relatedRecords: []
@@ -586,7 +586,7 @@ module('CacheIntegrityProcessor', function(hooks) {
 
 
     const removePlanetOp = {
-      op: 'replaceHasOne',
+      op: 'replaceRelatedRecord',
       record: europa,
       relationship: 'planet',
       relatedRecord: null
@@ -656,7 +656,7 @@ module('CacheIntegrityProcessor', function(hooks) {
     }, 'rev links match');
 
     const changePlanetOp = {
-      op: 'replaceHasOne',
+      op: 'replaceRelatedRecord',
       record: earth,
       relationship: 'next',
       relatedRecord: saturn
@@ -720,7 +720,7 @@ module('CacheIntegrityProcessor', function(hooks) {
     }, 'rev links match');
 
     const changePlanetOp = {
-      op: 'replaceHasOne',
+      op: 'replaceRelatedRecord',
       record: earth,
       relationship: 'next',
       relatedRecord: jupiter
@@ -766,7 +766,7 @@ module('CacheIntegrityProcessor', function(hooks) {
     assert.deepEqual(processor._rev, {}, 'empty rev links');
 
     const addPlanetOp = {
-      op: 'addToHasMany',
+      op: 'addToRelatedRecords',
       record: human,
       relationship: 'planets',
       relatedRecord: earth
@@ -819,7 +819,7 @@ module('CacheIntegrityProcessor', function(hooks) {
     }, 'rev links match');
 
     const removePlanetOp = {
-      op: 'removeFromHasMany',
+      op: 'removeFromRelatedRecords',
       record: human,
       relationship: 'planets',
       relatedRecord: earth
@@ -889,7 +889,7 @@ module('CacheIntegrityProcessor', function(hooks) {
       processor.after(removeInhabitantOp),
       [
         {
-          op: 'removeFromHasMany',
+          op: 'removeFromRelatedRecords',
           record: cloneRecordIdentity(earth),
           relationship: 'inhabitants',
           relatedRecord: cloneRecordIdentity(human)

--- a/packages/@orbit/store/test/cache/operation-processors/schema-consistency-processor-test.ts
+++ b/packages/@orbit/store/test/cache/operation-processors/schema-consistency-processor-test.ts
@@ -84,7 +84,7 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
     ]);
 
     const addPlanetOp = {
-      op: 'addToHasMany',
+      op: 'addToRelatedRecords',
       record: { type: 'moon', id: europa.id },
       relationship: 'planet',
       relatedRecord: { type: 'planet', id: saturn.id }
@@ -99,7 +99,7 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
       processor.after(addPlanetOp),
       [
         {
-          op: 'addToHasMany',
+          op: 'addToRelatedRecords',
           record: identity(saturn),
           relationship: 'moons',
           relatedRecord: identity(europa)
@@ -138,7 +138,7 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
     ]);
 
     const replacePlanetOp = {
-      op: 'replaceHasOne',
+      op: 'replaceRelatedRecord',
       record: identity(europa),
       relationship: 'planet',
       relatedRecord: identity(saturn)
@@ -153,13 +153,13 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
       processor.after(replacePlanetOp),
       [
         {
-          op: 'removeFromHasMany',
+          op: 'removeFromRelatedRecords',
           record: identity(jupiter),
           relationship: 'moons',
           relatedRecord: identity(europa)
         },
         {
-          op: 'addToHasMany',
+          op: 'addToRelatedRecords',
           record: identity(saturn),
           relationship: 'moons',
           relatedRecord: identity(europa)
@@ -189,7 +189,7 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
     ]);
 
     const clearMoonsOp = {
-      op: 'replaceHasMany',
+      op: 'replaceRelatedRecords',
       record: identity(saturn),
       relationship: 'moons',
       relatedRecords: []
@@ -204,7 +204,7 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
       processor.after(clearMoonsOp),
       [
         {
-          op: 'replaceHasOne',
+          op: 'replaceRelatedRecord',
           record: identity(titan),
           relationship: 'planet',
           relatedRecord: null
@@ -237,7 +237,7 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
     ]);
 
     const replaceMoonsOp = {
-      op: 'replaceHasMany',
+      op: 'replaceRelatedRecords',
       record: identity(jupiter),
       relationship: 'moons',
       relatedRecords: [identity(titan)]
@@ -252,7 +252,7 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
       processor.after(replaceMoonsOp),
       [
         {
-          op: 'replaceHasOne',
+          op: 'replaceRelatedRecord',
           record: identity(titan),
           relationship: 'planet',
           relatedRecord: identity(jupiter)
@@ -291,7 +291,7 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
     ]);
 
     const replaceMoonsOp = {
-      op: 'replaceHasMany',
+      op: 'replaceRelatedRecords',
       record: identity(saturn),
       relationship: 'moons',
       relatedRecords: [identity(europa)]
@@ -306,13 +306,13 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
       processor.after(replaceMoonsOp),
       [
         {
-          op: 'replaceHasOne',
+          op: 'replaceRelatedRecord',
           record: identity(titan),
           relationship: 'planet',
           relatedRecord: null
         },
         {
-          op: 'replaceHasOne',
+          op: 'replaceRelatedRecord',
           record: identity(europa),
           relationship: 'planet',
           relatedRecord: identity(saturn)
@@ -336,7 +336,7 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
     ]);
 
     const clearInhabitantsOp = {
-      op: 'replaceHasMany',
+      op: 'replaceRelatedRecords',
       record: identity(earth),
       relationship: 'inhabitants',
       relatedRecords: []
@@ -346,7 +346,7 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
       processor.after(clearInhabitantsOp),
       [
         {
-          op: 'removeFromHasMany',
+          op: 'removeFromRelatedRecords',
           record: identity(human),
           relationship: 'planets',
           relatedRecord: identity(earth)
@@ -374,7 +374,7 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
     ]);
 
     const clearInhabitantsOp = {
-      op: 'replaceHasMany',
+      op: 'replaceRelatedRecords',
       record: identity(earth),
       relationship: 'inhabitants',
       relatedRecords: [identity(human), identity(cat), identity(dog)]
@@ -384,13 +384,13 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
       processor.after(clearInhabitantsOp),
       [
         {
-          op: 'addToHasMany',
+          op: 'addToRelatedRecords',
           record: identity(cat),
           relationship: 'planets',
           relatedRecord: identity(earth)
         },
         {
-          op: 'addToHasMany',
+          op: 'addToRelatedRecords',
           record: identity(dog),
           relationship: 'planets',
           relatedRecord: identity(earth)
@@ -429,7 +429,7 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
     ]);
 
     const removePlanetOp = {
-      op: 'replaceHasOne',
+      op: 'replaceRelatedRecord',
       record: identity(europa),
       relationship: 'planet',
       relatedRecord: null
@@ -444,7 +444,7 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
       processor.after(removePlanetOp),
       [
         {
-          op: 'removeFromHasMany',
+          op: 'removeFromRelatedRecords',
           record: identity(jupiter),
           relationship: 'moons',
           relatedRecord: identity(europa)
@@ -477,7 +477,7 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
     ]);
 
     const changePlanetOp = {
-      op: 'replaceHasOne',
+      op: 'replaceRelatedRecord',
       record: identity(earth),
       relationship: 'next',
       relatedRecord: identity(saturn)
@@ -492,7 +492,7 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
       processor.after(changePlanetOp),
       [
         {
-          op: 'replaceHasOne',
+          op: 'replaceRelatedRecord',
           record: identity(saturn),
           relationship: 'previous',
           relatedRecord: identity(earth)
@@ -525,7 +525,7 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
     ]);
 
     const changePlanetOp = {
-      op: 'replaceHasOne',
+      op: 'replaceRelatedRecord',
       record: identity(earth),
       relationship: 'next',
       relatedRecord: identity(jupiter)
@@ -540,7 +540,7 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
       processor.after(changePlanetOp),
       [
         {
-          op: 'replaceHasOne',
+          op: 'replaceRelatedRecord',
           record: identity(jupiter),
           relationship: 'previous',
           relatedRecord: identity(earth)
@@ -573,7 +573,7 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
     ]);
 
     const changePlanetOp = {
-      op: 'replaceHasOne',
+      op: 'replaceRelatedRecord',
       record: identity(saturn),
       relationship: 'next',
       relatedRecord: identity(jupiter)
@@ -605,7 +605,7 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
     ]);
 
     const addPlanetOp = {
-      op: 'addToHasMany',
+      op: 'addToRelatedRecords',
       record: identity(human),
       relationship: 'planets',
       relatedRecord: identity(earth)
@@ -620,7 +620,7 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
       processor.after(addPlanetOp),
       [
         {
-          op: 'addToHasMany',
+          op: 'addToRelatedRecords',
           record: identity(earth),
           relationship: 'inhabitants',
           relatedRecord: identity(human)
@@ -644,7 +644,7 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
     ]);
 
     const removePlanetOp = {
-      op: 'removeFromHasMany',
+      op: 'removeFromRelatedRecords',
       record: identity(human),
       relationship: 'planets',
       relatedRecord: identity(earth)
@@ -659,7 +659,7 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
       processor.after(removePlanetOp),
       [
         {
-          op: 'removeFromHasMany',
+          op: 'removeFromRelatedRecords',
           record: identity(earth),
           relationship: 'inhabitants',
           relatedRecord: identity(human)
@@ -737,31 +737,31 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
       processor.after(clearInhabitantsOp),
       [
         {
-          op: 'addToHasMany',
+          op: 'addToRelatedRecords',
           record: identity(cat),
           relationship: 'planets',
           relatedRecord: identity(earth)
         },
         {
-          op: 'addToHasMany',
+          op: 'addToRelatedRecords',
           record: identity(dog),
           relationship: 'planets',
           relatedRecord: identity(earth)
         },
         {
-          op: 'replaceHasOne',
+          op: 'replaceRelatedRecord',
           record: identity(moon),
           relationship: 'planet',
           relatedRecord: identity(earth)
         },
         {
-          op: 'replaceHasOne',
+          op: 'replaceRelatedRecord',
           record: identity(jupiter),
           relationship: 'previous',
           relatedRecord: null
         },
         {
-          op: 'replaceHasOne',
+          op: 'replaceRelatedRecord',
           record: identity(saturn),
           relationship: 'previous',
           relatedRecord: identity(earth)


### PR DESCRIPTION
Provides consistency between transform and query operations.

[Closes #291]