### PR TITLE
Add queryBuilder and transformBuilder to Source

### DIFF
--- a/packages/@orbit/data/src/source-interfaces/pullable.ts
+++ b/packages/@orbit/data/src/source-interfaces/pullable.ts
@@ -2,7 +2,6 @@ import { assert } from '@orbit/utils';
 import { settleInSeries, fulfillInSeries } from '@orbit/core';
 import { Source, SourceClass } from '../source';
 import Query, { QueryOrExpression } from '../query';
-import QueryBuilder from '../query-builder';
 import Transform from '../transform';
 
 export const PULLABLE = '__pullable__';
@@ -85,11 +84,7 @@ export default function pullable(Klass: SourceClass): void {
   proto[PULLABLE] = true;
 
   proto.pull = function(queryOrExpression: QueryOrExpression, options?: object, id?: string): Promise<Transform[]> {
-    let queryBuilder = this.queryBuilder;
-    if (!queryBuilder) {
-      queryBuilder = this.queryBuilder = new QueryBuilder();
-    }
-    const query = Query.from(queryOrExpression, options, id, queryBuilder);
+    const query = Query.from(queryOrExpression, options, id, this.queryBuilder);
     return this._enqueueRequest('pull', query);
   }
 

--- a/packages/@orbit/data/src/source-interfaces/pushable.ts
+++ b/packages/@orbit/data/src/source-interfaces/pushable.ts
@@ -3,7 +3,6 @@ import { assert } from '@orbit/utils';
 import { settleInSeries, fulfillInSeries } from '@orbit/core';
 import { Source, SourceClass } from '../source';
 import Transform, { TransformOrOperations } from '../transform';
-import TransformBuilder from '../transform-builder';
 
 export const PUSHABLE = '__pushable__';
 
@@ -85,11 +84,7 @@ export default function pushable(Klass: SourceClass): void {
   proto[PUSHABLE] = true;
 
   proto.push = function(transformOrOperations: TransformOrOperations, options?: object, id?: string): Promise<Transform[]> {
-    let transformBuilder = this.transformBuilder;
-    if (!transformBuilder) {
-      transformBuilder = this.transformBuilder = new TransformBuilder();
-    }
-    const transform = Transform.from(transformOrOperations, options, id, transformBuilder);
+    const transform = Transform.from(transformOrOperations, options, id, this.transformBuilder);
 
     if (this.transformLog.contains(transform.id)) {
       return Orbit.Promise.resolve([]);

--- a/packages/@orbit/data/src/source-interfaces/queryable.ts
+++ b/packages/@orbit/data/src/source-interfaces/queryable.ts
@@ -1,7 +1,6 @@
 import { assert } from '@orbit/utils';
 import { settleInSeries, fulfillInSeries } from '@orbit/core';
 import Query, { QueryOrExpression } from '../query';
-import QueryBuilder from '../query-builder';
 import { Source, SourceClass } from '../source';
 
 export const QUERYABLE = '__queryable__';
@@ -81,11 +80,7 @@ export default function queryable(Klass: SourceClass): void {
   proto[QUERYABLE] = true;
 
   proto.query = function(queryOrExpression: QueryOrExpression, options?: object, id?: string): Promise<any> {
-    let queryBuilder = this.queryBuilder;
-    if (!queryBuilder) {
-      queryBuilder = this.queryBuilder = new QueryBuilder();
-    }
-    const query = Query.from(queryOrExpression, options, id, queryBuilder);
+    const query = Query.from(queryOrExpression, options, id, this.queryBuilder);
     return this._enqueueRequest('query', query);
   }
 

--- a/packages/@orbit/data/src/source-interfaces/updatable.ts
+++ b/packages/@orbit/data/src/source-interfaces/updatable.ts
@@ -4,7 +4,6 @@ import { settleInSeries, fulfillInSeries } from '@orbit/core';
 import { Operation } from '../operation';
 import { Source, SourceClass } from '../source';
 import Transform, { TransformOrOperations } from '../transform';
-import TransformBuilder from '../transform-builder';
 
 export const UPDATABLE = '__updatable__';
 
@@ -84,11 +83,7 @@ export default function updatable(Klass: SourceClass): void {
   proto[UPDATABLE] = true;
 
   proto.update = function(transformOrOperations: TransformOrOperations, options?: object, id?: string): Promise<void> {
-    let transformBuilder = this.transformBuilder;
-    if (!transformBuilder) {
-      transformBuilder = this.transformBuilder = new TransformBuilder();
-    }
-    const transform = Transform.from(transformOrOperations, options, id, transformBuilder);
+    const transform = Transform.from(transformOrOperations, options, id, this.transformBuilder);
 
     if (this.transformLog.contains(transform.id)) {
       return Orbit.Promise.resolve([]);

--- a/packages/@orbit/data/test/source-test.ts
+++ b/packages/@orbit/data/test/source-test.ts
@@ -1,6 +1,10 @@
-import { Source } from '../src/source';
-import Schema from '../src/schema';
-import Transform from '../src/transform';
+import {
+  Source,
+  Schema,
+  Transform,
+  TransformBuilder,
+  QueryBuilder
+} from '../src/index';
 import { isEvented } from '@orbit/core';
 import { FakeBucket } from './test-helper';
 
@@ -34,6 +38,26 @@ module('Source', function(hooks) {
     assert.strictEqual(source.transformLog.bucket, bucket, 'transformLog has been assigned bucket');
     assert.strictEqual(source.requestQueue.bucket, bucket, 'requestQueue has been assigned bucket');
     assert.strictEqual(source.syncQueue.bucket, bucket, 'syncQueue has been assigned bucket');
+  });
+
+  test('creates a `queryBuilder` upon first access', function(assert) {
+    const qb = source.queryBuilder;
+    assert.ok(qb, 'queryBuilder created');
+    assert.strictEqual(qb, source.queryBuilder, 'queryBuilder remains the same');
+  });
+
+  test('creates a `transformBuilder` upon first access', function(assert) {
+    const tb = source.transformBuilder;
+    assert.ok(tb, 'transformBuilder created');
+    assert.strictEqual(tb, source.transformBuilder, 'transformBuilder remains the same');
+  });
+
+  test('it can be instantiated with a `queryBuilder` and/or `transformBuilder`', function(assert) {
+    const queryBuilder = new QueryBuilder;
+    const transformBuilder = new TransformBuilder;
+    source = new MySource({ queryBuilder, transformBuilder });
+    assert.strictEqual(queryBuilder, source.queryBuilder, 'queryBuilder remains the same');
+    assert.strictEqual(transformBuilder, source.transformBuilder, 'transformBuilder remains the same');
   });
 
   test('#_transformed should trigger `transform` event BEFORE resolving', function(assert) {

--- a/packages/@orbit/store/src/cache.ts
+++ b/packages/@orbit/store/src/cache.ts
@@ -83,6 +83,14 @@ export default class Cache implements Evented {
     return this._schema;
   }
 
+  get queryBuilder(): QueryBuilder {
+    return this._queryBuilder;
+  }
+
+  get transformBuilder(): TransformBuilder {
+    return this._transformBuilder;
+  }
+
   records(type: string): ImmutableMap {
     return this._records[type];
   }

--- a/packages/@orbit/store/src/store.ts
+++ b/packages/@orbit/store/src/store.ts
@@ -62,6 +62,8 @@ export default class Store extends Source implements Syncable, Queryable, Updata
     let cacheSettings: CacheSettings = settings.cacheSettings || {};
     cacheSettings.schema = schema;
     cacheSettings.keyMap = keyMap;
+    cacheSettings.queryBuilder = cacheSettings.queryBuilder || this.queryBuilder;
+    cacheSettings.transformBuilder = cacheSettings.transformBuilder || this.transformBuilder;
     this._cache = new Cache(cacheSettings);
   }
 
@@ -114,6 +116,8 @@ export default class Store extends Source implements Syncable, Queryable, Updata
     settings.cacheSettings = settings.cacheSettings || {};
     settings.cacheSettings.base = this._cache;
     settings.keyMap = this._keyMap;
+    settings.queryBuilder = this.queryBuilder;
+    settings.transformBuilder = this.transformBuilder;
 
     return new Store(settings);
   }

--- a/packages/@orbit/store/test/cache-test.ts
+++ b/packages/@orbit/store/test/cache-test.ts
@@ -1,8 +1,7 @@
 import {
   KeyMap,
   RecordNotFoundException,
-  Schema,
-  TransformBuilder
+  Schema
 } from '@orbit/data';
 import Cache from '../src/cache';
 import { arrayMembershipMatches } from './test-helper';
@@ -177,7 +176,7 @@ module('Cache', function(hooks) {
 
     let cache = new Cache({ schema, keyMap });
 
-    const tb = new TransformBuilder();
+    const tb = cache.transformBuilder;
     const operation = tb.replaceRelatedRecord(
       { type: 'moon', id: 'moon1' },
       'planet',
@@ -195,7 +194,7 @@ module('Cache', function(hooks) {
 
     let cache = new Cache({ schema, keyMap });
 
-    const tb = new TransformBuilder();
+    const tb = cache.transformBuilder;
     const operation = tb.replaceRelatedRecord(
       { type: 'moon', id: 'moon1' },
       'planet',
@@ -409,7 +408,7 @@ module('Cache', function(hooks) {
 
   test('#patch merges records when "replacing" and will not stomp on attributes and relationships that are not replaced', function(assert) {
     let cache = new Cache({ schema, keyMap });
-    const tb = new TransformBuilder();
+    const tb = cache.transformBuilder;
 
     cache.patch(t => [
       t.addRecord({ type: 'planet', id: '1', attributes: { name: 'Earth' }, relationships: { moons: { data: { 'moon:m1': true } } } })
@@ -436,7 +435,7 @@ module('Cache', function(hooks) {
 
   test('#patch merges records when "replacing" and _will_ replace specified attributes and relationships', function(assert) {
     let cache = new Cache({ schema, keyMap });
-    const tb = new TransformBuilder();
+    const tb = cache.transformBuilder;
 
     cache.patch([
       tb.addRecord({ type: 'planet', id: '1', attributes: { name: 'Earth' }, relationships: { moons: { data: { 'moon:m1': true } } } })
@@ -475,7 +474,7 @@ module('Cache', function(hooks) {
 
   test('#query can perform a simple matching filter', function(assert) {
     let cache = new Cache({ schema, keyMap });
-    const tb = new TransformBuilder();
+    const tb = cache.transformBuilder;
 
     let jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
     let earth = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };

--- a/packages/@orbit/store/test/store-test.ts
+++ b/packages/@orbit/store/test/store-test.ts
@@ -64,10 +64,15 @@ module('Store', function(hooks) {
 
   test('internal cache\'s settings can be specified with `cacheSettings`', function(assert) {
     let store = new Store({ schema, keyMap, cacheSettings: { processors: [CacheIntegrityProcessor, SchemaConsistencyProcessor] } });
-    let cache = <any>store.cache;
+    let cache = store.cache as any;
 
     assert.ok(cache, 'cache exists');
     assert.equal(cache._processors.length, 2, 'cache has 2 processors');
+  });
+
+  test('automatically shares its `transformBuilder` and `queryBuilder` with its cache', function(assert) {
+    assert.strictEqual(store.cache.transformBuilder, store.transformBuilder, 'transformBuilder is shared');
+    assert.strictEqual(store.cache.queryBuilder, store.queryBuilder, 'queryBuilder is shared');
   });
 
   test('#update - transforms the store\'s cache', function(assert) {
@@ -267,6 +272,8 @@ module('Store', function(hooks) {
         assert.deepEqual(fork.cache.records('planet').get('jupiter-id'), jupiter, 'data in fork matches data in store');
         assert.strictEqual(store.schema, fork.schema, 'schema matches');
         assert.strictEqual(store.keyMap, fork.keyMap, 'keyMap matches');
+        assert.strictEqual(store.transformBuilder, fork.transformBuilder, 'transformBuilder is shared');
+        assert.strictEqual(store.queryBuilder, fork.queryBuilder, 'queryBuilder is shared');
       });
   });
 

--- a/packages/@orbit/store/test/store-test.ts
+++ b/packages/@orbit/store/test/store-test.ts
@@ -4,8 +4,7 @@ import {
   Schema,
   SchemaSettings,
   Source,
-  Transform,
-  TransformBuilder
+  Transform
 } from '@orbit/data';
 import Store from '../src/store';
 import CacheIntegrityProcessor from '../src/cache/operation-processors/cache-integrity-processor';
@@ -127,9 +126,8 @@ module('Store', function(hooks) {
 
   test('#getTransform - returns a particular transform given an id', function(assert) {
     const recordA = { id: 'jupiter', type: 'planet', attributes: { name: 'Jupiter' } };
-    const tb = new TransformBuilder();
 
-    const addRecordATransform = Transform.from(tb.addRecord(recordA));
+    const addRecordATransform = Transform.from(store.transformBuilder.addRecord(recordA));
     return store.sync(addRecordATransform)
       .then(() => {
         assert.strictEqual(store.getTransform(addRecordATransform.id), addRecordATransform);
@@ -138,9 +136,7 @@ module('Store', function(hooks) {
 
   test('#getInverseOperations - returns the inverse operations for a particular transform', function(assert) {
     const recordA = { id: 'jupiter', type: 'planet', attributes: { name: 'Jupiter' } };
-    const tb = new TransformBuilder();
-
-    const addRecordATransform = Transform.from(tb.addRecord(recordA));
+    const addRecordATransform = Transform.from(store.transformBuilder.addRecord(recordA));
 
     return store.sync(addRecordATransform)
       .then(() => {
@@ -154,7 +150,7 @@ module('Store', function(hooks) {
     const recordA = { id: 'jupiter', type: 'planet', attributes: { name: 'Jupiter' } };
     const recordB = { id: 'saturn', type: 'planet', attributes: { name: 'Saturn' } };
     const recordC = { id: 'pluto', type: 'planet', attributes: { name: 'Pluto' } };
-    const tb = new TransformBuilder();
+    const tb = store.transformBuilder;
 
     const addRecordATransform = Transform.from(tb.addRecord(recordA));
     const addRecordBTransform = Transform.from(tb.addRecord(recordB));
@@ -181,7 +177,7 @@ module('Store', function(hooks) {
     const recordA = { id: 'jupiter', type: 'planet', attributes: { name: 'Jupiter' } };
     const recordB = { id: 'saturn', type: 'planet', attributes: { name: 'Saturn' } };
     const recordC = { id: 'pluto', type: 'planet', attributes: { name: 'Pluto' } };
-    const tb = new TransformBuilder();
+    const tb = store.transformBuilder;
 
     const addRecordATransform = Transform.from(tb.addRecord(recordA));
     const addRecordBTransform = Transform.from(tb.addRecord(recordB));
@@ -209,7 +205,7 @@ module('Store', function(hooks) {
     const recordA = { id: 'jupiter', type: 'planet', attributes: { name: 'Jupiter' } };
     const recordB = { id: 'saturn', type: 'planet', attributes: { name: 'Saturn' } };
     const recordC = { id: 'pluto', type: 'planet', attributes: { name: 'Pluto' } };
-    const tb = new TransformBuilder();
+    const tb = store.transformBuilder;
 
     const addRecordATransform = Transform.from(tb.addRecord(recordA));
     const addRecordBTransform = Transform.from(tb.addRecord(recordB));
@@ -239,7 +235,7 @@ module('Store', function(hooks) {
     const recordA = { id: 'jupiter', type: 'planet', attributes: { name: 'Jupiter' } };
     const recordB = { id: 'saturn', type: 'planet', attributes: { name: 'Saturn' } };
     const recordC = { id: 'pluto', type: 'planet', attributes: { name: 'Pluto' } };
-    const tb = new TransformBuilder();
+    const tb = store.transformBuilder;
 
     const addRecordATransform = Transform.from(tb.addRecord(recordA));
     const addRecordBTransform = Transform.from(tb.addRecord(recordB));
@@ -320,7 +316,7 @@ module('Store', function(hooks) {
     const recordD = { id: 'neptune', type: 'planet', attributes: { name: 'Neptune' } };
     const recordE = { id: 'uranus', type: 'planet', attributes: { name: 'Uranus' } };
 
-    const tb = new TransformBuilder();
+    const tb = store.transformBuilder;
     const addRecordATransform = Transform.from(tb.addRecord(recordA));
     const addRecordBTransform = Transform.from(tb.addRecord(recordB));
     const addRecordCTransform = Transform.from(tb.addRecord(recordC));


### PR DESCRIPTION
These builders will be instantiated on first access, so there’s no
additional overhead to keeping them on every Source.

Furthermore, builders can be passed as settings, which simplifies 
sharing of builders for greater efficiency.