### PR TITLE
BREAKING: Normalize relationship data to conform to JSONAPI spec

### DIFF
--- a/packages/@orbit/data/src/record.ts
+++ b/packages/@orbit/data/src/record.ts
@@ -6,11 +6,11 @@ export interface RecordIdentity {
 }
 
 export interface RecordHasOneRelationship {
-  data: string;
+  data: RecordIdentity | null;
 }
 
 export interface RecordHasManyRelationship {
-  data: Dict<boolean>;
+  data: RecordIdentity[];
 }
 
 export type RecordRelationship = RecordHasOneRelationship | RecordHasManyRelationship;
@@ -19,23 +19,6 @@ export interface Record extends RecordIdentity {
   keys?: Dict<string>;
   attributes?: Dict<any>;
   relationships?: Dict<RecordRelationship>;
-}
-
-export function serializeRecordIdentity(identity: RecordIdentity): string {
-  if (isNone(identity)) {
-    return null;
-  }
-  const { type, id } = identity;
-  if (isNone(type) || isNone(id)) {
-    return null;
-  } else {
-    return `${type}:${id}`;
-  }
-}
-
-export function deserializeRecordIdentity(identity: string): RecordIdentity {
-  const [type, id] = identity.split(':');
-  return { type, id };
 }
 
 export function cloneRecordIdentity(identity: RecordIdentity): RecordIdentity {

--- a/packages/@orbit/data/test/operation-test.ts
+++ b/packages/@orbit/data/test/operation-test.ts
@@ -149,7 +149,7 @@ module('Operation', function() {
               attributes: { name: 'Joe' },
               relationships: {
                 phoneNumbers: {
-                  data: { 'phoneNumber:abc': true }
+                  data:  [{ type: 'phoneNumber', id: 'abc' }]
                 }
               }
             }
@@ -180,7 +180,7 @@ module('Operation', function() {
               attributes: { name: 'Joe' },
               relationships: {
                 address: {
-                  data: 'address:abc'
+                  data: { type: 'address', id: 'abc' }
                 }
               }
             }
@@ -211,7 +211,7 @@ module('Operation', function() {
               attributes: { name: 'Joe' },
               relationships: {
                 phoneNumbers: {
-                  data: { 'phoneNumber:abc': true }
+                  data: [{ type: 'phoneNumber', id: 'abc' }]
                 }
               }
             }
@@ -242,7 +242,7 @@ module('Operation', function() {
               attributes: { name: 'Joe' },
               relationships: {
                 address: {
-                  data: 'address:abc'
+                  data: { type: 'address', id: 'abc' }
                 }
               }
             }
@@ -259,7 +259,7 @@ module('Operation', function() {
             record: { type: 'contact', id: '1234', attributes: { name: 'Joe' },
               relationships: {
                 address: {
-                  data: 'address:def'
+                  data: { type: 'address', id: 'def' }
                 }
               }
             }
@@ -279,7 +279,7 @@ module('Operation', function() {
               attributes: { name: 'Joe' },
               relationships: {
                 address: {
-                  data: 'address:abc'
+                  data: { type: 'address', id: 'abc' }
                 }
               }
             }
@@ -340,7 +340,7 @@ module('Operation', function() {
             record: { type: 'contact', id: '1234', attributes: { name: 'Joe' },
               relationships: {
                 address: {
-                  data: 'address:def'
+                  data: { type: 'address', id: 'def' }
                 }
               }
             }
@@ -369,7 +369,7 @@ module('Operation', function() {
             record: { type: 'contact', id: '1234', attributes: { name: 'Joe' },
               relationships: {
                 address: {
-                  data: 'address:def'
+                  data: { type: 'address', id: 'def' }
                 }
               }
             }
@@ -510,7 +510,7 @@ module('Operation', function() {
               attributes: { street: 'abc' },
               relationships: {
                 phoneNumbers: {
-                  data: { 'phoneNumber:abc': true }
+                  data: [{ type: 'phoneNumber', id: 'abc' }]
                 }
               }
             }
@@ -531,10 +531,10 @@ module('Operation', function() {
               attributes: { street: 'abc' },
               relationships: {
                 phoneNumbers: {
-                  data: {
-                    'phoneNumber:abc': true,
-                    'phoneNumber:def': true
-                  }
+                  data: [
+                    { type: 'phoneNumber', id: 'abc' },
+                    { type: 'phoneNumber', id: 'def' }
+                  ]
                 }
               }
             }
@@ -554,7 +554,7 @@ module('Operation', function() {
               attributes: { street: 'abc' },
               relationships: {
                 phoneNumbers: {
-                  data: { 'phoneNumber:abc': true }
+                  data: [{ type: 'phoneNumber', id: 'abc' }]
                 }
               }
             }
@@ -575,10 +575,10 @@ module('Operation', function() {
               attributes: { street: 'abc' },
               relationships: {
                 phoneNumbers: {
-                  data: {
-                    'phoneNumber:abc': true,
-                    'phoneNumber:def': true
-                  }
+                  data: [
+                    { type: 'phoneNumber', id: 'abc' },
+                    { type: 'phoneNumber', id: 'def' }
+                  ]
                 }
               }
             }
@@ -619,7 +619,9 @@ module('Operation', function() {
               attributes: { street: 'abc' },
               relationships: {
                 phoneNumbers: {
-                  data: { 'phoneNumber:abc': true }
+                  data: [
+                    { type: 'phoneNumber', id: 'abc' }
+                  ]
                 }
               }
             }
@@ -640,8 +642,7 @@ module('Operation', function() {
               attributes: { street: 'abc' },
               relationships: {
                 phoneNumbers: {
-                  data: {
-                  }
+                  data: []
                 }
               }
             }

--- a/packages/@orbit/data/test/record-test.ts
+++ b/packages/@orbit/data/test/record-test.ts
@@ -1,18 +1,9 @@
-import { serializeRecordIdentity, deserializeRecordIdentity, cloneRecordIdentity, equalRecordIdentities } from '../src/record';
+import { cloneRecordIdentity, equalRecordIdentities } from '../src/record';
 import './test-helper';
 
 const { module, test } = QUnit;
 
 module('Record', function() {
-  test('`serializeRecordIdentity` converts inputs to an identifier', function(assert) {
-    assert.equal(serializeRecordIdentity(null), null, 'works with null');
-    assert.equal(serializeRecordIdentity({ type: 'planet', id: '1' }), 'planet:1', 'works with an identity object');
-  });
-
-  test('`deserializeRecordIdentity` converts an identifier string to an object with a `type` and `id`', function(assert) {
-    assert.deepEqual(deserializeRecordIdentity('planet:1'), { type: 'planet', id: '1' });
-  });
-
   test('`cloneRecordIdentity` returns a simple { type, id } identity object from any object with a `type` and `id`', function(assert) {
     assert.deepEqual(cloneRecordIdentity({ type: 'planet', id: '1' }), { type: 'planet', id: '1' });
   });

--- a/packages/@orbit/indexeddb/test/source-test.ts
+++ b/packages/@orbit/indexeddb/test/source-test.ts
@@ -213,7 +213,7 @@ module('IndexedDBSource', function(hooks) {
       },
       relationships: {
         moons: {
-          data: {}
+          data: []
         }
       }
     };
@@ -227,9 +227,7 @@ module('IndexedDBSource', function(hooks) {
       },
       relationships: {
         moons: {
-          data: {
-            'moon:moon1': true
-          }
+          data: [{ type: 'moon', id: 'moon1' }]
         }
       }
     };
@@ -251,10 +249,10 @@ module('IndexedDBSource', function(hooks) {
       },
       relationships: {
         moons: {
-          data: {
-            'moon:moon1': true,
-            'moon:moon2': true
-          }
+          data: [
+            { type: 'moon', id: 'moon1' },
+            { type: 'moon', id: 'moon2' }
+          ]
         }
       }
     };
@@ -268,9 +266,9 @@ module('IndexedDBSource', function(hooks) {
       },
       relationships: {
         moons: {
-          data: {
-            'moon:moon1': true
-          }
+          data: [
+            { type: 'moon', id: 'moon1' }
+          ]
         }
       }
     };
@@ -292,9 +290,9 @@ module('IndexedDBSource', function(hooks) {
       },
       relationships: {
         moons: {
-          data: {
-            'moon:moon1': true
-          }
+          data: [
+            { type: 'moon', id: 'moon1' }
+          ]
         }
       }
     };
@@ -308,10 +306,10 @@ module('IndexedDBSource', function(hooks) {
       },
       relationships: {
         moons: {
-          data: {
-            'moon:moon2': true,
-            'moon:moon3': true
-          }
+          data: [
+            { type: 'moon', id: 'moon2' },
+            { type: 'moon', id: 'moon3' }
+          ]
         }
       }
     };
@@ -347,7 +345,7 @@ module('IndexedDBSource', function(hooks) {
       },
       relationships: {
         solarSystem: {
-          data: 'solarSystem:ss1'
+          data: { type: 'solarSystem', id: 'ss1' }
         }
       }
     };

--- a/packages/@orbit/jsonapi/src/jsonapi-serializer.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-serializer.ts
@@ -1,7 +1,5 @@
 import { isArray, isObject, dasherize, camelize, deepSet, Dict } from '@orbit/utils';
 import {
-  deserializeRecordIdentity,
-  serializeRecordIdentity,
   Schema,
   KeyMap,
   Record,
@@ -173,10 +171,10 @@ export default class JSONAPISerializer {
     if (value !== undefined) {
       let data;
 
-      if (isObject(value)) {
-        data = Object.keys(value).map(id => this.resourceIdentity(deserializeRecordIdentity(id)));
+      if (isArray(value)) {
+        data = (value as RecordIdentity[]).map(id => this.resourceIdentity(id));
       } else if (value !== null) {
-        data = this.resourceIdentity(deserializeRecordIdentity(<string>value));
+        data = this.resourceIdentity(value as RecordIdentity);
       } else {
         data = null;
       }
@@ -285,12 +283,9 @@ export default class JSONAPISerializer {
       if (resourceData === null) {
         data = null;
       } else if (isArray(resourceData)) {
-        data = {};
-        (<ResourceIdentity[]>resourceData).forEach(resourceIdentity => {
-          data[serializeRecordIdentity(this.recordIdentity(resourceIdentity))] = true;
-        });
+        data = (resourceData as ResourceIdentity[]).map(resourceIdentity => this.recordIdentity(resourceIdentity));
       } else {
-        data = serializeRecordIdentity(this.recordIdentity(<ResourceIdentity>resourceData));
+        data = this.recordIdentity(resourceData as ResourceIdentity);
       }
 
       record.relationships = record.relationships || {};

--- a/packages/@orbit/jsonapi/src/lib/transform-requests.ts
+++ b/packages/@orbit/jsonapi/src/lib/transform-requests.ts
@@ -1,5 +1,4 @@
 import {
-  serializeRecordIdentity,
   cloneRecordIdentity,
   equalRecordIdentities,
   recordDiffs,
@@ -224,7 +223,7 @@ const OperationToRequestMap = {
       id: operation.record.id
     };
 
-    deepSet(record, ['relationships', operation.relationship, 'data'], serializeRecordIdentity(operation.relatedRecord));
+    deepSet(record, ['relationships', operation.relationship, 'data'], operation.relatedRecord);
 
     return {
       op: 'replaceRecord',
@@ -234,11 +233,7 @@ const OperationToRequestMap = {
 
   replaceRelatedRecords(operation: ReplaceRelatedRecordsOperation) {
     const record = cloneRecordIdentity(operation.record);
-    const relationshipData = {};
-    operation.relatedRecords.forEach(r => {
-      relationshipData[serializeRecordIdentity(r)] = true;
-    });
-    deepSet(record, ['relationships', operation.relationship, 'data'], relationshipData);
+    deepSet(record, ['relationships', operation.relationship, 'data'], operation.relatedRecords);
 
     return {
       op: 'replaceRecord',

--- a/packages/@orbit/jsonapi/test/jsonapi-serializer-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-serializer-test.ts
@@ -2,8 +2,7 @@ import { Dict } from '@orbit/utils';
 import {
   KeyMap,
   ModelDefinition,
-  Schema, SchemaSettings,
-  serializeRecordIdentity
+  Schema, SchemaSettings
 } from '@orbit/data';
 import JSONAPISerializer from '../src/jsonapi-serializer';
 import './test-helper';
@@ -156,10 +155,10 @@ module('JSONAPISerializer', function(hooks) {
             },
             relationships: {
               moons: {
-                data: {
-                  'moon:m1': true,
-                  'moon:m2': true
-                }
+                data: [
+                  { type: 'moon', id: 'm1' },
+                  { type: 'moon', id: 'm2' }
+                ]
               }
             }
           }
@@ -235,7 +234,7 @@ module('JSONAPISerializer', function(hooks) {
             },
             relationships: {
               solarSystem: {
-                data: 'solarSystem:ss1'
+                data: { type: 'solarSystem', id: 'ss1' }
               }
             }
           }
@@ -322,10 +321,6 @@ module('JSONAPISerializer', function(hooks) {
       let planet = result.data;
       let moon = result.included[0];
       let solarSystem = result.included[1];
-      let planetsMoons = {};
-      planetsMoons[`moon:${moon.id}`] = true;
-      let ssPlanets = {};
-      ssPlanets[`planet:${planet.id}`] = true;
 
       assert.deepEqual(
         result,
@@ -342,10 +337,12 @@ module('JSONAPISerializer', function(hooks) {
             },
             relationships: {
               moons: {
-                data: planetsMoons
+                data: [
+                  { type: 'moon', id: moon.id }
+                ]
               },
               solarSystem: {
-                data: `solarSystem:${solarSystem.id}`
+                data: { type: 'solarSystem', id: solarSystem.id }
               }
             }
           },
@@ -361,7 +358,7 @@ module('JSONAPISerializer', function(hooks) {
               },
               relationships: {
                 planet: {
-                  data: `planet:${planet.id}`
+                  data: { type: 'planet', id: planet.id }
                 }
               }
             },
@@ -376,7 +373,7 @@ module('JSONAPISerializer', function(hooks) {
               },
               relationships: {
                 planets: {
-                  data: ssPlanets
+                  data: [{ type: 'planet', id: planet.id }]
                 }
               }
             }
@@ -508,9 +505,7 @@ module('JSONAPISerializer', function(hooks) {
             },
             relationships: {
               moons: {
-                data: {
-                  'moon:5': true
-                }
+                data: [{ type: 'moon', id: '5' }]
               }
             }
           },
@@ -523,7 +518,7 @@ module('JSONAPISerializer', function(hooks) {
               },
               relationships: {
                 planet: {
-                  data: 'planet:12345'
+                  data: { type: 'planet', id: '12345' }
                 }
               }
             }

--- a/packages/@orbit/jsonapi/test/lib/transform-requests-test.ts
+++ b/packages/@orbit/jsonapi/test/lib/transform-requests-test.ts
@@ -148,7 +148,7 @@ module('TransformRequests', function(hooks) {
           id: 'io',
           relationships: {
             planet: {
-              data: 'planet:jupiter'
+              data: { type: 'planet', id: 'jupiter' }
             }
           }
         }
@@ -188,10 +188,10 @@ module('TransformRequests', function(hooks) {
           id: 'jupiter',
           relationships: {
             moons: {
-              data: {
-                'moon:io': true,
-                'moon:europa': true
-              }
+              data: [
+                { type: 'moon', id: 'io' },
+                { type: 'moon', id: 'europa' }
+              ]
             }
           }
         }

--- a/packages/@orbit/local-storage/test/source-test.ts
+++ b/packages/@orbit/local-storage/test/source-test.ts
@@ -179,7 +179,7 @@ module('LocalStorageSource', function(hooks) {
       },
       relationships: {
         moons: {
-          data: {}
+          data: []
         }
       }
     };
@@ -193,9 +193,7 @@ module('LocalStorageSource', function(hooks) {
       },
       relationships: {
         moons: {
-          data: {
-            'moon:moon1': true
-          }
+          data: [{ type: 'moon', id: 'moon1' }]
         }
       }
     };
@@ -217,10 +215,10 @@ module('LocalStorageSource', function(hooks) {
       },
       relationships: {
         moons: {
-          data: {
-            'moon:moon1': true,
-            'moon:moon2': true
-          }
+          data: [
+            { type: 'moon', id: 'moon1' },
+            { type: 'moon', id: 'moon2' }
+          ]
         }
       }
     };
@@ -234,9 +232,7 @@ module('LocalStorageSource', function(hooks) {
       },
       relationships: {
         moons: {
-          data: {
-            'moon:moon1': true
-          }
+          data: [{ type: 'moon', id: 'moon1' }]
         }
       }
     };
@@ -258,9 +254,9 @@ module('LocalStorageSource', function(hooks) {
       },
       relationships: {
         moons: {
-          data: {
-            'moon:moon1': true
-          }
+          data: [
+            { type: 'moon', id: 'moon1' }
+          ]
         }
       }
     };
@@ -274,10 +270,10 @@ module('LocalStorageSource', function(hooks) {
       },
       relationships: {
         moons: {
-          data: {
-            'moon:moon2': true,
-            'moon:moon3': true
-          }
+          data: [
+            { type: 'moon', id: 'moon2' },
+            { type: 'moon', id: 'moon3' }
+          ]
         }
       }
     };
@@ -313,7 +309,7 @@ module('LocalStorageSource', function(hooks) {
       },
       relationships: {
         solarSystem: {
-          data: 'solarSystem:ss1'
+          data: { type: 'solarSystem', id: 'ss1' }
         }
       }
     };
@@ -335,7 +331,7 @@ module('LocalStorageSource', function(hooks) {
       },
       relationships: {
         solarSystem: {
-          data: 'solarSystem:ss1'
+          data: { type: 'solarSystem', id: 'ss1' }
         }
       }
     };

--- a/packages/@orbit/store/src/cache/inverse-relationship-accessor.ts
+++ b/packages/@orbit/store/src/cache/inverse-relationship-accessor.ts
@@ -1,0 +1,153 @@
+import { Dict, isArray, isObject, clone, deepGet } from '@orbit/utils';
+import {
+  cloneRecordIdentity,
+  Record,
+  RecordIdentity
+} from '@orbit/data';
+import Cache from '../cache';
+import ImmutableMap from '../immutable-map';
+
+export interface InverseRelationship {
+  record: RecordIdentity,
+  relationship: string
+}
+
+export default class InverseRelationshipAccessor {
+  protected _cache: Cache;
+  protected _relationships: Dict<ImmutableMap>;
+
+  constructor(cache: Cache, base?: InverseRelationshipAccessor) {
+    this._cache = cache;
+    this.reset(base);
+  }
+
+  reset(base?: InverseRelationshipAccessor) {
+    let relationships = {};
+    if (base) {
+      Object.keys(base._relationships).forEach(type => {
+        relationships[type] = base._relationships;
+      });
+    } else {
+      Object.keys(this._cache.schema.models).forEach(type => {
+        relationships[type] = new ImmutableMap();
+      });
+    }
+    this._relationships = relationships;
+  }
+
+  all(record: RecordIdentity): InverseRelationship[] {
+    return this._relationships[record.type].get(record.id) || [];
+  }
+
+  recordAdded(record: Record) {
+    const relationships = record.relationships;
+    const recordIdentity = cloneRecordIdentity(record);
+    if (relationships) {
+      Object.keys(relationships).forEach(relationship => {
+        const relationshipData = relationships[relationship] && relationships[relationship].data;
+        if (relationshipData) {
+          if (isArray(relationshipData)) {
+            const relatedRecords = relationshipData as Record[];
+            relatedRecords.forEach(relatedRecord => {
+              this.add(relatedRecord, { record: recordIdentity, relationship })
+            });
+          } else {
+            const relatedRecord = relationshipData as Record;
+            this.add(relatedRecord, { record: recordIdentity, relationship })
+          }
+        }
+      });
+    }
+  }
+
+  recordRemoved(record: RecordIdentity): void {
+    const recordInCache: Record = this._cache.records(record.type).get(record.id);
+    const relationships = recordInCache && recordInCache.relationships;
+    if (relationships) {
+      Object.keys(relationships).forEach(relationship => {
+        const relationshipData = relationships[relationship] && relationships[relationship].data;
+        if (relationshipData) {
+          if (isArray(relationshipData)) {
+            const relatedRecords = relationshipData as Record[];
+            relatedRecords.forEach(relatedRecord => {
+              this.remove(relatedRecord, { record, relationship })
+            });
+          } else {
+            const relatedRecord = relationshipData as Record;
+            this.remove(relatedRecord, { record, relationship })
+          }
+        }
+      });
+    }
+    this._relationships[record.type].remove(record.id);
+  }
+
+  relatedRecordAdded(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): void {
+    if (relatedRecord) {
+      const relationshipDef = this._cache.schema.models[record.type].relationships[relationship];
+      if (relationshipDef.inverse) {
+        const recordIdentity = cloneRecordIdentity(record);
+        this.add(relatedRecord, { record: recordIdentity, relationship });
+      }
+    }
+  }
+
+  relatedRecordsAdded(record: RecordIdentity, relationship: string, relatedRecords: RecordIdentity[]): void {
+    if (relatedRecords && relatedRecords.length > 0) {
+      const relationshipDef = this._cache.schema.models[record.type].relationships[relationship];
+      if (relationshipDef.inverse) {
+        const recordIdentity = cloneRecordIdentity(record);
+        relatedRecords.forEach(relatedRecord => {
+          this.add(relatedRecord, { record: recordIdentity, relationship });
+        });
+      }
+    }
+  }
+
+  relatedRecordRemoved(record: RecordIdentity, relationship: string, relatedRecord?: RecordIdentity): void {
+    const relationshipDef = this._cache.schema.models[record.type].relationships[relationship];
+
+    if (relationshipDef.inverse) {
+      if (relatedRecord === undefined) {
+        const currentRecord = this._cache.records(record.type).get(record.id);
+        relatedRecord = currentRecord && deepGet(currentRecord, ['relationships', relationship, 'data']);
+      }
+
+      if (relatedRecord) {
+        this.remove(relatedRecord, { record, relationship });
+      }
+    }
+  }
+
+  relatedRecordsRemoved(record: RecordIdentity, relationship: string, relatedRecords?: RecordIdentity[]): void {
+    const relationshipDef = this._cache.schema.models[record.type].relationships[relationship];
+
+    if (relationshipDef.inverse) {
+      if (relatedRecords === undefined) {
+        const currentRecord = this._cache.records(record.type).get(record.id);
+        relatedRecords = currentRecord && deepGet(currentRecord, ['relationships', relationship, 'data']);
+      }
+
+      if (relatedRecords) {
+        relatedRecords.forEach(relatedRecord => this.remove(relatedRecord, { record, relationship }));
+      }
+    }
+  }
+
+  private add(record: RecordIdentity, inverseRelationship: InverseRelationship): void {
+    let rels = this._relationships[record.type].get(record.id);
+    rels = rels ? clone(rels) : [];
+    rels.push(inverseRelationship);
+    this._relationships[record.type].set(record.id, rels);
+  }
+
+  private remove(record: RecordIdentity, inverseRelationship: InverseRelationship): void {
+    let rels = this._relationships[record.type].get(record.id);
+    if (rels) {
+      let newRels = rels.filter(r => !(r.record.type === inverseRelationship.record.type &&
+                                       r.record.id === inverseRelationship.record.id &&
+                                       r.relationship === inverseRelationship.relationship));
+      this._relationships[record.type].set(record.id, newRels);
+    }
+  }
+}

--- a/packages/@orbit/store/src/cache/operation-processors/cache-integrity-processor.ts
+++ b/packages/@orbit/store/src/cache/operation-processors/cache-integrity-processor.ts
@@ -1,285 +1,140 @@
-import { deepGet, isObject, Dict } from '@orbit/utils';
+import { deepGet, isObject, isArray, Dict } from '@orbit/utils';
 import {
-  serializeRecordIdentity,
-  deserializeRecordIdentity,
+  cloneRecordIdentity,
   Record,
   RecordIdentity,
   RecordOperation
 } from '@orbit/data';
+import Cache from '../../cache';
 import { OperationProcessor } from './operation-processor';
+import InverseRelationshipAccessor, { InverseRelationship } from '../inverse-relationship-accessor';
 
 /**
- An operation processor that ensures that a cache's data is consistent and
- doesn't contain any dead references.
-
- This is achieved by maintaining a mapping of reverse relationships for each record.
- When a record is removed, any references to it can also be identified and
- removed.
-
- @class CacheIntegrityProcessor
- @namespace OC
- @extends OperationProcessor
- @param {OC.Cache} [cache] Cache that is monitored.
- @constructor
+ * An operation processor that ensures that a cache's data is consistent and
+ * doesn't contain any dead references.
+ *
+ * This is achieved by maintaining a mapping of reverse relationships for each
+ * record. When a record is removed, any references to it can also be identified
+ * and removed.
+ *
+ * @export
+ * @class CacheIntegrityProcessor
+ * @extends {OperationProcessor}
  */
 export default class CacheIntegrityProcessor extends OperationProcessor {
-  private _rev: Dict<Dict<object>>;
-
-  constructor(cache) {
-    super(cache);
-
-    this._rev = {};
-  }
-
-  reset(): void {
-    this._rev = {};
-
-    Object.keys(this.cache.records).forEach(type => {
-      this.cache.records(type).values.forEach(record => this._recordAdded(<RecordIdentity>record));
-    });
-  }
-
   after(operation: RecordOperation): RecordOperation[] {
     switch (operation.op) {
       case 'replaceRelatedRecord':
-        return this._relatedRecordRemoved(operation.record, operation.relationship);
+        this.cache.inverseRelationships.relatedRecordRemoved(operation.record, operation.relationship);
+        return [];
 
       case 'replaceRelatedRecords':
-        return this._relatedRecordsRemoved(operation.record, operation.relationship);
+        this.cache.inverseRelationships.relatedRecordsRemoved(operation.record, operation.relationship);
+        return [];
 
       case 'removeFromRelatedRecords':
-        return this._relatedRecordRemoved(operation.record, operation.relationship, operation.relatedRecord);
+        this.cache.inverseRelationships.relatedRecordRemoved(operation.record, operation.relationship, operation.relatedRecord);
+        return [];
 
       case 'removeRecord':
-        return this._recordRemoved(operation.record);
+        let ops = this.clearInverseRelationshipOps(operation.record);
+        this.cache.inverseRelationships.recordRemoved(operation.record);
+        return ops;
 
       case 'replaceRecord':
-        return this._recordRelationshipsRemoved(operation.record);
+        this.cache.inverseRelationships.recordRemoved(operation.record);
+        return [];
 
       default:
         return [];
+    }
+  }
+
+  immediate(operation): void {
+    switch (operation.op) {
+      case 'replaceRelatedRecord':
+        this.cache.relationships.replaceRelatedRecord(operation.record, operation.relationship, operation.relatedRecord);
+        return;
+
+      case 'replaceRelatedRecords':
+        this.cache.relationships.replaceRelatedRecords(operation.record, operation.relationship, operation.relatedRecords);
+        return;
+
+      case 'addToRelatedRecords':
+        this.cache.relationships.addToRelatedRecords(operation.record, operation.relationship, operation.relatedRecord);
+        return;
+
+      case 'removeFromRelatedRecords':
+        this.cache.relationships.removeFromRelatedRecords(operation.record, operation.relationship, operation.relatedRecord);
+        return;
+
+      case 'addRecord':
+        this.cache.relationships.addRecord(operation.record);
+        return;
+
+      case 'replaceRecord':
+        this.cache.inverseRelationships.recordAdded(operation.record);
+        return;
+
+      case 'removeRecord':
+        this.cache.relationships.clearRecord(operation.record);
+        return;
     }
   }
 
   finally(operation): RecordOperation[] {
     switch (operation.op) {
       case 'replaceRelatedRecord':
-        return this._relatedRecordAdded(operation.record, operation.relationship, operation.relatedRecord);
+        this.cache.inverseRelationships.relatedRecordAdded(operation.record, operation.relationship, operation.relatedRecord);
+        return [];
 
       case 'replaceRelatedRecords':
-        return this._relatedRecordsAdded(operation.record, operation.relationship, operation.relatedRecords);
+        this.cache.inverseRelationships.relatedRecordsAdded(operation.record, operation.relationship, operation.relatedRecords);
+        return [];
 
       case 'addToRelatedRecords':
-        return this._relatedRecordAdded(operation.record, operation.relationship, operation.relatedRecord);
+        this.cache.inverseRelationships.relatedRecordAdded(operation.record, operation.relationship, operation.relatedRecord);
+        return [];
 
       case 'addRecord':
-        return this._recordAdded(operation.record);
+        this.cache.inverseRelationships.recordAdded(operation.record);
+        return [];
 
       case 'replaceRecord':
-        return this._recordRelationshipsAdded(operation.record);
+        this.cache.inverseRelationships.recordAdded(operation.record);
+        return [];
 
       default:
         return [];
     }
   }
 
-  private _relatedRecordAdded(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): RecordOperation[] {
-    if (relatedRecord) {
-      const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
-      if (relationshipDef.inverse) {
-        this._addRevLink(record, relationship, relatedRecord);
-      }
-    }
-    return [];
-  }
-
-  private _relatedRecordsAdded(record: RecordIdentity, relationship: string, relatedRecords: RecordIdentity[]): RecordOperation[] {
-    if (relatedRecords && relatedRecords.length > 0) {
-      const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
-      if (relationshipDef.inverse) {
-        relatedRecords.forEach(relatedRecord => this._addRevLink(record, relationship, relatedRecord));
-      }
-    }
-    return [];
-  }
-
-  private _relatedRecordRemoved(record: RecordIdentity, relationship: string, relatedRecord?: RecordIdentity): RecordOperation[] {
-    const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
-
-    if (relationshipDef.inverse) {
-      if (relatedRecord === undefined) {
-        const currentRecord = this.cache.records(record.type).get(record.id);
-        const relationshipData = currentRecord && deepGet(currentRecord, ['relationships', relationship, 'data']);
-        if (relationshipData) {
-          relatedRecord = deserializeRecordIdentity(relationshipData);
-        }
-      }
-
-      if (relatedRecord) {
-        this._removeRevLink(record, relationship, relatedRecord);
-      }
-    }
-
-    return [];
-  }
-
-  private _relatedRecordsRemoved(record: RecordIdentity, relationship: string, relatedRecords?: RecordIdentity[]): RecordOperation[] {
-    const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
-
-    if (relationshipDef.inverse) {
-      if (relatedRecords === undefined) {
-        const currentRecord = this.cache.records(record.type).get(record.id);
-        const relationshipData = currentRecord && deepGet(currentRecord, ['relationships', relationship, 'data']);
-        if (relationshipData) {
-          relatedRecords = recordArrayFromData(relationshipData);
-        }
-      }
-
-      if (relatedRecords) {
-        relatedRecords.forEach(relatedRecord => this._removeRevLink(record, relationship, relatedRecord));
-      }
-    }
-
-    return [];
-  }
-
-  private _recordAdded(record: RecordIdentity): RecordOperation[] {
-    this._addAllRevLinks(record);
-
-    return [];
-  }
-
-  private _recordRemoved(record: RecordIdentity): RecordOperation[] {
+  private clearInverseRelationshipOps(record: RecordIdentity): RecordOperation[] {
     const ops: RecordOperation[] = [];
-    const revLink = this._revLink(record);
+    const inverseRels = this.cache.inverseRelationships.all(record);
 
-    if (revLink) {
-      Object.keys(revLink).forEach(_path => {
-        const path = _path.split('/');
-
-        if (path[2] === 'relationships' && path[4] === 'data') {
-          const isHasMany = path.length === 6;
-
-          if (isHasMany) {
-            ops.push({
-              op: 'removeFromRelatedRecords',
-              record: { type: path[0], id: path[1] },
-              relationship: path[3],
-              relatedRecord: deserializeRecordIdentity(path[5])
-            });
-          } else {
-            ops.push({
-              op: 'replaceRelatedRecord',
-              record: { type: path[0], id: path[1] },
-              relationship: path[3],
-              relatedRecord: null
-            });
-          }
+    if (inverseRels.length > 0) {
+      const recordIdentity = cloneRecordIdentity(record);
+      inverseRels.forEach(rel => {
+        const relationshipDef = this.cache.schema.models[rel.record.type].relationships[rel.relationship];
+        if (relationshipDef.type === 'hasMany') {
+          ops.push({
+            op: 'removeFromRelatedRecords',
+            record: rel.record,
+            relationship: rel.relationship,
+            relatedRecord: recordIdentity
+          });
+        } else {
+          ops.push({
+            op: 'replaceRelatedRecord',
+            record: rel.record,
+            relationship: rel.relationship,
+            relatedRecord: null
+          });
         }
       });
-
-      delete this._rev[record.type][record.id];
     }
-
-    this._removeAllRevLinks(record);
 
     return ops;
   }
-
-  private _recordRelationshipsAdded(record: RecordIdentity): RecordOperation[] {
-    this._addAllRevLinks(record);
-
-    return [];
-  }
-
-  private _recordRelationshipsRemoved(record: RecordIdentity): RecordOperation[] {
-    this._removeAllRevLinks(record);
-
-    return [];
-  }
-
-  private _revLink(record: RecordIdentity): object {
-    let revForType: Dict<object> = this._rev[record.type];
-    if (revForType === undefined) {
-      revForType = this._rev[record.type] = {};
-    }
-    let rev: object = revForType[record.id];
-    if (rev === undefined) {
-      rev = revForType[record.id] = {};
-    }
-    return rev;
-  }
-
-  private _addAllRevLinks(record: Record): void {
-    const relationships = record.relationships;
-    if (relationships) {
-      Object.keys(relationships).forEach(relationship => {
-        const relationshipData = relationships[relationship] && relationships[relationship].data;
-        if (relationshipData) {
-          const relatedRecords = recordArrayFromData(relationshipData);
-          relatedRecords.forEach(relatedRecord => {
-            this._addRevLink(record, relationship, relatedRecord);
-          });
-        }
-      });
-    }
-  }
-
-  private _removeAllRevLinks(record: RecordIdentity): void {
-    const recordInCache: Record = this.cache.records(record.type).get(record.id);
-    const relationships = recordInCache && recordInCache.relationships;
-    if (relationships) {
-      Object.keys(relationships).forEach(relationship => {
-        const relationshipData = relationships[relationship] && relationships[relationship].data;
-        if (relationshipData) {
-          const relatedRecords = recordArrayFromData(relationshipData);
-          relatedRecords.forEach(relatedRecord => {
-            this._removeRevLink(record, relationship, relatedRecord);
-          });
-        }
-      });
-    }
-  }
-
-  _addRevLink(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): void {
-    if (relatedRecord) {
-      const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
-      const relationshipPath = [record.type, record.id, 'relationships', relationship, 'data'];
-
-      if (relationshipDef.type === 'hasMany') {
-        relationshipPath.push(serializeRecordIdentity(relatedRecord));
-      }
-
-      const revLink = this._revLink(relatedRecord);
-      revLink[ relationshipPath.join('/') ] = true;
-    }
-  }
-
-  _removeRevLink(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): void {
-    if (relatedRecord) {
-      const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
-      const relationshipPath = [record.type, record.id, 'relationships', relationship, 'data'];
-
-      if (relationshipDef.type === 'hasMany') {
-        relationshipPath.push(serializeRecordIdentity(relatedRecord));
-      }
-
-      const revLink: object = this._revLink(relatedRecord);
-      delete revLink[ relationshipPath.join('/') ];
-    }
-  }
-}
-
-function recordArrayFromData(data: any): RecordIdentity[] {
-  let ids;
-
-  if (isObject(data)) {
-    ids = Object.keys(data);
-  } else if (typeof data === 'string') {
-    ids = [data];
-  } else {
-    ids = [];
-  }
-
-  return ids.map(id => deserializeRecordIdentity(id));
 }

--- a/packages/@orbit/store/src/cache/operation-processors/operation-processor.ts
+++ b/packages/@orbit/store/src/cache/operation-processors/operation-processor.ts
@@ -6,67 +6,100 @@ export interface OperationProcessorClass {
 }
 
 /**
- Operation processors are used to identify operations that should be performed
- together to ensure that a `Cache` or other container of data remains
- consistent and correct.
-
- `OperationProcessor` is an abstract base class to be extended by specific
- operation processors.
-
- @class OperationProcessor
- @namespace OC
- @param {OC.Cache} [cache] Cache that is monitored.
- @constructor
+ * Operation processors are used to identify operations that should be performed
+ * together to ensure that a `Cache` or other container of data remains
+ * consistent and correct.
+ *
+ * `OperationProcessor` is an abstract base class to be extended by specific
+ * operation processors.
+ *
+ * @export
+ * @abstract
+ * @class OperationProcessor
  */
 export abstract class OperationProcessor {
-  cache: Cache;
+  private _cache: Cache;
 
-  constructor(cache: Cache) {
-    this.cache = cache;
+  /**
+   * The `Cache` that is monitored.
+   *
+   * @readonly
+   * @memberof OperationProcessor
+   */
+  get cache() {
+    return this._cache;
   }
 
   /**
-   Called when all the data in a cache has been reset.
-
-   The return value is ignored.
+   * Creates an instance of OperationProcessor.
+   *
+   * @param {Cache} cache
+   * @memberof OperationProcessor
    */
-  reset(): void {}
+  constructor(cache: Cache) {
+    this._cache = cache;
+  }
 
   /**
-   Called before an `operation` has been applied.
+   * Called when all the data in a cache has been reset.
+   *
+   * If `base` is included, the cache is being reset to match a base cache.
+   *
+   * @param {Cache} [base]
+   * @memberof OperationProcessor
+   */
+  reset(base?: Cache): void {}
 
-   Return an array of operations to be applied **BEFORE** the `operation` itself
-   is applied.
-
-   @param  {Object} [operation]
-   @return {Array} an array of operations
+  /**
+   * Called before an `operation` has been applied.
+   *
+   * Returns an array of operations to be applied **BEFORE** the `operation`
+   * itself is applied.
+   *
+   * @param {RecordOperation} operation
+   * @returns {RecordOperation[]}
+   * @memberof OperationProcessor
    */
   before(operation: RecordOperation): RecordOperation[] {
     return [];
   }
 
   /**
-   Called before an `operation` has been applied.
-
-   Return an array of operations to be applied **AFTER** the `operation` itself
-   is applied.
-
-   @param  {Object} [operation]
-   @return {Array} an array of operations
+   * Called before an `operation` has been applied.
+   *
+   * Returns an array of operations to be applied **AFTER** the `operation`
+   * has been applied successfully.
+   *
+   * @param {RecordOperation} operation
+   * @returns {RecordOperation[]}
+   * @memberof OperationProcessor
    */
   after(operation: RecordOperation): RecordOperation[] {
     return [];
   }
 
   /**
-   Called **AFTER** an `operation` and any related operations have been
-   applied.
+   * Called immediately after an `operation` has been applied and before the
+   * `patch` event has been emitted (i.e. before any listeners have been
+   * notified that the operation was applied).
+   *
+   * No operations may be returned.
+   *
+   * @param {RecordOperation} operation
+   * @memberof OperationProcessor
+   */
+  immediate(operation: RecordOperation): void {
+  }
 
-   Return an array of operations to be applied **AFTER** `operation` itself
-   is applied.
-
-   @param  {Object} [operation]
-   @return {Array} an array of operations
+  /**
+   * Called after an `operation` _and_ any related operations have been applied.
+   *
+   * Returns an array of operations to be applied **AFTER** the `operation`
+   * itself and any operations returned from the `after` hook have been applied.
+   *
+   * @param {RecordOperation} operation
+   * @returns {RecordOperation[]}
+   * @memberof OperationProcessor
    */
   finally(operation: RecordOperation): RecordOperation[] {
     return [];

--- a/packages/@orbit/store/src/cache/query-operators.ts
+++ b/packages/@orbit/store/src/cache/query-operators.ts
@@ -8,7 +8,8 @@ import {
   FindRelatedRecord,
   FindRelatedRecords,
   SortSpecifier,
-  AttributeSortSpecifier
+  AttributeSortSpecifier,
+  RecordIdentity
 } from '@orbit/data';
 import Cache from '../cache';
 
@@ -53,16 +54,10 @@ export const QueryOperators: Dict<QueryOperator> = {
     const { type, id } = record;
     const currentRecord = cache.records(type).get(id);
     const data = currentRecord && deepGet(currentRecord, ['relationships', relationship, 'data']);
-    const results = [];
 
-    if (data) {
-      Object.keys(data).forEach(identifier => {
-        const [relType, relId] = identifier.split(':');
-        results.push(cache.records(relType).get(relId));
-      });
-    }
+    if (!data) { return []; }
 
-    return results;
+    return (data as RecordIdentity[]).map(r => cache.records(r.type).get(r.id));
   },
 
   findRelatedRecord(cache: Cache, expression: FindRelatedRecord) {
@@ -73,8 +68,8 @@ export const QueryOperators: Dict<QueryOperator> = {
 
     if (!data) { return null; }
 
-    const [relType, relId] = data.split(':');
-    return cache.records(relType).get(relId);
+    const r = data as RecordIdentity;
+    return cache.records(r.type).get(r.id);
   }
 };
 

--- a/packages/@orbit/store/src/cache/record-identity-map.ts
+++ b/packages/@orbit/store/src/cache/record-identity-map.ts
@@ -1,0 +1,51 @@
+import { Dict } from '@orbit/utils';
+import { RecordIdentity } from '@orbit/data';
+
+function serializeRecordIdentity(record: RecordIdentity): string {
+  return `${record.type}:${record.id}`;
+}
+
+function deserializeRecordIdentity(identity: string): RecordIdentity {
+  const [type, id] = identity.split(':');
+  return { type, id };
+}
+
+export default class RecordIdentityMap {
+  identities: Dict<boolean>;
+
+  constructor(base?: RecordIdentityMap) {
+    const identities = this.identities = {};
+
+    if (base) {
+      Object.keys(base.identities).forEach(k => {
+        identities[k] = true;
+      });
+    }
+  }
+
+  add(record: RecordIdentity): void {
+    this.identities[serializeRecordIdentity(record)] = true;
+  }
+
+  remove(record: RecordIdentity): void {
+    delete this.identities[serializeRecordIdentity(record)];
+  }
+
+  all(): RecordIdentity[] {
+    return Object.keys(this.identities).map(id => deserializeRecordIdentity(id));
+  }
+
+  has(record: RecordIdentity): boolean {
+    if (record) {
+      return !!this.identities[serializeRecordIdentity(record)];
+    } else {
+      return false;
+    }
+  }
+
+  exclusiveOf(other: RecordIdentityMap): RecordIdentity[] {
+    return Object.keys(this.identities)
+      .filter(id => !other.identities[id])
+      .map(id => deserializeRecordIdentity(id));
+  }
+}

--- a/packages/@orbit/store/src/cache/relationship-accessor.ts
+++ b/packages/@orbit/store/src/cache/relationship-accessor.ts
@@ -1,0 +1,138 @@
+import { clone, Dict, isObject, isArray } from '@orbit/utils';
+import {
+  equalRecordIdentities,
+  Record,
+  RecordIdentity
+} from '@orbit/data';
+import Cache from '../cache';
+import ImmutableMap from '../immutable-map';
+import RecordIdentityMap from './record-identity-map';
+
+export default class RelationshipAccessor {
+  protected _cache: Cache;
+  protected _relationships: Dict<ImmutableMap>;
+
+  constructor(cache: Cache, base?: RelationshipAccessor) {
+    this._cache = cache;
+    this.reset(base);
+  }
+
+  reset(base?: RelationshipAccessor) {
+    let relationships = {};
+    if (base) {
+      Object.keys(base._relationships).forEach(type => {
+        relationships[type] = base._relationships;
+      });
+    } else {
+      Object.keys(this._cache.schema.models).forEach(type => {
+        relationships[type] = new ImmutableMap();
+      });
+    }
+    this._relationships = relationships;
+  }
+
+  relationshipExists(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): boolean {
+    let rels = this._relationships[record.type].get(record.id);
+    if (rels) {
+      let rel = rels[relationship];
+      if (rel) {
+        if (rel instanceof RecordIdentityMap) {
+          return rel.has(relatedRecord);
+        } else {
+          return equalRecordIdentities(relatedRecord, rel);
+        }
+      }
+    }
+  }
+
+  relatedRecord(record: RecordIdentity, relationship: string): RecordIdentity {
+    let rels = this._relationships[record.type].get(record.id);
+    if (rels) {
+      return rels[relationship];
+    }
+  }
+
+  relatedRecords(record: RecordIdentity, relationship: string): RecordIdentity[] {
+    let rels = this._relationships[record.type].get(record.id);
+    let map = rels && rels[relationship] as RecordIdentityMap;
+    if (map) {
+      return map.all();
+    }
+  }
+
+  relatedRecordsMap(record: RecordIdentity, relationship: string): RecordIdentityMap {
+    let rels = this._relationships[record.type].get(record.id);
+    return rels && rels[relationship];
+  }
+
+  addRecord(record: Record) {
+    if (record.relationships) {
+      const rels = {};
+      Object.keys(record.relationships).forEach(name => {
+        let rel = record.relationships[name];
+        if (rel.data !== undefined) {
+          if (isArray(rel.data)) {
+            let relMap = rels[name] = new RecordIdentityMap();
+            (rel.data as RecordIdentity[]).forEach(r => relMap.add(r));
+          } else {
+            rels[name] = rel.data;
+          }
+        }
+      });
+      this._relationships[record.type].set(record.id, rels);
+    }
+  }
+
+  replaceRecord(record: Record) {
+    this.addRecord(record);
+  }
+
+  clearRecord(record: RecordIdentity): void {
+    this._relationships[record.type].remove(record.id);
+  }
+
+  addToRelatedRecords(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): void {
+    let rels = cloneRelationships(this._relationships[record.type].get(record.id));
+    let rel = rels[relationship] || new RecordIdentityMap();
+    rel.add(relatedRecord);
+    this._relationships[record.type].set(record.id, rels);
+  }
+
+  removeFromRelatedRecords(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): void {
+    let currentRels = this._relationships[record.type].get(record.id);
+    if (currentRels && currentRels[relationship]) {
+      let rels = cloneRelationships(currentRels);
+      let rel = rels[relationship];
+      rel.remove(relatedRecord);
+      this._relationships[record.type].set(record.id, rels);
+    }
+  }
+
+  replaceRelatedRecords(record: RecordIdentity, relationship: string, relatedRecords: RecordIdentity[]): void {
+    let rels = cloneRelationships(this._relationships[record.type].get(record.id));
+    let rel = rels[relationship] || new RecordIdentityMap();
+    relatedRecords.forEach(relatedRecord => rel.add(relatedRecord));
+    this._relationships[record.type].set(record.id, rels);
+  }
+
+  replaceRelatedRecord(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): void {
+    let rels = cloneRelationships(this._relationships[record.type].get(record.id));
+    rels[relationship] = relatedRecord;
+    this._relationships[record.type].set(record.id, rels);
+  }
+}
+
+function cloneRelationships(rels) {
+  const clonedRels = {};
+  if (rels) {
+    Object.keys(rels).forEach(name => {
+      let value = rels[name];
+      if (value instanceof RecordIdentityMap) {
+        clonedRels[name] = new RecordIdentityMap(value as RecordIdentityMap);
+      } else {
+        clonedRels[name] = value;
+      }
+    });
+  }
+  return clonedRels;
+}

--- a/packages/@orbit/store/test/cache/operation-processors/cache-integrity-processor-test.ts
+++ b/packages/@orbit/store/test/cache/operation-processors/cache-integrity-processor-test.ts
@@ -62,19 +62,19 @@ module('CacheIntegrityProcessor', function(hooks) {
   test('reset empty cache', function(assert) {
     const saturn = { type: 'planet', id: 'saturn',
                     attributes: { name: 'Saturn' },
-                    relationships: { moons: { data: { 'moon:titan': true } } } };
+                    relationships: { moons: { data: [{ type: 'moon', id: 'titan' }] } } };
 
     const jupiter = { type: 'planet', id: 'jupiter',
                       attributes: { name: 'Jupiter' },
-                      relationships: { moons: { data: { 'moon:europa': true } } } };
+                      relationships: { moons: { data: [{ type: 'moon', id: 'europa' }] } } };
 
     const titan = { type: 'moon', id: 'titan',
                     attributes: { name: 'Titan' },
-                    relationships: { planet: { data: 'planet:saturn' } } };
+                    relationships: { planet: { data: { type: 'planet', id: 'saturn' } } } };
 
     const europa = { type: 'moon', id: 'europa',
                     attributes: { name: 'Europa' },
-                    relationships: { planet: { data: 'planet:jupiter' } } };
+                    relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } } };
 
     cache.patch(t => [
       t.addRecord(saturn),
@@ -83,42 +83,43 @@ module('CacheIntegrityProcessor', function(hooks) {
       t.addRecord(europa)
     ]);
 
-    assert.deepEqual(processor._rev, {
-      'moon': {
-        'europa': {
-          'planet/jupiter/relationships/moons/data/moon:europa': true
-        },
-        'titan': {
-          'planet/saturn/relationships/moons/data/moon:titan': true
-        }
-      },
-      'planet': {
-        'jupiter': {
-          'moon/europa/relationships/planet/data': true
-        },
-        'saturn': {
-          'moon/titan/relationships/planet/data': true
-        }
-      }
-    }, 'rev links match');
+    assert.deepEqual(cache.inverseRelationships.all(europa), [{
+      record: { type: 'planet', id: 'jupiter' },
+      relationship: 'moons'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(titan), [{
+      record: { type: 'planet', id: 'saturn' },
+      relationship: 'moons'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(jupiter), [{
+      record: { type: 'moon', id: 'europa' },
+      relationship: 'planet'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(saturn), [{
+      record: { type: 'moon', id: 'titan' },
+      relationship: 'planet'
+    }]);
   });
 
   test('add to hasOne => hasMany', function(assert) {
     const saturn = { type: 'planet', id: 'saturn',
                     attributes: { name: 'Saturn' },
-                    relationships: { moons: { data: { 'moon:titan': true } } } };
+                    relationships: { moons: { data: [{ type: 'moon', id: 'titan' }] } } };
 
     const jupiter = { type: 'planet', id: 'jupiter',
                       attributes: { name: 'Jupiter' },
-                      relationships: { moons: { data: { 'moon:europa': true } } } };
+                      relationships: { moons: { data: [{ type: 'moon', id: 'europa' }] } } };
 
     const titan = { type: 'moon', id: 'titan',
                     attributes: { name: 'Titan' },
-                    relationships: { planet: { data: 'planet:saturn' } } };
+                    relationships: { planet: { data: { type: 'planet', id: 'saturn' }} } };
 
     const europa = { type: 'moon', id: 'europa',
                     attributes: { name: 'Europa' },
-                    relationships: { planet: { data: 'planet:jupiter' } } };
+                    relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } } };
 
     cache.patch(t => [
       t.addRecord(saturn),
@@ -127,27 +128,28 @@ module('CacheIntegrityProcessor', function(hooks) {
       t.addRecord(europa)
     ]);
 
-    assert.deepEqual(processor._rev, {
-      'moon': {
-        'europa': {
-          'planet/jupiter/relationships/moons/data/moon:europa': true
-        },
-        'titan': {
-          'planet/saturn/relationships/moons/data/moon:titan': true
-        }
-      },
-      'planet': {
-        'jupiter': {
-          'moon/europa/relationships/planet/data': true
-        },
-        'saturn': {
-          'moon/titan/relationships/planet/data': true
-        }
-      }
-    }, 'rev links match');
+    assert.deepEqual(cache.inverseRelationships.all(europa), [{
+      record: { type: 'planet', id: 'jupiter' },
+      relationship: 'moons'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(titan), [{
+      record: { type: 'planet', id: 'saturn' },
+      relationship: 'moons'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(jupiter), [{
+      record: { type: 'moon', id: 'europa' },
+      relationship: 'planet'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(saturn), [{
+      record: { type: 'moon', id: 'titan' },
+      relationship: 'planet'
+    }]);
 
     const addPlanetOp = {
-      op: 'addToRelatedRecords',
+      op: 'replaceRelatedRecord',
       record: { type: 'moon', id: europa.id },
       relationship: 'planet',
       relatedRecord: { type: 'planet', id: saturn.id }
@@ -168,43 +170,43 @@ module('CacheIntegrityProcessor', function(hooks) {
       []
     );
 
-    assert.deepEqual(processor._rev, {
-      'moon': {
-        'europa': {
-          'planet/jupiter/relationships/moons/data/moon:europa': true
-        },
-        'titan': {
-          'planet/saturn/relationships/moons/data/moon:titan': true
-        }
-      },
-      'planet': {
-        'jupiter': {
-          'moon/europa/relationships/planet/data': true
-        },
-        'saturn': {
-          'moon/europa/relationships/planet/data': true,
-          'moon/titan/relationships/planet/data': true
-        }
-      }
-    }, 'rev links match');
+    assert.deepEqual(cache.inverseRelationships.all(europa), [{
+      record: { type: 'planet', id: 'jupiter' },
+      relationship: 'moons'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(titan), [{
+      record: { type: 'planet', id: 'saturn' },
+      relationship: 'moons'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(jupiter), []);
+
+    assert.deepEqual(cache.inverseRelationships.all(saturn), [{
+      record: { type: 'moon', id: 'titan' },
+      relationship: 'planet'
+    }, {
+      record: { type: 'moon', id: 'europa' },
+      relationship: 'planet'
+    }]);
   });
 
   test('replace hasOne => hasMany', function(assert) {
     const saturn = { type: 'planet', id: 'saturn',
                     attributes: { name: 'Saturn' },
-                    relationships: { moons: { data: { 'moon:titan': true } } } };
+                    relationships: { moons: { data: [{ type: 'moon', id: 'titan' }] } } };
 
     const jupiter = { type: 'planet', id: 'jupiter',
                       attributes: { name: 'Jupiter' },
-                      relationships: { moons: { data: { 'moon:europa': true } } } };
+                      relationships: { moons: { data: [{ type: 'moon', id: 'europa' }] } } };
 
     const titan = { type: 'moon', id: 'titan',
                     attributes: { name: 'Titan' },
-                    relationships: { planet: { data: 'planet:saturn' } } };
+                    relationships: { planet: { data: { type: 'planet', id: 'saturn' }} } };
 
     const europa = { type: 'moon', id: 'europa',
                     attributes: { name: 'Europa' },
-                    relationships: { planet: { data: 'planet:jupiter' } } };
+                    relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } } };
 
     cache.patch(t => [
       t.addRecord(saturn),
@@ -213,24 +215,25 @@ module('CacheIntegrityProcessor', function(hooks) {
       t.addRecord(europa)
     ]);
 
-    assert.deepEqual(processor._rev, {
-      'moon': {
-        'europa': {
-          'planet/jupiter/relationships/moons/data/moon:europa': true
-        },
-        'titan': {
-          'planet/saturn/relationships/moons/data/moon:titan': true
-        }
-      },
-      'planet': {
-        'jupiter': {
-          'moon/europa/relationships/planet/data': true
-        },
-        'saturn': {
-          'moon/titan/relationships/planet/data': true
-        }
-      }
-    }, 'rev links match');
+    assert.deepEqual(cache.inverseRelationships.all(europa), [{
+      record: { type: 'planet', id: 'jupiter' },
+      relationship: 'moons'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(titan), [{
+      record: { type: 'planet', id: 'saturn' },
+      relationship: 'moons'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(jupiter), [{
+      record: { type: 'moon', id: 'europa' },
+      relationship: 'planet'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(saturn), [{
+      record: { type: 'moon', id: 'titan' },
+      relationship: 'planet'
+    }]);
 
     const replacePlanetOp = {
       op: 'replaceRelatedRecord',
@@ -256,52 +259,50 @@ module('CacheIntegrityProcessor', function(hooks) {
       []
     );
 
-    assert.deepEqual(processor._rev, {
-      'moon': {
-        'europa': {
-          'planet/jupiter/relationships/moons/data/moon:europa': true
-        },
-        'titan': {
-          'planet/saturn/relationships/moons/data/moon:titan': true
-        }
-      },
-      'planet': {
-        'jupiter': {
-        },
-        'saturn': {
-          'moon/europa/relationships/planet/data': true,
-          'moon/titan/relationships/planet/data': true
-        }
-      }
-    }, 'rev links match');
+   assert.deepEqual(cache.inverseRelationships.all(europa), [{
+      record: { type: 'planet', id: 'jupiter' },
+      relationship: 'moons'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(titan), [{
+      record: { type: 'planet', id: 'saturn' },
+      relationship: 'moons'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(jupiter), []);
+
+    assert.deepEqual(cache.inverseRelationships.all(saturn), [{
+      record: { type: 'moon', id: 'titan' },
+      relationship: 'planet'
+    }, {
+      record: { type: 'moon', id: 'europa' },
+      relationship: 'planet'
+    }]);
   });
 
   test('replace hasMany => hasOne with empty array', function(assert) {
     const saturn = { type: 'planet', id: 'saturn',
                     attributes: { name: 'Saturn' },
-                    relationships: { moons: { data: { 'moon:titan': true } } } };
+                    relationships: { moons: { data: [{ type: 'moon', id: 'titan' }] } } };
 
     const titan = { type: 'moon', id: 'titan',
                     attributes: { name: 'Titan' },
-                    relationships: { planet: { data: 'planet:saturn' } } };
+                    relationships: { planet: { data: { type: 'planet', id: 'saturn' }} } };
 
     cache.patch(t => [
       t.addRecord(saturn),
       t.addRecord(titan)
     ]);
 
-    assert.deepEqual(processor._rev, {
-      'moon': {
-        'titan': {
-          'planet/saturn/relationships/moons/data/moon:titan': true
-        }
-      },
-      'planet': {
-        'saturn': {
-          'moon/titan/relationships/planet/data': true
-        }
-      }
-    }, 'rev links match');
+    assert.deepEqual(cache.inverseRelationships.all(titan), [{
+      record: { type: 'planet', id: 'saturn' },
+      relationship: 'moons'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(saturn), [{
+      record: { type: 'moon', id: 'titan' },
+      relationship: 'planet'
+    }]);
 
     const clearMoonsOp = {
       op: 'replaceRelatedRecords',
@@ -325,30 +326,25 @@ module('CacheIntegrityProcessor', function(hooks) {
       []
     );
 
-    assert.deepEqual(processor._rev, {
-      'moon': {
-        'titan': {
-        }
-      },
-      'planet': {
-        'saturn': {
-          'moon/titan/relationships/planet/data': true
-        }
-      }
-    }, 'rev links match');
+    assert.deepEqual(cache.inverseRelationships.all(titan), []);
+
+    assert.deepEqual(cache.inverseRelationships.all(saturn), [{
+      record: { type: 'moon', id: 'titan' },
+      relationship: 'planet'
+    }]);
   });
 
   test('replace hasMany => hasOne with populated array', function(assert) {
     const saturn = { type: 'planet', id: 'saturn',
                     attributes: { name: 'Saturn' },
-                    relationships: { moons: { data: { 'moon:titan': true } } } };
+                    relationships: { moons: { data: [{ type: 'moon', id: 'titan' }] } } };
 
     const jupiter = { type: 'planet', id: 'jupiter',
                       attributes: { name: 'Jupiter' } };
 
     const titan = { type: 'moon', id: 'titan',
                     attributes: { name: 'Titan' },
-                    relationships: { planet: { data: 'planet:saturn' } } };
+                    relationships: { planet: { data: { type: 'planet', id: 'saturn' }} } };
 
     cache.patch(t => [
       t.addRecord(saturn),
@@ -356,18 +352,15 @@ module('CacheIntegrityProcessor', function(hooks) {
       t.addRecord(titan)
     ]);
 
-    assert.deepEqual(processor._rev, {
-      'moon': {
-        'titan': {
-          'planet/saturn/relationships/moons/data/moon:titan': true
-        }
-      },
-      'planet': {
-        'saturn': {
-          'moon/titan/relationships/planet/data': true
-        }
-      }
-    }, 'rev links match');
+    assert.deepEqual(cache.inverseRelationships.all(titan), [{
+      record: { type: 'planet', id: 'saturn' },
+      relationship: 'moons'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(saturn), [{
+      record: { type: 'moon', id: 'titan' },
+      relationship: 'planet'
+    }]);
 
     const replaceMoonsOp = {
       op: 'replaceRelatedRecords',
@@ -391,36 +384,33 @@ module('CacheIntegrityProcessor', function(hooks) {
       []
     );
 
-    assert.deepEqual(processor._rev, {
-      'moon': {
-        'titan': {
-          'planet/saturn/relationships/moons/data/moon:titan': true
-        }
-      },
-      'planet': {
-        'saturn': {
-          'moon/titan/relationships/planet/data': true
-        }
-      }
-    }, 'rev links match');
+    assert.deepEqual(cache.inverseRelationships.all(titan), [{
+      record: { type: 'planet', id: 'saturn' },
+      relationship: 'moons'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(saturn), [{
+      record: { type: 'moon', id: 'titan' },
+      relationship: 'planet'
+    }]);
   });
 
   test('replace hasMany => hasOne with populated array, when already populated', function(assert) {
     const saturn = { type: 'planet', id: 'saturn',
                     attributes: { name: 'Saturn' },
-                    relationships: { moons: { data: { 'moon:titan': true } } } };
+                    relationships: { moons: { data: [{ type: 'moon', id: 'titan' }] } } };
 
     const jupiter = { type: 'planet', id: 'jupiter',
                       attributes: { name: 'Jupiter' },
-                      relationships: { moons: { data: { 'moon:europa': true } } } };
+                      relationships: { moons: { data: [{ type: 'moon', id: 'europa' }] } } };
 
     const titan = { type: 'moon', id: 'titan',
                     attributes: { name: 'Titan' },
-                    relationships: { planet: { data: 'planet:saturn' } } };
+                    relationships: { planet: { data: { type: 'planet', id: 'saturn' } } } };
 
     const europa = { type: 'moon', id: 'europa',
                     attributes: { name: 'Europa' },
-                    relationships: { planet: { data: 'planet:jupiter' } } };
+                    relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } } };
 
     cache.patch(t => [
       t.addRecord(saturn),
@@ -429,24 +419,25 @@ module('CacheIntegrityProcessor', function(hooks) {
       t.addRecord(europa)
     ]);
 
-    assert.deepEqual(processor._rev, {
-      'moon': {
-        'europa': {
-          'planet/jupiter/relationships/moons/data/moon:europa': true
-        },
-        'titan': {
-          'planet/saturn/relationships/moons/data/moon:titan': true
-        }
-      },
-      'planet': {
-        'jupiter': {
-          'moon/europa/relationships/planet/data': true
-        },
-        'saturn': {
-          'moon/titan/relationships/planet/data': true
-        }
-      }
-    }, 'rev links match');
+    assert.deepEqual(cache.inverseRelationships.all(europa), [{
+      record: { type: 'planet', id: 'jupiter' },
+      relationship: 'moons'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(titan), [{
+      record: { type: 'planet', id: 'saturn' },
+      relationship: 'moons'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(jupiter), [{
+      record: { type: 'moon', id: 'europa' },
+      relationship: 'planet'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(saturn), [{
+      record: { type: 'moon', id: 'titan' },
+      relationship: 'planet'
+    }]);
 
     const replaceMoonsOp = {
       op: 'replaceRelatedRecords',
@@ -470,46 +461,45 @@ module('CacheIntegrityProcessor', function(hooks) {
       []
     );
 
-    assert.deepEqual(processor._rev, {
-      'moon': {
-        'europa': {
-          'planet/jupiter/relationships/moons/data/moon:europa': true,
-          'planet/saturn/relationships/moons/data/moon:europa': true
-        },
-        'titan': {}
-      },
-      'planet': {
-        'jupiter': {
-          'moon/europa/relationships/planet/data': true
-        },
-        'saturn': {
-          'moon/titan/relationships/planet/data': true
-        }
-      }
-    }, 'rev links match');
+    assert.deepEqual(cache.inverseRelationships.all(europa), [{
+      record: { type: 'planet', id: 'jupiter' },
+      relationship: 'moons'
+    }, {
+      record: { type: 'planet', id: 'saturn' },
+      relationship: 'moons'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(titan), []);
+
+    assert.deepEqual(cache.inverseRelationships.all(jupiter), [{
+      record: { type: 'moon', id: 'europa' },
+      relationship: 'planet'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(saturn), [{
+      record: { type: 'moon', id: 'titan' },
+      relationship: 'planet'
+    }]);
   });
 
   test('replace hasMany => hasMany', function(assert) {
-    const human = { type: 'inhabitant', id: 'human', relationships: { planets: { data: { 'planet:earth': true } } } };
-    const earth = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: { 'inhabitant:human': true } } } };
+    const human = { type: 'inhabitant', id: 'human', relationships: { planets: { data: [{ type: 'planet', id: 'earth' }] } } };
+    const earth = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: [{ type: 'inhabitant', id: 'human' }] } } };
 
     cache.patch(t => [
       t.addRecord(human),
       t.addRecord(earth)
     ]);
 
-    assert.deepEqual(processor._rev, {
-      'planet': {
-        'earth': {
-          'inhabitant/human/relationships/planets/data/planet:earth': true
-        }
-      },
-      'inhabitant': {
-        'human': {
-          'planet/earth/relationships/inhabitants/data/inhabitant:human': true
-        }
-      }
-    }, 'rev links match');
+    assert.deepEqual(cache.inverseRelationships.all(earth), [{
+      record: { type: 'inhabitant', id: 'human' },
+      relationship: 'planets'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(human), [{
+      record: { type: 'planet', id: 'earth' },
+      relationship: 'inhabitants'
+    }]);
 
     const clearInhabitantsOp = {
       op: 'replaceRelatedRecords',
@@ -528,35 +518,30 @@ module('CacheIntegrityProcessor', function(hooks) {
       []
     );
 
-    assert.deepEqual(processor._rev, {
-      'planet': {
-        'earth': {
-          'inhabitant/human/relationships/planets/data/planet:earth': true
-        }
-      },
-      'inhabitant': {
-        'human': {
-        }
-      }
-    }, 'rev links match');
+    assert.deepEqual(cache.inverseRelationships.all(earth), [{
+      record: { type: 'inhabitant', id: 'human' },
+      relationship: 'planets'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(human), []);
   });
 
   test('remove hasOne => hasMany', function(assert) {
     const saturn = { type: 'planet', id: 'saturn',
                     attributes: { name: 'Saturn' },
-                    relationships: { moons: { data: { 'moon:titan': true } } } };
+                    relationships: { moons: { data: [{ type: 'moon', id: 'titan' }] } } };
 
     const jupiter = { type: 'planet', id: 'jupiter',
                     attributes: { name: 'Jupiter' },
-                    relationships: { moons: { data: { 'moon:europa': true } } } };
+                    relationships: { moons: { data: [{ type: 'moon', id: 'europa' }] } } };
 
     const titan = { type: 'moon', id: 'titan',
                   attributes: { name: 'Titan' },
-                  relationships: { planet: { data: 'planet:saturn' } } };
+                  relationships: { planet: { data: { type: 'planet', id: 'saturn' }} } };
 
     const europa = { type: 'moon', id: 'europa',
                     attributes: { name: 'Europa' },
-                    relationships: { planet: { data: 'planet:jupiter' } } };
+                    relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } } };
 
     cache.patch(t => [
       t.addRecord(saturn),
@@ -565,25 +550,25 @@ module('CacheIntegrityProcessor', function(hooks) {
       t.addRecord(europa)
     ]);
 
-    assert.deepEqual(processor._rev, {
-      'moon': {
-        'europa': {
-          'planet/jupiter/relationships/moons/data/moon:europa': true
-        },
-        'titan': {
-          'planet/saturn/relationships/moons/data/moon:titan': true
-        }
-      },
-      'planet': {
-        'jupiter': {
-          'moon/europa/relationships/planet/data': true
-        },
-        'saturn': {
-          'moon/titan/relationships/planet/data': true
-        }
-      }
-    }, 'rev links match');
+    assert.deepEqual(cache.inverseRelationships.all(europa), [{
+      record: { type: 'planet', id: 'jupiter' },
+      relationship: 'moons'
+    }]);
 
+    assert.deepEqual(cache.inverseRelationships.all(titan), [{
+      record: { type: 'planet', id: 'saturn' },
+      relationship: 'moons'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(jupiter), [{
+      record: { type: 'moon', id: 'europa' },
+      relationship: 'planet'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(saturn), [{
+      record: { type: 'moon', id: 'titan' },
+      relationship: 'planet'
+    }]);
 
     const removePlanetOp = {
       op: 'replaceRelatedRecord',
@@ -607,33 +592,32 @@ module('CacheIntegrityProcessor', function(hooks) {
       []
     );
 
-    assert.deepEqual(processor._rev, {
-      'moon': {
-        'europa': {
-          'planet/jupiter/relationships/moons/data/moon:europa': true
-        },
-        'titan': {
-          'planet/saturn/relationships/moons/data/moon:titan': true
-        }
-      },
-      'planet': {
-        'jupiter': {
-        },
-        'saturn': {
-          'moon/titan/relationships/planet/data': true
-        }
-      }
-    }, 'rev links match');
+    assert.deepEqual(cache.inverseRelationships.all(europa), [{
+      record: { type: 'planet', id: 'jupiter' },
+      relationship: 'moons'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(titan), [{
+      record: { type: 'planet', id: 'saturn' },
+      relationship: 'moons'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(jupiter), []);
+
+    assert.deepEqual(cache.inverseRelationships.all(saturn), [{
+      record: { type: 'moon', id: 'titan' },
+      relationship: 'planet'
+    }]);
   });
 
   test('add to hasOne => hasOne', function(assert) {
     const saturn = { type: 'planet', id: 'saturn',
                     attributes: { name: 'Saturn' },
-                    relationships: { next: { data: 'planet:jupiter' } } };
+                    relationships: { next: { data: { type: 'planet', id: 'jupiter' } } } };
 
     const jupiter = { type: 'planet', id: 'jupiter',
                       attributes: { name: 'Jupiter' },
-                      relationships: { previous: { data: 'planet:saturn' } } };
+                      relationships: { previous: { data: { type: 'planet', id: 'saturn' }} } };
 
     const earth = { type: 'planet', id: 'earth',
                     attributes: { name: 'Earth' } };
@@ -644,16 +628,15 @@ module('CacheIntegrityProcessor', function(hooks) {
       t.addRecord(earth)
     ]);
 
-    assert.deepEqual(processor._rev, {
-      'planet': {
-        'jupiter': {
-          'planet/saturn/relationships/next/data': true
-        },
-        'saturn': {
-          'planet/jupiter/relationships/previous/data': true
-        }
-      }
-    }, 'rev links match');
+    assert.deepEqual(cache.inverseRelationships.all(jupiter), [{
+      record: { type: 'planet', id: 'saturn' },
+      relationship: 'next'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(saturn), [{
+      record: { type: 'planet', id: 'jupiter' },
+      relationship: 'previous'
+    }]);
 
     const changePlanetOp = {
       op: 'replaceRelatedRecord',
@@ -677,27 +660,29 @@ module('CacheIntegrityProcessor', function(hooks) {
       []
     );
 
-    assert.deepEqual(processor._rev, {
-      'planet': {
-        'jupiter': {
-          'planet/saturn/relationships/next/data': true
-        },
-        'saturn': {
-          'planet/earth/relationships/next/data': true,
-          'planet/jupiter/relationships/previous/data': true
-        }
-      }
-    }, 'rev links match');
+
+    assert.deepEqual(cache.inverseRelationships.all(jupiter), [{
+      record: { type: 'planet', id: 'saturn' },
+      relationship: 'next'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(saturn), [{
+      record: { type: 'planet', id: 'jupiter' },
+      relationship: 'previous'
+    }, {
+      record: { type: 'planet', id: 'earth' },
+      relationship: 'next'
+    }]);
   });
 
   test('replace hasOne => hasOne with existing value', function(assert) {
     const saturn = { type: 'planet', id: 'saturn',
                     attributes: { name: 'Saturn' },
-                    relationships: { next: { data: 'planet:jupiter' } } };
+                    relationships: { next: { data: { type: 'planet', id: 'jupiter' } } } };
 
     const jupiter = { type: 'planet', id: 'jupiter',
                       attributes: { name: 'Jupiter' },
-                      relationships: { previous: { data: 'planet:saturn' } } };
+                      relationships: { previous: { data: { type: 'planet', id: 'saturn' }} } };
 
     const earth = { type: 'planet', id: 'earth',
                     attributes: { name: 'Earth' } };
@@ -708,16 +693,15 @@ module('CacheIntegrityProcessor', function(hooks) {
       t.addRecord(earth)
     ]);
 
-    assert.deepEqual(processor._rev, {
-      'planet': {
-        'jupiter': {
-          'planet/saturn/relationships/next/data': true
-        },
-        'saturn': {
-          'planet/jupiter/relationships/previous/data': true
-        }
-      }
-    }, 'rev links match');
+    assert.deepEqual(cache.inverseRelationships.all(jupiter), [{
+      record: { type: 'planet', id: 'saturn' },
+      relationship: 'next'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(saturn), [{
+      record: { type: 'planet', id: 'jupiter' },
+      relationship: 'previous'
+    }]);
 
     const changePlanetOp = {
       op: 'replaceRelatedRecord',
@@ -741,17 +725,18 @@ module('CacheIntegrityProcessor', function(hooks) {
       []
     );
 
-    assert.deepEqual(processor._rev, {
-      'planet': {
-        'jupiter': {
-          'planet/earth/relationships/next/data': true,
-          'planet/saturn/relationships/next/data': true
-        },
-        'saturn': {
-          'planet/jupiter/relationships/previous/data': true
-        }
-      }
-    }, 'rev links match');
+    assert.deepEqual(cache.inverseRelationships.all(jupiter), [{
+      record: { type: 'planet', id: 'saturn' },
+      relationship: 'next'
+    }, {
+      record: { type: 'planet', id: 'earth' },
+      relationship: 'next'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(saturn), [{
+      record: { type: 'planet', id: 'jupiter' },
+      relationship: 'previous'
+    }]);
   });
 
   test('add to hasMany => hasMany', function(assert) {
@@ -763,7 +748,8 @@ module('CacheIntegrityProcessor', function(hooks) {
       t.addRecord(human)
     ]);
 
-    assert.deepEqual(processor._rev, {}, 'empty rev links');
+    assert.deepEqual(cache.inverseRelationships.all(earth), []);
+    assert.deepEqual(cache.inverseRelationships.all(human), []);
 
     const addPlanetOp = {
       op: 'addToRelatedRecords',
@@ -787,36 +773,30 @@ module('CacheIntegrityProcessor', function(hooks) {
       []
     );
 
-    assert.deepEqual(processor._rev, {
-      'planet': {
-        'earth': {
-          'inhabitant/human/relationships/planets/data/planet:earth': true
-        }
-      }
-    }, 'rev links match');
+    assert.deepEqual(cache.inverseRelationships.all(earth), [{
+      record: { type: 'inhabitant', id: 'human' },
+      relationship: 'planets'
+    }]);
   });
 
   test('remove from hasMany => hasMany', function(assert) {
-    const earth = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: { 'inhabitant:human': true } } } };
-    const human = { type: 'inhabitant', id: 'human', relationships: { planets: { data: { 'planet:earth': true } } } };
+    const earth = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: [{ type: 'inhabitant', id: 'human' }] } } };
+    const human = { type: 'inhabitant', id: 'human', relationships: { planets: { data: [{ type: 'planet', id: 'earth' }] } } };
 
     cache.patch(t => [
       t.addRecord(earth),
       t.addRecord(human)
     ]);
 
-    assert.deepEqual(processor._rev, {
-      'planet': {
-        'earth': {
-          'inhabitant/human/relationships/planets/data/planet:earth': true
-        }
-      },
-      'inhabitant': {
-        'human': {
-          'planet/earth/relationships/inhabitants/data/inhabitant:human': true
-        }
-      }
-    }, 'rev links match');
+    assert.deepEqual(cache.inverseRelationships.all(earth), [{
+      record: { type: 'inhabitant', id: 'human' },
+      relationship: 'planets'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(human), [{
+      record: { type: 'planet', id: 'earth' },
+      relationship: 'inhabitants'
+    }]);
 
     const removePlanetOp = {
       op: 'removeFromRelatedRecords',
@@ -840,40 +820,32 @@ module('CacheIntegrityProcessor', function(hooks) {
       []
     );
 
-    assert.deepEqual(processor._rev, {
-      'planet': {
-        'earth': {
-        }
-      },
-      'inhabitant': {
-        'human': {
-          'planet/earth/relationships/inhabitants/data/inhabitant:human': true
-        }
-      }
-    }, 'rev links match');
+    assert.deepEqual(cache.inverseRelationships.all(earth), []);
+
+    assert.deepEqual(cache.inverseRelationships.all(human), [{
+      record: { type: 'planet', id: 'earth' },
+      relationship: 'inhabitants'
+    }]);
   });
 
   test('remove record with hasMany relationships', function(assert) {
-    const earth = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: { 'inhabitant:human': true } } } };
-    const human = { type: 'inhabitant', id: 'human', relationships: { planets: { data: { 'planet:earth': true } } } };
+    const earth = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: [{ type: 'inhabitant', id: 'human' }] } } };
+    const human = { type: 'inhabitant', id: 'human', relationships: { planets: { data: [{ type: 'planet', id: 'earth' }] } } };
 
     cache.patch(t => [
       t.addRecord(earth),
       t.addRecord(human)
     ]);
 
-    assert.deepEqual(processor._rev, {
-      'planet': {
-        'earth': {
-          'inhabitant/human/relationships/planets/data/planet:earth': true
-        }
-      },
-      'inhabitant': {
-        'human': {
-          'planet/earth/relationships/inhabitants/data/inhabitant:human': true
-        }
-      }
-    }, 'rev links match');
+    assert.deepEqual(cache.inverseRelationships.all(earth), [{
+      record: { type: 'inhabitant', id: 'human' },
+      relationship: 'planets'
+    }]);
+
+    assert.deepEqual(cache.inverseRelationships.all(human), [{
+      record: { type: 'planet', id: 'earth' },
+      relationship: 'inhabitants'
+    }]);
 
     const removeInhabitantOp = {
       op: 'removeRecord',
@@ -902,14 +874,8 @@ module('CacheIntegrityProcessor', function(hooks) {
       []
     );
 
-    assert.deepEqual(processor._rev, {
-      'planet': {
-        'earth': {
-        }
-      },
-      'inhabitant': {
-      }
-    }, 'rev links match');
+    assert.deepEqual(cache.inverseRelationships.all(earth), []);
+    assert.deepEqual(cache.inverseRelationships.all(human), []);
   });
 
   test('replaceRecord', function(assert) {
@@ -921,13 +887,14 @@ module('CacheIntegrityProcessor', function(hooks) {
       t.addRecord(human)
     ]);
 
-    assert.deepEqual(processor._rev, {}, 'empty rev links');
+    assert.deepEqual(cache.inverseRelationships.all(earth), []);
+    assert.deepEqual(cache.inverseRelationships.all(human), []);
 
     const humanOnEarth = {
       type: 'inhabitant',
       id: 'human',
       relationships: {
-        planets: { data: { 'planet:earth': true } }
+        planets: { data: [{ type: 'planet', id: 'earth' }] }
       }
     };
 
@@ -951,12 +918,10 @@ module('CacheIntegrityProcessor', function(hooks) {
       []
     );
 
-    assert.deepEqual(processor._rev, {
-      'planet': {
-        'earth': {
-          'inhabitant/human/relationships/planets/data/planet:earth': true
-        }
-      }
-    }, 'rev links match');
+    assert.deepEqual(cache.inverseRelationships.all(earth), [{
+      record: { type: 'inhabitant', id: 'human' },
+      relationship: 'planets'
+    }]);
+    assert.deepEqual(cache.inverseRelationships.all(human), []);
   });
 });

--- a/packages/@orbit/store/test/cache/operation-processors/schema-consistency-processor-test.ts
+++ b/packages/@orbit/store/test/cache/operation-processors/schema-consistency-processor-test.ts
@@ -5,12 +5,13 @@ import {
   SchemaSettings
 } from '@orbit/data';
 import Cache from '../../../src/cache';
+import CacheIntegrityProcessor from '../../../src/cache/operation-processors/cache-integrity-processor';
 import SchemaConsistencyProcessor from '../../../src/cache/operation-processors/schema-consistency-processor';
 import '../../test-helper';
 
 const { module, test } = QUnit;
 
-module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
+module('SchemaConsistencyProcessor', function(hooks) {
   let schema, cache, processor;
 
   const schemaDefinition: SchemaSettings = {
@@ -49,8 +50,8 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
   hooks.beforeEach(function() {
     let keyMap = new KeyMap();
     schema = new Schema(schemaDefinition);
-    cache = new Cache({ schema, keyMap, processors: [SchemaConsistencyProcessor] });
-    processor = cache._processors[0];
+    cache = new Cache({ schema, keyMap, processors: [CacheIntegrityProcessor, SchemaConsistencyProcessor] });
+    processor = cache._processors[1];
   });
 
   hooks.afterEach(function() {
@@ -62,19 +63,19 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
   test('add to hasOne => hasMany', function(assert) {
     const saturn = { type: 'planet', id: 'saturn',
                     attributes: { name: 'Saturn' },
-                    relationships: { moons: { data: { 'moon:titan': true } } } };
+                    relationships: { moons: { data: [{ type: 'moon', id: 'titan' }] } } };
 
     const jupiter = { type: 'planet', id: 'jupiter',
                       attributes: { name: 'Jupiter' },
-                      relationships: { moons: { data: { 'moon:europa': true } } } };
+                      relationships: { moons: { data: [{ type: 'moon', id: 'europa' }] } } };
 
     const titan = { type: 'moon', id: 'titan',
                     attributes: { name: 'Titan' },
-                    relationships: { planet: { data: 'planet:saturn' } } };
+                    relationships: { planet: { data: { type: 'planet', id: 'saturn' } } } };
 
     const europa = { type: 'moon', id: 'europa',
                     attributes: { name: 'Europa' },
-                    relationships: { planet: { data: 'planet:jupiter' } } };
+                    relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } } };
 
     cache.patch(t => [
       t.addRecord(saturn),
@@ -116,19 +117,19 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
   test('replace hasOne => hasMany', function(assert) {
     const saturn = { type: 'planet', id: 'saturn',
                     attributes: { name: 'Saturn' },
-                    relationships: { moons: { data: { 'moon:titan': true } } } };
+                    relationships: { moons: { data: [{ type: 'moon', id: 'titan' }] } } };
 
     const jupiter = { type: 'planet', id: 'jupiter',
                       attributes: { name: 'Jupiter' },
-                      relationships: { moons: { data: { 'moon:europa': true } } } };
+                      relationships: { moons: { data: [{ type: 'moon', id: 'europa' }] } } };
 
     const titan = { type: 'moon', id: 'titan',
                     attributes: { name: 'Titan' },
-                    relationships: { planet: { data: 'planet:saturn' } } };
+                    relationships: { planet: { data: { type: 'planet', id: 'saturn' } } } };
 
     const europa = { type: 'moon', id: 'europa',
                     attributes: { name: 'Europa' },
-                    relationships: { planet: { data: 'planet:jupiter' } } };
+                    relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } } };
 
     cache.patch(t => [
       t.addRecord(saturn),
@@ -177,11 +178,11 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
   test('replace hasMany => hasOne with empty array', function(assert) {
     const saturn = { type: 'planet', id: 'saturn',
                     attributes: { name: 'Saturn' },
-                    relationships: { moons: { data: { 'moon:titan': true } } } };
+                    relationships: { moons: { data: [{ type: 'moon', id: 'titan' }] } } };
 
     const titan = { type: 'moon', id: 'titan',
                     attributes: { name: 'Titan' },
-                    relationships: { planet: { data: 'planet:saturn' } } };
+                    relationships: { planet: { data: { type: 'planet', id: 'saturn' } } } };
 
     cache.patch(t => [
       t.addRecord(saturn),
@@ -221,11 +222,11 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
   test('replace hasMany => hasOne with populated array', function(assert) {
     const saturn = { type: 'planet', id: 'saturn',
                     attributes: { name: 'Saturn' },
-                    relationships: { moons: { data: { 'moon:titan': true } } } };
+                    relationships: { moons: { data: [{ type: 'moon', id: 'titan' }] } } };
 
     const titan = { type: 'moon', id: 'titan',
                     attributes: { name: 'Titan' },
-                    relationships: { planet: { data: 'planet:saturn' } } };
+                    relationships: { planet: { data: { type: 'planet', id: 'saturn' } } } };
 
     const jupiter = { type: 'planet', id: 'jupiter',
                       attributes: { name: 'Jupiter' } };
@@ -269,19 +270,19 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
   test('replace hasMany => hasOne with populated array, when already populated', function(assert) {
     const saturn = { type: 'planet', id: 'saturn',
                   attributes: { name: 'Saturn' },
-                  relationships: { moons: { data: { 'moon:titan': true } } } };
+                  relationships: { moons: { data: [{ type: 'moon', id: 'titan' }] } } };
 
     const jupiter = { type: 'planet', id: 'jupiter',
                     attributes: { name: 'Jupiter' },
-                    relationships: { moons: { data: { 'moon:europa': true } } } };
+                    relationships: { moons: { data: [{ type: 'moon', id: 'europa' }] } } };
 
     const titan = { type: 'moon', id: 'titan',
                   attributes: { name: 'Titan' },
-                  relationships: { planet: { data: 'planet:saturn' } } };
+                  relationships: { planet: { data: { type: 'planet', id: 'saturn' } } } };
 
     const europa = { type: 'moon', id: 'europa',
                   attributes: { name: 'Europa' },
-                  relationships: { planet: { data: 'planet:jupiter' } } };
+                  relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } } };
 
     cache.patch(t => [
       t.addRecord(saturn),
@@ -327,8 +328,8 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
   });
 
   test('replace hasMany => hasMany, clearing records', function(assert) {
-    const human = { type: 'inhabitant', id: 'human', relationships: { planets: { data: { 'planet:earth': true } } } };
-    const earth = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: { 'inhabitant:human': true } } } };
+    const human = { type: 'inhabitant', id: 'human', relationships: { planets: { data: [{ type: 'planet', id: 'earth' }] } } };
+    const earth = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: [{ type: 'inhabitant', id: 'human' }] } } };
 
     cache.patch(t => [
       t.addRecord(earth),
@@ -361,10 +362,10 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
   });
 
   test('replace hasMany => hasMany, replacing some records', function(assert) {
-    const human = { type: 'inhabitant', id: 'human', relationships: { planets: { data: { 'planet:earth': true } } } };
+    const human = { type: 'inhabitant', id: 'human', relationships: { planets: { data: [{ type: 'planet', id: 'earth' }] } } };
     const cat = { type: 'inhabitant', id: 'cat' };
     const dog = { type: 'inhabitant', id: 'dog' };
-    const earth = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: { 'inhabitant:human': true } } } };
+    const earth = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: [{ type: 'inhabitant', id: 'human' }] } } };
 
     cache.patch(t => [
       t.addRecord(earth),
@@ -407,19 +408,19 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
   test('remove hasOne => hasMany', function(assert) {
     const saturn = { type: 'planet', id: 'saturn',
                   attributes: { name: 'Saturn' },
-                  relationships: { moons: { data: { 'moon:titan': true } } } };
+                  relationships: { moons: { data: [{ type: 'moon', id: 'titan' }] } } };
 
     const jupiter = { type: 'planet', id: 'jupiter',
                     attributes: { name: 'Jupiter' },
-                    relationships: { moons: { data: { 'moon:europa': true } } } };
+                    relationships: { moons: { data: [{ type: 'moon', id: 'europa' }] } } };
 
     const titan = { type: 'moon', id: 'titan',
                   attributes: { name: 'Titan' },
-                  relationships: { planet: { data: 'planet:saturn' } } };
+                  relationships: { planet: { data: { type: 'planet', id: 'saturn' } } } };
 
     const europa = { type: 'moon', id: 'europa',
                   attributes: { name: 'Europa' },
-                  relationships: { planet: { data: 'planet:jupiter' } } };
+                  relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } } };
 
     cache.patch(t => [
       t.addRecord(saturn),
@@ -461,11 +462,11 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
   test('add to hasOne => hasOne', function(assert) {
     const saturn = { type: 'planet', id: 'saturn',
                   attributes: { name: 'Saturn' },
-                  relationships: { next: { data: 'planet:jupiter' } } };
+                  relationships: { next: { data: { type: 'planet', id: 'jupiter' } } } };
 
     const jupiter = { type: 'planet', id: 'jupiter',
                     attributes: { name: 'Jupiter' },
-                    relationships: { previous: { data: 'planet:saturn' } } };
+                    relationships: { previous: { data: { type: 'planet', id: 'saturn' } } } };
 
     const earth = { type: 'planet', id: 'earth',
                   attributes: { name: 'Earth' } };
@@ -509,11 +510,11 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
   test('replace hasOne => hasOne with existing value', function(assert) {
     const saturn = { type: 'planet', id: 'saturn',
                   attributes: { name: 'Saturn' },
-                  relationships: { next: { data: 'planet:jupiter' } } };
+                  relationships: { next: { data: { type: 'planet', id: 'jupiter' } } } };
 
     const jupiter = { type: 'planet', id: 'jupiter',
                     attributes: { name: 'Jupiter' },
-                    relationships: { previous: { data: 'planet:saturn' } } };
+                    relationships: { previous: { data: { type: 'planet', id: 'saturn' } } } };
 
     const earth = { type: 'planet', id: 'earth',
                   attributes: { name: 'Earth' } };
@@ -557,11 +558,11 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
   test('replace hasOne => hasOne with current existing value', function(assert) {
     const saturn = { type: 'planet', id: 'saturn',
                   attributes: { name: 'Saturn' },
-                  relationships: { next: { data: 'planet:jupiter' } } };
+                  relationships: { next: { data: { type: 'planet', id: 'jupiter' } } } };
 
     const jupiter = { type: 'planet', id: 'jupiter',
                     attributes: { name: 'Jupiter' },
-                    relationships: { previous: { data: 'planet:saturn' } } };
+                    relationships: { previous: { data: { type: 'planet', id: 'saturn' } } } };
 
     const earth = { type: 'planet', id: 'earth',
                   attributes: { name: 'Earth' } };
@@ -635,8 +636,8 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
   });
 
   test('remove from hasMany => hasMany', function(assert) {
-    const earth = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: { 'inhabitant:human': true } } } };
-    const human = { type: 'inhabitant', id: 'human', relationships: { planets: { data: { 'planet:earth': true } } } };
+    const earth = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: [{ type: 'inhabitant', id: 'human' }] } } };
+    const human = { type: 'inhabitant', id: 'human', relationships: { planets: { data: [{ type: 'planet', id: 'earth' }] } } };
 
     cache.patch(t => [
       t.addRecord(earth),
@@ -674,26 +675,24 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
   });
 
   test('replaceRecord', function(assert) {
-    const human = { type: 'inhabitant', id: 'human', relationships: { planets: { data: { 'planet:earth': true } } } };
+    const human = { type: 'inhabitant', id: 'human', relationships: { planets: { data: [{ type: 'planet', id: 'earth' }] } } };
     const cat = { type: 'inhabitant', id: 'cat' };
     const dog = { type: 'inhabitant', id: 'dog' };
     const moon = { type: 'moon', id: 'themoon' };
     const saturn = { type: 'planet', id: 'saturn',
                   attributes: { name: 'Saturn' },
-                  relationships: { next: { data: 'planet:jupiter' } } };
+                  relationships: { next: { data: { type: 'planet', id: 'jupiter' } } } };
     const jupiter = { type: 'planet', id: 'jupiter',
                     attributes: { name: 'Jupiter' },
-                    relationships: { previous: { data: 'planet:saturn' } } };
+                    relationships: { previous: { data: { type: 'planet', id: 'saturn' } } } };
     const earth = {
       type: 'planet', id: 'earth',
       relationships: {
         inhabitants: {
-          data: {
-            'inhabitant:human': true
-          }
+          data: [{ type: 'inhabitant', id: 'human' }]
         },
         next: {
-          data: 'planet:jupiter'
+          data: { type: 'planet', id: 'jupiter' }
         }
       }
     };
@@ -701,19 +700,17 @@ module('OperationProcessors - SchemaConsistencyProcessor', function(hooks) {
       type: 'planet', id: 'earth',
       relationships: {
         inhabitants: {
-          data: {
-            'inhabitant:human': true,
-            'inhabitant:cat': true,
-            'inhabitant:dog': true
-          }
+          data: [
+            { type: 'inhabitant', id: 'human' },
+            { type: 'inhabitant', id: 'cat' },
+            { type: 'inhabitant', id: 'dog' }
+          ]
         },
         moons: {
-          data: {
-            'moon:themoon': true
-          }
+          data: [{ type: 'moon', id: 'themoon' }]
         },
         next: {
-          data: 'planet:saturn'
+          data: { type: 'planet', id: 'saturn' }
         }
       }
     };

--- a/packages/@orbit/store/test/cache/relationship-accessor-test.ts
+++ b/packages/@orbit/store/test/cache/relationship-accessor-test.ts
@@ -1,0 +1,273 @@
+import {
+  Schema,
+  SchemaSettings,
+  cloneRecordIdentity
+} from '@orbit/data';
+import RelationshipAccessor from '../../src/cache/relationship-accessor';
+import Cache from '../../src/cache';
+import '../test-helper';
+
+const { module, test } = QUnit;
+
+module('RelationshipAccessor', function(hooks) {
+  let schema: Schema;
+  let cache: Cache;
+  let accessor: RelationshipAccessor;
+
+  const schemaDefinition: SchemaSettings = {
+    models: {
+      planet: {
+        attributes: {
+          name: { type: 'string' },
+          classification: { type: 'string' }
+        },
+        relationships: {
+          moons: { type: 'hasMany', model: 'moon', inverse: 'planet' },
+          inhabitants: { type: 'hasMany', model: 'inhabitant', inverse: 'planets' },
+          next: { type: 'hasOne', model: 'planet', inverse: 'previous' },
+          previous: { type: 'hasOne', model: 'planet', inverse: 'next' }
+        }
+      },
+      moon: {
+        attributes: {
+          name: { type: 'string' }
+        },
+        relationships: {
+          planet: { type: 'hasOne', model: 'planet', inverse: 'moons' }
+        }
+      },
+      inhabitant: {
+        attributes: {
+          name: { type: 'string' }
+        },
+        relationships: {
+          planets: { type: 'hasMany', model: 'planet', inverse: 'inhabitants' }
+        }
+      }
+    }
+  };
+
+  hooks.beforeEach(function() {
+    schema = new Schema(schemaDefinition);
+    cache = new Cache({ schema, processors: [] });
+  });
+
+  hooks.afterEach(function() {
+    schema = null;
+    cache = null;
+    accessor = null;
+  });
+
+  test('#addRecord can create has-one relationships', function(assert) {
+    const europa = {
+      type: 'moon', id: 'm2',
+      attributes: { name: 'Europa' },
+      relationships: {
+        planet: { data: { type: 'planet', id: 'p1'} }
+      }
+    };
+
+    accessor = new RelationshipAccessor(cache);
+
+    assert.ok(!accessor.relationshipExists(europa, 'planet', { type: 'planet', id: 'p1' }), 'relationship does not exist');
+
+    accessor.addRecord(europa);
+
+    assert.ok(accessor.relationshipExists(europa, 'planet', { type: 'planet', id: 'p1' }), 'relationship exists');
+    assert.deepEqual(accessor.relatedRecord(europa, 'planet'), { type: 'planet', id: 'p1' }, 'relatedRecord returns record identity');
+  });
+
+  test('#addRecord can create has-many relationships', function(assert) {
+    const jupiter = {
+      type: 'planet', id: 'jupiter',
+      attributes: { name: 'Europa' },
+      relationships: {
+        moons: { data: [
+          { type: 'moon', id: 'io'},
+          { type: 'moon', id: 'europa'},
+        ]}
+      }
+    };
+
+    accessor = new RelationshipAccessor(cache);
+
+    assert.ok(!accessor.relationshipExists(jupiter, 'moons', { type: 'moon', id: 'io' }), 'relationship does not exist');
+
+    accessor.addRecord(jupiter);
+
+    assert.ok(accessor.relationshipExists(jupiter, 'moons', { type: 'moon', id: 'io' }), 'relationship exists');
+    assert.ok(accessor.relationshipExists(jupiter, 'moons', { type: 'moon', id: 'europa' }), 'relationship exists');
+    assert.deepEqual(
+      accessor.relatedRecords(jupiter, 'moons'),
+      [{ type: 'moon', id: 'io' }, { type: 'moon', id: 'europa' }],
+      'relatedRecords returns record identities');
+  });
+
+  test('#replaceRecord can overwrite has-many relationships', function(assert) {
+    let jupiter = {
+      type: 'planet', id: 'jupiter',
+      relationships: {
+        moons: { data: [
+          { type: 'moon', id: 'io'},
+          { type: 'moon', id: 'europa'},
+        ]}
+      }
+    };
+
+    accessor = new RelationshipAccessor(cache);
+
+    assert.ok(!accessor.relationshipExists(jupiter, 'moons', { type: 'moon', id: 'io' }), 'relationship does not exist');
+
+    accessor.addRecord(jupiter);
+
+    assert.ok(accessor.relationshipExists(jupiter, 'moons', { type: 'moon', id: 'io' }), 'relationship exists');
+
+    let jupiter2 = {
+      type: 'planet', id: 'jupiter',
+      relationships: {
+        moons: { data: [
+          { type: 'moon', id: 'europa'},
+        ]}
+      }
+    };
+
+    accessor.replaceRecord(jupiter2);
+
+    assert.ok(!accessor.relationshipExists(jupiter, 'moons', { type: 'moon', id: 'io' }), 'relationship does not exist');
+    assert.ok(accessor.relationshipExists(jupiter, 'moons', { type: 'moon', id: 'europa' }), 'relationship exists');
+    assert.deepEqual(
+      accessor.relatedRecords(jupiter, 'moons'),
+      [{ type: 'moon', id: 'europa' }],
+      'relatedRecords returns record identities');
+  });
+
+  test('#clearRecord clears all relationships for a record', function(assert) {
+    let jupiter = {
+      type: 'planet', id: 'jupiter',
+      relationships: {
+        moons: { data: [
+          { type: 'moon', id: 'io'},
+          { type: 'moon', id: 'europa'},
+        ]}
+      }
+    };
+
+    accessor = new RelationshipAccessor(cache);
+
+    assert.ok(!accessor.relationshipExists(jupiter, 'moons', { type: 'moon', id: 'io' }), 'relationship does not exist');
+
+    accessor.addRecord(jupiter);
+
+    assert.ok(accessor.relationshipExists(jupiter, 'moons', { type: 'moon', id: 'io' }), 'relationship exists');
+
+    accessor.clearRecord(jupiter);
+
+    assert.ok(!accessor.relationshipExists(jupiter, 'moons', { type: 'moon', id: 'io' }), 'relationship does not exist');
+  });
+
+  test('#addToRelatedRecords adds members to has-many relationships', function(assert) {
+    const jupiter = {
+      type: 'planet', id: 'jupiter',
+      attributes: { name: 'Europa' },
+      relationships: {
+        moons: { data: [
+        ]}
+      }
+    };
+
+    accessor = new RelationshipAccessor(cache);
+
+    accessor.addRecord(jupiter);
+
+    assert.ok(!accessor.relationshipExists(jupiter, 'moons', { type: 'moon', id: 'io' }), 'relationship does not exist');
+
+    accessor.addToRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'io' });
+    accessor.addToRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'europa' });
+
+    assert.ok(accessor.relationshipExists(jupiter, 'moons', { type: 'moon', id: 'io' }), 'relationship exists');
+    assert.ok(accessor.relationshipExists(jupiter, 'moons', { type: 'moon', id: 'europa' }), 'relationship exists');
+    assert.deepEqual(
+      accessor.relatedRecords(jupiter, 'moons'),
+      [{ type: 'moon', id: 'io' }, { type: 'moon', id: 'europa' }],
+      'relatedRecords returns record identities');
+  });
+
+  test('#removeFromRelatedRecords removes members from has-many relationships', function(assert) {
+    const jupiter = {
+      type: 'planet', id: 'jupiter',
+      attributes: { name: 'Europa' },
+      relationships: {
+        moons: { data: [
+          { type: 'moon', id: 'io'},
+          { type: 'moon', id: 'europa'},
+        ]}
+      }
+    };
+
+    accessor = new RelationshipAccessor(cache);
+
+    accessor.addRecord(jupiter);
+
+    assert.ok(accessor.relationshipExists(jupiter, 'moons', { type: 'moon', id: 'io' }), 'relationship exists');
+    assert.ok(accessor.relationshipExists(jupiter, 'moons', { type: 'moon', id: 'europa' }), 'relationship exists');
+
+    accessor.removeFromRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'io' });
+    accessor.removeFromRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'europa' });
+
+    assert.ok(!accessor.relationshipExists(jupiter, 'moons', { type: 'moon', id: 'io' }), 'relationship does not exist');
+    assert.ok(!accessor.relationshipExists(jupiter, 'moons', { type: 'moon', id: 'europa' }), 'relationship does not exist');
+    assert.deepEqual(
+      accessor.relatedRecords(jupiter, 'moons'),
+      [],
+      'relatedRecords returns record identities');
+  });
+
+
+  test('#replaceRelatedRecord can create has-one relationships', function(assert) {
+    const europa = {
+      type: 'moon', id: 'm2',
+      attributes: { name: 'Europa' },
+      relationships: {
+        planet: { data: { type: 'planet', id: 'p1'} }
+      }
+    };
+
+    accessor = new RelationshipAccessor(cache);
+
+    accessor.addRecord(europa);
+
+    assert.ok(accessor.relationshipExists(europa, 'planet', { type: 'planet', id: 'p1' }), 'relationship exists');
+
+    accessor.replaceRelatedRecord(europa, 'planet', { type: 'planet', id: 'p2' });
+
+    assert.deepEqual(accessor.relatedRecord(europa, 'planet'), { type: 'planet', id: 'p2' }, 'relatedRecord returns record identity');
+  });
+
+  test('#replaceRelatedRecords removes members from has-many relationships', function(assert) {
+    const jupiter = {
+      type: 'planet', id: 'jupiter',
+      attributes: { name: 'Europa' },
+      relationships: {
+        moons: { data: [
+          { type: 'moon', id: 'europa'}
+        ]}
+      }
+    };
+
+    accessor = new RelationshipAccessor(cache);
+
+    accessor.addRecord(jupiter);
+
+    assert.ok(!accessor.relationshipExists(jupiter, 'moons', { type: 'moon', id: 'io' }), 'relationship does not exist');
+    assert.ok(accessor.relationshipExists(jupiter, 'moons', { type: 'moon', id: 'europa' }), 'relationship exists');
+
+    accessor.replaceRelatedRecords(jupiter, 'moons', [{ type: 'moon', id: 'io' }, { type: 'moon', id: 'europa' }]);
+
+    assert.ok(accessor.relationshipExists(jupiter, 'moons', { type: 'moon', id: 'io' }), 'relationship exists');
+    assert.ok(accessor.relationshipExists(jupiter, 'moons', { type: 'moon', id: 'europa' }), 'relationship exists');
+    assert.deepEqual(
+      accessor.relatedRecords(jupiter, 'moons'),
+      [{ type: 'moon', id: 'europa' }, { type: 'moon', id: 'io' }],
+      'relatedRecords returns record identities');
+  });
+});


### PR DESCRIPTION
Relationships will no longer be normalized to `type:id` string 
identifiers, like `planet:earth`. Instead they will remain in expanded
`{ type, id }` form, like `{ type: 'planet', id: 'earth' }`.

This change is fairly mechanical in most places, but required extensive
changes in @orbit/store, such as the introduction of a new 
RecordIdentityMap, RelationshipAccessor, and 
InverseRelationshipAccessor.