### PR TITLE
Improve globals support

### DIFF
--- a/packages/@orbit/core/src/main.ts
+++ b/packages/@orbit/core/src/main.ts
@@ -1,9 +1,25 @@
 import { uuid } from '@orbit/utils';
 
 declare const self: any;
+declare const global: any;
+
+// Establish the root object, `window` (`self`) in the browser, `global`
+// on the server, or `this` in some virtual machines. We use `self`
+// instead of `window` for `WebWorker` support.
+//
+// Source: https://github.com/jashkenas/underscore/blob/master/underscore.js#L11-L17
+//     Underscore.js 1.8.3
+//     http://underscorejs.org
+//     (c) 2009-2017 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+//     Underscore may be freely distributed under the MIT license.
+const globals = typeof self == 'object' && self.self === self && self ||
+                typeof global == 'object' && global.global === global && global ||
+                this ||
+                {};
 
 const Orbit: any = {
-  Promise: self.Promise,
+  globals,
+  Promise: globals.Promise,
   uuid
 };
 

--- a/packages/@orbit/indexeddb-bucket/src/bucket.ts
+++ b/packages/@orbit/indexeddb-bucket/src/bucket.ts
@@ -4,7 +4,6 @@ import Orbit, {
 import { assert } from '@orbit/utils';
 import { supportsIndexedDB } from './lib/indexeddb';
 
-declare const self: any;
 declare const console: any;
 
 export interface IndexedDBBucketSettings extends BucketSettings {
@@ -93,7 +92,7 @@ export default class IndexedDBBucket extends Bucket {
       if (this._db) {
         resolve(this._db);
       } else {
-        let request = self.indexedDB.open(this.dbName, this.dbVersion);
+        let request = Orbit.globals.indexedDB.open(this.dbName, this.dbVersion);
 
         request.onerror = (/* event */) => {
           console.error('error opening indexedDB', this.dbName);
@@ -149,7 +148,7 @@ export default class IndexedDBBucket extends Bucket {
     this.closeDB();
 
     return new Orbit.Promise((resolve, reject) => {
-      let request = self.indexedDB.deleteDatabase(this.dbName);
+      let request = Orbit.globals.indexedDB.deleteDatabase(this.dbName);
 
       request.onerror = (/* event */) => {
         console.error('error deleting indexedDB', this.dbName);

--- a/packages/@orbit/indexeddb-bucket/src/lib/indexeddb.ts
+++ b/packages/@orbit/indexeddb-bucket/src/lib/indexeddb.ts
@@ -1,9 +1,5 @@
-declare const self: any;
+import Orbit from '@orbit/core';
 
-export function supportsIndexedDB() {
-  try {
-    return 'indexedDB' in self && self['indexedDB'] !== null;
-  } catch (e) {
-    return false;
-  }
-};
+export function supportsIndexedDB(): boolean {
+  return !!Orbit.globals.indexedDB;
+}

--- a/packages/@orbit/indexeddb/src/lib/indexeddb.ts
+++ b/packages/@orbit/indexeddb/src/lib/indexeddb.ts
@@ -1,9 +1,5 @@
-declare const self: any;
+import Orbit from '@orbit/core';
 
-export function supportsIndexedDB() {
-  try {
-    return 'indexedDB' in self && self['indexedDB'] !== null;
-  } catch (e) {
-    return false;
-  }
-};
+export function supportsIndexedDB(): boolean {
+  return !!Orbit.globals.indexedDB;
+}

--- a/packages/@orbit/indexeddb/src/source.ts
+++ b/packages/@orbit/indexeddb/src/source.ts
@@ -15,7 +15,6 @@ import transformOperators from './lib/transform-operators';
 import { PullOperator, PullOperators } from './lib/pull-operators';
 import { supportsIndexedDB } from './lib/indexeddb';
 
-declare const self: any;
 declare const console: any;
 
 export interface IndexedDBSourceSettings extends SourceSettings {
@@ -95,7 +94,7 @@ export default class IndexedDBSource extends Source implements Pullable, Pushabl
       if (this._db) {
         resolve(this._db);
       } else {
-        let request = self.indexedDB.open(this.dbName, this.dbVersion);
+        let request = Orbit.globals.indexedDB.open(this.dbName, this.dbVersion);
 
         request.onerror = (/* event */) => {
           // console.error('error opening indexedDB', this.dbName);
@@ -154,7 +153,7 @@ export default class IndexedDBSource extends Source implements Pullable, Pushabl
     this.closeDB();
 
     return new Orbit.Promise((resolve, reject) => {
-      let request = self.indexedDB.deleteDatabase(this.dbName);
+      let request = Orbit.globals.indexedDB.deleteDatabase(this.dbName);
 
       request.onerror = (/* event */) => {
         // console.error('error deleting indexedDB', this.dbName);

--- a/packages/@orbit/jsonapi/src/jsonapi-source.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-source.ts
@@ -23,10 +23,8 @@ import { PullOperator, PullOperators } from './lib/pull-operators';
 import { getTransformRequests, TransformRequestProcessors } from './lib/transform-requests';
 import { InvalidServerResponse } from './lib/exceptions';
 
-declare const self: any;
-
-if (typeof self.fetch !== 'undefined' && Orbit.fetch === undefined) {
-  Orbit.fetch = self.fetch;
+if (typeof Orbit.globals.fetch !== 'undefined' && Orbit.fetch === undefined) {
+  Orbit.fetch = Orbit.globals.fetch;
 }
 
 export interface FetchSettings {
@@ -174,14 +172,14 @@ export default class JSONAPISource extends Source implements Pullable, Pushable 
       return new Orbit.Promise((resolve, reject) => {
         let timedOut;
 
-        let timer = self.setTimeout(() => {
+        let timer = Orbit.globals.setTimeout(() => {
           timedOut = true;
           reject(new NetworkError(`No fetch response within ${timeout}ms.`));
         }, timeout);
 
         Orbit.fetch(url, settings)
           .catch(e => {
-            self.clearTimeout(timer);
+            Orbit.globals.clearTimeout(timer);
 
             if (!timedOut) {
               return this.handleFetchError(e)
@@ -190,7 +188,7 @@ export default class JSONAPISource extends Source implements Pullable, Pushable 
             }
           })
           .then(response => {
-            self.clearTimeout(timer);
+            Orbit.globals.clearTimeout(timer);
 
             if (!timedOut) {
               return this.handleFetchResponse(response)

--- a/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
@@ -16,7 +16,6 @@ import { jsonapiResponse } from './support/jsonapi';
 import './test-helper';
 
 declare const sinon: any;
-declare const self: any;
 
 const { module, test } = QUnit;
 
@@ -136,13 +135,13 @@ module('JSONAPISource', function(hooks) {
     });
 
     test('#responseHasContent - returns true if JSONAPI media type appears anywhere in Content-Type header', function(assert) {
-      let response = new self.Response('{ data: null }', { headers: { 'Content-Type': 'application/vnd.api+json' } });
+      let response = new Orbit.globals.Response('{ data: null }', { headers: { 'Content-Type': 'application/vnd.api+json' } });
       assert.equal(source.responseHasContent(response), true, 'Accepts content that is _only_ the JSONAPI media type.');
 
-      response = new self.Response('{ data: null }', { headers: { 'Content-Type': 'application/json,application/vnd.api+json; charset=utf-8' } });
+      response = new Orbit.globals.Response('{ data: null }', { headers: { 'Content-Type': 'application/json,application/vnd.api+json; charset=utf-8' } });
       assert.equal(source.responseHasContent(response), true, 'Position of JSONAPI media type is not important.');
 
-      response = new self.Response('{ data: null }', { headers: { 'Content-Type': 'application/json' } });
+      response = new Orbit.globals.Response('{ data: null }', { headers: { 'Content-Type': 'application/json' } });
       assert.equal(source.responseHasContent(response), false, 'Plain json can not be parsed by default.');
     });
 

--- a/packages/@orbit/jsonapi/test/support/jsonapi.ts
+++ b/packages/@orbit/jsonapi/test/support/jsonapi.ts
@@ -1,7 +1,5 @@
 import Orbit from '@orbit/core';
 
-declare const self: any;
-
 export function jsonapiResponse(_options, body?, timeout?) {
   let options;
   let response;
@@ -16,17 +14,17 @@ export function jsonapiResponse(_options, body?, timeout?) {
 
   if (body) {
     options.headers['Content-Type'] = 'application/vnd.api+json';
-    response = new self.Response(JSON.stringify(body), options);
+    response = new Orbit.globals.Response(JSON.stringify(body), options);
   } else {
-    response = new self.Response(options);
+    response = new Orbit.globals.Response(options);
   }
 
   // console.log('jsonapiResponse', body, options, response.headers.get('Content-Type'));
 
   if (timeout) {
     return new Orbit.Promise((resolve, reject) => {
-        let timer = self.setTimeout(() => {
-          self.clearTimeout(timer);
+        let timer = Orbit.globals.setTimeout(() => {
+          Orbit.globals.clearTimeout(timer);
           resolve(response);
         }, timeout);
       });

--- a/packages/@orbit/jsonapi/test/support/orbit-setup.ts
+++ b/packages/@orbit/jsonapi/test/support/orbit-setup.ts
@@ -1,12 +1,11 @@
 import Orbit from '@orbit/core';
 
 declare const RSVP: any;
-declare const self: any;
 
 Orbit.Promise = RSVP.Promise;
 
 // Polyfill environment Promise to keep whatwg-fetch polyfill happy
-self.Promise = self.Promise || RSVP.Promise;
+Orbit.globals.Promise = Orbit.globals.Promise || RSVP.Promise;
 
 // Use polyfilled fetch
-Orbit.fetch = self.fetch;
+Orbit.fetch = Orbit.globals.fetch;

--- a/packages/@orbit/local-storage-bucket/src/bucket.ts
+++ b/packages/@orbit/local-storage-bucket/src/bucket.ts
@@ -4,8 +4,6 @@ import Orbit, {
 import { assert } from '@orbit/utils';
 import { supportsLocalStorage } from './lib/local-storage';
 
-declare const self: any;
-
 export interface LocalStorageBucketSettings extends BucketSettings {
   delimiter?: string;
 }
@@ -49,18 +47,18 @@ export default class LocalStorageBucket extends Bucket {
 
   getItem(key: string): Promise<any> {
     const fullKey: string = this.getFullKeyForItem(key);
-    return Orbit.Promise.resolve(JSON.parse(self.localStorage.getItem(fullKey)));
+    return Orbit.Promise.resolve(JSON.parse(Orbit.globals.localStorage.getItem(fullKey)));
   }
 
   setItem(key: string, value: any): Promise<void> {
     const fullKey: string = this.getFullKeyForItem(key);
-    self.localStorage.setItem(fullKey, JSON.stringify(value));
+    Orbit.globals.localStorage.setItem(fullKey, JSON.stringify(value));
     return Orbit.Promise.resolve();
   }
 
   removeItem(key: string): Promise<void> {
     const fullKey: string = this.getFullKeyForItem(key);
-    self.localStorage.removeItem(fullKey);
+    Orbit.globals.localStorage.removeItem(fullKey);
     return Orbit.Promise.resolve();
   }
 }

--- a/packages/@orbit/local-storage-bucket/src/lib/local-storage.ts
+++ b/packages/@orbit/local-storage-bucket/src/lib/local-storage.ts
@@ -1,9 +1,5 @@
-declare const self: any;
+import Orbit from '@orbit/core';
 
 export function supportsLocalStorage(): boolean {
-  try {
-    return 'localStorage' in self && self['localStorage'] !== null;
-  } catch (e) {
-    return false;
-  }
+  return !!Orbit.globals.localStorage;
 }

--- a/packages/@orbit/local-storage/src/lib/local-storage.ts
+++ b/packages/@orbit/local-storage/src/lib/local-storage.ts
@@ -1,9 +1,5 @@
-declare const self: any;
+import Orbit from '@orbit/core';
 
 export function supportsLocalStorage(): boolean {
-  try {
-    return 'localStorage' in self && self['localStorage'] !== null;
-  } catch (e) {
-    return false;
-  }
+  return !!Orbit.globals.localStorage;
 }

--- a/packages/@orbit/local-storage/src/lib/pull-operators.ts
+++ b/packages/@orbit/local-storage/src/lib/pull-operators.ts
@@ -7,8 +7,6 @@ import Orbit, {
 } from '@orbit/data';
 import LocalStorageSource from '../source';
 
-declare const self: any;
-
 export interface PullOperator {
   (source: LocalStorageSource, expression: QueryExpression): Promise<Transform[]>;
 }
@@ -19,7 +17,7 @@ export const PullOperators: Dict<PullOperator> = {
 
     const typeFilter = expression.type;
 
-    for (let key in self.localStorage) {
+    for (let key in Orbit.globals.localStorage) {
       if (key.indexOf(source.namespace) === 0) {
         let typesMatch = isNone(typeFilter);
 
@@ -30,7 +28,7 @@ export const PullOperators: Dict<PullOperator> = {
         }
 
         if (typesMatch) {
-          let record = JSON.parse(self.localStorage.getItem(key));
+          let record = JSON.parse(Orbit.globals.localStorage.getItem(key));
 
           operations.push({
             op: 'addRecord',
@@ -47,7 +45,7 @@ export const PullOperators: Dict<PullOperator> = {
     const operations = [];
     const requestedRecord = expression.record;
 
-    for (let key in self.localStorage) {
+    for (let key in Orbit.globals.localStorage) {
       if (key.indexOf(source.namespace) === 0) {
         let fragments = key.split(source.delimiter);
         let type = fragments[1];
@@ -55,7 +53,7 @@ export const PullOperators: Dict<PullOperator> = {
 
         if (type === requestedRecord.type &&
             id === requestedRecord.id) {
-          let record = JSON.parse(self.localStorage.getItem(key));
+          let record = JSON.parse(Orbit.globals.localStorage.getItem(key));
 
           operations.push({
             op: 'addRecord',

--- a/packages/@orbit/local-storage/src/source.ts
+++ b/packages/@orbit/local-storage/src/source.ts
@@ -15,8 +15,6 @@ import transformOperators from './lib/transform-operators';
 import { PullOperator, PullOperators } from './lib/pull-operators';
 import { supportsLocalStorage } from './lib/local-storage';
 
-declare const self: any;
-
 export interface LocalStorageSourceSettings extends SourceSettings {
   delimiter?: string;
   namespace?: string;
@@ -80,7 +78,7 @@ export default class LocalStorageSource extends Source implements Pullable, Push
   getRecord(record: RecordIdentity): Record {
     const key = this.getKeyForRecord(record);
 
-    return JSON.parse(self.localStorage.getItem(key));
+    return JSON.parse(Orbit.globals.localStorage.getItem(key));
   }
 
   putRecord(record: Record): void {
@@ -88,7 +86,7 @@ export default class LocalStorageSource extends Source implements Pullable, Push
 
     // console.log('LocalStorageSource#putRecord', key, JSON.stringify(record));
 
-    self.localStorage.setItem(key, JSON.stringify(record));
+    Orbit.globals.localStorage.setItem(key, JSON.stringify(record));
   }
 
   removeRecord(record: RecordIdentity): void {
@@ -96,7 +94,7 @@ export default class LocalStorageSource extends Source implements Pullable, Push
 
     // console.log('LocalStorageSource#removeRecord', key, JSON.stringify(record));
 
-    self.localStorage.removeItem(key);
+    Orbit.globals.localStorage.removeItem(key);
   }
 
   /////////////////////////////////////////////////////////////////////////////
@@ -104,9 +102,9 @@ export default class LocalStorageSource extends Source implements Pullable, Push
   /////////////////////////////////////////////////////////////////////////////
 
   reset(): Promise<void> {
-    for (let key in self.localStorage) {
+    for (let key in Orbit.globals.localStorage) {
       if (key.indexOf(this.namespace) === 0) {
-        self.localStorage.removeItem(key);
+        Orbit.globals.localStorage.removeItem(key);
       }
     }
     return Orbit.Promise.resolve();

--- a/packages/@orbit/local-storage/test/support/local-storage.ts
+++ b/packages/@orbit/local-storage/test/support/local-storage.ts
@@ -1,9 +1,9 @@
-declare const self: any;
+import Orbit from '@orbit/core';
 
 function getRecord(source, record) {
   let recordKey = [source.namespace, record.type, record.id].join(source.delimiter);
 
-  return JSON.parse(self.localStorage.getItem(recordKey));
+  return JSON.parse(Orbit.globals.localStorage.getItem(recordKey));
 }
 
 export function verifyLocalStorageContainsRecord(assert, source, record, ignoreFields?) {
@@ -27,7 +27,7 @@ export function verifyLocalStorageDoesNotContainRecord(assert, source, record) {
 
 export function verifyLocalStorageIsEmpty(assert, source) {
   let isEmpty = true;
-  for (let key in self.localStorage) {
+  for (let key in Orbit.globals.localStorage) {
     if (key.indexOf(source.namespace) === 0) {
       isEmpty = false;
       break;


### PR DESCRIPTION
Introduce a new `globals` member on the main `Orbit` export.
`Orbit.globals` will be assigned to either `self`, `global`, `this`, 
or `{}` (checked in that priority). This approach to globals checking
matches the one used by underscore.js.

Packages now use `Orbit.globals.x` instead of `self.x` when checking
for any global variable.

Custom overrides, such as `Orbit.Promise`, should still be done as
before.

[Closes #434]