### PR TITLE
Allow Updatable#update to return resultant data (just like Queryable)

### DIFF
--- a/packages/@orbit/data/src/record.ts
+++ b/packages/@orbit/data/src/record.ts
@@ -21,6 +21,10 @@ export interface Record extends RecordIdentity {
   relationships?: Dict<RecordRelationship>;
 }
 
+export interface RecordInitializer {
+  initializeRecord(record: Record): void;
+}
+
 export function cloneRecordIdentity(identity: RecordIdentity): RecordIdentity {
   const { type, id } = identity;
   return { type, id };

--- a/packages/@orbit/data/src/schema.ts
+++ b/packages/@orbit/data/src/schema.ts
@@ -2,7 +2,7 @@
 import Orbit from './main';
 import { assert, clone, Dict } from '@orbit/utils';
 import { evented, Evented } from '@orbit/core';
-import { Record } from './record';
+import { Record, RecordInitializer } from './record';
 
 export interface AttributeDefinition {
   type?: string;
@@ -79,7 +79,7 @@ export interface SchemaSettings {
  * @implements {Evented}
  */
 @evented
-export default class Schema implements Evented {
+export default class Schema implements Evented, RecordInitializer {
   models: Dict<ModelDefinition>;
 
   private _version: number;
@@ -202,6 +202,12 @@ export default class Schema implements Evented {
       return word.substr(0, word.length - 1);
     } else {
       return word;
+    }
+  }
+
+  initializeRecord(record: Record): void {
+    if (record.id === undefined) {
+      record.id = this.generateId(record.type);
     }
   }
 }

--- a/packages/@orbit/data/src/source-interfaces/updatable.ts
+++ b/packages/@orbit/data/src/source-interfaces/updatable.ts
@@ -38,9 +38,9 @@ export interface Updatable {
    *
    * @memberOf Updatable
    */
-  update(transformOrOperations: TransformOrOperations, options?: object, id?: string): Promise<void>;
+  update(transformOrOperations: TransformOrOperations, options?: object, id?: string): Promise<any>;
 
-  _update(transform: Transform): Promise<void>;
+  _update(transform: Transform): Promise<any>;
 }
 
 /**
@@ -99,8 +99,11 @@ export default function updatable(Klass: SourceClass): void {
 
     return fulfillInSeries(this, 'beforeUpdate', transform)
       .then(() => this._update(transform))
-      .then(() => this._transformed([transform]))
-      .then(() => settleInSeries(this, 'update', transform))
+      .then(result => {
+        return this._transformed([transform])
+          .then(() => settleInSeries(this, 'update', transform, result))
+          .then(() => result);
+      })
       .catch(error => {
         return settleInSeries(this, 'updateFail', transform, error)
           .then(() => { throw error; });

--- a/packages/@orbit/data/src/source.ts
+++ b/packages/@orbit/data/src/source.ts
@@ -109,7 +109,9 @@ export abstract class Source implements Evented, Performer {
   get transformBuilder(): TransformBuilder {
     let tb = this._transformBuilder;
     if (tb === undefined) {
-      tb = this._transformBuilder = new TransformBuilder();
+      tb = this._transformBuilder = new TransformBuilder({
+        recordInitializer: this._schema
+      });
     }
     return tb;
   }

--- a/packages/@orbit/data/src/transform-builder.ts
+++ b/packages/@orbit/data/src/transform-builder.ts
@@ -1,6 +1,7 @@
 import {
   Record,
-  RecordIdentity
+  RecordIdentity,
+  RecordInitializer
 } from './record';
 import {
   AddRecordOperation,
@@ -15,7 +16,17 @@ import {
 } from './operation';
 import { eq } from '@orbit/utils';
 
+export interface TransformBuilderSettings {
+  recordInitializer?: RecordInitializer;
+}
+
 export default class TransformBuilder {
+  private _recordInitializer: RecordInitializer;
+
+  constructor(settings: TransformBuilderSettings = {}) {
+    this._recordInitializer = settings.recordInitializer;
+  }
+
   /**
    * Instantiate a new `addRecord` operation.
    *
@@ -23,6 +34,9 @@ export default class TransformBuilder {
    * @returns {AddRecordOperation}
    */
   addRecord(record: Record): AddRecordOperation {
+    if (this._recordInitializer) {
+      this._recordInitializer.initializeRecord(record);
+    }
     return { op: 'addRecord', record};
   }
 

--- a/packages/@orbit/data/src/transform-builder.ts
+++ b/packages/@orbit/data/src/transform-builder.ts
@@ -27,6 +27,10 @@ export default class TransformBuilder {
     this._recordInitializer = settings.recordInitializer;
   }
 
+  get recordInitializer(): RecordInitializer {
+    return this._recordInitializer;
+  }
+
   /**
    * Instantiate a new `addRecord` operation.
    *

--- a/packages/@orbit/data/test/schema-test.ts
+++ b/packages/@orbit/data/test/schema-test.ts
@@ -82,4 +82,21 @@ module('Schema', function() {
 
     assert.equal(schema.generateId('moon'), 'moon-123', 'provides the default value for the ID');
   });
+
+  test('#initializeRecord', function(assert) {
+    const schema = new Schema({
+      generateId: (modelName) => `${modelName}-123`,
+
+      models: {
+        moon: {}
+      }
+    });
+
+    let moon = { type: 'moon', id: undefined };
+    schema.initializeRecord(moon);
+    assert.equal(moon.id, 'moon-123', 'generates an ID if `id` is undefined');
+
+    moon = { type: 'moon', id: '234' };
+    assert.equal(moon.id, '234', 'does not alter an `id` that is already set');
+  });
 });

--- a/packages/@orbit/data/test/source-test.ts
+++ b/packages/@orbit/data/test/source-test.ts
@@ -50,6 +50,7 @@ module('Source', function(hooks) {
     const tb = source.transformBuilder;
     assert.ok(tb, 'transformBuilder created');
     assert.strictEqual(tb, source.transformBuilder, 'transformBuilder remains the same');
+    assert.strictEqual(source.transformBuilder.recordInitializer, source.schema, 'transformBuilder uses the schema to initialize records');
   });
 
   test('it can be instantiated with a `queryBuilder` and/or `transformBuilder`', function(assert) {

--- a/packages/@orbit/data/test/transform-builder-test.ts
+++ b/packages/@orbit/data/test/transform-builder-test.ts
@@ -1,4 +1,4 @@
-import TransformBuilder from '../src/transform-builder';
+import { Record, TransformBuilder } from '../src/index';
 import './test-helper';
 
 const { module, test } = QUnit;
@@ -92,6 +92,25 @@ module('TransformBuilder', function(hooks) {
     assert.deepEqual(
       tb.replaceRelatedRecord(record, 'planet', relatedRecord),
       { op: 'replaceRelatedRecord', record, relationship: 'planet', relatedRecord }
+    );
+  });
+
+  test('#addRecord - when a recordInitializer has been set', function(assert) {
+    const recordInitializer = {
+      initializeRecord(record: Record) {
+        if (record.id === undefined) {
+          record.id = 'abc123';
+        }
+      }
+    }
+
+    tb = new TransformBuilder({ recordInitializer });
+
+    let record = { type: 'planet' };
+
+    assert.deepEqual(
+      tb.addRecord(record),
+      { op: 'addRecord', record: { type: 'planet', id: 'abc123' } }
     );
   });
 });

--- a/packages/@orbit/store/src/index.ts
+++ b/packages/@orbit/store/src/index.ts
@@ -1,2 +1,2 @@
 export { default, StoreSettings, StoreMergeOptions } from './store';
-export { default as Cache, CacheSettings } from './cache';
+export { default as Cache, CacheSettings, PatchResult, PatchResultData } from './cache';

--- a/packages/@orbit/store/test/store-test.ts
+++ b/packages/@orbit/store/test/store-test.ts
@@ -75,7 +75,7 @@ module('Store', function(hooks) {
   });
 
   test('#update - transforms the store\'s cache', function(assert) {
-    assert.expect(3);
+    assert.expect(4);
 
     const jupiter = {
       id: 'jupiter',
@@ -86,9 +86,32 @@ module('Store', function(hooks) {
     assert.equal(store.cache.records('planet').size, 0, 'cache should start empty');
 
     return store.update(t => t.addRecord(jupiter))
-      .then(() => {
+      .then((record) => {
         assert.equal(store.cache.records('planet').size, 1, 'cache should contain one planet');
         assert.deepEqual(store.cache.records('planet').get('jupiter'), jupiter, 'planet should be jupiter');
+        assert.strictEqual(record, jupiter, 'result should be returned');
+      });
+  });
+
+  test('#update - can perform multiple operations and return the results', function(assert) {
+    assert.expect(3);
+
+    const jupiter = {
+      type: 'planet',
+      attributes: { name: 'Jupiter', classification: 'gas giant' }
+    };
+
+    const earth = {
+      type: 'planet',
+      attributes: { name: 'Earth', classification: 'terrestrial' }
+    }
+
+    assert.equal(store.cache.records('planet').size, 0, 'cache should start empty');
+
+    return store.update(t => [t.addRecord(jupiter), t.addRecord(earth)])
+      .then((records) => {
+        assert.equal(store.cache.records('planet').size, 2, 'cache should contain two planets');
+        assert.deepEqual(records, [ jupiter, earth ], 'results array should be returned');
       });
   });
 


### PR DESCRIPTION
The signature of `Updatable#update` has been changed to return `Promise<any>` instead of `Promise<void>`. This improves the DX of calling `update` directly by allowing results to be returned. See #439 for motivation.

The only standard source that implements `Updatable` is the `Store`, which now returns the record, or records, that result from an update.

When performing a single update operation, the primary data will be returned directly:

```javascript
    return store.update(t => t.addRecord(jupiter))
      .then(record => {
        // record = jupiter 
      });
```

When performing an update that involves several operations, the primary data will be returned as an array:

```javascript
    return store.update(t => [t.addRecord(jupiter), t.addRecord(earth)])
      .then(records => {
        // records = [jupiter, earth]
      });
```

This change requires `Cache#patch` to return primary data results, along with inverse ops (which it had been returning). A new `PatchResult` interface is introduced to contain both.

In addition, a `RecordInitializer` interface is introduced and implemented by `Schema`. This allows the `TransformBuilder` to initialize records, including their IDs, as necessary. It's important that this happen _before_ the Transform itself is created, since transforms and their operations should be treated as immutable.