### PR TITLE
Short circuit sync, push, and update calls if possible

### DIFF
--- a/packages/@orbit/data/src/source-interfaces/syncable.ts
+++ b/packages/@orbit/data/src/source-interfaces/syncable.ts
@@ -88,9 +88,15 @@ export default function syncable(Klass: SourceClass): void {
     }
 
     return fulfillInSeries(this, 'beforeSync', transform)
-      .then(() => this._sync(transform))
-      .then(() => this._transformed([transform]))
-      .then(() => settleInSeries(this, 'sync', transform))
+      .then(() => {
+        if (this.transformLog.contains(transform.id)) {
+          return Orbit.Promise.resolve();
+        } else {
+          return this._sync(transform)
+            .then(() => this._transformed([transform]))
+            .then(() => settleInSeries(this, 'sync', transform));
+        }
+      })
       .catch(error => {
         return settleInSeries(this, 'syncFail', transform, error)
           .then(() => { throw error; });

--- a/packages/@orbit/data/test/source-interfaces/pushable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/pushable-test.ts
@@ -1,4 +1,4 @@
-import Orbit, { 
+import Orbit, {
   Source,
   pushable, isPushable,
   Transform
@@ -164,6 +164,36 @@ module('@pushable', function(hooks) {
       .then((result) => {
         assert.equal(++order, 6, 'promise resolved last');
         assert.deepEqual(result, resultingTransforms, 'applied transforms are returned on success');
+      });
+  });
+
+  test('#push should not call `_push` if the transform has been applied as a result of `beforePush` resolution', function(assert) {
+    assert.expect(2);
+
+    let order = 0;
+
+    const addRecordTransform = Transform.from({ op: 'addRecord' });
+
+    source.on('beforePush', () => {
+      assert.equal(++order, 1, 'beforePush triggered first');
+
+      // source transformed
+      source.transformLog.append(addRecordTransform.id);
+
+      return Promise.resolve();
+    });
+
+    source._push = function() {
+      assert.ok(false, '_push should not be reached');
+    };
+
+    source.on('push', () => {
+      assert.ok(false, 'push should not be reached');
+    });
+
+    return source.push(addRecordTransform)
+      .then(() => {
+        assert.equal(++order, 2, 'promise resolved last');
       });
   });
 


### PR DESCRIPTION
After `beforeX` has been settled, it’s possible that the transform has
already been applied to a source. In that case, we can avoid further
processing.

This should improve performance and consistency in pessimistic update
(i.e. blocking) scenarios.