### PR TITLE
BREAKING: Convert Query and Transform from classes to interfaces

### DIFF
--- a/packages/@orbit/coordinator/test/coordinator-test.ts
+++ b/packages/@orbit/coordinator/test/coordinator-test.ts
@@ -2,7 +2,8 @@ import Coordinator, { Strategy } from '../src/index';
 import Orbit, {
   Source,
   Transform,
-  TransformBuilder
+  TransformBuilder,
+  buildTransform
 } from '@orbit/data';
 import './test-helper';
 
@@ -12,9 +13,9 @@ const { module, test } = QUnit;
 
 module('Coordinator', function(hooks) {
   const t = new TransformBuilder();
-  const tA = new Transform([t.addRecord({ type: 'planet', id: 'a', attributes: { name: 'a' } })], null, 'a');
-  const tB = new Transform([t.addRecord({ type: 'planet', id: 'b', attributes: { name: 'b' } })], null, 'b');
-  const tC = new Transform([t.addRecord({ type: 'planet', id: 'c', attributes: { name: 'c' } })], null, 'c');
+  const tA = buildTransform([t.addRecord({ type: 'planet', id: 'a', attributes: { name: 'a' } })], null, 'a');
+  const tB = buildTransform([t.addRecord({ type: 'planet', id: 'b', attributes: { name: 'b' } })], null, 'b');
+  const tC = buildTransform([t.addRecord({ type: 'planet', id: 'c', attributes: { name: 'c' } })], null, 'c');
 
   class MySource extends Source {}
   class MyStrategy extends Strategy {}

--- a/packages/@orbit/coordinator/test/strategies/connection-strategy-test.ts
+++ b/packages/@orbit/coordinator/test/strategies/connection-strategy-test.ts
@@ -6,7 +6,8 @@ import Orbit, {
   Transform,
   TransformBuilder,
   pushable,
-  updatable
+  updatable,
+  buildTransform
 } from '@orbit/data';
 import '../test-helper';
 
@@ -16,10 +17,10 @@ const { module, test } = QUnit;
 
 module('ConnectionStrategy', function(hooks) {
   const t = new TransformBuilder();
-  const tA = new Transform([t.addRecord({ type: 'planet', id: 'a', attributes: { name: 'a' } })], null, 'a');
-  const tB = new Transform([t.addRecord({ type: 'planet', id: 'b', attributes: { name: 'b' } })], null, 'b');
-  const tC = new Transform([t.addRecord({ type: 'planet', id: 'c', attributes: { name: 'c' } })], null, 'c');
-  const tD = new Transform([t.addRecord({ type: 'planet', id: 'd', attributes: { name: 'd' } })], null, 'd');
+  const tA = buildTransform([t.addRecord({ type: 'planet', id: 'a', attributes: { name: 'a' } })], null, 'a');
+  const tB = buildTransform([t.addRecord({ type: 'planet', id: 'b', attributes: { name: 'b' } })], null, 'b');
+  const tC = buildTransform([t.addRecord({ type: 'planet', id: 'c', attributes: { name: 'c' } })], null, 'c');
+  const tD = buildTransform([t.addRecord({ type: 'planet', id: 'd', attributes: { name: 'd' } })], null, 'd');
 
   let strategy, coordinator, s1, s2;
 

--- a/packages/@orbit/coordinator/test/strategies/event-logging-strategy-test.ts
+++ b/packages/@orbit/coordinator/test/strategies/event-logging-strategy-test.ts
@@ -4,7 +4,8 @@ import Coordinator, {
 import {
   Source,
   Transform,
-  TransformBuilder
+  TransformBuilder,
+  buildTransform
 } from '@orbit/data';
 import '../test-helper';
 
@@ -14,9 +15,9 @@ const { module, test } = QUnit;
 
 module('EventLoggingStrategy', function(hooks) {
   const t = new TransformBuilder();
-  const tA = new Transform([t.addRecord({ type: 'planet', id: 'a', attributes: { name: 'a' } })], null, 'a');
-  const tB = new Transform([t.addRecord({ type: 'planet', id: 'b', attributes: { name: 'b' } })], null, 'b');
-  const tC = new Transform([t.addRecord({ type: 'planet', id: 'c', attributes: { name: 'c' } })], null, 'c');
+  const tA = buildTransform([t.addRecord({ type: 'planet', id: 'a', attributes: { name: 'a' } })], null, 'a');
+  const tB = buildTransform([t.addRecord({ type: 'planet', id: 'b', attributes: { name: 'b' } })], null, 'b');
+  const tC = buildTransform([t.addRecord({ type: 'planet', id: 'c', attributes: { name: 'c' } })], null, 'c');
 
   let eventLoggingStrategy;
 

--- a/packages/@orbit/coordinator/test/strategies/log-truncation-strategy-test.ts
+++ b/packages/@orbit/coordinator/test/strategies/log-truncation-strategy-test.ts
@@ -4,7 +4,8 @@ import Coordinator, {
 import Orbit, {
   Source,
   Transform,
-  TransformBuilder
+  TransformBuilder,
+  buildTransform
 } from '@orbit/data';
 import '../test-helper';
 
@@ -14,10 +15,10 @@ const { module, test } = QUnit;
 
 module('LogTruncationStrategy', function(hooks) {
   const t = new TransformBuilder();
-  const tA = new Transform([t.addRecord({ type: 'planet', id: 'a', attributes: { name: 'a' } })], null, 'a');
-  const tB = new Transform([t.addRecord({ type: 'planet', id: 'b', attributes: { name: 'b' } })], null, 'b');
-  const tC = new Transform([t.addRecord({ type: 'planet', id: 'c', attributes: { name: 'c' } })], null, 'c');
-  const tD = new Transform([t.addRecord({ type: 'planet', id: 'd', attributes: { name: 'd' } })], null, 'd');
+  const tA = buildTransform([t.addRecord({ type: 'planet', id: 'a', attributes: { name: 'a' } })], null, 'a');
+  const tB = buildTransform([t.addRecord({ type: 'planet', id: 'b', attributes: { name: 'b' } })], null, 'b');
+  const tC = buildTransform([t.addRecord({ type: 'planet', id: 'c', attributes: { name: 'c' } })], null, 'c');
+  const tD = buildTransform([t.addRecord({ type: 'planet', id: 'd', attributes: { name: 'd' } })], null, 'd');
 
   let logTruncationStrategy, coordinator, s1, s2, s3;
 

--- a/packages/@orbit/coordinator/test/strategies/request-strategy-test.ts
+++ b/packages/@orbit/coordinator/test/strategies/request-strategy-test.ts
@@ -6,7 +6,8 @@ import Orbit, {
   Transform,
   TransformBuilder,
   pushable,
-  updatable
+  updatable,
+  buildTransform
 } from '@orbit/data';
 import '../test-helper';
 
@@ -16,10 +17,10 @@ const { module, test } = QUnit;
 
 module('RequestStrategy', function(hooks) {
   const t = new TransformBuilder();
-  const tA = new Transform([t.addRecord({ type: 'planet', id: 'a', attributes: { name: 'a' } })], null, 'a');
-  const tB = new Transform([t.addRecord({ type: 'planet', id: 'b', attributes: { name: 'b' } })], null, 'b');
-  const tC = new Transform([t.addRecord({ type: 'planet', id: 'c', attributes: { name: 'c' } })], null, 'c');
-  const tD = new Transform([t.addRecord({ type: 'planet', id: 'd', attributes: { name: 'd' } })], null, 'd');
+  const tA = buildTransform([t.addRecord({ type: 'planet', id: 'a', attributes: { name: 'a' } })], null, 'a');
+  const tB = buildTransform([t.addRecord({ type: 'planet', id: 'b', attributes: { name: 'b' } })], null, 'b');
+  const tC = buildTransform([t.addRecord({ type: 'planet', id: 'c', attributes: { name: 'c' } })], null, 'c');
+  const tD = buildTransform([t.addRecord({ type: 'planet', id: 'd', attributes: { name: 'd' } })], null, 'd');
 
   let strategy, coordinator, s1, s2;
 

--- a/packages/@orbit/coordinator/test/strategies/sync-strategy-test.ts
+++ b/packages/@orbit/coordinator/test/strategies/sync-strategy-test.ts
@@ -5,7 +5,8 @@ import Orbit, {
   Source,
   Transform,
   TransformBuilder,
-  syncable, isSyncable
+  syncable, isSyncable,
+  buildTransform
 } from '@orbit/data';
 import '../test-helper';
 
@@ -15,10 +16,10 @@ const { module, test } = QUnit;
 
 module('SyncStrategy', function(hooks) {
   const t = new TransformBuilder();
-  const tA = new Transform([t.addRecord({ type: 'planet', id: 'a', attributes: { name: 'a' } })], null, 'a');
-  const tB = new Transform([t.addRecord({ type: 'planet', id: 'b', attributes: { name: 'b' } })], null, 'b');
-  const tC = new Transform([t.addRecord({ type: 'planet', id: 'c', attributes: { name: 'c' } })], null, 'c');
-  const tD = new Transform([t.addRecord({ type: 'planet', id: 'd', attributes: { name: 'd' } })], null, 'd');
+  const tA = buildTransform([t.addRecord({ type: 'planet', id: 'a', attributes: { name: 'a' } })], null, 'a');
+  const tB = buildTransform([t.addRecord({ type: 'planet', id: 'b', attributes: { name: 'b' } })], null, 'b');
+  const tC = buildTransform([t.addRecord({ type: 'planet', id: 'c', attributes: { name: 'c' } })], null, 'c');
+  const tD = buildTransform([t.addRecord({ type: 'planet', id: 'd', attributes: { name: 'd' } })], null, 'd');
 
   let strategy, coordinator, s1, s2;
 

--- a/packages/@orbit/data/src/index.ts
+++ b/packages/@orbit/data/src/index.ts
@@ -9,7 +9,7 @@ export { default as Query, QueryOrExpression, QueryBuilderFunc } from './query';
 export * from './record';
 export { default as Schema, AttributeDefinition, RelationshipDefinition, KeyDefinition, ModelDefinition, SchemaSettings } from './schema';
 export * from './source';
-export { default as Transform, TransformOrOperations, TransformBuilderFunc } from './transform';
+export * from './transform';
 export { default as TransformBuilder } from './transform-builder';
 export { default as pullable, Pullable, isPullable } from './source-interfaces/pullable';
 export { default as pushable, Pushable, isPushable } from './source-interfaces/pushable';

--- a/packages/@orbit/data/src/index.ts
+++ b/packages/@orbit/data/src/index.ts
@@ -5,7 +5,7 @@ export * from './operation';
 export { default as QueryBuilder } from './query-builder';
 export * from './query-expression';
 export * from './query-term';
-export { default as Query, QueryOrExpression, QueryBuilderFunc } from './query';
+export * from './query';
 export * from './record';
 export { default as Schema, AttributeDefinition, RelationshipDefinition, KeyDefinition, ModelDefinition, SchemaSettings } from './schema';
 export * from './source';

--- a/packages/@orbit/data/src/source-interfaces/pullable.ts
+++ b/packages/@orbit/data/src/source-interfaces/pullable.ts
@@ -1,7 +1,7 @@
 import { assert } from '@orbit/utils';
 import { settleInSeries, fulfillInSeries } from '@orbit/core';
 import { Source, SourceClass } from '../source';
-import Query, { QueryOrExpression } from '../query';
+import { Query, QueryOrExpression, buildQuery } from '../query';
 import { Transform } from '../transform';
 
 export const PULLABLE = '__pullable__';
@@ -84,7 +84,7 @@ export default function pullable(Klass: SourceClass): void {
   proto[PULLABLE] = true;
 
   proto.pull = function(queryOrExpression: QueryOrExpression, options?: object, id?: string): Promise<Transform[]> {
-    const query = Query.from(queryOrExpression, options, id, this.queryBuilder);
+    const query = buildQuery(queryOrExpression, options, id, this.queryBuilder);
     return this._enqueueRequest('pull', query);
   }
 

--- a/packages/@orbit/data/src/source-interfaces/pullable.ts
+++ b/packages/@orbit/data/src/source-interfaces/pullable.ts
@@ -2,7 +2,7 @@ import { assert } from '@orbit/utils';
 import { settleInSeries, fulfillInSeries } from '@orbit/core';
 import { Source, SourceClass } from '../source';
 import Query, { QueryOrExpression } from '../query';
-import Transform from '../transform';
+import { Transform } from '../transform';
 
 export const PULLABLE = '__pullable__';
 

--- a/packages/@orbit/data/src/source-interfaces/pushable.ts
+++ b/packages/@orbit/data/src/source-interfaces/pushable.ts
@@ -2,7 +2,7 @@ import Orbit from '../main';
 import { assert } from '@orbit/utils';
 import { settleInSeries, fulfillInSeries } from '@orbit/core';
 import { Source, SourceClass } from '../source';
-import Transform, { TransformOrOperations } from '../transform';
+import { Transform, TransformOrOperations, buildTransform } from '../transform';
 
 export const PUSHABLE = '__pushable__';
 
@@ -84,7 +84,7 @@ export default function pushable(Klass: SourceClass): void {
   proto[PUSHABLE] = true;
 
   proto.push = function(transformOrOperations: TransformOrOperations, options?: object, id?: string): Promise<Transform[]> {
-    const transform = Transform.from(transformOrOperations, options, id, this.transformBuilder);
+    const transform = buildTransform(transformOrOperations, options, id, this.transformBuilder);
 
     if (this.transformLog.contains(transform.id)) {
       return Orbit.Promise.resolve([]);

--- a/packages/@orbit/data/src/source-interfaces/queryable.ts
+++ b/packages/@orbit/data/src/source-interfaces/queryable.ts
@@ -1,6 +1,6 @@
 import { assert } from '@orbit/utils';
 import { settleInSeries, fulfillInSeries } from '@orbit/core';
-import Query, { QueryOrExpression } from '../query';
+import { Query, QueryOrExpression, buildQuery } from '../query';
 import { Source, SourceClass } from '../source';
 
 export const QUERYABLE = '__queryable__';
@@ -80,7 +80,7 @@ export default function queryable(Klass: SourceClass): void {
   proto[QUERYABLE] = true;
 
   proto.query = function(queryOrExpression: QueryOrExpression, options?: object, id?: string): Promise<any> {
-    const query = Query.from(queryOrExpression, options, id, this.queryBuilder);
+    const query = buildQuery(queryOrExpression, options, id, this.queryBuilder);
     return this._enqueueRequest('query', query);
   }
 

--- a/packages/@orbit/data/src/source-interfaces/syncable.ts
+++ b/packages/@orbit/data/src/source-interfaces/syncable.ts
@@ -2,7 +2,7 @@ import Orbit from '../main';
 import { assert, isArray } from '@orbit/utils';
 import { fulfillInSeries, settleInSeries } from '@orbit/core';
 import { Source, SourceClass } from '../source';
-import Transform from '../transform';
+import { Transform } from '../transform';
 
 export const SYNCABLE = '__syncable__';
 

--- a/packages/@orbit/data/src/source-interfaces/updatable.ts
+++ b/packages/@orbit/data/src/source-interfaces/updatable.ts
@@ -3,7 +3,7 @@ import { assert } from '@orbit/utils';
 import { settleInSeries, fulfillInSeries } from '@orbit/core';
 import { Operation } from '../operation';
 import { Source, SourceClass } from '../source';
-import Transform, { TransformOrOperations } from '../transform';
+import { Transform, TransformOrOperations, buildTransform } from '../transform';
 
 export const UPDATABLE = '__updatable__';
 
@@ -83,7 +83,7 @@ export default function updatable(Klass: SourceClass): void {
   proto[UPDATABLE] = true;
 
   proto.update = function(transformOrOperations: TransformOrOperations, options?: object, id?: string): Promise<any> {
-    const transform = Transform.from(transformOrOperations, options, id, this.transformBuilder);
+    const transform = buildTransform(transformOrOperations, options, id, this.transformBuilder);
 
     if (this.transformLog.contains(transform.id)) {
       return Orbit.Promise.resolve();

--- a/packages/@orbit/data/src/source.ts
+++ b/packages/@orbit/data/src/source.ts
@@ -9,7 +9,7 @@ import {
 import KeyMap from './key-map';
 import Schema from './schema';
 import QueryBuilder from './query-builder';
-import Transform from './transform';
+import { Transform } from './transform';
 import TransformBuilder from './transform-builder';
 import { assert } from '@orbit/utils';
 

--- a/packages/@orbit/data/test/query-test.ts
+++ b/packages/@orbit/data/test/query-test.ts
@@ -1,4 +1,4 @@
-import Query from '../src/query';
+import { Query, buildQuery } from '../src/query';
 import { QueryTerm } from '../src/query-term';
 import { FindRecords } from '../src/query-expression';
 import QueryBuilder from '../src/query-builder';
@@ -8,70 +8,60 @@ const { module, test } = QUnit;
 
 ///////////////////////////////////////////////////////////////////////////////
 
-module('Query', function() {
-  test('it exists', function(assert) {
+module('buildQuery', function() {
+  test('can instantiate a query from an expression', function(assert) {
     let expression: FindRecords = {
       op: 'findRecords'
     };
-    let query = new Query(expression);
+    let query = buildQuery(expression);
     assert.ok(query);
   });
 
-  test('it is assigned an `id`', function(assert) {
+  test('can instantiate a query that will be assigned an `id`', function(assert) {
     let expression: FindRecords = {
       op: 'findRecords'
     };
-    let query = new Query(expression);
+    let query = buildQuery(expression);
     assert.ok(query.id, 'query has an id');
   });
 
-  test('can be created from with all attributes specified as options', function(assert) {
+  test('can instantiate a query with an expression, options, and an id', function(assert) {
     let expression: FindRecords = {
       op: 'findRecords'
     };
     let options = { sources: { jsonapi: { include: 'comments' } }}
-    let query = new Query(expression, options, 'abc123');
+    let query = buildQuery(expression, options, 'abc123');
 
     assert.strictEqual(query.id, 'abc123', 'id was populated');
-    assert.deepEqual(query.expression, expression, 'expression was populated');
-    assert.deepEqual(query.options, options, 'options was populated');
+    assert.strictEqual(query.expression, expression, 'expression was populated');
+    assert.strictEqual(query.options, options, 'options was populated');
   });
 
-  test('.from will return a query passed into it', function(assert) {
+  test('will return a query passed into it', function(assert) {
     let expression: FindRecords = {
       op: 'findRecords'
     };
-    let query = new Query(expression);
-    assert.strictEqual(Query.from(query), query);
+    let query = buildQuery(expression);
+    assert.strictEqual(buildQuery(query), query);
   });
 
-  test('.from will create a query from an expression passed into it', function(assert) {
-    let expression: FindRecords = {
-      op: 'findRecords'
-    };
-    let query = Query.from(expression);
-    assert.ok(query instanceof Query);
-    assert.deepEqual(query.expression, expression, 'expression was populated');
-  });
-
-  test('.from will create a query using a QueryBuilder if a function is passed into it', function(assert) {
+  test('will create a query using a QueryBuilder if a function is passed into it', function(assert) {
     let qb = new QueryBuilder();
     let expression: FindRecords = {
       op: 'findRecords',
       type: 'planet'
     };
-    let query = Query.from(q => q.findRecords('planet'), null, null, qb);
-    assert.ok(query instanceof Query);
+    let query = buildQuery(q => q.findRecords('planet'), null, null, qb);
     assert.deepEqual(query.expression, expression, 'expression was populated');
   });
 
-  test('.from should call toQueryExpression() if available', function(assert) {
+  test('should call toQueryExpression() if available', function(assert) {
     let expression: FindRecords = {
       op: 'findRecords',
       type: 'planet'
     };
     let queryFactory = new QueryTerm(expression);
-    let query = Query.from(queryFactory);
+    let query = buildQuery(queryFactory);
     assert.strictEqual(query.expression, expression, 'expression was populated');
   });
 });

--- a/packages/@orbit/data/test/source-interfaces/pullable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/pullable-test.ts
@@ -1,8 +1,8 @@
 import Orbit, {
   Source,
   pullable, isPullable,
-  Transform,
-  Query
+  Query,
+  buildTransform
 } from '../../src/index';
 import '../test-helper';
 
@@ -58,8 +58,8 @@ module('@pullable', function(hooks) {
     let qe = { op: 'findRecords', type: 'planet' };
 
     const resultingTransforms = [
-      Transform.from({ op: 'addRecord' }, { op: 'addRecord' }),
-      Transform.from({ op: 'replaceRecordAttribute' })
+      buildTransform({ op: 'addRecord' }),
+      buildTransform({ op: 'replaceRecordAttribute' })
     ];
 
     source._pull = function(query) {
@@ -94,8 +94,8 @@ module('@pullable', function(hooks) {
     let qe = { op: 'findRecords', type: 'planet' };
 
     const resultingTransforms = [
-      Transform.from({ op: 'addRecord' }, { op: 'addRecord' }),
-      Transform.from({ op: 'replaceRecordAttribute' })
+      buildTransform({ op: 'addRecord' }),
+      buildTransform({ op: 'replaceRecordAttribute' })
     ];
 
     source.on('beforePull', () => {

--- a/packages/@orbit/data/test/source-interfaces/pushable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/pushable-test.ts
@@ -1,7 +1,7 @@
 import Orbit, {
   Source,
   pushable, isPushable,
-  Transform
+  buildTransform
 } from '../../src/index';
 import '../test-helper';
 
@@ -55,8 +55,8 @@ module('@pushable', function(hooks) {
 
     let order = 0;
 
-    const addRecordTransform = Transform.from({ op: 'addRecord' });
-    const replaceAttributeTransform = Transform.from({ op: 'replaceRecordAttribute' });
+    const addRecordTransform = buildTransform({ op: 'addRecord' });
+    const replaceAttributeTransform = buildTransform({ op: 'replaceRecordAttribute' });
 
     const resultingTransforms = [
       addRecordTransform,
@@ -96,7 +96,7 @@ module('@pushable', function(hooks) {
   test('#push should trigger `pushFail` event after an unsuccessful push', function(assert) {
     assert.expect(7);
 
-    const addRecordTransform = Transform.from({ op: 'addRecord' });
+    const addRecordTransform = buildTransform({ op: 'addRecord' });
 
     let order = 0;
 
@@ -128,8 +128,8 @@ module('@pushable', function(hooks) {
 
     let order = 0;
 
-    const addRecordTransform = Transform.from({ op: 'addRecord' });
-    const replaceAttributeTransform = Transform.from({ op: 'replaceRecordAttribute' });
+    const addRecordTransform = buildTransform({ op: 'addRecord' });
+    const replaceAttributeTransform = buildTransform({ op: 'replaceRecordAttribute' });
 
     const resultingTransforms = [
       addRecordTransform,
@@ -172,7 +172,7 @@ module('@pushable', function(hooks) {
 
     let order = 0;
 
-    const addRecordTransform = Transform.from({ op: 'addRecord' });
+    const addRecordTransform = buildTransform({ op: 'addRecord' });
 
     source.on('beforePush', () => {
       assert.equal(++order, 1, 'beforePush triggered first');
@@ -202,7 +202,7 @@ module('@pushable', function(hooks) {
 
     let order = 0;
 
-    const addRecordTransform = Transform.from({ op: 'addRecord' });
+    const addRecordTransform = buildTransform({ op: 'addRecord' });
 
     source.on('beforePush', () => {
       assert.equal(++order, 1, 'beforePush triggered first');

--- a/packages/@orbit/data/test/source-interfaces/queryable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/queryable-test.ts
@@ -1,7 +1,6 @@
 import Orbit, {
   Source,
   queryable, isQueryable,
-  Transform,
   Query
 } from '../../src/index';
 import '../test-helper';

--- a/packages/@orbit/data/test/source-interfaces/syncable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/syncable-test.ts
@@ -1,7 +1,7 @@
 import Orbit, {
   Source,
   syncable, isSyncable,
-  Transform
+  buildTransform
 } from '../../src/index';
 import '../test-helper';
 
@@ -71,7 +71,7 @@ module('@syncable', function(hooks) {
 
     let order = 0;
 
-    const addRecordTransform = Transform.from({ op: 'addRecord' });
+    const addRecordTransform = buildTransform({ op: 'addRecord' });
 
     source.on('beforeSync', (transform) => {
       assert.equal(++order, 1, 'beforeSync triggered first');
@@ -104,7 +104,7 @@ module('@syncable', function(hooks) {
   test('#sync should trigger `syncFail` event after an unsuccessful sync', function(assert) {
     assert.expect(7);
 
-    const addRecordTransform = Transform.from({ op: 'addRecord' });
+    const addRecordTransform = buildTransform({ op: 'addRecord' });
 
     let order = 0;
 
@@ -136,7 +136,7 @@ module('@syncable', function(hooks) {
 
     let order = 0;
 
-    const addRecordTransform = Transform.from({ op: 'addRecord' });
+    const addRecordTransform = buildTransform({ op: 'addRecord' });
 
     source.on('beforeSync', () => {
       assert.equal(++order, 1, 'beforeSync triggered first');
@@ -166,7 +166,7 @@ module('@syncable', function(hooks) {
 
     let order = 0;
 
-    const addRecordTransform = Transform.from({ op: 'addRecord' });
+    const addRecordTransform = buildTransform({ op: 'addRecord' });
 
     source.on('beforeSync', () => {
       assert.equal(++order, 1, 'beforeSync triggered first');
@@ -203,7 +203,7 @@ module('@syncable', function(hooks) {
 
     let order = 0;
 
-    const addRecordTransform = Transform.from({ op: 'addRecord' });
+    const addRecordTransform = buildTransform({ op: 'addRecord' });
 
     source.on('beforeSync', () => {
       assert.equal(++order, 1, 'beforeSync triggered first');

--- a/packages/@orbit/data/test/source-interfaces/updatable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/updatable-test.ts
@@ -1,7 +1,7 @@
 import Orbit, {
   Source,
   updatable, isUpdatable,
-  Transform
+  buildTransform
 } from '../../src/index';
 import '../test-helper';
 
@@ -55,7 +55,7 @@ module('@updatable', function(hooks) {
 
     let order = 0;
 
-    const addRecordTransform = Transform.from({ op: 'addRecord' });
+    const addRecordTransform = buildTransform({ op: 'addRecord' });
 
     source.on('beforeUpdate', (transform) => {
       assert.equal(++order, 1, 'beforeUpdate triggered first');
@@ -92,7 +92,7 @@ module('@updatable', function(hooks) {
 
     let order = 0;
 
-    const addRecordTransform = Transform.from({ op: 'addRecord' });
+    const addRecordTransform = buildTransform({ op: 'addRecord' });
 
     source.on('beforeUpdate', (transform) => {
       assert.equal(++order, 1, 'beforeUpdate triggered first');
@@ -128,7 +128,7 @@ module('@updatable', function(hooks) {
   test('#update should trigger `updateFail` event after an unsuccessful update', function(assert) {
     assert.expect(7);
 
-    const addRecordTransform = Transform.from({ op: 'addRecord' });
+    const addRecordTransform = buildTransform({ op: 'addRecord' });
 
     let order = 0;
 
@@ -160,7 +160,7 @@ module('@updatable', function(hooks) {
 
     let order = 0;
 
-    const addRecordTransform = Transform.from({ op: 'addRecord' });
+    const addRecordTransform = buildTransform({ op: 'addRecord' });
 
     source.on('beforeUpdate', () => {
       assert.equal(++order, 1, 'beforeUpdate triggered first');
@@ -197,7 +197,7 @@ module('@updatable', function(hooks) {
 
     let order = 0;
 
-    const addRecordTransform = Transform.from({ op: 'addRecord' });
+    const addRecordTransform = buildTransform({ op: 'addRecord' });
 
     source.on('beforeUpdate', () => {
       assert.equal(++order, 1, 'beforeUpdate triggered first');
@@ -227,7 +227,7 @@ module('@updatable', function(hooks) {
 
     let order = 0;
 
-    const addRecordTransform = Transform.from({ op: 'addRecord' });
+    const addRecordTransform = buildTransform({ op: 'addRecord' });
 
     source.on('beforeUpdate', () => {
       assert.equal(++order, 1, 'beforeUpdate triggered first');

--- a/packages/@orbit/data/test/source-test.ts
+++ b/packages/@orbit/data/test/source-test.ts
@@ -1,7 +1,7 @@
 import {
   Source,
   Schema,
-  Transform,
+  buildTransform,
   TransformBuilder,
   QueryBuilder
 } from '../src/index';
@@ -66,7 +66,7 @@ module('Source', function(hooks) {
 
     source = new MySource();
     let order = 0;
-    const appliedTransform = Transform.from({ op: 'addRecord' });
+    const appliedTransform = buildTransform({ op: 'addRecord' });
 
     source.on('transform', (transform) => {
       assert.equal(++order, 1, '`transform` event triggered after action performed successfully');
@@ -83,7 +83,7 @@ module('Source', function(hooks) {
     assert.expect(2);
 
     source = new MySource();
-    const appliedTransform = Transform.from({ op: 'addRecord' });
+    const appliedTransform = buildTransform({ op: 'addRecord' });
 
     assert.ok(!source.transformLog.contains(appliedTransform.id));
 

--- a/packages/@orbit/data/test/transform-test.ts
+++ b/packages/@orbit/data/test/transform-test.ts
@@ -1,40 +1,48 @@
-import Transform from '../src/transform';
+import { Transform, buildTransform } from '../src/transform';
+import TransformBuilder from '../src/transform-builder';
 import './test-helper';
 
 const { module, test } = QUnit;
 
 ///////////////////////////////////////////////////////////////////////////////
 
-module('Transform', function() {
-  test('it exists', function(assert) {
-    let transform = new Transform([]);
+module('buildTransform', function() {
+  test('can instantiate a transform from an empty array of operations', function(assert) {
+    let transform = buildTransform([]);
     assert.ok(transform);
   });
 
-  test('it is assigned an `id`', function(assert) {
-    let transform = new Transform([]);
+  test('can instantiate a transform that will be assigned an `id`', function(assert) {
+    let transform = buildTransform([]);
     assert.ok(transform.id, 'transform has an id');
   });
 
-  test('can be created from with operations, options, and an id', function(assert) {
+  test('can instantiate a transform with operations, options, and an id', function(assert) {
     let operations = [{ op: 'addRecord' }];
     let options = { sources: { jsonapi: { include: 'comments' } }}
     let id = 'abc123';
 
-    let transform = new Transform(operations, options, id);
+    let transform = buildTransform(operations, options, id);
 
     assert.strictEqual(transform.id, id, 'id was populated');
-    assert.deepEqual(transform.operations, operations, 'operations was populated');
-    assert.deepEqual(transform.options, options, 'options was populated');
+    assert.strictEqual(transform.operations, operations, 'operations was populated');
+    assert.strictEqual(transform.options, options, 'options was populated');
   });
 
-  test('.from will return a transform passed into it', function(assert) {
-    let transform = new Transform([]);
-    assert.strictEqual(Transform.from(transform), transform);
+  test('will return a transform passed into it', function(assert) {
+    let transform = buildTransform([]);
+    assert.strictEqual(buildTransform(transform), transform);
   });
 
-  test('.from will create a transform from operations passed into it', function(assert) {
-    let transform = Transform.from([{ op: 'addRecord' }, { op: 'removeRecord' }]);
-    assert.ok(transform instanceof Transform);
+  test('will create a transform using a TransformBuilder if a function is passed into it', function(assert) {
+    let tb = new TransformBuilder();
+    let planet = { type: 'planet', id: 'earth' };
+    let operation = {
+      op: 'addRecord',
+      record: planet
+    };
+
+    let query = buildTransform(t => t.addRecord(planet), null, null, tb);
+    assert.deepEqual(query.operations, [operation], 'operations was populated');
   });
 });

--- a/packages/@orbit/indexeddb/src/lib/pull-operators.ts
+++ b/packages/@orbit/indexeddb/src/lib/pull-operators.ts
@@ -3,7 +3,8 @@ import Orbit, {
   QueryExpression,
   Transform,
   FindRecord,
-  FindRecords
+  FindRecords,
+  buildTransform
 } from '@orbit/data';
 import IndexedDBSource from '../source';
 
@@ -30,7 +31,7 @@ export const PullOperators: Dict<PullOperator> = {
           });
       });
     }, Orbit.Promise.resolve())
-      .then(() => [Transform.from(operations)]);
+      .then(() => [buildTransform(operations)]);
   },
 
   findRecord(source: IndexedDBSource, expression: FindRecord): Promise<Transform[]> {
@@ -40,7 +41,7 @@ export const PullOperators: Dict<PullOperator> = {
           op: 'addRecord',
           record
         }];
-        return [Transform.from(operations)];
+        return [buildTransform(operations)];
       });
   }
 };

--- a/packages/@orbit/jsonapi/src/lib/pull-operators.ts
+++ b/packages/@orbit/jsonapi/src/lib/pull-operators.ts
@@ -11,7 +11,8 @@ import {
   FilterSpecifier,
   SortSpecifier,
   AttributeFilterSpecifier,
-  AttributeSortSpecifier
+  AttributeSortSpecifier,
+  buildTransform
 } from '@orbit/data';
 import JSONAPISource from '../jsonapi-source';
 import { DeserializedDocument } from '../jsonapi-serializer';
@@ -33,7 +34,7 @@ function deserialize(source: JSONAPISource, document: JSONAPIDocument): Transfor
     };
   });
 
-  return [Transform.from(operations)];
+  return [buildTransform(operations)];
 }
 
 export interface PullOperator {

--- a/packages/@orbit/jsonapi/src/lib/transform-requests.ts
+++ b/packages/@orbit/jsonapi/src/lib/transform-requests.ts
@@ -13,7 +13,8 @@ import {
   AddToRelatedRecordsOperation,
   RemoveFromRelatedRecordsOperation,
   ReplaceRelatedRecordOperation,
-  ReplaceRelatedRecordsOperation
+  ReplaceRelatedRecordsOperation,
+  buildTransform
 } from '@orbit/data';
 import { clone, deepSet } from '@orbit/utils';
 import JSONAPISource from '../jsonapi-source';
@@ -35,7 +36,7 @@ export const TransformRequestProcessors = {
 
         let updateOps = recordDiffs(record, updatedRecord);
         if (updateOps.length > 0) {
-          return [Transform.from(updateOps)];
+          return [buildTransform(updateOps)];
         }
       });
   },

--- a/packages/@orbit/jsonapi/test/lib/transform-requests-test.ts
+++ b/packages/@orbit/jsonapi/test/lib/transform-requests-test.ts
@@ -1,7 +1,8 @@
 import {
   Schema,
   Transform,
-  TransformBuilder
+  TransformBuilder,
+  buildTransform
 } from '@orbit/data';
 import { getTransformRequests } from '../../src/lib/transform-requests';
 import JSONAPISource from '../../src/jsonapi-source';
@@ -68,7 +69,7 @@ module('TransformRequests', function(hooks) {
     test('addRecord', function(assert) {
       const jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter' } };
 
-      const t = Transform.from(tb.addRecord(jupiter));
+      const t = buildTransform(tb.addRecord(jupiter));
 
       assert.deepEqual(getTransformRequests(source, t), [{
         op: 'addRecord',
@@ -79,7 +80,7 @@ module('TransformRequests', function(hooks) {
     test('removeRecord', function(assert) {
       const jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter' } };
 
-      const t = Transform.from(tb.removeRecord(jupiter));
+      const t = buildTransform(tb.removeRecord(jupiter));
 
       assert.deepEqual(getTransformRequests(source, t), [{
         op: 'removeRecord',
@@ -88,7 +89,7 @@ module('TransformRequests', function(hooks) {
     });
 
     test('replaceAttribute => replaceRecord', function(assert) {
-      const t = Transform.from(tb.replaceAttribute({ type: 'planet', id: 'jupiter' }, 'name', 'Earth'));
+      const t = buildTransform(tb.replaceAttribute({ type: 'planet', id: 'jupiter' }, 'name', 'Earth'));
 
       assert.deepEqual(getTransformRequests(source, t), [{
         op: 'replaceRecord',
@@ -99,7 +100,7 @@ module('TransformRequests', function(hooks) {
     test('replaceRecord', function(assert) {
       const jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter' } };
 
-      const t = Transform.from(tb.replaceRecord(jupiter));
+      const t = buildTransform(tb.replaceRecord(jupiter));
 
       assert.deepEqual(getTransformRequests(source, t), [{
         op: 'replaceRecord',
@@ -111,7 +112,7 @@ module('TransformRequests', function(hooks) {
       const jupiter = { type: 'planet', id: 'jupiter' };
       const io = { type: 'moon', id: 'io' };
 
-      const t = Transform.from(tb.addToRelatedRecords(jupiter, 'moons', io));
+      const t = buildTransform(tb.addToRelatedRecords(jupiter, 'moons', io));
 
       assert.deepEqual(getTransformRequests(source, t), [{
         op: 'addToRelatedRecords',
@@ -125,7 +126,7 @@ module('TransformRequests', function(hooks) {
       const jupiter = { type: 'planet', id: 'jupiter' };
       const io = { type: 'moon', id: 'io' };
 
-      const t = Transform.from(tb.removeFromRelatedRecords(jupiter, 'moons', io));
+      const t = buildTransform(tb.removeFromRelatedRecords(jupiter, 'moons', io));
 
       assert.deepEqual(getTransformRequests(source, t), [{
         op: 'removeFromRelatedRecords',
@@ -139,7 +140,7 @@ module('TransformRequests', function(hooks) {
       const jupiter = { type: 'planet', id: 'jupiter' };
       const io = { type: 'moon', id: 'io' };
 
-      const t = Transform.from(tb.replaceRelatedRecord(io, 'planet', jupiter));
+      const t = buildTransform(tb.replaceRelatedRecord(io, 'planet', jupiter));
 
       assert.deepEqual(getTransformRequests(source, t), [{
         op: 'replaceRecord',
@@ -158,7 +159,7 @@ module('TransformRequests', function(hooks) {
     test('replaceRelatedRecord (with null) => replaceRecord', function(assert) {
       const io = { type: 'moon', id: 'io' };
 
-      const t = Transform.from(tb.replaceRelatedRecord(io, 'planet', null));
+      const t = buildTransform(tb.replaceRelatedRecord(io, 'planet', null));
 
       assert.deepEqual(getTransformRequests(source, t), [{
         op: 'replaceRecord',
@@ -179,7 +180,7 @@ module('TransformRequests', function(hooks) {
       const io = { type: 'moon', id: 'io' };
       const europa = { type: 'moon', id: 'europa' };
 
-      const t = Transform.from(tb.replaceRelatedRecords(jupiter, 'moons', [io, europa]));
+      const t = buildTransform(tb.replaceRelatedRecords(jupiter, 'moons', [io, europa]));
 
       assert.deepEqual(getTransformRequests(source, t), [{
         op: 'replaceRecord',
@@ -199,7 +200,7 @@ module('TransformRequests', function(hooks) {
     });
 
     test('addRecord + removeRecord => []', function(assert) {
-      const t = Transform.from([
+      const t = buildTransform([
         tb.addRecord({ type: 'planet', id: 'jupiter', attributes: { name: 'Earth' } }),
         tb.removeRecord({ type: 'planet', id: 'jupiter' })
       ]);
@@ -208,7 +209,7 @@ module('TransformRequests', function(hooks) {
     });
 
     test('removeRecord + removeRecord => [removeRecord]', function(assert) {
-      const t = Transform.from([
+      const t = buildTransform([
         tb.removeRecord({ type: 'planet', id: 'jupiter' }),
         tb.removeRecord({ type: 'planet', id: 'jupiter' })
       ]);
@@ -220,7 +221,7 @@ module('TransformRequests', function(hooks) {
     });
 
     test('addRecord + replaceAttribute => [addRecord]', function(assert) {
-      const t = Transform.from([
+      const t = buildTransform([
         tb.addRecord({ type: 'planet', id: 'jupiter', attributes: { name: 'Earth' } }),
         tb.replaceAttribute({ type: 'planet', id: 'jupiter' }, 'atmosphere', 'gaseous')
       ]);
@@ -232,7 +233,7 @@ module('TransformRequests', function(hooks) {
     });
 
     test('replaceAttribute + replaceAttribute => [replaceRecord]', function(assert) {
-      const t = Transform.from([
+      const t = buildTransform([
         tb.replaceAttribute({ type: 'planet', id: 'jupiter' }, 'name', 'Earth'),
         tb.replaceAttribute({ type: 'planet', id: 'jupiter' }, 'atmosphere', 'gaseous')
       ]);
@@ -248,7 +249,7 @@ module('TransformRequests', function(hooks) {
       const io = { type: 'moon', id: 'io' };
       const europa = { type: 'moon', id: 'europa' };
 
-      const t = Transform.from([
+      const t = buildTransform([
         tb.addToRelatedRecords(jupiter, 'moons', io),
         tb.addToRelatedRecords(jupiter, 'moons', europa)
       ]);

--- a/packages/@orbit/local-storage/src/lib/pull-operators.ts
+++ b/packages/@orbit/local-storage/src/lib/pull-operators.ts
@@ -3,7 +3,8 @@ import Orbit, {
   QueryExpression,
   Transform,
   FindRecord,
-  FindRecords
+  FindRecords,
+  buildTransform
 } from '@orbit/data';
 import LocalStorageSource from '../source';
 
@@ -38,7 +39,7 @@ export const PullOperators: Dict<PullOperator> = {
       }
     }
 
-    return Orbit.Promise.resolve([Transform.from(operations)]);
+    return Orbit.Promise.resolve([buildTransform(operations)]);
   },
 
   findRecord(source: LocalStorageSource, expression: FindRecord): Promise<Transform[]> {
@@ -65,6 +66,6 @@ export const PullOperators: Dict<PullOperator> = {
       }
     }
 
-    return Orbit.Promise.resolve([Transform.from(operations)]);
+    return Orbit.Promise.resolve([buildTransform(operations)]);
   }
 };

--- a/packages/@orbit/store/src/cache.ts
+++ b/packages/@orbit/store/src/cache.ts
@@ -15,7 +15,8 @@ import {
   QueryBuilder,
   Schema,
   TransformBuilder,
-  TransformBuilderFunc
+  TransformBuilderFunc,
+  buildQuery
 } from '@orbit/data';
 import { OperationProcessor, OperationProcessorClass } from './cache/operation-processors/operation-processor';
 import CacheIntegrityProcessor from './cache/operation-processors/cache-integrity-processor';
@@ -135,7 +136,7 @@ export default class Cache implements Evented {
    @return {Object} result of query (type depends on query)
    */
   query(queryOrExpression: QueryOrExpression, options?: object, id?: string): any {
-    const query = Query.from(queryOrExpression, options, id, this._queryBuilder);
+    const query = buildQuery(queryOrExpression, options, id, this._queryBuilder);
     return this._query(query.expression);
   }
 

--- a/packages/@orbit/store/src/store.ts
+++ b/packages/@orbit/store/src/store.ts
@@ -9,7 +9,8 @@ import Orbit, {
   Updatable, updatable,
   Transform,
   TransformOrOperations,
-  coalesceRecordOperations
+  coalesceRecordOperations,
+  buildTransform
 } from '@orbit/data';
 import { Log } from '@orbit/core';
 import { assert, Dict } from '@orbit/utils';
@@ -158,7 +159,7 @@ export default class Store extends Source implements Syncable, Queryable, Updata
       ops = coalesceRecordOperations(ops);
     }
 
-    reducedTransform = new Transform(ops, options.transformOptions);
+    reducedTransform = buildTransform(ops, options.transformOptions);
 
     return this.update(reducedTransform);
   }

--- a/packages/@orbit/store/test/store-test.ts
+++ b/packages/@orbit/store/test/store-test.ts
@@ -4,7 +4,8 @@ import {
   Schema,
   SchemaSettings,
   Source,
-  Transform
+  Transform,
+  buildTransform
 } from '@orbit/data';
 import Store from '../src/store';
 import CacheIntegrityProcessor from '../src/cache/operation-processors/cache-integrity-processor';
@@ -150,7 +151,7 @@ module('Store', function(hooks) {
   test('#getTransform - returns a particular transform given an id', function(assert) {
     const recordA = { id: 'jupiter', type: 'planet', attributes: { name: 'Jupiter' } };
 
-    const addRecordATransform = Transform.from(store.transformBuilder.addRecord(recordA));
+    const addRecordATransform = buildTransform(store.transformBuilder.addRecord(recordA));
     return store.sync(addRecordATransform)
       .then(() => {
         assert.strictEqual(store.getTransform(addRecordATransform.id), addRecordATransform);
@@ -159,7 +160,7 @@ module('Store', function(hooks) {
 
   test('#getInverseOperations - returns the inverse operations for a particular transform', function(assert) {
     const recordA = { id: 'jupiter', type: 'planet', attributes: { name: 'Jupiter' } };
-    const addRecordATransform = Transform.from(store.transformBuilder.addRecord(recordA));
+    const addRecordATransform = buildTransform(store.transformBuilder.addRecord(recordA));
 
     return store.sync(addRecordATransform)
       .then(() => {
@@ -175,9 +176,9 @@ module('Store', function(hooks) {
     const recordC = { id: 'pluto', type: 'planet', attributes: { name: 'Pluto' } };
     const tb = store.transformBuilder;
 
-    const addRecordATransform = Transform.from(tb.addRecord(recordA));
-    const addRecordBTransform = Transform.from(tb.addRecord(recordB));
-    const addRecordCTransform = Transform.from(tb.addRecord(recordC));
+    const addRecordATransform = buildTransform(tb.addRecord(recordA));
+    const addRecordBTransform = buildTransform(tb.addRecord(recordB));
+    const addRecordCTransform = buildTransform(tb.addRecord(recordC));
 
     return all([
       store.sync(addRecordATransform),
@@ -202,9 +203,9 @@ module('Store', function(hooks) {
     const recordC = { id: 'pluto', type: 'planet', attributes: { name: 'Pluto' } };
     const tb = store.transformBuilder;
 
-    const addRecordATransform = Transform.from(tb.addRecord(recordA));
-    const addRecordBTransform = Transform.from(tb.addRecord(recordB));
-    const addRecordCTransform = Transform.from(tb.addRecord(recordC));
+    const addRecordATransform = buildTransform(tb.addRecord(recordA));
+    const addRecordBTransform = buildTransform(tb.addRecord(recordB));
+    const addRecordCTransform = buildTransform(tb.addRecord(recordC));
 
     return all([
       store.sync(addRecordATransform),
@@ -230,9 +231,9 @@ module('Store', function(hooks) {
     const recordC = { id: 'pluto', type: 'planet', attributes: { name: 'Pluto' } };
     const tb = store.transformBuilder;
 
-    const addRecordATransform = Transform.from(tb.addRecord(recordA));
-    const addRecordBTransform = Transform.from(tb.addRecord(recordB));
-    const addRecordCTransform = Transform.from(tb.addRecord(recordC));
+    const addRecordATransform = buildTransform(tb.addRecord(recordA));
+    const addRecordBTransform = buildTransform(tb.addRecord(recordB));
+    const addRecordCTransform = buildTransform(tb.addRecord(recordC));
 
     return all([
       store.sync(addRecordATransform),
@@ -260,9 +261,9 @@ module('Store', function(hooks) {
     const recordC = { id: 'pluto', type: 'planet', attributes: { name: 'Pluto' } };
     const tb = store.transformBuilder;
 
-    const addRecordATransform = Transform.from(tb.addRecord(recordA));
-    const addRecordBTransform = Transform.from(tb.addRecord(recordB));
-    const addRecordCTransform = Transform.from(tb.addRecord(recordC));
+    const addRecordATransform = buildTransform(tb.addRecord(recordA));
+    const addRecordBTransform = buildTransform(tb.addRecord(recordB));
+    const addRecordCTransform = buildTransform(tb.addRecord(recordC));
 
     return all([
       store.sync(addRecordATransform),
@@ -340,9 +341,9 @@ module('Store', function(hooks) {
     const recordE = { id: 'uranus', type: 'planet', attributes: { name: 'Uranus' } };
 
     const tb = store.transformBuilder;
-    const addRecordATransform = Transform.from(tb.addRecord(recordA));
-    const addRecordBTransform = Transform.from(tb.addRecord(recordB));
-    const addRecordCTransform = Transform.from(tb.addRecord(recordC));
+    const addRecordATransform = buildTransform(tb.addRecord(recordA));
+    const addRecordBTransform = buildTransform(tb.addRecord(recordB));
+    const addRecordCTransform = buildTransform(tb.addRecord(recordC));
 
     const rollbackOperations = [];
 
@@ -350,7 +351,7 @@ module('Store', function(hooks) {
       store.sync(addRecordATransform),
       store.sync(addRecordBTransform),
       store.sync(addRecordCTransform),
-      store.sync(Transform.from([
+      store.sync(buildTransform([
         tb.addRecord(recordD),
         tb.addRecord(recordE)
       ]))


### PR DESCRIPTION
In order to make queries and transforms as simple to create and serialize as possible, the `Transform` and `Query` classes have been converted to interfaces.

Also, the `buildTransform` method replaces the static `Transform.from()` and `buildQuery` replaces `Query.from()`.

Will push a new minor release to contain these changes. Probably won't affect you at all if you're using query and transform builders. 

Sorry about the constant churn as I do cleanup and finish the docs. 