### PR TITLE
Improve efficiency and correctness of KeyMap

### DIFF
--- a/packages/@orbit/data/src/key-map.ts
+++ b/packages/@orbit/data/src/key-map.ts
@@ -3,51 +3,53 @@ import { Record } from './record';
 
 /**
  * Maintains a map between records' ids and keys.
- * 
+ *
  * @export
  * @class KeyMap
  */
 export default class KeyMap {
-  private _data: Dict<any>;
+  private _idsToKeys: Dict<Dict<string>>;
+  private _keysToIds: Dict<Dict<string>>;
 
   constructor() {
-    this._data = {};
+    this._idsToKeys = {};
+    this._keysToIds = {};
   }
 
   /**
    * Return a key value given a model type, key name, and id.
-   * 
-   * @param {string} type 
-   * @param {string} keyName 
-   * @param {string} idValue 
-   * @returns {string} 
-   * 
+   *
+   * @param {string} type
+   * @param {string} keyName
+   * @param {string} idValue
+   * @returns {string}
+   *
    * @memberOf KeyMap
    */
   idToKey(type: string, keyName: string, idValue: string): string {
-    return deepGet(this._data, [type, keyName, 'idToKeyMap', idValue]);
+    return deepGet(this._idsToKeys, [type, keyName, idValue]);
   }
 
   /**
    * Return an id value given a model type, key name, and key value.
-   * 
-   * @param {string} type 
-   * @param {string} keyName 
-   * @param {string} keyValue 
-   * @returns {string} 
-   * 
+   *
+   * @param {string} type
+   * @param {string} keyName
+   * @param {string} keyValue
+   * @returns {string}
+   *
    * @memberOf KeyMap
    */
   keyToId(type: string, keyName: string, keyValue: string): string {
-    return deepGet(this._data, [type, keyName, 'keyToIdMap', keyValue]);
+    return deepGet(this._keysToIds, [type, keyName, keyValue]);
   }
 
   /**
    * Store the id and key values of a record in this key map.
-   * 
-   * @param {Record} record 
-   * @returns {void} 
-   * 
+   *
+   * @param {Record} record
+   * @returns {void}
+   *
    * @memberOf KeyMap
    */
   pushRecord(record: Record): void {
@@ -59,18 +61,18 @@ export default class KeyMap {
 
     Object.keys(keys).forEach(keyName => {
       let keyValue = keys[keyName];
-      deepSet(this._data, [type, keyName, 'idToKeyMap', id], keyValue);
-      deepSet(this._data, [type, keyName, 'keyToIdMap', keyValue], id);
+      deepSet(this._idsToKeys, [type, keyName, id], keyValue);
+      deepSet(this._keysToIds, [type, keyName, keyValue], id);
     });
   }
 
   /**
    * Given a record, find the cached id if it exists.
-   * 
-   * @param {string} type 
-   * @param {Dict<string>} keys 
-   * @returns {string} 
-   * 
+   *
+   * @param {string} type
+   * @param {Dict<string>} keys
+   * @returns {string}
+   *
    * @memberOf KeyMap
    */
   idFromKeys(type: string, keys: Dict<string>): string {

--- a/packages/@orbit/data/src/key-map.ts
+++ b/packages/@orbit/data/src/key-map.ts
@@ -55,14 +55,16 @@ export default class KeyMap {
   pushRecord(record: Record): void {
     const { type, id, keys } = record;
 
-    if (!keys) {
+    if (!keys || !id) {
       return;
     }
 
     Object.keys(keys).forEach(keyName => {
       let keyValue = keys[keyName];
-      deepSet(this._idsToKeys, [type, keyName, id], keyValue);
-      deepSet(this._keysToIds, [type, keyName, keyValue], id);
+      if (keyValue) {
+        deepSet(this._idsToKeys, [type, keyName, id], keyValue);
+        deepSet(this._keysToIds, [type, keyName, keyValue], id);
+      }
     });
   }
 

--- a/packages/@orbit/data/test/key-map-test.ts
+++ b/packages/@orbit/data/test/key-map-test.ts
@@ -24,6 +24,16 @@ module('KeyMap', function(hooks) {
     assert.equal(keyMap.idToKey('planet', 'remoteId', 'bogus'), undefined);
   });
 
+  test('#pushRecord with incomplete records', function(assert) {
+    let keyMap = new KeyMap();
+
+    keyMap.pushRecord({ type: 'planet', id: null, keys: { remoteId: 'a' } });
+    assert.strictEqual(keyMap.keyToId('planet', 'remoteId', 'a'), undefined);
+
+    keyMap.pushRecord({ type: 'planet', id: '1', keys: { remoteId: null } });
+    assert.strictEqual(keyMap.idToKey('planet', 'remoteId', '1'), undefined);
+  });
+
   test('#idFromKeys', function(assert) {
     let keyMap = new KeyMap();
 


### PR DESCRIPTION
* Avoids creating mappings when either ID or key is null / undefined
* Now uses two separate maps for `idsToKeys` and `keysToIds` to reduce the depth of sets/gets