### PR TITLE
Key mapping improvements

### DIFF
--- a/packages/@orbit/data/src/key-map.ts
+++ b/packages/@orbit/data/src/key-map.ts
@@ -12,6 +12,15 @@ export default class KeyMap {
   private _keysToIds: Dict<Dict<string>>;
 
   constructor() {
+    this.reset();
+  }
+
+  /**
+   * Resets the contents of the key map.
+   *
+   * @memberof KeyMap
+   */
+  reset(): void {
     this._idsToKeys = {};
     this._keysToIds = {};
   }

--- a/packages/@orbit/data/test/key-map-test.ts
+++ b/packages/@orbit/data/test/key-map-test.ts
@@ -4,7 +4,7 @@ import './test-helper';
 const { module, test } = QUnit;
 
 module('KeyMap', function(hooks) {
-  test('#pushRecord', function(assert) {
+  test('#pushRecord adds mappings; #keyToId and #idToKey access them', function(assert) {
     let keyMap = new KeyMap();
 
     keyMap.pushRecord({ type: 'planet', id: '1', keys: { remoteId: 'a' } });
@@ -24,7 +24,21 @@ module('KeyMap', function(hooks) {
     assert.equal(keyMap.idToKey('planet', 'remoteId', 'bogus'), undefined);
   });
 
-  test('#pushRecord with incomplete records', function(assert) {
+  test('#reset clears mappings', function(assert) {
+    let keyMap = new KeyMap();
+
+    keyMap.pushRecord({ type: 'planet', id: '1', keys: { remoteId: 'a' } });
+
+    assert.equal(keyMap.keyToId('planet', 'remoteId', 'a'), '1');
+    assert.equal(keyMap.idToKey('planet', 'remoteId', '1'), 'a');
+
+    keyMap.reset();
+
+    assert.equal(keyMap.keyToId('planet', 'remoteId', 'a'), undefined);
+    assert.equal(keyMap.idToKey('planet', 'remoteId', '1'), undefined);
+  });
+
+  test('#pushRecord does not set incomplete records', function(assert) {
     let keyMap = new KeyMap();
 
     keyMap.pushRecord({ type: 'planet', id: null, keys: { remoteId: 'a' } });
@@ -34,7 +48,7 @@ module('KeyMap', function(hooks) {
     assert.strictEqual(keyMap.idToKey('planet', 'remoteId', '1'), undefined);
   });
 
-  test('#idFromKeys', function(assert) {
+  test('#idFromKeys retrieves an id given a set of keys', function(assert) {
     let keyMap = new KeyMap();
 
     keyMap.pushRecord({ type: 'planet', id: '1', keys: { remoteId: 'a' } });

--- a/packages/@orbit/indexeddb/src/source.ts
+++ b/packages/@orbit/indexeddb/src/source.ts
@@ -184,9 +184,15 @@ export default class IndexedDBSource extends Source implements Pullable, Pushabl
         reject(request.error);
       };
 
-      request.onsuccess = function(/* event */) {
+      request.onsuccess = (/* event */) => {
         // console.log('success - getRecord', request.result);
-        resolve(request.result);
+        let record = request.result;
+
+        if (this._keyMap) {
+          this._keyMap.pushRecord(record);
+        }
+
+        resolve(record);
       };
     });
   }
@@ -203,11 +209,17 @@ export default class IndexedDBSource extends Source implements Pullable, Pushabl
         reject(request.error);
       };
 
-      request.onsuccess = function(event) {
+      request.onsuccess = (event) => {
         // console.log('success - getRecords', request.result);
         const cursor = event.target.result;
         if (cursor) {
-          records.push(cursor.value);
+          let record = cursor.value;
+
+          if (this._keyMap) {
+            this._keyMap.pushRecord(record);
+          }
+
+          records.push(record);
           cursor.continue();
         } else {
           resolve(records);
@@ -239,8 +251,12 @@ export default class IndexedDBSource extends Source implements Pullable, Pushabl
         reject(request.error);
       };
 
-      request.onsuccess = function(/* event */) {
+      request.onsuccess = (/* event */) => {
         // console.log('success - putRecord');
+        if (this._keyMap) {
+          this._keyMap.pushRecord(record);
+        }
+
         resolve();
       };
     });

--- a/packages/@orbit/local-storage/src/lib/pull-operators.ts
+++ b/packages/@orbit/local-storage/src/lib/pull-operators.ts
@@ -31,6 +31,10 @@ export const PullOperators: Dict<PullOperator> = {
         if (typesMatch) {
           let record = JSON.parse(Orbit.globals.localStorage.getItem(key));
 
+          if (source.keyMap) {
+            source.keyMap.pushRecord(record);
+          }
+
           operations.push({
             op: 'addRecord',
             record
@@ -55,6 +59,10 @@ export const PullOperators: Dict<PullOperator> = {
         if (type === requestedRecord.type &&
             id === requestedRecord.id) {
           let record = JSON.parse(Orbit.globals.localStorage.getItem(key));
+
+          if (source.keyMap) {
+            source.keyMap.pushRecord(record);
+          }
 
           operations.push({
             op: 'addRecord',

--- a/packages/@orbit/local-storage/src/source.ts
+++ b/packages/@orbit/local-storage/src/source.ts
@@ -78,13 +78,23 @@ export default class LocalStorageSource extends Source implements Pullable, Push
   getRecord(record: RecordIdentity): Record {
     const key = this.getKeyForRecord(record);
 
-    return JSON.parse(Orbit.globals.localStorage.getItem(key));
+    let result = JSON.parse(Orbit.globals.localStorage.getItem(key));
+
+    if (this._keyMap) {
+      this._keyMap.pushRecord(result);
+    }
+
+    return result;
   }
 
   putRecord(record: Record): void {
     const key = this.getKeyForRecord(record);
 
     // console.log('LocalStorageSource#putRecord', key, JSON.stringify(record));
+
+    if (this._keyMap) {
+      this._keyMap.pushRecord(record);
+    }
 
     Orbit.globals.localStorage.setItem(key, JSON.stringify(record));
   }


### PR DESCRIPTION
Introduce KeyMap#reset for clearing a key map (especially useful for testing)

Ensure that IndexedDB and LocalStorage sources add records to their key maps, if one has been assigned.