### PR TITLE
Fix issue in JSONAPISource#fetch error handling

### DIFF
--- a/packages/@orbit/jsonapi/src/jsonapi-source.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-source.ts
@@ -182,20 +182,17 @@ export default class JSONAPISource extends Source implements Pullable, Pushable 
             Orbit.globals.clearTimeout(timer);
 
             if (!timedOut) {
-              return this.handleFetchError(e)
-                .then(response => resolve(response))
-                .catch(e => reject(e));
+              return this.handleFetchError(e);
             }
           })
           .then(response => {
             Orbit.globals.clearTimeout(timer);
 
             if (!timedOut) {
-              return this.handleFetchResponse(response)
-                .then(response => resolve(response))
-                .catch(e => reject(e));
+              return this.handleFetchResponse(response);
             }
-          });
+          })
+          .then(resolve, reject);
       });
     } else {
       return Orbit.fetch(url, settings)


### PR DESCRIPTION
There was an issue in `JSONAPISource#fetch` that caused an extra `JSONAPISource#handleFetchResponse` function call with a null argument, when there is a timeout and the `Orbit#fetch` call rejects.

I noticed this while developing an Orbit app with Angular. I'm not sure how to add unit test for this without Zone.js, since the TypeError is thrown after the promise has already been rejected before the `JSONAPISource#handleFetchResponse` function call.