### PR TITLE
Add Schema#getModel

### DIFF
--- a/packages/@orbit/data/src/exception.ts
+++ b/packages/@orbit/data/src/exception.ts
@@ -104,6 +104,34 @@ export class TransformNotAllowed extends Exception {
 }
 
 /**
+ * An error occured related to the schema.
+ * 
+ * @export
+ * @class SchemaError
+ */
+export class SchemaError extends Exception {
+  public description: string;
+
+  constructor(description: string) {
+    super(`Schema error: ${description}`);
+    this.description = description;
+  }
+}
+
+
+/**
+ * A model could not be found in the schema.
+ * 
+ * @export
+ * @class ModelNotFound
+ */
+export class ModelNotFound extends SchemaError {
+  constructor(type: string) {
+    super(`Model definition for ${type} not found`);
+  }
+}
+
+/**
  * An error occurred related to a particular record.
  * 
  * @export

--- a/packages/@orbit/data/src/schema.ts
+++ b/packages/@orbit/data/src/schema.ts
@@ -108,6 +108,10 @@ export default class Schema implements Evented, RecordInitializer {
       settings.version = 1;
     }
 
+    if (settings.models === undefined) {
+      settings.models = {};
+    }
+
     this._applySettings(settings);
   }
 

--- a/packages/@orbit/data/src/schema.ts
+++ b/packages/@orbit/data/src/schema.ts
@@ -1,5 +1,6 @@
 /* eslint-disable valid-jsdoc */
 import Orbit from './main';
+import { ModelNotFound } from './exception';
 import { assert, clone, Dict } from '@orbit/utils';
 import { evented, Evented } from '@orbit/core';
 import { Record, RecordInitializer } from './record';
@@ -80,7 +81,7 @@ export interface SchemaSettings {
  */
 @evented
 export default class Schema implements Evented, RecordInitializer {
-  models: Dict<ModelDefinition>;
+  private _models: Dict<ModelDefinition>;
 
   private _version: number;
 
@@ -165,7 +166,7 @@ export default class Schema implements Evented, RecordInitializer {
 
     // Register model schemas
     if (settings.models) {
-      this.models = settings.models;
+      this._models = settings.models;
     }
   }
 
@@ -212,6 +213,19 @@ export default class Schema implements Evented, RecordInitializer {
   initializeRecord(record: Record): void {
     if (record.id === undefined) {
       record.id = this.generateId(record.type);
+    }
+  }
+
+  get models(): Dict<ModelDefinition> {
+    return this._models;
+  }
+
+  getModel(type: string): ModelDefinition {
+    let model = this.models[type];
+    if (model) {
+      return model;
+    } else {
+      throw new ModelNotFound(type);
     }
   }
 }

--- a/packages/@orbit/data/test/schema-test.ts
+++ b/packages/@orbit/data/test/schema-test.ts
@@ -29,7 +29,7 @@ module('Schema', function() {
     schema.on('upgrade', (version) => {
       assert.equal(version, 2, 'version is passed as argument');
       assert.equal(schema.version, 2, 'version === 2');
-      assert.ok(schema.models.planet.attributes.name, 'model attribute has been added');
+      assert.ok(schema.getModel('planet').attributes.name, 'model attribute has been added');
       done();
     });
 
@@ -58,6 +58,30 @@ module('Schema', function() {
     });
 
     assert.deepEqual(schema.models.planet.attributes, planetDefinition.attributes);
+  });
+
+  test('#getModel provides access to a model definition', function(assert) {
+    const planetDefinition = {
+      attributes: {
+        name: { type: 'string', defaultValue: 'Earth' }
+      }
+    };
+
+    const schema = new Schema({
+      models: {
+        planet: planetDefinition
+      }
+    });
+
+    assert.deepEqual(schema.getModel('planet').attributes, planetDefinition.attributes);
+  });
+
+  test('#getModel throws an exception if a model definition is not found', function(assert) {
+    const schema = new Schema();
+
+    assert.throws(function() {
+      schema.getModel('planet');
+    }, /Schema error: Model definition for planet not found/)
   });
 
   test('#pluralize simply adds an `s` to the end of words', function(assert) {

--- a/packages/@orbit/store/src/cache/inverse-relationship-accessor.ts
+++ b/packages/@orbit/store/src/cache/inverse-relationship-accessor.ts
@@ -79,7 +79,7 @@ export default class InverseRelationshipAccessor {
 
   relatedRecordAdded(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): void {
     if (relatedRecord) {
-      const relationshipDef = this._cache.schema.models[record.type].relationships[relationship];
+      const relationshipDef = this._cache.schema.getModel(record.type).relationships[relationship];
       if (relationshipDef.inverse) {
         const recordIdentity = cloneRecordIdentity(record);
         this.add(relatedRecord, { record: recordIdentity, relationship });
@@ -89,7 +89,7 @@ export default class InverseRelationshipAccessor {
 
   relatedRecordsAdded(record: RecordIdentity, relationship: string, relatedRecords: RecordIdentity[]): void {
     if (relatedRecords && relatedRecords.length > 0) {
-      const relationshipDef = this._cache.schema.models[record.type].relationships[relationship];
+      const relationshipDef = this._cache.schema.getModel(record.type).relationships[relationship];
       if (relationshipDef.inverse) {
         const recordIdentity = cloneRecordIdentity(record);
         relatedRecords.forEach(relatedRecord => {
@@ -100,7 +100,7 @@ export default class InverseRelationshipAccessor {
   }
 
   relatedRecordRemoved(record: RecordIdentity, relationship: string, relatedRecord?: RecordIdentity): void {
-    const relationshipDef = this._cache.schema.models[record.type].relationships[relationship];
+    const relationshipDef = this._cache.schema.getModel(record.type).relationships[relationship];
 
     if (relationshipDef.inverse) {
       if (relatedRecord === undefined) {
@@ -115,7 +115,7 @@ export default class InverseRelationshipAccessor {
   }
 
   relatedRecordsRemoved(record: RecordIdentity, relationship: string, relatedRecords?: RecordIdentity[]): void {
-    const relationshipDef = this._cache.schema.models[record.type].relationships[relationship];
+    const relationshipDef = this._cache.schema.getModel(record.type).relationships[relationship];
 
     if (relationshipDef.inverse) {
       if (relatedRecords === undefined) {

--- a/packages/@orbit/store/src/cache/operation-processors/cache-integrity-processor.ts
+++ b/packages/@orbit/store/src/cache/operation-processors/cache-integrity-processor.ts
@@ -114,7 +114,7 @@ export default class CacheIntegrityProcessor extends OperationProcessor {
     if (inverseRels.length > 0) {
       const recordIdentity = cloneRecordIdentity(record);
       inverseRels.forEach(rel => {
-        const relationshipDef = this.cache.schema.models[rel.record.type].relationships[rel.relationship];
+        const relationshipDef = this.cache.schema.getModel(rel.record.type).relationships[rel.relationship];
         if (relationshipDef.type === 'hasMany') {
           ops.push({
             op: 'removeFromRelatedRecords',

--- a/packages/@orbit/store/src/cache/operation-processors/schema-consistency-processor.ts
+++ b/packages/@orbit/store/src/cache/operation-processors/schema-consistency-processor.ts
@@ -55,7 +55,7 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
 
   _relatedRecordAdded(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): RecordOperation[] {
     const ops: RecordOperation[] = [];
-    const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
+    const relationshipDef = this.cache.schema.getModel(record.type).relationships[relationship];
     const inverseRelationship = relationshipDef.inverse;
 
     if (inverseRelationship && relatedRecord) {
@@ -67,7 +67,7 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
 
   _relatedRecordsAdded(record: RecordIdentity, relationship: string, relatedRecords: RecordIdentity[]): RecordOperation[] {
     const ops: RecordOperation[] = [];
-    const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
+    const relationshipDef = this.cache.schema.getModel(record.type).relationships[relationship];
     const inverseRelationship = relationshipDef.inverse;
 
     if (inverseRelationship && relatedRecords && relatedRecords.length > 0) {
@@ -81,7 +81,7 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
 
   _relatedRecordRemoved(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): RecordOperation[] {
     const ops: RecordOperation[] = [];
-    const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
+    const relationshipDef = this.cache.schema.getModel(record.type).relationships[relationship];
     const inverseRelationship = relationshipDef.inverse;
 
     if (inverseRelationship) {
@@ -100,7 +100,7 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
 
   _relatedRecordReplaced(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): RecordOperation[] {
     const ops: RecordOperation[] = [];
-    const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
+    const relationshipDef = this.cache.schema.getModel(record.type).relationships[relationship];
     const inverseRelationship = relationshipDef.inverse;
 
     if (inverseRelationship) {
@@ -122,7 +122,7 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
 
   _relatedRecordsRemoved(record: RecordIdentity, relationship: string, relatedRecords: RecordIdentity[]): RecordOperation[] {
     const ops: RecordOperation[] = [];
-    const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
+    const relationshipDef = this.cache.schema.getModel(record.type).relationships[relationship];
     const inverseRelationship = relationshipDef.inverse;
 
     if (inverseRelationship) {
@@ -140,7 +140,7 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
 
   _relatedRecordsReplaced(record: RecordIdentity, relationship: string, relatedRecords: RecordIdentity[]): RecordOperation[] {
     const ops: RecordOperation[] = [];
-    const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
+    const relationshipDef = this.cache.schema.getModel(record.type).relationships[relationship];
     const currentRelatedRecordsMap = this.cache.relationships.relatedRecordsMap(record, relationship);
 
     let addedRecords;
@@ -167,7 +167,7 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
     const relationships = record.relationships;
 
     if (relationships) {
-      const modelDef = this.cache.schema.models[record.type];
+      const modelDef = this.cache.schema.getModel(record.type);
       const recordIdentity = cloneRecordIdentity(record);
 
       Object.keys(relationships).forEach(relationship => {
@@ -190,7 +190,7 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
     const relationships = currentRecord && currentRecord.relationships;
 
     if (relationships) {
-      const modelDef = this.cache.schema.models[record.type];
+      const modelDef = this.cache.schema.getModel(record.type);
       const recordIdentity = cloneRecordIdentity(record);
 
       Object.keys(relationships).forEach(relationship => {
@@ -210,7 +210,7 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
     const ops: RecordOperation[] = [];
 
     if (record.relationships) {
-      const modelDef = this.cache.schema.models[record.type];
+      const modelDef = this.cache.schema.getModel(record.type);
       const recordIdentity = cloneRecordIdentity(record);
 
       for (let relationship in record.relationships) {
@@ -247,7 +247,7 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
   }
 
   _addRelationshipOp(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): RecordOperation {
-    const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
+    const relationshipDef = this.cache.schema.getModel(record.type).relationships[relationship];
     const isHasMany = relationshipDef.type === 'hasMany';
 
     return <RecordOperation>{
@@ -259,7 +259,7 @@ export default class SchemaConsistencyProcessor extends OperationProcessor {
   }
 
   _removeRelationshipOp(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): RecordOperation {
-    const relationshipDef = this.cache.schema.models[record.type].relationships[relationship];
+    const relationshipDef = this.cache.schema.getModel(record.type).relationships[relationship];
     const isHasMany = relationshipDef.type === 'hasMany';
 
     return <RecordOperation>{


### PR DESCRIPTION
Switching this API to a method allows us to give better, earlier error messages when a model definition is missing.

Schema#models is still around as a private member so its only breaking in the sense of TypeScript type errors.