### PR TITLE
Add `OrbitType` for main `Orbit` object

### DIFF
--- a/packages/@orbit/core/src/main.ts
+++ b/packages/@orbit/core/src/main.ts
@@ -17,7 +17,13 @@ const globals = typeof self == 'object' && self.self === self && self ||
                 this ||
                 {};
 
-const Orbit: any = {
+export interface OrbitType {
+  globals: any;
+  Promise: PromiseConstructor;
+  uuid: () => string;
+};
+
+const Orbit: OrbitType = {
   globals,
   Promise: globals.Promise,
   uuid

--- a/packages/@orbit/core/src/task-queue.ts
+++ b/packages/@orbit/core/src/task-queue.ts
@@ -88,7 +88,7 @@ export default class TaskQueue implements Evented {
    * @memberOf TaskQueue
    */
   constructor(target: Performer, settings: TaskQueueSettings = {}) {
-    assert('TaskQueue requires Orbit.Promise to be defined', Orbit.Promise);
+    assert('TaskQueue requires Orbit.Promise to be defined', !!Orbit.Promise);
 
     this._performer = target;
     this._name = settings.name;

--- a/packages/@orbit/core/test/task-processor-test.ts
+++ b/packages/@orbit/core/test/task-processor-test.ts
@@ -23,7 +23,7 @@ module('TaskProcessor', function() {
     assert.expect(5);
 
     const target: Performer = {
-      perform(task: Task): Promise<void> { 
+      perform(task: Task): Promise<string> {
         assert.equal(task.type, 'doSomething', 'perform invoked with task');
         assert.ok(processor.started, 'processor started');
         assert.ok(!processor.settled, 'processor not settled');
@@ -49,7 +49,7 @@ module('TaskProcessor', function() {
     assert.expect(6);
 
     const target: Performer = {
-      perform(task: Task): Promise<void> { 
+      perform(task: Task): Promise<void> {
         assert.equal(task.type, 'doSomething', 'perform invoked with task');
         assert.equal(task.data, '1', 'argument matches');
         assert.ok(processor.started, 'processor started');
@@ -73,7 +73,7 @@ module('TaskProcessor', function() {
     assert.expect(5);
 
     const target: Performer = {
-      perform(task: Task): Promise<void> { 
+      perform(task: Task): Promise<void> {
         assert.equal(task.type, 'doSomething', 'perform invoked with task');
         assert.equal(task.data, '1', 'argument matches');
         assert.ok(processor.started, 'processor started');
@@ -96,7 +96,7 @@ module('TaskProcessor', function() {
     assert.expect(8);
 
     const target: Performer = {
-      perform(task: Task): Promise<void> { 
+      perform(task: Task): Promise<string> {
         assert.equal(task.type, 'doSomething', 'perform invoked with task');
         assert.equal(task.data, '1', 'argument matches');
         assert.ok(processor.started, 'processor started');

--- a/packages/@orbit/indexeddb-bucket/src/bucket.ts
+++ b/packages/@orbit/indexeddb-bucket/src/bucket.ts
@@ -88,7 +88,7 @@ export default class IndexedDBBucket extends Bucket {
   }
 
   openDB() {
-    return new Orbit.Promise((resolve, reject) => {
+    return new Orbit.Promise<void>((resolve, reject) => {
       if (this._db) {
         resolve(this._db);
       } else {
@@ -147,7 +147,7 @@ export default class IndexedDBBucket extends Bucket {
   deleteDB() {
     this.closeDB();
 
-    return new Orbit.Promise((resolve, reject) => {
+    return new Orbit.Promise<void>((resolve, reject) => {
       let request = Orbit.globals.indexedDB.deleteDatabase(this.dbName);
 
       request.onerror = (/* event */) => {
@@ -190,7 +190,7 @@ export default class IndexedDBBucket extends Bucket {
         const transaction = this._db.transaction([this.dbStoreName], 'readwrite');
         const objectStore = transaction.objectStore(this.dbStoreName);
 
-        return new Orbit.Promise((resolve, reject) => {
+        return new Orbit.Promise<void>((resolve, reject) => {
           const request = objectStore.put(value, key);
 
           request.onerror = function(/* event */) {
@@ -209,7 +209,7 @@ export default class IndexedDBBucket extends Bucket {
   removeItem(key: string): Promise<void> {
     return this.openDB()
       .then(() => {
-        return new Orbit.Promise((resolve, reject) => {
+        return new Orbit.Promise<void>((resolve, reject) => {
           const transaction = this._db.transaction([this.dbStoreName], 'readwrite');
           const objectStore = transaction.objectStore(this.dbStoreName);
           const request = objectStore.delete(key);

--- a/packages/@orbit/jsonapi/src/jsonapi-source.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-source.ts
@@ -1,5 +1,5 @@
 /* eslint-disable valid-jsdoc */
-import Orbit, {
+import {
   KeyMap,
   RecordOperation,
   Schema,
@@ -15,7 +15,7 @@ import Orbit, {
   ServerError,
   NetworkError
 } from '@orbit/data';
-import { Log } from '@orbit/core';
+import Orbit, { Log } from '@orbit/core';
 import { assert } from '@orbit/utils';
 import JSONAPISerializer, { JSONAPISerializerSettings } from './jsonapi-serializer';
 import { encodeQueryParams } from './lib/query-params';
@@ -25,6 +25,12 @@ import { InvalidServerResponse } from './lib/exceptions';
 
 if (typeof Orbit.globals.fetch !== 'undefined' && Orbit.fetch === undefined) {
   Orbit.fetch = Orbit.globals.fetch;
+}
+
+declare module '@orbit/core/dist/types/main' {
+  interface OrbitType {
+    fetch: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
+  }
 }
 
 export interface FetchSettings {
@@ -77,8 +83,8 @@ export default class JSONAPISource extends Source implements Pullable, Pushable 
 
   constructor(settings: JSONAPISourceSettings = {}) {
     assert('JSONAPISource\'s `schema` must be specified in `settings.schema` constructor argument', !!settings.schema);
-    assert('JSONAPISource requires Orbit.Promise be defined', Orbit.Promise);
-    assert('JSONAPISource requires Orbit.fetch be defined', Orbit.fetch);
+    assert('JSONAPISource requires Orbit.Promise be defined', !!Orbit.Promise);
+    assert('JSONAPISource requires Orbit.fetch be defined', !!Orbit.fetch);
 
     settings.name = settings.name || 'jsonapi';
 


### PR DESCRIPTION
Using `any` for main `Orbit` object nullifies the compile-time benefits of the
type system. Packages can still extend the `Orbit` object with custom
properties by augmenting the `OrbitType` (see `@orbit/jsonapi` package and
`fetch` in this commit for an example).