### PR TITLE
Ensure that IndexedDB and LocalStorage sources can perform sparse updates

### DIFF
--- a/packages/@orbit/indexeddb/src/source.ts
+++ b/packages/@orbit/indexeddb/src/source.ts
@@ -8,7 +8,8 @@ import Orbit, {
   Record, RecordIdentity,
   Source, SourceSettings,
   Transform,
-  TransformOrOperations
+  TransformOrOperations,
+  RecordNotFoundException
 } from '@orbit/data';
 import { assert } from '@orbit/utils';
 import transformOperators from './lib/transform-operators';
@@ -186,13 +187,16 @@ export default class IndexedDBSource extends Source implements Pullable, Pushabl
 
       request.onsuccess = (/* event */) => {
         // console.log('success - getRecord', request.result);
-        let record = request.result;
+        let result = request.result;
 
-        if (this._keyMap) {
-          this._keyMap.pushRecord(record);
+        if (result) {
+          if (this._keyMap) {
+            this._keyMap.pushRecord(result);
+          }
+          resolve(result);
+        } else {
+          reject(new RecordNotFoundException(record.type, record.id));
         }
-
-        resolve(record);
       };
     });
   }

--- a/packages/@orbit/indexeddb/test/source-test.ts
+++ b/packages/@orbit/indexeddb/test/source-test.ts
@@ -151,6 +151,23 @@ module('IndexedDBSource', function(hooks) {
       });
   });
 
+  test('#push - replaceRecord - when record does not exist', function(assert) {
+    assert.expect(1);
+
+    let revised = {
+      type: 'planet',
+      id: 'jupiter',
+      attributes: {
+        name: 'Jupiter',
+        classification: 'gas giant',
+        revised: true
+      }
+    };
+
+    return source.push(t => t.replaceRecord(revised))
+      .then(() => verifyIndexedDBContainsRecord(assert, source, revised));
+  });
+
   test('#push - removeRecord', function(assert) {
     assert.expect(1);
 
@@ -165,6 +182,18 @@ module('IndexedDBSource', function(hooks) {
 
     return source.push(t => t.addRecord(planet))
       .then(() => source.push(t => t.removeRecord(planet)))
+      .then(() => verifyIndexedDBDoesNotContainRecord(assert, source, planet));
+  });
+
+  test('#push - removeRecord - when record does not exist', function(assert) {
+    assert.expect(1);
+
+    let planet = {
+      type: 'planet',
+      id: 'jupiter'
+    };
+
+    return source.push(t => t.removeRecord(planet))
       .then(() => verifyIndexedDBDoesNotContainRecord(assert, source, planet));
   });
 
@@ -200,6 +229,24 @@ module('IndexedDBSource', function(hooks) {
       });
   });
 
+  test('#push - replaceKey - when base record does not exist', function(assert) {
+    assert.expect(2);
+
+    let revised = {
+      type: 'planet',
+      id: 'jupiter',
+      keys: {
+        remoteId: '123'
+      }
+    };
+
+    return source.push(t => t.replaceKey({ type: 'planet', id: 'jupiter' }, 'remoteId', '123'))
+      .then(() => verifyIndexedDBContainsRecord(assert, source, revised))
+      .then(() => {
+        assert.equal(keyMap.keyToId('planet', 'remoteId', '123'), 'jupiter', 'key has been mapped');
+      });
+  });
+
   test('#push - replaceAttribute', function(assert) {
     assert.expect(1);
 
@@ -224,6 +271,21 @@ module('IndexedDBSource', function(hooks) {
 
     return source.push(t => t.addRecord(original))
       .then(() => source.push(t => t.replaceAttribute(original, 'order', 5)))
+      .then(() => verifyIndexedDBContainsRecord(assert, source, revised));
+  });
+
+  test('#push - replaceAttribute - when base record does not exist', function(assert) {
+    assert.expect(1);
+
+    let revised = {
+      type: 'planet',
+      id: 'jupiter',
+      attributes: {
+        order: 5
+      }
+    };
+
+    return source.push(t => t.replaceAttribute({ type: 'planet', id: 'jupiter' }, 'order', 5))
       .then(() => verifyIndexedDBContainsRecord(assert, source, revised));
   });
 
@@ -260,6 +322,23 @@ module('IndexedDBSource', function(hooks) {
 
     return source.push(t => t.addRecord(original))
       .then(() => source.push(t => t.addToRelatedRecords(original, 'moons', { type: 'moon', id: 'moon1' })))
+      .then(() => verifyIndexedDBContainsRecord(assert, source, revised));
+  });
+
+  test('#push - addToRelatedRecords - when base record does not exist', function(assert) {
+    assert.expect(1);
+
+    let revised = {
+      type: 'planet',
+      id: 'jupiter',
+      relationships: {
+        moons: {
+          data: [{ type: 'moon', id: 'moon1' }]
+        }
+      }
+    };
+
+    return source.push(t => t.addToRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons', { type: 'moon', id: 'moon1' }))
       .then(() => verifyIndexedDBContainsRecord(assert, source, revised));
   });
 
@@ -304,6 +383,24 @@ module('IndexedDBSource', function(hooks) {
       .then(() => verifyIndexedDBContainsRecord(assert, source, revised));
   });
 
+  test('#push - removeFromRelatedRecords - when base record does not exist', function(assert) {
+    assert.expect(1);
+
+    let revised = {
+      type: 'planet',
+      id: 'jupiter',
+      relationships: {
+        moons: {
+          data: [
+          ]
+        }
+      }
+    };
+
+    return source.push(t => t.removeFromRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons', { type: 'moon', id: 'moon2' }))
+      .then(() => verifyIndexedDBDoesNotContainRecord(assert, source, revised));
+  });
+
   test('#push - replaceRelatedRecords', function(assert) {
     assert.expect(1);
 
@@ -345,7 +442,27 @@ module('IndexedDBSource', function(hooks) {
       .then(() => verifyIndexedDBContainsRecord(assert, source, revised));
   });
 
-  test('#push - replaceRelatedRecord - record', function(assert) {
+  test('#push - replaceRelatedRecords - when base record does not exist', function(assert) {
+    assert.expect(1);
+
+    let revised = {
+      type: 'planet',
+      id: 'jupiter',
+      relationships: {
+        moons: {
+          data: [
+            { type: 'moon', id: 'moon2' },
+            { type: 'moon', id: 'moon3' }
+          ]
+        }
+      }
+    };
+
+    return source.push(t => t.replaceRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons', [{ type: 'moon', id: 'moon2' }, { type: 'moon', id: 'moon3' }]))
+      .then(() => verifyIndexedDBContainsRecord(assert, source, revised));
+  });
+
+  test('#push - replaceRelatedRecord - with record', function(assert) {
     assert.expect(1);
 
     let original = {
@@ -381,7 +498,24 @@ module('IndexedDBSource', function(hooks) {
       .then(() => verifyIndexedDBContainsRecord(assert, source, revised));
   });
 
-  test('#push - replaceRelatedRecord - null', function(assert) {
+  test('#push - replaceRelatedRecord - with record - when base record does not exist', function(assert) {
+    assert.expect(1);
+
+    let revised = {
+      type: 'planet',
+      id: 'jupiter',
+      relationships: {
+        solarSystem: {
+          data: { type: 'solarSystem', id: 'ss1' }
+        }
+      }
+    };
+
+    return source.push(t => t.replaceRelatedRecord({ type: 'planet', id: 'jupiter' }, 'solarSystem', { type: 'solarSystem', id: 'ss1' }))
+      .then(() => verifyIndexedDBContainsRecord(assert, source, revised));
+  });
+
+  test('#push - replaceRelatedRecord - with null', function(assert) {
     assert.expect(1);
 
     let original = {
@@ -414,6 +548,23 @@ module('IndexedDBSource', function(hooks) {
 
     return source.push(t => t.addRecord(original))
       .then(() => source.push(t => t.replaceRelatedRecord(original, 'solarSystem', null)))
+      .then(() => verifyIndexedDBContainsRecord(assert, source, revised));
+  });
+
+  test('#push - replaceRelatedRecord - with null - when base record does not exist', function(assert) {
+    assert.expect(1);
+
+    let revised = {
+      type: 'planet',
+      id: 'jupiter',
+      relationships: {
+        solarSystem: {
+          data: null
+        }
+      }
+    };
+
+    return source.push(t => t.replaceRelatedRecord({ type: 'planet', id: 'jupiter' }, 'solarSystem', null))
       .then(() => verifyIndexedDBContainsRecord(assert, source, revised));
   });
 

--- a/packages/@orbit/local-storage/src/lib/transform-operators.ts
+++ b/packages/@orbit/local-storage/src/lib/transform-operators.ts
@@ -58,15 +58,17 @@ export default {
 
   removeFromRelatedRecords(source: Source, operation: RemoveFromRelatedRecordsOperation) {
     let record: Record = source.getRecord(operation.record);
-    let relationships = deepGet(record, ['relationships', operation.relationship, 'data']) as RecordIdentity[];
-    if (relationships) {
-      for (let i = 0, l = relationships.length; i < l; i++) {
-        if (equalRecordIdentities(relationships[i], operation.relatedRecord)) {
-          relationships.splice(i, 1);
-          break;
+    if (record) {
+      let relationships = deepGet(record, ['relationships', operation.relationship, 'data']) as RecordIdentity[];
+      if (relationships) {
+        for (let i = 0, l = relationships.length; i < l; i++) {
+          if (equalRecordIdentities(relationships[i], operation.relatedRecord)) {
+            relationships.splice(i, 1);
+            break;
+          }
         }
+        return source.putRecord(record);
       }
-      return source.putRecord(record);
     }
   },
 

--- a/packages/@orbit/local-storage/src/source.ts
+++ b/packages/@orbit/local-storage/src/source.ts
@@ -80,7 +80,7 @@ export default class LocalStorageSource extends Source implements Pullable, Push
 
     let result = JSON.parse(Orbit.globals.localStorage.getItem(key));
 
-    if (this._keyMap) {
+    if (result && this._keyMap) {
       this._keyMap.pushRecord(result);
     }
 


### PR DESCRIPTION
Any update operation should be possible in browser storage, including
updates to records’ attributes, keys, and relationships even if those 
records are not yet present. These updates should result in a sparse 
representation of the record.