### PR TITLE
Schema validation processor

### DIFF
--- a/packages/@orbit/data/src/operation.ts
+++ b/packages/@orbit/data/src/operation.ts
@@ -128,7 +128,7 @@ export interface ReplaceRelatedRecordOperation extends Operation {
   op: 'replaceRelatedRecord';
   record: RecordIdentity;
   relationship: string;
-  relatedRecord: RecordIdentity;
+  relatedRecord: RecordIdentity | null;
 }
 
 /**

--- a/packages/@orbit/store/src/cache.ts
+++ b/packages/@orbit/store/src/cache.ts
@@ -206,6 +206,8 @@ export default class Cache implements Evented {
   }
 
   protected _applyOperation(operation: RecordOperation, result: PatchResult, primary: boolean = false) {
+    this._processors.forEach(processor => processor.validate(operation));
+
     const inverseTransform: InverseTransformFunc = InverseTransforms[ operation.op ];
     const inverseOp: RecordOperation = inverseTransform(this, operation);
 

--- a/packages/@orbit/store/src/cache.ts
+++ b/packages/@orbit/store/src/cache.ts
@@ -21,6 +21,7 @@ import {
 import { OperationProcessor, OperationProcessorClass } from './cache/operation-processors/operation-processor';
 import CacheIntegrityProcessor from './cache/operation-processors/cache-integrity-processor';
 import SchemaConsistencyProcessor from './cache/operation-processors/schema-consistency-processor';
+import SchemaValidationProcessor from './cache/operation-processors/schema-validation-processor';
 import { QueryOperators } from './cache/query-operators';
 import PatchTransforms, { PatchTransformFunc } from './cache/patch-transforms';
 import InverseTransforms, { InverseTransformFunc } from './cache/inverse-transforms';
@@ -82,7 +83,7 @@ export default class Cache implements Evented {
       recordInitializer: this._schema
     });
 
-    const processors: OperationProcessorClass[] = settings.processors ? settings.processors : [SchemaConsistencyProcessor, CacheIntegrityProcessor];
+    const processors: OperationProcessorClass[] = settings.processors ? settings.processors : [SchemaValidationProcessor, SchemaConsistencyProcessor, CacheIntegrityProcessor];
     this._processors = processors.map(Processor => new Processor(this));
 
     this.reset(settings.base);

--- a/packages/@orbit/store/src/cache/operation-processors/operation-processor.ts
+++ b/packages/@orbit/store/src/cache/operation-processors/operation-processor.ts
@@ -51,6 +51,14 @@ export abstract class OperationProcessor {
   reset(base?: Cache): void {}
 
   /**
+   * Validates an operation before processing it.
+   *
+   * @param {RecordOperation} operation
+   * @memberof OperationProcessor
+   */
+  validate(operation: RecordOperation): void {}
+
+  /**
    * Called before an `operation` has been applied.
    *
    * Returns an array of operations to be applied **BEFORE** the `operation`

--- a/packages/@orbit/store/src/cache/operation-processors/schema-validation-processor.ts
+++ b/packages/@orbit/store/src/cache/operation-processors/schema-validation-processor.ts
@@ -1,0 +1,104 @@
+import {
+  Record,
+  RecordIdentity,
+  RecordOperation,
+} from '@orbit/data';
+import { OperationProcessor } from './operation-processor';
+
+/**
+ * An operation processor that ensures that an operation is compatible with
+ * its associated schema.
+ *
+ * @export
+ * @class SchemaValidationProcessor
+ * @extends {OperationProcessor}
+ */
+export default class SchemaValidationProcessor extends OperationProcessor {
+  validate(operation: RecordOperation) {
+    switch (operation.op) {
+      case 'addRecord':
+        return this._recordAdded(operation.record);
+
+      case 'replaceRecord':
+        return this._recordReplaced(operation.record);
+
+      case 'removeRecord':
+        return this._recordRemoved(operation.record);
+
+      case 'replaceKey':
+        return this._keyReplaced(operation.record);
+
+      case 'replaceAttribute':
+        return this._attributeReplaced(operation.record);
+
+      case 'addToRelatedRecords':
+        return this._relatedRecordAdded(operation.record, operation.relationship, operation.relatedRecord);
+
+      case 'removeFromRelatedRecords':
+        return this._relatedRecordRemoved(operation.record, operation.relationship, operation.relatedRecord);
+
+      case 'replaceRelatedRecords':
+        return this._relatedRecordsReplaced(operation.record, operation.relationship, operation.relatedRecords);
+
+      case 'replaceRelatedRecord':
+        return this._relatedRecordReplaced(operation.record, operation.relationship, operation.relatedRecord);
+
+      default:
+        return;
+    }
+  }
+
+  _recordAdded(record: Record) {
+    this._validateRecord(record);
+  }
+
+  _recordReplaced(record: Record) {
+    this._validateRecord(record);
+  }
+
+  _recordRemoved(record: RecordIdentity) {
+    this._validateRecordIdentity(record);
+  }
+
+  _keyReplaced(record: RecordIdentity) {
+    this._validateRecordIdentity(record);
+  }
+
+  _attributeReplaced(record: RecordIdentity) {
+    this._validateRecordIdentity(record);
+  }
+
+  _relatedRecordAdded(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity) {
+    this._validateRecordIdentity(record);
+    this._validateRecordIdentity(relatedRecord);
+  }
+
+  _relatedRecordRemoved(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity) {
+    this._validateRecordIdentity(record);
+    this._validateRecordIdentity(relatedRecord);
+  }
+
+  _relatedRecordsReplaced(record: RecordIdentity, relationship: string, relatedRecords: RecordIdentity[]) {
+    this._validateRecordIdentity(record);
+
+    relatedRecords.forEach(record => {
+      this._validateRecordIdentity(record);
+    });
+  }
+
+  _relatedRecordReplaced(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity | null) {
+    this._validateRecordIdentity(record);
+
+    if (relatedRecord) {
+      this._validateRecordIdentity(relatedRecord);
+    }
+  }
+
+  _validateRecord(record: Record) {
+    this._validateRecordIdentity(record);
+  }
+
+  _validateRecordIdentity(record: RecordIdentity) {
+    this.cache.schema.getModel(record.type);
+  }
+}

--- a/packages/@orbit/store/test/cache/operation-processors/schema-validation-processor-test.ts
+++ b/packages/@orbit/store/test/cache/operation-processors/schema-validation-processor-test.ts
@@ -1,0 +1,129 @@
+import {
+  KeyMap,
+  Schema,
+  SchemaSettings,
+  ModelNotFound
+} from '@orbit/data';
+import Cache from '../../../src/cache';
+import SchemaValidationProcessor from '../../../src/cache/operation-processors/schema-validation-processor';
+import '../../test-helper';
+
+const { module, test } = QUnit;
+
+module('SchemaValidationProcessor', function(hooks) {
+  let schema, cache, processor;
+
+  const schemaDefinition: SchemaSettings = {
+    models: {
+      node: {
+        attributes: {
+          name: { type: 'string' },
+        },
+        relationships: {
+          parent: { type: 'hasOne', model: 'node', inverse: 'children' },
+          children: { type: 'hasMany', model: 'node', inverse: 'parent' }
+        }
+      }
+    }
+  };
+
+  const node = { type: 'node', id: '1' };
+  const unknown = { type: 'unknown', id: '?' };
+  const unknownError = new ModelNotFound('unknown');
+
+  hooks.beforeEach(function() {
+    let keyMap = new KeyMap();
+    schema = new Schema(schemaDefinition);
+    cache = new Cache({ schema, keyMap, processors: [SchemaValidationProcessor] });
+    processor = cache._processors[0];
+  });
+
+  hooks.afterEach(function() {
+    schema = null;
+    cache = null;
+    processor = null;
+  });
+
+  test('addRecord with an unknown model type', assert => {
+    assert.throws(() => {
+      cache.patch(t => t.addRecord(unknown));
+    }, unknownError);
+  });
+
+  test('replaceRecord with an unknown model type', assert => {
+    assert.throws(() => {
+      cache.patch(t => t.replaceRecord(unknown));
+    }, unknownError);
+  });
+
+  test('removeRecord with an unknown model type', assert => {
+    assert.throws(() => {
+      cache.patch(t => t.removeRecord(unknown));
+    }, unknownError);
+  });
+
+  test('replaceKey with an unknown model type', assert => {
+    assert.throws(() => {
+      cache.patch(t => t.replaceKey(unknown, 'key', 'value'));
+    }, unknownError);
+  });
+
+  test('replaceAttribute with an unknown model type', assert => {
+    assert.throws(() => {
+      cache.patch(t => t.replaceAttribute(unknown, 'attribute', 'value'));
+    }, unknownError);
+  });
+
+  test('addToRelatedRecords with an unknown model type', assert => {
+    assert.throws(() => {
+      cache.patch(t => t.addToRelatedRecords(unknown, 'children', node));
+    }, unknownError);
+  });
+
+  test('addToRelatedRecords with an unknown related model type', assert => {
+    assert.throws(() => {
+      cache.patch(t => t.addToRelatedRecords(node, 'children', unknown));
+    }, unknownError);
+  });
+
+  test('removeFromRelatedRecords with an unknown model type', assert => {
+    assert.throws(() => {
+      cache.patch(t => t.removeFromRelatedRecords(unknown, 'children', node));
+    }, unknownError);
+  });
+
+  test('removeFromRelatedRecords with an unknown related model type', assert => {
+    assert.throws(() => {
+      cache.patch(t => t.removeFromRelatedRecords(node, 'children', unknown));
+    }, unknownError);
+  });
+
+  test('replaceRelatedRecords with an unknown model type', assert => {
+    assert.throws(() => {
+      cache.patch(t => t.replaceRelatedRecords(unknown, 'children', [node]));
+    }, unknownError);
+  });
+
+  test('replaceRelatedRecords with an unknown related model type', assert => {
+    assert.throws(() => {
+      cache.patch(t => t.replaceRelatedRecords(node, 'children', [unknown]));
+    }, unknownError);
+  });
+
+  test('replaceRelatedRecord with an unknown model type', assert => {
+    assert.throws(() => {
+      cache.patch(t => t.replaceRelatedRecord(unknown, 'parent', node));
+    }, unknownError);
+  });
+
+  test('replaceRelatedRecord with an unknown related model type', assert => {
+    assert.throws(() => {
+      cache.patch(t => t.replaceRelatedRecord(node, 'parent', unknown));
+    }, unknownError);
+  });
+
+  test('replaceRelatedRecord with a null related model', assert => {
+    cache.patch(t => t.replaceRelatedRecord(node, 'parent', null));
+    assert.ok(true, 'no error is thrown');
+  });
+});


### PR DESCRIPTION
This new operations processor leverages a new validate hook (also added in this PR) to validate whether an operation is compatible with the schema.  With this implementation we only check that the record's type has an associated model definition in the schema, but in the future we may want to validate relationships and attributes.

I also fixed a type that was unexpectedly popping up null in the tests.