### PR TITLE
JSONAPISerializer should ignore attrs/rels not defined in the schema

### DIFF
--- a/packages/@orbit/data/src/schema.ts
+++ b/packages/@orbit/data/src/schema.ts
@@ -228,4 +228,22 @@ export default class Schema implements Evented, RecordInitializer {
       throw new ModelNotFound(type);
     }
   }
+
+  hasAttribute(type: string, attribute: string): boolean {
+    let model = this.getModel(type);
+    if (model.attributes && model.attributes[attribute]) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  hasRelationship(type: string, relationship: string): boolean {
+    let model = this.getModel(type);
+    if (model.relationships && model.relationships[relationship]) {
+      return true;
+    } else {
+      return false;
+    }
+  }
 }

--- a/packages/@orbit/data/test/schema-test.ts
+++ b/packages/@orbit/data/test/schema-test.ts
@@ -83,6 +83,37 @@ module('Schema', function() {
       schema.getModel('planet');
     }, /Schema error: Model definition for planet not found/)
   });
+  
+  test('#hasAttribute', function(assert) {
+    const schema = new Schema({
+      models: {
+        planet: {
+          attributes: {
+            name: { type: 'string', defaultValue: 'Earth' }
+          }
+        }
+      }
+    });
+
+    assert.equal(schema.hasAttribute('planet', 'name'), true);
+    assert.equal(schema.hasAttribute('planet', 'unknown'), false);
+  });
+
+  test('#hasRelationship', function(assert) {
+    const schema = new Schema({
+      models: {
+        planet: {
+          relationships: {
+            moons: { type: 'hasMany', model: 'moon' },
+          }
+        },
+        moon: {}
+      },
+    });
+
+    assert.equal(schema.hasRelationship('planet', 'moons'), true);
+    assert.equal(schema.hasRelationship('planet', 'unknown'), false);
+  });
 
   test('#pluralize simply adds an `s` to the end of words', function(assert) {
     const schema = new Schema();

--- a/packages/@orbit/jsonapi/src/jsonapi-serializer.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-serializer.ts
@@ -248,10 +248,10 @@ export default class JSONAPISerializer {
   deserializeAttributes(record: Record, resource: Resource): void {
     if (resource.attributes) {
       Object.keys(resource.attributes).forEach(resourceAttribute => {
-        var value = resource.attributes[resourceAttribute];
-        if (value !== undefined) {
-          let attr = this.recordAttribute(record.type, resourceAttribute);
-          this.deserializeAttribute(record, attr, value);
+        let attribute = this.recordAttribute(record.type, resourceAttribute);
+        if (this.schema.hasAttribute(record.type, attribute)) {
+          let value = resource.attributes[resourceAttribute];
+          this.deserializeAttribute(record, attribute, value);
         }
       });
     }
@@ -265,9 +265,9 @@ export default class JSONAPISerializer {
   deserializeRelationships(record: Record, resource: Resource): void {
     if (resource.relationships) {
       Object.keys(resource.relationships).forEach(resourceRel => {
-        let value: ResourceRelationship = resource.relationships[resourceRel];
-        if (value !== undefined) {
-          let relationship = this.recordRelationship(record.type, resourceRel);
+        let relationship = this.recordRelationship(record.type, resourceRel);
+        if (this.schema.hasRelationship(record.type, relationship)) {
+          let value = resource.relationships[resourceRel];
           this.deserializeRelationship(record, relationship, value);
         }
       });

--- a/packages/@orbit/jsonapi/test/jsonapi-serializer-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-serializer-test.ts
@@ -527,5 +527,42 @@ module('JSONAPISerializer', function(hooks) {
         'deserialized document matches'
       );
     });
+
+    test('#deserialize - ignores attributes and relationships not defined in the schema', function(assert) {
+      let result = serializer.deserializeDocument(
+        {
+          data: {
+            id: '12345',
+            type: 'planets',
+            attributes: {
+              name: 'Jupiter',
+              unknownAttribute: 'gas giant'
+            },
+            relationships: {
+              moons: { data: [{ type: 'moons', id: '5' }] },
+              unknownRelationship: { type: 'solarSystem', id: 'ss1' }
+            }
+          }
+        }
+      );
+
+      assert.deepEqual(
+        result,
+        {
+          data: {
+            type: 'planet',
+            id: '12345',
+            attributes: {
+              name: 'Jupiter'
+            },
+            relationships: {
+              moons: {
+                data: [{ type: 'moon', id: '5' }]
+              }
+            }
+          }
+        }
+      );
+    });
   });
 });


### PR DESCRIPTION
Prior to this PR, if your JSON API response contained attributes or relationships that were not defined in your schema you would get unclear errors.

This PR changes the behaviour of the JSON API serializer so that unknown attributes and relationships are simply ignored.