### PR TITLE
Fix replaceRecord handling for IndexedDB and LocalStorage

### DIFF
--- a/packages/@orbit/data/src/record.ts
+++ b/packages/@orbit/data/src/record.ts
@@ -1,4 +1,4 @@
-import { Dict, isObject, isNone } from '@orbit/utils';
+import { Dict, isObject, isNone, merge } from '@orbit/utils';
 
 export interface RecordIdentity {
   type: string;
@@ -35,4 +35,24 @@ export function equalRecordIdentities(record1: RecordIdentity, record2: RecordId
          (isObject(record1) && isObject(record2) &&
           record1.type === record2.type &&
           record1.id === record2.id);
+}
+
+export function mergeRecords(current: Record | null, updates: Record): Record {
+  if (current) {
+    let record = cloneRecordIdentity(current);
+
+    ['attributes', 'keys', 'relationships'].forEach(grouping => {
+      if (current[grouping] && updates[grouping]) {
+        record[grouping] = merge({}, current[grouping], updates[grouping]);
+      } else if (current[grouping]) {
+        record[grouping] = merge({}, current[grouping]);
+      } else if (updates[grouping]) {
+        record[grouping] = merge({}, updates[grouping]);
+      }
+    });
+
+    return record;
+  } else {
+    return updates;
+  }
 }

--- a/packages/@orbit/indexeddb/src/lib/transform-operators.ts
+++ b/packages/@orbit/indexeddb/src/lib/transform-operators.ts
@@ -1,4 +1,5 @@
 import {
+  mergeRecords,
   cloneRecordIdentity,
   equalRecordIdentities,
   Record, RecordIdentity,
@@ -14,8 +15,7 @@ import {
 } from '@orbit/data';
 import {
   deepGet,
-  deepSet,
-  merge
+  deepSet
 } from '@orbit/utils';
 import Source from '../source';
 
@@ -32,31 +32,14 @@ export default {
   },
 
   replaceRecord(source: Source, operation: ReplaceRecordOperation) {
-    let replacement = operation.record;
+    let updates = operation.record;
 
-    return source.getRecord(replacement)
+    return source.getRecord(updates)
       .catch(() => null)
       .then(current => {
-        let record;
-
-        if (current) {
-          record = cloneRecordIdentity(current);
-
-          ['attributes', 'keys', 'relationships'].forEach(grouping => {
-            if (current[grouping] && replacement[grouping]) {
-              record[grouping] = merge({}, current[grouping], replacement[grouping]);
-            } else if (current[grouping]) {
-              record[grouping] = merge({}, current[grouping]);
-            } else if (replacement[grouping]) {
-              record[grouping] = merge({}, replacement[grouping]);
-            }
-          });
-        } else {
-          record = replacement;
-        }
-
+        let record = mergeRecords(current, updates);
         return source.putRecord(record);
-      });    
+      });
   },
 
   removeRecord(source: Source, operation: RemoveRecordOperation) {

--- a/packages/@orbit/indexeddb/test/source-test.ts
+++ b/packages/@orbit/indexeddb/test/source-test.ts
@@ -22,11 +22,21 @@ module('IndexedDBSource', function(hooks) {
     schema = new Schema({
       models: {
         planet: {
-          keys: { remoteId: {} }
+          keys: { remoteId: {} },
+          attributes: {
+            name: { type: 'string' },
+            classification: { type: 'string' },
+            revised: { type: 'boolean' }
+          },
+          relationships: {
+            moons: { type: 'hasMany', model: 'moon' },
+            solarSystem: { type: 'hasMany', model: 'solarSystem' }
+          }
         },
         moon: {
           keys: { remoteId: {} }
-        }
+        },
+        solarSystem: {}
       }
     });
 
@@ -129,23 +139,50 @@ module('IndexedDBSource', function(hooks) {
       },
       attributes: {
         name: 'Jupiter',
-        classification: 'gas giant'
+      },
+      relationships: {
+        moons: {
+          data: [{ type: 'moon', id: 'moon1' }]
+        }
       }
     };
 
-    let revised = {
+    let updates = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
+        classification: 'gas giant'
+      },
+      relationships: {
+        solarSystem: {
+          data: { type: 'solarSystem', id: 'ss1' }
+        }
+      }
+    };
+
+    let expected = {
+      type: 'planet',
+      id: 'jupiter',
+      keys: {
+        remoteId: 'j'
+      },
+      attributes: {
         name: 'Jupiter',
-        classification: 'gas giant',
-        revised: true
+        classification: 'gas giant'
+      },
+      relationships: {
+        moons: {
+          data: [{ type: 'moon', id: 'moon1' }]
+        },
+        solarSystem: {
+          data: { type: 'solarSystem', id: 'ss1' }
+        }
       }
     };
 
     return source.push(t => t.addRecord(original))
-      .then(() => source.push(t => t.replaceRecord(revised)))
-      .then(() => verifyIndexedDBContainsRecord(assert, source, revised))
+      .then(() => source.push(t => t.replaceRecord(updates)))
+      .then(() => verifyIndexedDBContainsRecord(assert, source, expected))
       .then(() => {
         assert.equal(keyMap.keyToId('planet', 'remoteId', 'j'), 'jupiter', 'key has been mapped');
       });

--- a/packages/@orbit/local-storage/src/lib/transform-operators.ts
+++ b/packages/@orbit/local-storage/src/lib/transform-operators.ts
@@ -14,7 +14,8 @@ import {
 } from '@orbit/data';
 import {
   deepGet,
-  deepSet
+  deepSet,
+  merge
 } from '@orbit/utils';
 import Source from '../source';
 
@@ -24,7 +25,28 @@ export default {
   },
 
   replaceRecord(source: Source, operation: ReplaceRecordOperation) {
-    source.putRecord(operation.record);
+    let replacement = operation.record;
+    let current = source.getRecord(replacement);
+
+    let record;
+
+    if (current) {
+      record = cloneRecordIdentity(current);
+
+      ['attributes', 'keys', 'relationships'].forEach(grouping => {
+        if (current[grouping] && replacement[grouping]) {
+          record[grouping] = merge({}, current[grouping], replacement[grouping]);
+        } else if (current[grouping]) {
+          record[grouping] = merge({}, current[grouping]);
+        } else if (replacement[grouping]) {
+          record[grouping] = merge({}, replacement[grouping]);
+        }
+      });
+    } else {
+      record = replacement;
+    }
+
+    source.putRecord(record);
   },
 
   removeRecord(source: Source, operation: RemoveRecordOperation) {

--- a/packages/@orbit/local-storage/src/lib/transform-operators.ts
+++ b/packages/@orbit/local-storage/src/lib/transform-operators.ts
@@ -1,4 +1,5 @@
 import {
+  mergeRecords,
   cloneRecordIdentity,
   equalRecordIdentities,
   Record, RecordIdentity,
@@ -25,27 +26,9 @@ export default {
   },
 
   replaceRecord(source: Source, operation: ReplaceRecordOperation) {
-    let replacement = operation.record;
-    let current = source.getRecord(replacement);
-
-    let record;
-
-    if (current) {
-      record = cloneRecordIdentity(current);
-
-      ['attributes', 'keys', 'relationships'].forEach(grouping => {
-        if (current[grouping] && replacement[grouping]) {
-          record[grouping] = merge({}, current[grouping], replacement[grouping]);
-        } else if (current[grouping]) {
-          record[grouping] = merge({}, current[grouping]);
-        } else if (replacement[grouping]) {
-          record[grouping] = merge({}, replacement[grouping]);
-        }
-      });
-    } else {
-      record = replacement;
-    }
-
+    let updates = operation.record;
+    let current = source.getRecord(updates);
+    let record = mergeRecords(current, updates);
     source.putRecord(record);
   },
 

--- a/packages/@orbit/local-storage/test/source-test.ts
+++ b/packages/@orbit/local-storage/test/source-test.ts
@@ -23,9 +23,21 @@ module('LocalStorageSource', function(hooks) {
     schema = new Schema({
       models: {
         planet: {
-          keys: { remoteId: {} }
+          keys: { remoteId: {} },
+          attributes: {
+            name: { type: 'string' },
+            classification: { type: 'string' },
+            revised: { type: 'boolean' }
+          },
+          relationships: {
+            moons: { type: 'hasMany', model: 'moon' },
+            solarSystem: { type: 'hasMany', model: 'solarSystem' }
+          }
         },
         moon: {
+          keys: { remoteId: {} }
+        },
+        solarSystem: {
           keys: { remoteId: {} }
         }
       }
@@ -98,23 +110,50 @@ module('LocalStorageSource', function(hooks) {
       },
       attributes: {
         name: 'Jupiter',
-        classification: 'gas giant'
+      },
+      relationships: {
+        moons: {
+          data: [{ type: 'moon', id: 'moon1' }]
+        }
       }
     };
 
-    let revised = {
+    let updates = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
+        classification: 'gas giant'
+      },
+      relationships: {
+        solarSystem: {
+          data: { type: 'solarSystem', id: 'ss1' }
+        }
+      }
+    };
+
+    let expected = {
+      type: 'planet',
+      id: 'jupiter',
+      keys: {
+        remoteId: 'j'
+      },
+      attributes: {
         name: 'Jupiter',
-        classification: 'gas giant',
-        revised: true
+        classification: 'gas giant'
+      },
+      relationships: {
+        moons: {
+          data: [{ type: 'moon', id: 'moon1' }]
+        },
+        solarSystem: {
+          data: { type: 'solarSystem', id: 'ss1' }
+        }
       }
     };
 
     return source.push(t => t.addRecord(original))
-      .then(() => source.push(t => t.replaceRecord(revised)))
-      .then(() => verifyLocalStorageContainsRecord(assert, source, revised))
+      .then(() => source.push(t => t.replaceRecord(updates)))
+      .then(() => verifyLocalStorageContainsRecord(assert, source, expected))
       .then(() => {
         assert.equal(keyMap.keyToId('planet', 'remoteId', 'j'), 'jupiter', 'key has been mapped');
       });


### PR DESCRIPTION
Fixes the handling of the `replaceRecord` operation in the IndexedDB and LocalStorage sources.

Prior to this PR, `replaceRecord` would complete clobber the existing record. This PR changes that behaviour that so that it merges the new fields into the old fields.