### PR TITLE
Allow base store to be passed as Store constructor option

### DIFF
--- a/packages/@orbit/store/test/store-test.ts
+++ b/packages/@orbit/store/test/store-test.ts
@@ -294,6 +294,8 @@ module('Store', function(hooks) {
         assert.strictEqual(store.keyMap, fork.keyMap, 'keyMap matches');
         assert.strictEqual(store.transformBuilder, fork.transformBuilder, 'transformBuilder is shared');
         assert.strictEqual(store.queryBuilder, fork.queryBuilder, 'queryBuilder is shared');
+        assert.strictEqual(fork.forkPoint, store.transformLog.head, 'forkPoint is set on the forked store');
+        assert.strictEqual(fork.base, store, 'base store is set on the forked store');
       });
   });
 


### PR DESCRIPTION
When forking, the base store is stashed in the fork, as well as the
`forkPoint`, which is the `head` pointer of the base store’s log.