### PR TITLE
Provide standard approach for sources to respond to schema upgrades

### DIFF
--- a/packages/@orbit/data/test/source-test.ts
+++ b/packages/@orbit/data/test/source-test.ts
@@ -5,7 +5,7 @@ import {
   TransformBuilder,
   QueryBuilder
 } from '../src/index';
-import { isEvented } from '@orbit/core';
+import Orbit, { isEvented } from '@orbit/core';
 import { FakeBucket } from './test-helper';
 
 const { module, test } = QUnit;
@@ -24,6 +24,36 @@ module('Source', function(hooks) {
     source = new MySource();
     assert.ok(source);
     assert.ok(source.transformLog, 'has a transform log');
+  });
+
+  test('it can be assigned a schema, which will be observed for upgrades by default', function(assert) {
+    assert.expect(2);
+
+    class MyDynamicSource extends Source {
+      upgrade() {
+        assert.ok(true, 'upgrade called');
+        return Orbit.Promise.resolve();
+      }
+    };
+
+    source = new MyDynamicSource({ schema });
+    schema.upgrade({});
+    assert.ok(true, 'after upgrade');
+  });
+
+  test('it will not be auto-upgraded if autoUpgrade: false option is specified', function(assert) {
+    assert.expect(1);
+
+    class MyDynamicSource extends Source {
+      upgrade() {
+        assert.ok(false, 'upgrade should not be called');
+        return Orbit.Promise.resolve();
+      }
+    };
+
+    source = new MyDynamicSource({ schema, autoUpgrade: false });
+    schema.upgrade({});
+    assert.ok(true, 'after upgrade');
   });
 
   test('creates a `transformLog`, `requestQueue`, and `syncQueue`, and assigns each the same bucket as the Source', function(assert) {

--- a/packages/@orbit/indexeddb/src/source.ts
+++ b/packages/@orbit/indexeddb/src/source.ts
@@ -62,8 +62,10 @@ export default class IndexedDBSource extends Source implements Pullable, Pushabl
     super(settings);
 
     this._namespace = settings.namespace || 'orbit';
+  }
 
-    this.schema.on('upgrade', () => this.reopenDB());
+  upgrade(): Promise<void> {
+    return this.reopenDB();
   }
 
   /**

--- a/packages/@orbit/store/src/cache.ts
+++ b/packages/@orbit/store/src/cache.ts
@@ -172,6 +172,23 @@ export default class Cache implements Evented {
   }
 
   /**
+   * Upgrade the cache based on the current state of the schema.
+   *
+   * @memberof Cache
+   */
+  upgrade() {
+    Object.keys(this._schema.models).forEach(type => {
+      if (!this._records[type]) {
+        this._records[type] = new ImmutableMap<string, Record>();
+      }
+    });
+
+    this._relationships.upgrade();
+    this._inverseRelationships.upgrade();
+    this._processors.forEach(processor => processor.upgrade());
+  }
+
+  /**
    * Patches the document with an operation.
    *
    * @param {(Operation | Operation[] | TransformBuilderFunc)} operationOrOperations

--- a/packages/@orbit/store/src/cache/inverse-relationship-accessor.ts
+++ b/packages/@orbit/store/src/cache/inverse-relationship-accessor.ts
@@ -30,6 +30,14 @@ export default class InverseRelationshipAccessor {
     this._relationships = relationships;
   }
 
+  upgrade() {
+    Object.keys(this._cache.schema.models).forEach(type => {
+      if (!this._relationships[type]) {
+        this._relationships[type] = new ImmutableMap();
+      }
+    });
+  }
+
   all(record: RecordIdentity): InverseRelationship[] {
     return this._relationships[record.type].get(record.id) || [];
   }

--- a/packages/@orbit/store/src/cache/operation-processors/operation-processor.ts
+++ b/packages/@orbit/store/src/cache/operation-processors/operation-processor.ts
@@ -51,6 +51,13 @@ export abstract class OperationProcessor {
   reset(base?: Cache): void {}
 
   /**
+   * Allow the processor to perform an upgrade as part of a cache upgrade.
+   *
+   * @memberof OperationProcessor
+   */
+  upgrade(): void {}
+
+  /**
    * Validates an operation before processing it.
    *
    * @param {RecordOperation} operation

--- a/packages/@orbit/store/src/cache/relationship-accessor.ts
+++ b/packages/@orbit/store/src/cache/relationship-accessor.ts
@@ -26,6 +26,14 @@ export default class RelationshipAccessor {
     this._relationships = relationships;
   }
 
+  upgrade() {
+    Object.keys(this._cache.schema.models).forEach(type => {
+      if (!this._relationships[type]) {
+        this._relationships[type] = new ImmutableMap();
+      }
+    });
+  }
+
   relationshipExists(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity): boolean {
     let rels = this._relationships[record.type].get(record.id);
     if (rels) {

--- a/packages/@orbit/store/src/store.ts
+++ b/packages/@orbit/store/src/store.ts
@@ -88,6 +88,11 @@ export default class Store extends Source implements Syncable, Queryable, Updata
     return this._forkPoint;
   }
 
+  upgrade(): Promise<void> {
+    this._cache.upgrade();
+    return Orbit.Promise.resolve();
+  }
+
   /////////////////////////////////////////////////////////////////////////////
   // Syncable interface implementation
   /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
All sources can now implement an `upgrade` method that upgrades them to the latest version of the schema.

By default, `Source#upgrade` will be invoked automatically whenever the schema emits an `upgrade` event. However, sources can explicitly opt-out of automatic upgrades via the `autoUpgrade: false` option. It is still possible to manually call `Source#upgrade` to provide finer control of the process.
