### PR TITLE
Perf Fix: Push each inverse op and reverse array once

### DIFF
--- a/packages/@orbit/store/src/cache.ts
+++ b/packages/@orbit/store/src/cache.ts
@@ -212,6 +212,8 @@ export default class Cache implements Evented {
       this._applyOperation(<RecordOperation>operationOrOperations, result, true);
     }
 
+    result.inverse.reverse();
+
     return result;
   }
 
@@ -230,7 +232,7 @@ export default class Cache implements Evented {
     const inverseOp: RecordOperation = inverseTransform(this, operation);
 
     if (inverseOp) {
-      result.inverse.unshift(inverseOp);
+      result.inverse.push(inverseOp);
 
       // Query and perform related `before` operations
       this._processors


### PR DESCRIPTION
Using `unshift` to add inverse ops has been causing performance problems when adding large numbers of records into the store’s cache (described in #473).

This fix replaces usage of `unshift` for each op with `push`, and then the array is `reverse`d once before returning.