### PR TITLE
globals react-native support

### DIFF
--- a/packages/@orbit/core/src/main.ts
+++ b/packages/@orbit/core/src/main.ts
@@ -13,8 +13,7 @@ declare const global: any;
 //     (c) 2009-2017 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
 //     Underscore may be freely distributed under the MIT license.
 const globals = typeof self == 'object' && self.self === self && self ||
-                typeof global == 'object' && global.global === global && global ||
-                this ||
+                typeof global == 'object' && global ||
                 {};
 
 const Orbit: any = {


### PR DESCRIPTION
in some contexts like react native `global.global` does not exist so orbit doesn't work because it can't find `Promise`. Also that `this` (hard)compiles to `undefined` so I removed it.