### PR TITLE
Add explicit any type annotation to args

### DIFF
--- a/packages/@orbit/store/src/cache.ts
+++ b/packages/@orbit/store/src/cache.ts
@@ -71,7 +71,7 @@ export default class Cache implements Evented {
   on: (event: string, callback: Function, binding?: object) => void;
   off: (event: string, callback: Function, binding?: object) => void;
   one: (event: string, callback: Function, binding?: object) => void;
-  emit: (event: string, ...args) => void;
+  emit: (event: string, ...args: any[]) => void;
   listeners: (event: string) => any[];
 
   constructor(settings: CacheSettings = {}) {


### PR DESCRIPTION
Resolves the following error when TS compiler is configured with `noImplicitAny` is `true`.

```
node_modules/@orbit/store/dist/types/cache.d.ts
(43,27): error TS7019: Rest parameter 'args' implicitly has an 'any[]' type.
```