### PR TITLE
Allow for injection of task queue settings in Source initialization

### DIFF
--- a/packages/@orbit/data/src/source.ts
+++ b/packages/@orbit/data/src/source.ts
@@ -22,6 +22,7 @@ export interface SourceSettings {
   transformBuilder?: TransformBuilder;
   autoUpgrade?: boolean;
   requestQueueSettings?: TaskQueueSettings;
+  syncQueueSettings?: TaskQueueSettings;
 }
 
 export type SourceClass = (new () => Source);
@@ -63,6 +64,7 @@ export abstract class Source implements Evented, Performer {
     this._queryBuilder = settings.queryBuilder;
     this._transformBuilder = settings.transformBuilder;
     const requestQueueSettings = settings.requestQueueSettings || {};
+    const syncQueueSettings = settings.syncQueueSettings || {};
 
     if (bucket) {
       assert('TransformLog requires a name if it has a bucket', !!name);
@@ -78,7 +80,8 @@ export abstract class Source implements Evented, Performer {
 
     this._syncQueue = new TaskQueue(this, {
       name: name ? `${name}-sync` : undefined,
-      bucket
+      bucket,
+      ...syncQueueSettings
     });
 
     if (this._schema && (settings.autoUpgrade === undefined || settings.autoUpgrade)) {

--- a/packages/@orbit/data/src/source.ts
+++ b/packages/@orbit/data/src/source.ts
@@ -21,6 +21,7 @@ export interface SourceSettings {
   queryBuilder?: QueryBuilder;
   transformBuilder?: TransformBuilder;
   autoUpgrade?: boolean;
+  requestQueueSettings?: TaskQueueSettings;
 }
 
 export type SourceClass = (new () => Source);
@@ -61,14 +62,24 @@ export abstract class Source implements Evented, Performer {
     const bucket = this._bucket = settings.bucket;
     this._queryBuilder = settings.queryBuilder;
     this._transformBuilder = settings.transformBuilder;
+    const requestQueueSettings = settings.requestQueueSettings || {};
 
     if (bucket) {
       assert('TransformLog requires a name if it has a bucket', !!name);
     }
 
     this._transformLog = new Log({ name: name ? `${name}-log` : undefined, bucket });
-    this._requestQueue = new TaskQueue(this, { name: name ? `${name}-requests` : undefined, bucket });
-    this._syncQueue = new TaskQueue(this, { name: name ? `${name}-sync` : undefined, bucket });
+
+    this._requestQueue = new TaskQueue(this, {
+      name: name ? `${name}-requests` : undefined,
+      bucket,
+      ...requestQueueSettings
+    });
+
+    this._syncQueue = new TaskQueue(this, {
+      name: name ? `${name}-sync` : undefined,
+      bucket
+    });
 
     if (this._schema && (settings.autoUpgrade === undefined || settings.autoUpgrade)) {
       this._schema.on('upgrade', () => this.upgrade());

--- a/packages/@orbit/data/test/source-test.ts
+++ b/packages/@orbit/data/test/source-test.ts
@@ -89,6 +89,25 @@ module('Source', function(hooks) {
     assert.equal(source.requestQueue.bucket, requestQueueBucket, 'requestQueue has been assigned overriden bucket');
   });
 
+  test('overrides default syncQueue settings with injected syncQueueSettings', function(assert) {
+    assert.expect(3)
+
+    const defaultBucket = new FakeBucket();
+    const syncQueueBucket = new FakeBucket();
+
+    const syncQueueSettings = {
+      name: 'my-sync-queue',
+      autoProcess: false,
+      bucket: syncQueueBucket
+    };
+
+    source = new MySource({ name: 'src1', bucket: defaultBucket, syncQueueSettings });
+
+    assert.equal(source.syncQueue.name, 'my-sync-queue', 'syncQueue has been assigned overriden name');
+    assert.equal(source.syncQueue.autoProcess, false, 'syncQueue has been assigned overriden autoProcess');
+    assert.equal(source.syncQueue.bucket, syncQueueBucket, 'syncQueue has been assigned overriden bucket');
+  });
+
   test('creates a `queryBuilder` upon first access', function(assert) {
     const qb = source.queryBuilder;
     assert.ok(qb, 'queryBuilder created');

--- a/packages/@orbit/data/test/source-test.ts
+++ b/packages/@orbit/data/test/source-test.ts
@@ -70,6 +70,25 @@ module('Source', function(hooks) {
     assert.strictEqual(source.syncQueue.bucket, bucket, 'syncQueue has been assigned bucket');
   });
 
+  test('overrides default requestQueue settings with injected requestQueueSettings', function(assert) {
+    assert.expect(3)
+
+    const defaultBucket = new FakeBucket();
+    const requestQueueBucket = new FakeBucket();
+
+    const requestQueueSettings = {
+      name: 'my-request-queue',
+      autoProcess: false,
+      bucket: requestQueueBucket
+    };
+
+    source = new MySource({ name: 'src1', bucket: defaultBucket, requestQueueSettings });
+
+    assert.equal(source.requestQueue.name, 'my-request-queue', 'requestQueue has been assigned overriden name');
+    assert.equal(source.requestQueue.autoProcess, false, 'requestQueue has been assigned overriden autoProcess');
+    assert.equal(source.requestQueue.bucket, requestQueueBucket, 'requestQueue has been assigned overriden bucket');
+  });
+
   test('creates a `queryBuilder` upon first access', function(assert) {
     const qb = source.queryBuilder;
     assert.ok(qb, 'queryBuilder created');


### PR DESCRIPTION
It currently does not seem possible to inject the `autoProcess` setting of a TaskQueue from any extension of the `Source` class.  The changes in this PR support the injection of any of the `TaskQueueSettings` for both the `requestQueue` and `syncQueue` of a `Source`.