### PR TITLE
TaskQueue#push must return the result of processing the pushed task

### DIFF
--- a/packages/@orbit/core/src/task-queue.ts
+++ b/packages/@orbit/core/src/task-queue.ts
@@ -260,11 +260,9 @@ export default class TaskQueue implements Evented {
       })
       .then(() => {
         if (this.autoProcess) {
-          return this.process()
-            .then(() => processor.settle());
-        } else {
-          return processor.settle();
+          this.process();
         }
+        return processor.settle();
       });
   }
 


### PR DESCRIPTION
The result of `push` should not be dependent upon all processing being completed, nor should it be impacted by errors that occur while processing other tasks.

Fixes #496