### PR TITLE
Correct TaskQueue#retry and TaskQueue#skip

### DIFF
--- a/packages/@orbit/core/src/task-queue.ts
+++ b/packages/@orbit/core/src/task-queue.ts
@@ -274,13 +274,19 @@ export default class TaskQueue implements Evented {
    * @memberOf TaskQueue
    */
   retry(): Promise<void> {
+    let processor;
+
     return this._reified
       .then(() => {
         this._cancel();
-        this.currentProcessor.reset();
+        processor = this.currentProcessor;
+        processor.reset();
         return this._persist();
       })
-      .then(() => this.process());
+      .then(() => {
+        this.process();
+        return processor.settle();
+      });
   }
 
   /**

--- a/packages/@orbit/core/src/task-queue.ts
+++ b/packages/@orbit/core/src/task-queue.ts
@@ -290,8 +290,10 @@ export default class TaskQueue implements Evented {
   }
 
   /**
-   * Cancels and discards the current task and proceeds to process the next
-   * task.
+   * Cancels and discards the current task.
+   *
+   * If `autoProcess` is enabled, this will automatically trigger processing of
+   * the queue.
    *
    * @returns {Promise<void>}
    *
@@ -328,6 +330,8 @@ export default class TaskQueue implements Evented {
 
   /**
    * Cancels the current task and removes it, but does not continue processing.
+   *
+   * Returns the canceled and removed task.
    *
    * @returns {Promise<Task>}
    *

--- a/packages/@orbit/core/src/task-queue.ts
+++ b/packages/@orbit/core/src/task-queue.ts
@@ -307,7 +307,11 @@ export default class TaskQueue implements Evented {
         this._processors.shift();
         return this._persist();
       })
-      .then(() => this.process());
+      .then(() => {
+        if (this.autoProcess) {
+          this.process();
+        }
+      });
   }
 
   /**

--- a/packages/@orbit/core/test/task-queue-test.ts
+++ b/packages/@orbit/core/test/task-queue-test.ts
@@ -381,7 +381,7 @@ module('TaskQueue', function() {
         } else if (transformCount === 4) {
           assert.strictEqual(op, op3, 'transform - op3 passed as argument');
         }
-        return Promise.resolve();
+        return Promise.resolve(`${transformCount}`);
       }
     };
 
@@ -434,7 +434,10 @@ module('TaskQueue', function() {
         assert.strictEqual(queue.current.data, op2, 'op2 is current failed task');
 
         // skip current task and continue processing
-        return queue.retry();
+        return queue.retry()
+          .then(result => {
+            assert.equal(result, '3', 'the result of the retried task should be returned');
+          });
       });
   });
 

--- a/packages/@orbit/core/test/task-queue-test.ts
+++ b/packages/@orbit/core/test/task-queue-test.ts
@@ -302,7 +302,7 @@ module('TaskQueue', function() {
         transformCount++;
         if (transformCount === 1) {
           assert.strictEqual(task.data, op1, 'transform - op1 passed as argument');
-      } else if (transformCount === 2) {
+        } else if (transformCount === 2) {
           return Promise.reject(new Error(':('));
         } else {
           assert.ok(false, 'additional transforms should not be performed');

--- a/packages/@orbit/core/test/task-queue-test.ts
+++ b/packages/@orbit/core/test/task-queue-test.ts
@@ -366,7 +366,7 @@ module('TaskQueue', function() {
   });
 
   test('#retry resets the current task in an inactive queue and restarts processing', function(assert) {
-    assert.expect(13);
+    assert.expect(14);
 
     const performer: Performer = {
       perform(task: Task): Promise<void> {
@@ -441,7 +441,87 @@ module('TaskQueue', function() {
       });
   });
 
-  test('#skip removes the current task from an inactive queue and restarts processing', function(assert) {
+  test('#skip removes the current task from an inactive queue', function(assert) {
+    assert.expect(9);
+
+    const performer: Performer = {
+      perform(task: Task): Promise<void> {
+        transformCount++;
+        let op = task.data;
+        if (transformCount === 1) {
+          assert.strictEqual(op, op1, 'transform - op1 passed as argument');
+        } else if (transformCount === 2) {
+          return Promise.reject(new Error(':('));
+        } else if (transformCount === 3) {
+          assert.ok(false, 'processing should not be restarted');
+        }
+        return Promise.resolve();
+      }
+    };
+
+    const queue = new TaskQueue(performer, { autoProcess: false });
+
+    let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
+    let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
+    let op3 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
+    let transformCount = 0;
+
+    queue.on('task', function(task) {
+      if (transformCount === 1) {
+        assert.strictEqual(task.data, op1, 'task - op1 processed');
+      } else if (transformCount === 2) {
+        assert.ok(false, 'processing should not be restarted');
+      }
+    });
+
+    queue.on('fail', function(task, err) {
+      assert.strictEqual(task.data, op2, 'fail - op2 failed processing');
+      assert.equal(err.message, ':(', 'fail - error matches expectation');
+    });
+
+    queue.on('complete', function() {
+      assert.ok(true, 'queue should complete after processing has restarted');
+    });
+
+    queue.push({
+      type: 'transform',
+      data: op1
+    })
+      .then(() => {
+        assert.ok(true, 'op1 should be processed');
+      });
+
+    queue.push({
+      type: 'transform',
+      data: op2
+    })
+      .then(() => {
+        assert.ok(false, 'op2 should fail');
+      })
+      .catch((e) => {
+        assert.ok(true, 'op2 should fail');
+      });
+
+    queue.push({
+      type: 'transform',
+      data: op3
+    })
+      .then(() => {
+        assert.ok(false, 'op3 should not be processed because processing should not be restarted');
+      });
+
+    return queue.process()
+      .catch((e) => {
+        assert.equal(queue.empty, false, 'queue processing encountered a problem');
+        assert.equal(queue.error.message, ':(', 'process error matches expectation');
+        assert.strictEqual(queue.error, e, 'process error matches expectation');
+
+        // skip current task and continue processing
+        return queue.skip();
+      });
+  });
+
+  test('#skip removes the current task from an inactive queue and restarts processing if autoProcess=true', function(assert) {
     assert.expect(9);
 
     const performer: Performer = {
@@ -459,7 +539,7 @@ module('TaskQueue', function() {
       }
     };
 
-    const queue = new TaskQueue(performer, { autoProcess: false });
+    const queue = new TaskQueue(performer, { autoProcess: true });
 
     let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
     let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };


### PR DESCRIPTION
Aligns `TaskQueue#retry` with `TaskQueue#push`, in that the result of processing the retried task is returned rather than the result of invoking `process`.

Also fixes `TaskQueue#skip` to only continue processing when `autoProcess = true`.