### PR TITLE
[JSONAPI] Allow global and per-request fetch settings

### DIFF
--- a/packages/@orbit/jsonapi/src/lib/query-params.ts
+++ b/packages/@orbit/jsonapi/src/lib/query-params.ts
@@ -35,3 +35,17 @@ export function encodeQueryParams(obj) {
     .map(param => encodeURIComponent(param.path) + '=' + encodeURIComponent(param.val))
     .join('&');
 }
+
+export function appendQueryParams(url: string, obj: object): string {
+  let fullUrl = url;
+  let queryParams = encodeQueryParams(obj);
+  if (queryParams.length > 0) {
+    if (fullUrl.indexOf('?') === -1) {
+      fullUrl += '?';
+    } else {
+      fullUrl += '&';
+    }
+    fullUrl += queryParams;
+  }
+  return fullUrl;
+}

--- a/packages/@orbit/jsonapi/src/lib/request-settings.ts
+++ b/packages/@orbit/jsonapi/src/lib/request-settings.ts
@@ -1,23 +1,40 @@
-import { deepSet } from '@orbit/utils';
+import { clone, deepGet, deepMerge, deepSet, deprecate, isArray } from '@orbit/utils';
 import { FetchSettings } from '../jsonapi-source';
+import { Source, Query, Transform } from '@orbit/data';
 
 export interface RequestOptions {
   filter?: any;
   sort?: any;
   page?: any;
   include?: any;
-  timeout?: number;
+  settings?: FetchSettings;
 }
 
-export function buildFetchSettings(options: RequestOptions, settings: FetchSettings = {}): FetchSettings {
+export function customRequestOptions(source: Source, queryOrTransform: Query | Transform): RequestOptions {
+  return deepGet(queryOrTransform, ['options', 'sources', source.name]);
+}
+
+export function buildFetchSettings(options: RequestOptions = {}, customSettings?: FetchSettings): FetchSettings {
+  let settings = options.settings ? clone(options.settings) : {};
+
+  if (customSettings) {
+    deepMerge(settings, customSettings);
+  }
+
   ['filter', 'include', 'page', 'sort'].forEach(param => {
     if (options[param]) {
-      deepSet(settings, ['params', param], options[param]);
+      let value = options[param];
+      if (param === 'include' && isArray(value)) {
+        value = value.join(',');
+      }
+
+      deepSet(settings, ['params', param], value);
     }
   });
 
-  if (options.timeout) {
-    settings.timeout = options.timeout;
+  if (options['timeout']) {
+    deprecate("JSONAPI: Specify `timeout` option inside a `settings` object.")
+    settings.timeout = options['timeout'];
   }
 
   return settings;

--- a/packages/@orbit/jsonapi/src/lib/transform-requests.ts
+++ b/packages/@orbit/jsonapi/src/lib/transform-requests.ts
@@ -20,14 +20,14 @@ import { clone, deepSet } from '@orbit/utils';
 import JSONAPISource from '../jsonapi-source';
 import { JSONAPIDocument } from '../jsonapi-document';
 import { DeserializedDocument } from '../jsonapi-serializer';
-import { RequestOptions, buildFetchSettings } from './request-settings';
+import { buildFetchSettings, customRequestOptions, RequestOptions } from './request-settings';
 
 export const TransformRequestProcessors = {
   addRecord(source: JSONAPISource, request) {
     const { serializer } = source;
     const record = request.record;
     const requestDoc: JSONAPIDocument = serializer.serializeDocument(record);
-    const settings = buildFetchSettings(request, { method: 'POST', json: requestDoc });
+    const settings = buildFetchSettings(request.options, { method: 'POST', json: requestDoc });
 
     return source.fetch(source.resourceURL(record.type), settings)
       .then((raw: JSONAPIDocument) => {
@@ -43,7 +43,7 @@ export const TransformRequestProcessors = {
 
   removeRecord(source: JSONAPISource, request) {
     const { type, id } = request.record;
-    const settings = buildFetchSettings(request, { method: 'DELETE' });
+    const settings = buildFetchSettings(request.options, { method: 'DELETE' });
 
     return source.fetch(source.resourceURL(type, id), settings)
       .then(() => []);
@@ -53,7 +53,7 @@ export const TransformRequestProcessors = {
     const record = request.record;
     const { type, id } = record;
     const requestDoc: JSONAPIDocument = source.serializer.serializeDocument(record);
-    const settings = buildFetchSettings(request, { method: 'PATCH', json: requestDoc });
+    const settings = buildFetchSettings(request.options, { method: 'PATCH', json: requestDoc });
 
     return source.fetch(source.resourceURL(type, id), settings)
       .then(() => []);
@@ -65,7 +65,7 @@ export const TransformRequestProcessors = {
     const json = {
       data: request.relatedRecords.map(r => source.serializer.resourceIdentity(r))
     };
-    const settings = buildFetchSettings(request, { method: 'POST', json });
+    const settings = buildFetchSettings(request.options, { method: 'POST', json });
 
     return source.fetch(source.resourceRelationshipURL(type, id, relationship), settings)
       .then(() => []);
@@ -77,7 +77,7 @@ export const TransformRequestProcessors = {
     const json = {
       data: request.relatedRecords.map(r => source.serializer.resourceIdentity(r))
     };
-    const settings = buildFetchSettings(request, { method: 'DELETE', json });
+    const settings = buildFetchSettings(request.options, { method: 'DELETE', json });
 
     return source.fetch(source.resourceRelationshipURL(type, id, relationship), settings)
       .then(() => []);
@@ -89,7 +89,7 @@ export const TransformRequestProcessors = {
     const json = {
       data: relatedRecord ? source.serializer.resourceIdentity(relatedRecord) : null
     };
-    const settings = buildFetchSettings(request, { method: 'PATCH', json });
+    const settings = buildFetchSettings(request.options, { method: 'PATCH', json });
 
     return source.fetch(source.resourceRelationshipURL(type, id, relationship), settings)
       .then(() => []);
@@ -101,7 +101,7 @@ export const TransformRequestProcessors = {
     const json = {
       data: relatedRecords.map(r => source.serializer.resourceIdentity(r))
     };
-    const settings = buildFetchSettings(request, { method: 'PATCH', json });
+    const settings = buildFetchSettings(request.options, { method: 'PATCH', json });
 
     return source.fetch(source.resourceRelationshipURL(type, id, relationship), settings)
       .then(() => []);
@@ -109,11 +109,8 @@ export const TransformRequestProcessors = {
 };
 
 export function getTransformRequests(source: JSONAPISource, transform: Transform) {
-  const operations: RecordOperation[] = <RecordOperation[]>transform.operations;
   const requests = [];
   let prevRequest;
-
-  const options = (transform.options && transform.options.sources && transform.options.sources[source.name]) || {};
 
   transform.operations.forEach((operation: RecordOperation) => {
     let request;
@@ -151,14 +148,10 @@ export function getTransformRequests(source: JSONAPISource, transform: Transform
     }
 
     if (request) {
-      if (options.include) {
-        request.include = options.include.join(',');
+      let options = customRequestOptions(source, transform);
+      if (options) {
+        request.options = options;
       }
-
-      if (options.timeout) {
-        request.timeout = options.timeout;
-      }
-
       requests.push(request);
       prevRequest = request;
     }

--- a/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
@@ -4,9 +4,7 @@ import Orbit, {
   NetworkError,
   Record,
   RecordIdentity,
-  RecordOperation,
   ReplaceRecordOperation,
-  Transform,
   TransformNotAllowed,
   Schema,
   Source
@@ -679,7 +677,9 @@ module('JSONAPISource', function(hooks) {
       const options = {
         sources: {
           jsonapi: {
-            timeout: 10 // 10ms timeout
+            settings: {
+              timeout: 10 // 10ms timeout
+            }
           }
         }
       };
@@ -831,7 +831,9 @@ module('JSONAPISource', function(hooks) {
       const options = {
         sources: {
           jsonapi: {
-            timeout: 10 // 10ms timeout
+            settings: {
+              timeout: 10 // 10ms timeout
+            }
           }
         }
       };

--- a/packages/@orbit/jsonapi/test/lib/query-params-test.ts
+++ b/packages/@orbit/jsonapi/test/lib/query-params-test.ts
@@ -1,4 +1,4 @@
-import { encodeQueryParams } from '../../src/lib/query-params';
+import { encodeQueryParams, appendQueryParams } from '../../src/lib/query-params';
 
 const { module, test } = QUnit;
 
@@ -61,6 +61,38 @@ module('QueryParams', function() {
         encodeURIComponent('d[e]') + '=f&' +
         encodeURIComponent('d[g][h]') + '=' + encodeURIComponent('long sentence here') + '&' +
         encodeURIComponent('d[g][i]') + '=null'
+      );
+    });
+  });
+
+  module('appendQueryParams', function() {
+    test('empty', function(assert) {
+      assert.strictEqual(
+        appendQueryParams(
+          'http://example.com',
+          { }
+        ),
+        'http://example.com'
+      );
+    });
+
+    test('simple', function(assert) {
+      assert.strictEqual(
+        appendQueryParams(
+          'http://example.com',
+          { a: 'b' }
+        ),
+        'http://example.com?a=b'
+      );
+    });
+
+    test('appended to existing query params', function(assert) {
+      assert.strictEqual(
+        appendQueryParams(
+          'http://example.com?c=d',
+          { a: 'b' }
+        ),
+        'http://example.com?c=d&a=b'
       );
     });
   });

--- a/packages/@orbit/utils/src/deprecate.ts
+++ b/packages/@orbit/utils/src/deprecate.ts
@@ -1,14 +1,15 @@
 declare const console: any;
 
 /**
- * Display a deprecation warning with the provided message.
- * 
+ * Display a deprecation warning with the provided message if the
+ * provided `test` evaluates to a falsy value (or is missing).
+ *
  * @export
  * @param {string} message Description of the deprecation
- * @param {(() => boolean | boolean)} test An optional boolean or function that evaluates to a boolean.
- * @returns 
+ * @param {(boolean | (() => boolean))} test An optional boolean or function that evaluates to a boolean.
+ * @returns
  */
-export function deprecate(message: string, test?: () => boolean | boolean) {
+export function deprecate(message: string, test?: boolean | (() => boolean) ): void {
   if (typeof test === 'function') {
     if (test()) { return; }
   } else {

--- a/packages/@orbit/utils/src/objects.ts
+++ b/packages/@orbit/utils/src/objects.ts
@@ -153,8 +153,38 @@ export function merge(object: any, ...sources: any[]): any {
     Object.keys(source).forEach(field => {
       if (source.hasOwnProperty(field)) {
         let value = source[field];
-        if (!(value === undefined && object[field] !== undefined)) {
+        if (value !== undefined) {
           object[field] = value;
+        }
+      }
+    });
+  });
+  return object;
+}
+
+/**
+ * Merges properties from other objects into a base object, traversing and
+ * merging any objects that are encountered.
+ *
+ * Properties that resolve to `undefined` will not overwrite properties on the
+ * base object that already exist.
+ *
+ * @export
+ * @param {*} base
+ * @param {...any[]} sources
+ * @returns {*}
+ */
+export function deepMerge(object: any, ...sources: any[]): any {
+  sources.forEach(source => {
+    Object.keys(source).forEach(field => {
+      if (source.hasOwnProperty(field)) {
+        let a = object[field];
+        let b = source[field];
+        if (isObject(a) && isObject(b) &&
+            !isArray(a) && !isArray(b)) {
+          deepMerge(a, b);
+        } else if (b !== undefined) {
+          object[field] = b;
         }
       }
     });

--- a/packages/@orbit/utils/test/object-test.js
+++ b/packages/@orbit/utils/test/object-test.js
@@ -1,4 +1,4 @@
-import { clone, expose, extend, isArray, toArray, isObject, isNone, merge, deepGet, deepSet, objectValues } from '../src/objects';
+import { clone, expose, extend, isArray, toArray, isObject, isNone, merge, deepMerge, deepGet, deepSet, objectValues } from '../src/objects';
 
 const { module, test } = QUnit;
 
@@ -175,6 +175,56 @@ module('Lib / Object', function() {
     assert.strictEqual(actual, a, 'Passed object is mutated and returned');
   });
 
+  test('`deepMerge` can combine multiple objects at every level', function(assert) {
+    let a = { firstName: 'Bob',
+              underling: false,
+              details: {
+                address: '123 Main St.',
+                family: {
+                  spouse: 'Jane'
+                }
+              } };
+    let b = { lastName: 'Dobbs',
+              'title': 'Mr.',
+              underlings: null,
+              details: {
+                city: 'Boston',
+                state: 'Massachussetts',
+                family: {
+                  children: [
+                    'Bob, Jr.',
+                    'Sally'
+                  ]
+                }
+              } };
+    let c = { lastName: 'Johnson',
+              underlings: undefined,
+              details: {
+                state: 'MA',
+                family: {
+                  children: [
+                    'Joe'
+                  ]
+                }
+              } };
+    let expected = { title: 'Mr.', firstName: 'Bob', lastName: 'Johnson',
+                     underling: false, underlings: null,
+                     details: {
+                       address: '123 Main St.',
+                       city: 'Boston',
+                       state: 'MA',
+                       family: {
+                         spouse: 'Jane',
+                         children: [
+                           'Joe'
+                         ]
+                       }
+                     } };
+    let actual = deepMerge(a, b, c);
+
+    assert.deepEqual(actual, expected, 'Objects are merged');
+    assert.strictEqual(actual, a, 'Passed object is mutated and returned');
+  });
 
   test('`deepGet` retrieves a value from a nested object', function(assert) {
     let obj = {


### PR DESCRIPTION
The `FetchSettings` interface has been expanded to include the full-range of [options available for `fetch`](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch).

The `JSONAPISource` can now accept a `defaultFetchSettings` option that will be applied to all requests. Note that the `Content-Type` header can be specified and it will be removed for requests with no content.

Specifying `defaultFetchSettings.headers` is now preferred over `defaultFetchHeaders`, which has been deprecated. Similarly, `defaultFetchSettings.timeout` deprecates `defaultFetchTimeout`.

The full range of fetch settings can also be specified on a per-request basis, as an option to a `Query` or `Transform`. These settings should be specified as options under `sources.[sourceName]`. For instance, the following request specifies some general `fetch` settings alongside the special `include` param used by JSON:API:

```
remote.query(q => q.findRecords('group'), {
  sources: {
    remote: {
      include: ['users'],
      settings: {
        timeout: 10000,
        headers: { 'Accept': 'application/json' },
        params: { locale: 'en' }
      }
    }
  }
});
```

Settings will be deeply merged so that any per-request settings will win over any default settings.

Closes #517 