### PR TITLE
`merge` and `deepMerge` should use clone

### DIFF
--- a/packages/@orbit/utils/src/objects.ts
+++ b/packages/@orbit/utils/src/objects.ts
@@ -154,7 +154,7 @@ export function merge(object: any, ...sources: any[]): any {
       if (source.hasOwnProperty(field)) {
         let value = source[field];
         if (value !== undefined) {
-          object[field] = value;
+          object[field] = clone(value);
         }
       }
     });
@@ -184,7 +184,7 @@ export function deepMerge(object: any, ...sources: any[]): any {
             !isArray(a) && !isArray(b)) {
           deepMerge(a, b);
         } else if (b !== undefined) {
-          object[field] = b;
+          object[field] = clone(b);
         }
       }
     });

--- a/packages/@orbit/utils/test/object-test.js
+++ b/packages/@orbit/utils/test/object-test.js
@@ -165,14 +165,20 @@ module('Lib / Object', function() {
 
   test('`merge` can combine multiple objects', function(assert) {
     let a = { firstName: 'Bob', underling: false };
-    let b = { lastName: 'Dobbs', 'title': 'Mr.', underlings: null };
+    let b = { lastName: 'Dobbs', 'title': 'Mr.', underlings: null,
+              identity: { ssn: '123-456-7890' },
+              children: [ 'Bob, Jr.', 'Sally' ] };
     let c = { lastName: 'Johnson', underlings: undefined };
     let expected = { title: 'Mr.', firstName: 'Bob',
-                     lastName: 'Johnson', underling: false, underlings: null };
+                     lastName: 'Johnson', underling: false, underlings: null,
+                     identity: { ssn: '123-456-7890' },
+                     children: [ 'Bob, Jr.', 'Sally' ] };
     let actual = merge(a, b, c);
 
     assert.deepEqual(actual, expected, 'Objects are merged');
     assert.strictEqual(actual, a, 'Passed object is mutated and returned');
+    assert.notStrictEqual(actual.identity, b.identity, 'object properties are cloned, not copied');
+    assert.notStrictEqual(actual.children, b.children, 'array properties are cloned, not copied');
   });
 
   test('`deepMerge` can combine multiple objects at every level', function(assert) {
@@ -196,6 +202,9 @@ module('Lib / Object', function() {
                     'Sally'
                   ]
                 }
+              },
+              identity: {
+                ssn: '123-456-7890'
               } };
     let c = { lastName: 'Johnson',
               underlings: undefined,
@@ -219,11 +228,16 @@ module('Lib / Object', function() {
                            'Joe'
                          ]
                        }
-                     } };
-    let actual = deepMerge(a, b, c);
+                      },
+                      identity: {
+                        ssn: '123-456-7890'
+                      } };
+            let actual = deepMerge(a, b, c);
 
     assert.deepEqual(actual, expected, 'Objects are merged');
     assert.strictEqual(actual, a, 'Passed object is mutated and returned');
+    assert.notStrictEqual(actual.identity, b.identity, 'object properties are cloned, not copied');
+    assert.notStrictEqual(actual.details.family.children, c.details.family.children, 'array properties are cloned, not copied');
   });
 
   test('`deepGet` retrieves a value from a nested object', function(assert) {


### PR DESCRIPTION
Objects and arrays in source objects should always be cloned, never copied, into the base object.

Fixes #519