### PR TITLE
Remote key within a single transform

### DIFF
--- a/packages/@orbit/jsonapi/src/jsonapi-serializer.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-serializer.ts
@@ -1,4 +1,4 @@
-import { isArray, isObject, dasherize, camelize, deepSet, Dict } from '@orbit/utils';
+import { isArray, isObject, dasherize, camelize, clone, deepSet, Dict } from '@orbit/utils';
 import {
   Schema,
   KeyMap,
@@ -290,6 +290,19 @@ export default class JSONAPISerializer {
 
       record.relationships = record.relationships || {};
       record.relationships[relationship] = { data };
+    }
+  }
+
+  storeKey(record: Record, key: String, value: String): void {
+    if (this.keyMap) {
+      this.keyMap.pushRecord({
+        type: record.type,
+        id: record.id,
+        keys: {
+          ...clone(record.keys || {}),
+          [key]: value
+        }
+      });
     }
   }
 

--- a/packages/@orbit/jsonapi/src/lib/transform-requests.ts
+++ b/packages/@orbit/jsonapi/src/lib/transform-requests.ts
@@ -35,6 +35,11 @@ export const TransformRequestProcessors = {
         let updatedRecord: Record = <Record>responseDoc.data;
 
         let updateOps = recordDiffs(record, updatedRecord);
+        updateOps.forEach(operation => {
+          if (operation.op === 'replaceKey') {
+            serializer.storeKey(record, operation.key, operation.value);
+          }
+        });
         if (updateOps.length > 0) {
           return [buildTransform(updateOps)];
         }


### PR DESCRIPTION
Here's my attempt to resolve the issue I've written on Gitter some time ago.

To give a bit of context:

```javascript
await store.update(t => t.addRecord({
  type: 'planet',
  id: 'jupiter'
}));

let forkedStore = store.fork();

await forkedStore.update(t => t.addRecord({
  type: 'moon',
  id: 'io'
}));

await forkedStore.update(t => t.addToRelatedRecords(
  { type: 'planet', id: 'jupiter' },
  'moons',
  { type: 'moon', id: 'io' }
));

await store.merge(forkedStore);
```

The above code won't work with server-generated ids. After a successful Io creation a remote id update will be queued in a new transform - _after_ the fork merge. It means it's impossible to save the addToRelatedRecords operation, since the server generated id wasn't stored yet.

I made a patch here that applies server generated id immediately after successful push. It's not a nice solution, but I can't really come up with anything better.