### PR TITLE
Apply changes returned by a server after PATCH request

### DIFF
--- a/packages/@orbit/jsonapi/src/lib/transform-requests.ts
+++ b/packages/@orbit/jsonapi/src/lib/transform-requests.ts
@@ -30,22 +30,7 @@ export const TransformRequestProcessors = {
     const settings = buildFetchSettings(request.options, { method: 'POST', json: requestDoc });
 
     return source.fetch(source.resourceURL(record.type), settings)
-      .then((raw: JSONAPIDocument) => {
-        let responseDoc: DeserializedDocument = serializer.deserializeDocument(raw, record);
-        let updatedRecord: Record = <Record>responseDoc.data;
-        let transforms = [];
-        let updateOps = recordDiffs(record, updatedRecord);
-        if (updateOps.length > 0) {
-          transforms.push(buildTransform(updateOps));
-        }
-        if (responseDoc.included && responseDoc.included.length > 0) {
-          let includedOps = responseDoc.included.map(record => {
-            return { op: 'replaceRecord', record };
-          });
-          transforms.push(buildTransform(includedOps));
-        }
-        return transforms;
-      });
+      .then((raw: JSONAPIDocument) => handleChanges(record, serializer.deserializeDocument(raw, record)));
   },
 
   removeRecord(source: JSONAPISource, request) {
@@ -57,13 +42,18 @@ export const TransformRequestProcessors = {
   },
 
   replaceRecord(source: JSONAPISource, request) {
+    const { serializer } = source;
     const record = request.record;
     const { type, id } = record;
-    const requestDoc: JSONAPIDocument = source.serializer.serializeDocument(record);
+    const requestDoc: JSONAPIDocument = serializer.serializeDocument(record);
     const settings = buildFetchSettings(request.options, { method: 'PATCH', json: requestDoc });
 
     return source.fetch(source.resourceURL(type, id), settings)
-      .then(() => []);
+      .then((raw: JSONAPIDocument) => {
+        if (raw) {
+          return handleChanges(record, serializer.deserializeDocument(raw, record));
+        }
+      });
   },
 
   addToRelatedRecords(source: JSONAPISource, request) {
@@ -253,4 +243,20 @@ function replaceRecordHasOne(record: RecordIdentity, relationship: string, relat
 
 function replaceRecordHasMany(record: RecordIdentity, relationship: string, relatedRecords: RecordIdentity[]) {
   deepSet(record, ['relationships', relationship, 'data'], relatedRecords.map(r => cloneRecordIdentity(r)));
+}
+
+function handleChanges(record: Record, responseDoc: DeserializedDocument) {
+  let updatedRecord: Record = <Record>responseDoc.data;
+  let transforms = [];
+  let updateOps = recordDiffs(record, updatedRecord);
+  if (updateOps.length > 0) {
+    transforms.push(buildTransform(updateOps));
+  }
+  if (responseDoc.included && responseDoc.included.length > 0) {
+    let includedOps = responseDoc.included.map(record => {
+      return { op: 'replaceRecord', record };
+    });
+    transforms.push(buildTransform(includedOps));
+  }
+  return transforms;
 }

--- a/packages/@orbit/jsonapi/src/lib/transform-requests.ts
+++ b/packages/@orbit/jsonapi/src/lib/transform-requests.ts
@@ -52,6 +52,8 @@ export const TransformRequestProcessors = {
       .then((raw: JSONAPIDocument) => {
         if (raw) {
           return handleChanges(record, serializer.deserializeDocument(raw, record));
+        } else {
+          return [];
         }
       });
   },


### PR DESCRIPTION
JSONAPI allows server to return [new data in response to PATCH request](http://jsonapi.org/format/#crud-updating-responses-200). Currently Orbit ignores these updates. I added this function by reusing the code that handles POST requests.