### PR TITLE
Fix LS-source interfering with LS-bucket

### DIFF
--- a/packages/@orbit/local-storage/src/lib/pull-operators.ts
+++ b/packages/@orbit/local-storage/src/lib/pull-operators.ts
@@ -19,7 +19,7 @@ export const PullOperators: Dict<PullOperator> = {
     const typeFilter = expression.type;
 
     for (let key in Orbit.globals.localStorage) {
-      if (key.indexOf(source.namespace) === 0) {
+      if (key.indexOf(source.namespace + source.delimiter) === 0) {
         let typesMatch = isNone(typeFilter);
 
         if (!typesMatch) {
@@ -51,7 +51,7 @@ export const PullOperators: Dict<PullOperator> = {
     const requestedRecord = expression.record;
 
     for (let key in Orbit.globals.localStorage) {
-      if (key.indexOf(source.namespace) === 0) {
+      if (key.indexOf(source.namespace + source.delimiter) === 0) {
         let fragments = key.split(source.delimiter);
         let type = fragments[1];
         let id = fragments[2];

--- a/packages/@orbit/local-storage/src/source.ts
+++ b/packages/@orbit/local-storage/src/source.ts
@@ -113,7 +113,7 @@ export default class LocalStorageSource extends Source implements Pullable, Push
 
   reset(): Promise<void> {
     for (let key in Orbit.globals.localStorage) {
-      if (key.indexOf(this.namespace) === 0) {
+      if (key.indexOf(this.namespace + this.delimiter) === 0) {
         Orbit.globals.localStorage.removeItem(key);
       }
     }

--- a/packages/@orbit/local-storage/test/support/local-storage.ts
+++ b/packages/@orbit/local-storage/test/support/local-storage.ts
@@ -28,7 +28,7 @@ export function verifyLocalStorageDoesNotContainRecord(assert, source, record) {
 export function verifyLocalStorageIsEmpty(assert, source) {
   let isEmpty = true;
   for (let key in Orbit.globals.localStorage) {
-    if (key.indexOf(source.namespace) === 0) {
+    if (key.indexOf(source.namespace + source.delimiter) === 0) {
       isEmpty = false;
       break;
     }


### PR DESCRIPTION
When using the localStorage source and bucket at the same time, pulling the source would mistakenly create addRecord operations out of bucket entries, i.e. treat `orbit-bucket/*` keys as records.