### PR TITLE
replaceRelatedRecords after pulling a relationship with JSONAPI

### DIFF
--- a/packages/@orbit/jsonapi/src/lib/pull-operators.ts
+++ b/packages/@orbit/jsonapi/src/lib/pull-operators.ts
@@ -1,14 +1,19 @@
 import { Dict, toArray } from '@orbit/utils';
 import {
   Query,
-  Transform,
+  Operation,
+  ReplaceRelatedRecordOperation,
+  ReplaceRelatedRecordsOperation,
   buildTransform,
+  FindRelatedRecords,
+  FindRelatedRecord,
+  Record
 } from '@orbit/data';
 import JSONAPISource from '../jsonapi-source';
 import { JSONAPIDocument } from '../jsonapi-document';
 import { GetOperators } from "./get-operators";
 
-function deserialize(source: JSONAPISource, document: JSONAPIDocument): Transform[] {
+function deserialize(source: JSONAPISource, document: JSONAPIDocument): Operation[] {
   const deserialized = source.serializer.deserializeDocument(document);
   const records = toArray(deserialized.data);
 
@@ -16,15 +21,19 @@ function deserialize(source: JSONAPISource, document: JSONAPIDocument): Transfor
     Array.prototype.push.apply(records, deserialized.included);
   }
 
-  const operations = records.map(record => {
+  return records.map(record => {
     return {
       op: 'replaceRecord',
       record
     };
   });
-
-  return [buildTransform(operations)];
 }
+
+function extractRecords(source: JSONAPISource, document: JSONAPIDocument): Record[] {
+  const deserialized = source.serializer.deserializeDocument(document);
+  return toArray(deserialized.data);
+}
+
 
 export interface PullOperator {
   (source: JSONAPISource, query: Query): any;
@@ -33,21 +42,53 @@ export interface PullOperator {
 export const PullOperators: Dict<PullOperator> = {
   findRecord(source: JSONAPISource, query: Query) {
     return GetOperators.findRecord(source, query)
-      .then(data => deserialize(source, data));
+      .then(data => [buildTransform(deserialize(source, data))]);
   },
 
   findRecords(source: JSONAPISource, query: Query) {
     return GetOperators.findRecords(source, query)
-      .then(data => deserialize(source, data));
+      .then(data => [buildTransform(deserialize(source, data))]);
   },
 
   findRelatedRecord(source: JSONAPISource, query: Query) {
+    const expression = query.expression as FindRelatedRecord;
+    const { record, relationship } = expression;
+
     return GetOperators.findRelatedRecord(source, query)
-      .then(data => deserialize(source, data));
+      .then((data) => {
+        const operations = deserialize(source, data);
+        const records = extractRecords(source, data);
+        operations.push({
+          op: 'replaceRelatedRecord',
+          record,
+          relationship,
+          relatedRecord: {
+            type: records[0].type,
+            id:   records[0].id
+          }
+        } as ReplaceRelatedRecordOperation);
+        return [buildTransform(operations)];
+      });
   },
 
   findRelatedRecords(source: JSONAPISource, query: Query) {
+    const expression = query.expression as FindRelatedRecords;
+    const { record, relationship } = expression;
+
     return GetOperators.findRelatedRecords(source, query)
-      .then(data => deserialize(source, data));
+      .then((data) => {
+        const operations = deserialize(source, data);
+        const records = extractRecords(source, data);
+        operations.push({
+          op: 'replaceRelatedRecords',
+          record,
+          relationship,
+          relatedRecords: records.map(r => ({
+            type: r.type,
+            id:   r.id
+          }))
+        } as ReplaceRelatedRecordsOperation);
+        return [buildTransform(operations)];
+      });
   }
 };

--- a/packages/@orbit/jsonapi/src/lib/query-operators.ts
+++ b/packages/@orbit/jsonapi/src/lib/query-operators.ts
@@ -51,11 +51,11 @@ export const QueryOperators: Dict<QueryOperator> = {
 
   findRelatedRecord(source: JSONAPISource, query: Query) {
     return GetOperators.findRelatedRecord(source, query)
-      .then(data => deserialize(source, data));
+      .then((data) => deserialize(source, data));
   },
 
   findRelatedRecords(source: JSONAPISource, query: Query) {
     return GetOperators.findRelatedRecords(source, query)
-      .then(data => deserialize(source, data));
+      .then((data) => deserialize(source, data));
   }
 };

--- a/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
@@ -1431,7 +1431,7 @@ module('JSONAPISource', function(hooks) {
     });
 
     test('#pull - relatedRecords', function(assert) {
-      assert.expect(5);
+      assert.expect(8);
 
       let planetRecord: Record = <Record>source.serializer.deserializeDocument({
         data: {
@@ -1454,8 +1454,12 @@ module('JSONAPISource', function(hooks) {
 
       return source.pull(q => q.findRelatedRecords(planetRecord, 'moons')).then((transforms) => {
         assert.equal(transforms.length, 1, 'one transform returned');
-        assert.deepEqual(transforms[0].operations.map(o => o.op), ['replaceRecord']);
-        assert.deepEqual(transforms[0].operations.map((o: ReplaceRecordOperation) => o.record.attributes.name), ['Io']);
+        assert.deepEqual(transforms[0].operations.map(o => o.op), ['replaceRecord', 'replaceRelatedRecords']);
+
+        assert.equal(transforms[0].operations[0].record.attributes.name, 'Io');
+        assert.equal(transforms[0].operations[1].record.id, planetRecord.id);
+        assert.equal(transforms[0].operations[1].relationship, 'moons');
+        assert.deepEqual(transforms[0].operations[1].relatedRecords.map(r => r.id),  [transforms[0].operations[0].record.id]);
 
         assert.equal(fetchStub.callCount, 1, 'fetch called once');
         assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');


### PR DESCRIPTION
Let's say I do `store.query(q => q.findRelatedRecords(jupiter, 'moons'))`. Now what Orbit does is it requests `GET /planets/jupiter/relationships/moons` and then adds all returned records to the store. My problem is that this response not necessarily include inverse relationship definition (moon has one planet) and if it doesn't, Orbit won't create relationship between Jupiter and its moons.

What I propose here is to always add an `ReplaceRelatedRecordsOperation` to transform returned by relationship loading pull operators. It's based on an assumption that whatever was returned by server it is a current relationship state.

This code isn't written very well, I feel it should be DRY-ed a bit and I don't understand fully what is the difference between pull and query operators. Nevertheless I'm doing this PR to present the problem I'm facing, more as a starting point for a discussion.