### PR TITLE
Expand capabilities of ImmutableMap

### DIFF
--- a/packages/@orbit/immutable/src/immutable-map.ts
+++ b/packages/@orbit/immutable/src/immutable-map.ts
@@ -15,6 +15,10 @@ export default class ImmutableMap<K, V> {
     return this._data.size;
   }
 
+  clear() {
+    this._data = new HAMTMap();
+  }
+
   get(key: K): V {
     return this._data.get(key);
   }

--- a/packages/@orbit/immutable/src/immutable-map.ts
+++ b/packages/@orbit/immutable/src/immutable-map.ts
@@ -27,6 +27,14 @@ export default class ImmutableMap<K, V> {
     this._data = this._data.set(key, value);
   }
 
+  setMany(entries: [K, V][]): void {
+    let data = this._data.beginMutation();
+    entries.forEach(entry => {
+      data.set(entry[0], entry[1]);
+    });
+    this._data = data.endMutation();
+  }
+
   remove(key: K): void {
     this._data = this._data.remove(key);
   }

--- a/packages/@orbit/immutable/src/immutable-map.ts
+++ b/packages/@orbit/immutable/src/immutable-map.ts
@@ -39,6 +39,10 @@ export default class ImmutableMap<K, V> {
     return this._data.values();
   }
 
+  entries(): IterableIterator<[number, V]> {
+    return this._data.entries();
+  }
+
   protected get data(): HAMTMap {
     return this._data;
   }

--- a/packages/@orbit/immutable/src/immutable-map.ts
+++ b/packages/@orbit/immutable/src/immutable-map.ts
@@ -39,6 +39,14 @@ export default class ImmutableMap<K, V> {
     this._data = this._data.remove(key);
   }
 
+  removeMany(keys: K[]): void {
+    let data = this._data.beginMutation();
+    keys.forEach(key => {
+      data.remove(key);
+    });
+    this._data = data.endMutation();
+  }
+
   has(key: K): boolean {
     return this.get(key) !== undefined;
   }

--- a/packages/@orbit/immutable/test/immutable-map-test.ts
+++ b/packages/@orbit/immutable/test/immutable-map-test.ts
@@ -41,31 +41,31 @@ module('ImmutableMap', function() {
     assert.equal(map.size, 0, 'size matches expectations');
   });
 
-	test('maps can be instantiated based on other maps and their contents will be equal (but then will diverge)', function(assert) {
-		let map = new ImmutableMap<string, object>();
+  test('maps can be instantiated based on other maps and their contents will be equal (but then will diverge)', function(assert) {
+    let map = new ImmutableMap<string, object>();
 
-		let jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter' }};
-		map.set('jupiter', jupiter);
+    let jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter' }};
+    map.set('jupiter', jupiter);
 
-		assert.strictEqual(map.get('jupiter'), jupiter, 'record matches expectations');
+    assert.strictEqual(map.get('jupiter'), jupiter, 'record matches expectations');
 
     // create a new map based on the original
     let map2 = new ImmutableMap<string, object>(map);
 
-		assert.strictEqual(map2.get('jupiter'), jupiter, 'record matches expectations');
+    assert.strictEqual(map2.get('jupiter'), jupiter, 'record matches expectations');
 
-		let jupiter2 = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter2' }};
-		map2.set('jupiter', jupiter2);
+    let jupiter2 = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter2' }};
+    map2.set('jupiter', jupiter2);
 
-		let pluto = { type: 'planet', id: 'pluto', attributes: { name: 'Pluto' }};
-		map2.set('pluto', pluto);
+    let pluto = { type: 'planet', id: 'pluto', attributes: { name: 'Pluto' }};
+    map2.set('pluto', pluto);
 
     assert.equal(map.size, 1, 'original map still has one member');
-		assert.strictEqual(map.get('jupiter'), jupiter, 'original map is unchanged');
+    assert.strictEqual(map.get('jupiter'), jupiter, 'original map is unchanged');
 
     assert.equal(map2.size, 2, 'new map now has two members');
-		assert.strictEqual(map2.get('jupiter'), jupiter2, 'replacement record matches expectations');
-		assert.strictEqual(map2.get('pluto'), pluto, 'new record matches expectations');
+    assert.strictEqual(map2.get('jupiter'), jupiter2, 'replacement record matches expectations');
+    assert.strictEqual(map2.get('pluto'), pluto, 'new record matches expectations');
 
     map2.remove('jupiter');
     map2.remove('pluto');
@@ -73,6 +73,34 @@ module('ImmutableMap', function() {
     assert.equal(map2.size, 0, 'size matches expectations');
 
     assert.equal(map.size, 1, 'original map still has one member');
-		assert.strictEqual(map.get('jupiter'), jupiter, 'original map is unchanged');
-	});
+    assert.strictEqual(map.get('jupiter'), jupiter, 'original map is unchanged');
+  });
+
+  test('maps can set and remove multiple items at once', function(assert) {
+    let jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter' }};
+    let jupiter2 = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter2' }};
+    let pluto = { type: 'planet', id: 'pluto', attributes: { name: 'Pluto' }};
+    let earth = { type: 'planet', id: 'earth', attributes: { name: 'Earth' }};
+
+    let map = new ImmutableMap<string, object>();
+    map.setMany([
+      ['jupiter', jupiter],
+      ['jupiter', jupiter2],
+      ['pluto', pluto],
+      ['earth', earth]
+    ]);
+
+    assert.equal(map.size, 3, 'map has three members');
+    assert.strictEqual(map.get('jupiter'), jupiter2, 'jupiter has been updated');
+    assert.strictEqual(map.get('pluto'), pluto, 'pluto is set');
+    assert.strictEqual(map.get('earth'), earth, 'earth is set');
+
+    map.removeMany(['jupiter', 'earth']);
+    assert.equal(map.size, 1, 'map has one members');
+    assert.strictEqual(map.get('pluto'), pluto, 'pluto is set');
+
+    map.clear();
+
+    assert.equal(map.size, 0, 'map has been cleared');
+  });
 });

--- a/packages/@orbit/immutable/test/immutable-map-test.ts
+++ b/packages/@orbit/immutable/test/immutable-map-test.ts
@@ -33,6 +33,7 @@ module('ImmutableMap', function() {
     assert.equal(map.size, 2, 'size matches expectations');
     assert.deepEqual(Array.from(map.keys()), ['pluto', 'jupiter'], 'keys match expectations');
     assert.deepEqual(Array.from(map.values()), [pluto, jupiter2], 'values match expectations');
+    assert.deepEqual(Array.from(map.entries()), [['pluto', pluto], ['jupiter', jupiter2]], 'entries match expectations');
 
     map.remove('jupiter');
     map.remove('pluto');


### PR DESCRIPTION
Introduce new methods to `ImmutableMap`:

* `entries`
* `clear`
* `setMany`
* `removeMany`

`setMany` and `removeMany` are more efficient than calling `set` or `remove` multiple times.