### PR TITLE
Fix queryBuilder type

### DIFF
--- a/packages/@orbit/data/src/query.ts
+++ b/packages/@orbit/data/src/query.ts
@@ -4,7 +4,7 @@ import { QueryTerm } from './query-term';
 import QueryBuilder from './query-builder';
 import { isObject } from '@orbit/utils';
 
-export type QueryBuilderFunc = (QueryBuilder) => QueryExpression;
+export type QueryBuilderFunc = (QueryBuilder: QueryBuilder) => QueryExpression;
 export type QueryOrExpression = Query | QueryExpression | QueryTerm | QueryBuilderFunc;
 
 /**


### PR DESCRIPTION
This PR effectively fixes the `any` type mistakenly set to the queryBuilder object.