### PR TITLE
Define Listener interface and remove support for explicit binding object in listeners

### DIFF
--- a/packages/@orbit/coordinator/src/strategies/connection-strategy.ts
+++ b/packages/@orbit/coordinator/src/strategies/connection-strategy.ts
@@ -1,5 +1,6 @@
 import Coordinator, { ActivationOptions } from '../coordinator';
 import { Strategy, StrategyOptions } from '../strategy';
+import { Listener } from '@orbit/core';
 import { Source } from '@orbit/data';
 import { assert } from '@orbit/utils';
 
@@ -55,7 +56,7 @@ export class ConnectionStrategy extends Strategy {
   protected _event: string;
   protected _action: string | Function;
   protected _catch: Function;
-  protected _listener: Function;
+  protected _listener: Listener;
   protected _filter: Function;
 
   constructor(options: ConnectionStrategyOptions) {
@@ -99,16 +100,16 @@ export class ConnectionStrategy extends Strategy {
   async activate(coordinator: Coordinator, options: ActivationOptions = {}): Promise<void> {
     await super.activate(coordinator, options);
     this._listener = this._generateListener();
-    this.source.on(this._event, this._listener, this);
+    this.source.on(this._event, this._listener);
   }
 
   async deactivate(): Promise<void> {
     await super.deactivate()
-    this.source.off(this._event, this._listener, this);
+    this.source.off(this._event, this._listener);
     this._listener = null;
   }
 
-  protected _generateListener(): Function {
+  protected _generateListener(): Listener {
     const target = this.target as any;
 
     return (...args: any[]) => {

--- a/packages/@orbit/coordinator/src/strategies/event-logging-strategy.ts
+++ b/packages/@orbit/coordinator/src/strategies/event-logging-strategy.ts
@@ -1,5 +1,6 @@
 import Coordinator, { ActivationOptions, LogLevel } from '../coordinator';
 import { Strategy, StrategyOptions } from '../strategy';
+import { Listener } from '@orbit/core';
 import {
   Source,
   isPullable,
@@ -20,7 +21,7 @@ export interface EventLoggingStrategyOptions extends StrategyOptions {
 export class EventLoggingStrategy extends Strategy {
   protected _events?: string[];
   protected _interfaces?: string[];
-  protected _eventListeners: Dict<Dict<Function>>;
+  protected _eventListeners: Dict<Dict<Listener>>;
 
   constructor(options: EventLoggingStrategyOptions = {}) {
     options.name = options.name || 'event-logging';
@@ -115,17 +116,17 @@ export class EventLoggingStrategy extends Strategy {
   protected _addListener(source: Source, event: string): void {
     const listener = this._generateListener(source, event);
     deepSet(this._eventListeners, [source.name, event], listener);
-    source.on(event, listener, this);
+    source.on(event, listener);
   }
 
   protected _removeListener(source: Source, event: string): void {
     const listener = deepGet(this._eventListeners, [source.name, event]);
-    source.off(event, listener, this);
+    source.off(event, listener);
     this._eventListeners[source.name][event] = null;
   }
 
-  protected _generateListener(source: Source, event: string): Function {
-    return (...args: any[]): void => {
+  protected _generateListener(source: Source, event: string): Listener {
+    return (...args: any[]) => {
       console.log(this._logPrefix, source.name, event, ...args);
     };
   }

--- a/packages/@orbit/coordinator/test/strategies/event-logging-strategy-test.ts
+++ b/packages/@orbit/coordinator/test/strategies/event-logging-strategy-test.ts
@@ -3,17 +3,13 @@ import Coordinator, {
 } from '../../src/index';
 import {
   Source,
-  TransformBuilder,
-  buildTransform
+  TransformBuilder
 } from '@orbit/data';
 
 const { module, test } = QUnit;
 
 module('EventLoggingStrategy', function(hooks) {
   const t = new TransformBuilder();
-  const tA = buildTransform([t.addRecord({ type: 'planet', id: 'a', attributes: { name: 'a' } })], null, 'a');
-  const tB = buildTransform([t.addRecord({ type: 'planet', id: 'b', attributes: { name: 'b' } })], null, 'b');
-  const tC = buildTransform([t.addRecord({ type: 'planet', id: 'c', attributes: { name: 'c' } })], null, 'c');
 
   let eventLoggingStrategy;
 

--- a/packages/@orbit/core/src/bucket.ts
+++ b/packages/@orbit/core/src/bucket.ts
@@ -1,4 +1,5 @@
 import evented, { Evented } from './evented';
+import { Listener } from './notifier';
 
 /**
  * Settings used to instantiate and/or upgrade a `Bucket`.
@@ -47,11 +48,11 @@ export abstract class Bucket implements Evented {
   private _version: number;
 
   // Evented interface stubs
-  on: (event: BUCKET_EVENTS, callback: Function, binding?: object) => void;
-  off: (event: BUCKET_EVENTS, callback: Function, binding?: object) => void;
-  one: (event: BUCKET_EVENTS, callback: Function, binding?: object) => void;
+  on: (event: BUCKET_EVENTS, listener: Listener) => void;
+  off: (event: BUCKET_EVENTS, listener: Listener) => void;
+  one: (event: BUCKET_EVENTS, listener: Listener) => void;
   emit: (event: BUCKET_EVENTS, ...args: any[]) => void;
-  listeners: (event: BUCKET_EVENTS) => any[];
+  listeners: (event: BUCKET_EVENTS) => Listener[];
 
   constructor(settings: BucketSettings = {}) {
     if (settings.version === undefined) {

--- a/packages/@orbit/core/src/index.ts
+++ b/packages/@orbit/core/src/index.ts
@@ -5,5 +5,5 @@ export { default as TaskProcessor } from './task-processor';
 export { Bucket, BucketSettings, BUCKET_EVENTS } from './bucket';
 export { default as evented, Evented, isEvented, settleInSeries, fulfillInSeries } from './evented';
 export * from './exception';
-export { default as Notifier } from './notifier';
+export { default as Notifier, Listener } from './notifier';
 export { default as Log, LogOptions } from './log';

--- a/packages/@orbit/core/src/log.ts
+++ b/packages/@orbit/core/src/log.ts
@@ -1,5 +1,6 @@
 import { assert } from '@orbit/utils';
 import evented, { Evented } from './evented';
+import { Listener } from './notifier';
 import { Bucket } from './bucket';
 import { NotLoggedException, OutOfRangeException } from './exception';
 
@@ -25,11 +26,11 @@ export default class Log implements Evented {
   public reified: Promise<void>;
 
   // Evented interface stubs
-  on: (event: string, callback: () => void, binding?: any) => void;
-  off: (event: string, callback: () => void, binding?: any) => void;
-  one: (event: string, callback: () => void, binding?: any) => void;
+  on: (event: string, listener: Listener) => void;
+  off: (event: string, listener: Listener) => void;
+  one: (event: string, listener: Listener) => void;
   emit: (event: string, ...args: any[]) => void;
-  listeners: (event: string) => any[];
+  listeners: (event: string) => Listener[];
 
   constructor(options: LogOptions = {}) {
     this._name = options.name;

--- a/packages/@orbit/core/src/task-queue.ts
+++ b/packages/@orbit/core/src/task-queue.ts
@@ -2,6 +2,7 @@ import { Task, Performer } from './task';
 import TaskProcessor from './task-processor';
 import { Bucket } from './bucket';
 import evented, { Evented, settleInSeries } from './evented';
+import { Listener } from './notifier';
 import { assert } from '@orbit/utils';
 
 /**
@@ -56,11 +57,11 @@ export default class TaskQueue implements Evented {
   private _reified: Promise<any>;
 
   // Evented interface stubs
-  on: (event: TASK_QUEUE_EVENTS, callback: Function, binding?: object) => void;
-  off: (event: TASK_QUEUE_EVENTS, callback: Function, binding?: object) => void;
-  one: (event: TASK_QUEUE_EVENTS, callback: Function, binding?: object) => void;
+  on: (event: TASK_QUEUE_EVENTS, listener: Listener) => void;
+  off: (event: TASK_QUEUE_EVENTS, listener: Listener) => void;
+  one: (event: TASK_QUEUE_EVENTS, listener: Listener) => void;
   emit: (event: TASK_QUEUE_EVENTS, ...args: any[]) => void;
-  listeners: (event: TASK_QUEUE_EVENTS) => [Function, object][];
+  listeners: (event: TASK_QUEUE_EVENTS) => Listener[];
 
   /**
    * Creates an instance of `TaskQueue`.

--- a/packages/@orbit/core/test/evented-test.ts
+++ b/packages/@orbit/core/test/evented-test.ts
@@ -125,26 +125,6 @@ module('Evented', function(hooks) {
     obj.emit('salutation', 'hello');
   });
 
-  test('#emit - notifies listeners using custom bindings, if specified', function(assert) {
-    assert.expect(4);
-
-    let binding1 = {};
-    let binding2 = {};
-    let listener1 = function(message) {
-      assert.equal(this, binding1, 'custom binding should match');
-      assert.equal(message, 'hello', 'notification message should match');
-    };
-    let listener2 = function(message) {
-      assert.equal(this, binding2, 'custom binding should match');
-      assert.equal(message, 'hello', 'notification message should match');
-    };
-
-    obj.on('greeting', listener1, binding1);
-    obj.on('greeting', listener2, binding2);
-
-    obj.emit('greeting', 'hello');
-  });
-
   test('#emit - notifies listeners when emitting events with any number of arguments', function(assert) {
     assert.expect(4);
 
@@ -163,22 +143,21 @@ module('Evented', function(hooks) {
     obj.emit('greeting', 'hello', 'world');
   });
 
-  test('#listeners - can return all the listeners (and bindings) for an event', function(assert) {
+  test('#listeners - can return all the listeners for an event', function(assert) {
     assert.expect(1);
 
-    let binding1 = {};
-    let binding2 = {};
     let greeting1 = function() {
       return 'Hello';
     };
+
     let greeting2 = function() {
       return 'Bon jour';
     };
 
-    obj.on('greeting', greeting1, binding1);
-    obj.on('greeting', greeting2, binding2);
+    obj.on('greeting', greeting1);
+    obj.on('greeting', greeting2);
 
-    assert.deepEqual(obj.listeners('greeting'), [[greeting1, binding1], [greeting2, binding2]], 'listeners include nested arrays of functions and bindings');
+    assert.deepEqual(obj.listeners('greeting'), [greeting1, greeting2], 'listeners match');
   });
 
   test('settleInSeries - can fulfill all promises returned by listeners to an event, in order, until all are settled', function(assert) {
@@ -206,10 +185,10 @@ module('Evented', function(hooks) {
       return failedOperation();
     };
 
-    obj.on('greeting', listener1, this);
-    obj.on('greeting', listener2, this);
-    obj.on('greeting', listener3, this);
-    obj.on('greeting', listener4, this);
+    obj.on('greeting', listener1);
+    obj.on('greeting', listener2);
+    obj.on('greeting', listener3);
+    obj.on('greeting', listener4);
 
     return settleInSeries(obj, 'greeting', 'hello')
       .then(result => {
@@ -247,8 +226,8 @@ module('Evented', function(hooks) {
       return successfulOperation();
     };
 
-    obj.on('greeting', listener1, this);
-    obj.on('greeting', listener2, this);
+    obj.on('greeting', listener1);
+    obj.on('greeting', listener2);
 
     return fulfillInSeries(obj, 'greeting', 'hello').then(
       function(result) {
@@ -283,10 +262,10 @@ module('Evented', function(hooks) {
       assert.ok(false, 'listener4 should not be triggered');
     };
 
-    obj.on('greeting', listener1, this);
-    obj.on('greeting', listener2, this);
-    obj.on('greeting', listener3, this);
-    obj.on('greeting', listener4, this);
+    obj.on('greeting', listener1);
+    obj.on('greeting', listener2);
+    obj.on('greeting', listener3);
+    obj.on('greeting', listener4);
 
     return fulfillInSeries(obj, 'greeting', 'hello')
       .then(() => {

--- a/packages/@orbit/core/test/notifier-test.ts
+++ b/packages/@orbit/core/test/notifier-test.ts
@@ -50,26 +50,6 @@ module('Notifier', function(hooks) {
     notifier.emit('hello');
   });
 
-  test('it notifies listeners using custom bindings, if specified', function(assert) {
-    assert.expect(4);
-
-    let binding1 = {};
-    let binding2 = {};
-    let listener1 = function(message) {
-      assert.equal(this, binding1, 'custom binding should match');
-      assert.equal(message, 'hello', 'notification message should match');
-    };
-    let listener2 = function(message) {
-      assert.equal(this, binding2, 'custom binding should match');
-      assert.equal(message, 'hello', 'notification message should match');
-    };
-
-    notifier.addListener(listener1, binding1);
-    notifier.addListener(listener2, binding2);
-
-    notifier.emit('hello');
-  });
-
   test('it notifies listeners when publishing any number of arguments', function(assert) {
     assert.expect(4);
 

--- a/packages/@orbit/data/src/schema.ts
+++ b/packages/@orbit/data/src/schema.ts
@@ -2,7 +2,7 @@
 import Orbit from './main';
 import { ModelNotFound } from './exception';
 import { Dict } from '@orbit/utils';
-import { evented, Evented } from '@orbit/core';
+import { evented, Evented, Listener } from '@orbit/core';
 import { Record, RecordInitializer } from './record';
 
 export interface AttributeDefinition {
@@ -86,11 +86,11 @@ export default class Schema implements Evented, RecordInitializer {
   private _version: number;
 
   // Evented interface stubs
-  on: (event: string, callback: () => void, binding?: any) => void;
-  off: (event: string, callback: () => void, binding?: any) => void;
-  one: (event: string, callback: () => void, binding?: any) => void;
+  on: (event: string, listener: Listener) => void;
+  off: (event: string, listener: Listener) => void;
+  one: (event: string, listener: Listener) => void;
   emit: (event: string, ...args: any[]) => void;
-  listeners: (event: string) => any[];
+  listeners: (event: string) => Listener[];
 
   constructor(settings: SchemaSettings = {}) {
     if (settings.version === undefined) {

--- a/packages/@orbit/data/src/source.ts
+++ b/packages/@orbit/data/src/source.ts
@@ -5,6 +5,7 @@ import {
   TaskQueue,
   TaskQueueSettings,
   Task, Performer,
+  Listener,
   Log
 } from '@orbit/core';
 import KeyMap from './key-map';
@@ -44,11 +45,11 @@ export abstract class Source implements Evented, Performer {
   protected _transformBuilder: TransformBuilder;
 
   // Evented interface stubs
-  on: (event: string, callback: Function, binding?: object) => void;
-  off: (event: string, callback: Function, binding?: object) => void;
-  one: (event: string, callback: Function, binding?: object) => void;
+  on: (event: string, listener: Listener) => void;
+  off: (event: string, listener: Listener) => void;
+  one: (event: string, listener: Listener) => void;
   emit: (event: string, ...args: any[]) => void;
-  listeners: (event: string) => any[];
+  listeners: (event: string) => Listener[];
 
   constructor(settings: SourceSettings = {}) {
     this._schema = settings.schema;

--- a/packages/@orbit/record-cache/src/async-record-cache.ts
+++ b/packages/@orbit/record-cache/src/async-record-cache.ts
@@ -1,6 +1,7 @@
 import {
   evented,
-  Evented
+  Evented,
+  Listener
 } from '@orbit/core';
 import { assert, isArray, deepGet, Dict } from '@orbit/utils';
 import {
@@ -50,11 +51,11 @@ export abstract class AsyncRecordCache implements Evented, AsyncRecordAccessor {
   protected _inversePatchOperators: Dict<AsyncInversePatchOperator>;
 
   // Evented interface stubs
-  on: (event: string, callback: Function, binding?: object) => void;
-  off: (event: string, callback: Function, binding?: object) => void;
-  one: (event: string, callback: Function, binding?: object) => void;
+  on: (event: string, listener: Listener) => void;
+  off: (event: string, listener: Listener) => void;
+  one: (event: string, listener: Listener) => void;
   emit: (event: string, ...args: any[]) => void;
-  listeners: (event: string) => any[];
+  listeners: (event: string) => Listener[];
 
   constructor(settings: AsyncRecordCacheSettings) {
     this._schema = settings.schema;

--- a/packages/@orbit/record-cache/src/sync-record-cache.ts
+++ b/packages/@orbit/record-cache/src/sync-record-cache.ts
@@ -1,6 +1,7 @@
 import {
   evented,
-  Evented
+  Evented,
+  Listener
 } from '@orbit/core';
 import { assert, isArray, deepGet, Dict } from '@orbit/utils';
 import {
@@ -50,11 +51,11 @@ export abstract class SyncRecordCache implements Evented, SyncRecordAccessor {
   protected _inversePatchOperators: Dict<SyncInversePatchOperator>;
 
   // Evented interface stubs
-  on: (event: string, callback: Function, binding?: object) => void;
-  off: (event: string, callback: Function, binding?: object) => void;
-  one: (event: string, callback: Function, binding?: object) => void;
+  on: (event: string, listener: Listener) => void;
+  off: (event: string, listener: Listener) => void;
+  one: (event: string, listener: Listener) => void;
   emit: (event: string, ...args: any[]) => void;
-  listeners: (event: string) => any[];
+  listeners: (event: string) => Listener[];
 
   constructor(settings: SyncRecordCacheSettings) {
     this._schema = settings.schema;

--- a/packages/@orbit/store/src/store.ts
+++ b/packages/@orbit/store/src/store.ts
@@ -59,9 +59,9 @@ export default class Store extends Source implements Syncable, Queryable, Updata
     this._transforms = {};
     this._transformInverses = {};
 
-    this.transformLog.on('clear', <() => void>this._logCleared, this);
-    this.transformLog.on('truncate', <() => void>this._logTruncated, this);
-    this.transformLog.on('rollback', <() => void>this._logRolledback, this);
+    this.transformLog.on('clear', this._logCleared.bind(this));
+    this.transformLog.on('truncate', this._logTruncated.bind(this));
+    this.transformLog.on('rollback', this._logRolledback.bind(this));
 
     let cacheSettings: CacheSettings = settings.cacheSettings || {};
     cacheSettings.schema = schema;


### PR DESCRIPTION
Event listeners no longer need to be able to support an explicit `binding`, when the listeners themselves can be directly bound instead (if necessary).

Also, explicitly defines a `Listener` interface for better typings (vs. the generic `Function`).