### PR TITLE
Further typing improvements + test refactor

### DIFF
--- a/packages/@orbit/coordinator/test/coordinator-test.ts
+++ b/packages/@orbit/coordinator/test/coordinator-test.ts
@@ -1,4 +1,4 @@
-import Coordinator, { Strategy } from '../src/index';
+import Coordinator, { Strategy, CoordinatorOptions, ActivationOptions } from '../src/index';
 import { Source } from '@orbit/data';
 
 const { module, test } = QUnit;
@@ -7,7 +7,7 @@ module('Coordinator', function(hooks) {
   class MySource extends Source {}
   class MyStrategy extends Strategy {}
 
-  let coordinator;
+  let coordinator: Coordinator;
 
   test('can be instantiated', function(assert) {
     coordinator = new Coordinator();
@@ -204,7 +204,7 @@ module('Coordinator', function(hooks) {
     let deactivatedCount = 0;
 
     class CustomStrategy extends Strategy {
-      async activate(coordinator, options): Promise<void> {
+      async activate(coordinator: Coordinator, options: ActivationOptions): Promise<void> {
         activatedCount++;
         if (activatedCount === 1) {
           assert.strictEqual(this.name, 's2', 'expected order');
@@ -249,7 +249,7 @@ module('Coordinator', function(hooks) {
     assert.expect(2);
 
     class CustomStrategy extends Strategy {
-      async activate(coordinator, options): Promise<void> {
+      async activate(coordinator: Coordinator, options: ActivationOptions): Promise<void> {
         assert.ok(false, 'strategies should not be activated');
       }
 

--- a/packages/@orbit/coordinator/test/strategies/connection-strategy-test.ts
+++ b/packages/@orbit/coordinator/test/strategies/connection-strategy-test.ts
@@ -16,10 +16,11 @@ module('ConnectionStrategy', function(hooks) {
   const t = new TransformBuilder();
   const tA = buildTransform([t.addRecord({ type: 'planet', id: 'a', attributes: { name: 'a' } })], null, 'a');
   const tB = buildTransform([t.addRecord({ type: 'planet', id: 'b', attributes: { name: 'b' } })], null, 'b');
-  const tC = buildTransform([t.addRecord({ type: 'planet', id: 'c', attributes: { name: 'c' } })], null, 'c');
-  const tD = buildTransform([t.addRecord({ type: 'planet', id: 'd', attributes: { name: 'd' } })], null, 'd');
 
-  let strategy, coordinator, s1, s2;
+  let strategy: ConnectionStrategy;
+  let coordinator: Coordinator;
+  let s1: any;
+  let s2: any;
 
   hooks.beforeEach(function() {
     @pushable
@@ -85,11 +86,11 @@ module('ConnectionStrategy', function(hooks) {
       strategies: [strategy]
     });
 
-    s1._update = async function(transform) {
+    s1._update = async function(transform: Transform): Promise<any> {
       assert.strictEqual(transform, tA, 'argument to _update is expected Transform');
     };
 
-    s2._push = async function(transform) {
+    s2._push = async function(transform: Transform): Promise<Transform[]> {
       assert.strictEqual(transform, tA, 'argument to _push is expected Transform');
       assert.strictEqual(this, s2, 'context is that of the target');
       return [];
@@ -118,10 +119,10 @@ module('ConnectionStrategy', function(hooks) {
       strategies: [strategy]
     });
 
-    s1._update = async function(transform) {
+    s1._update = async function(transform: Transform): Promise<any> {
     };
 
-    s2._push = async function(transform) {
+    s2._push = async function(transform: Transform): Promise<Transform[]> {
       assert.strictEqual(transform, tB, 'argument to _push is expected Transform');
       assert.strictEqual(this, s2, 'context is that of the target');
       return [];

--- a/packages/@orbit/coordinator/test/strategies/event-logging-strategy-test.ts
+++ b/packages/@orbit/coordinator/test/strategies/event-logging-strategy-test.ts
@@ -9,9 +9,7 @@ import {
 const { module, test } = QUnit;
 
 module('EventLoggingStrategy', function(hooks) {
-  const t = new TransformBuilder();
-
-  let eventLoggingStrategy;
+  let eventLoggingStrategy: EventLoggingStrategy;
 
   test('can be instantiated', function(assert) {
     eventLoggingStrategy = new EventLoggingStrategy();

--- a/packages/@orbit/coordinator/test/strategies/log-truncation-strategy-test.ts
+++ b/packages/@orbit/coordinator/test/strategies/log-truncation-strategy-test.ts
@@ -16,7 +16,11 @@ module('LogTruncationStrategy', function(hooks) {
   const tC = buildTransform([t.addRecord({ type: 'planet', id: 'c', attributes: { name: 'c' } })], null, 'c');
   const tD = buildTransform([t.addRecord({ type: 'planet', id: 'd', attributes: { name: 'd' } })], null, 'd');
 
-  let logTruncationStrategy, coordinator, s1, s2, s3;
+  let logTruncationStrategy: LogTruncationStrategy;
+  let coordinator: Coordinator;
+  let s1: any;
+  let s2: any;
+  let s3: any;
 
   hooks.beforeEach(function() {
     class MySource extends Source {}

--- a/packages/@orbit/coordinator/test/strategies/request-strategy-test.ts
+++ b/packages/@orbit/coordinator/test/strategies/request-strategy-test.ts
@@ -16,10 +16,11 @@ module('RequestStrategy', function(hooks) {
   const t = new TransformBuilder();
   const tA = buildTransform([t.addRecord({ type: 'planet', id: 'a', attributes: { name: 'a' } })], null, 'a');
   const tB = buildTransform([t.addRecord({ type: 'planet', id: 'b', attributes: { name: 'b' } })], null, 'b');
-  const tC = buildTransform([t.addRecord({ type: 'planet', id: 'c', attributes: { name: 'c' } })], null, 'c');
-  const tD = buildTransform([t.addRecord({ type: 'planet', id: 'd', attributes: { name: 'd' } })], null, 'd');
 
-  let strategy, coordinator, s1, s2;
+  let strategy: RequestStrategy;
+  let coordinator: Coordinator;
+  let s1: any;
+  let s2: any;
 
   hooks.beforeEach(function() {
     @pushable
@@ -85,11 +86,11 @@ module('RequestStrategy', function(hooks) {
       strategies: [strategy]
     });
 
-    s1._update = async function(transform) {
+    s1._update = async function(transform: Transform): Promise<any> {
       assert.strictEqual(transform, tA, 'argument to _update is expected Transform');
     };
 
-    s2._push = async function(transform) {
+    s2._push = async function(transform: Transform): Promise<Transform[]> {
       assert.strictEqual(transform, tA, 'argument to _push is expected Transform');
       assert.strictEqual(this, s2, 'context is that of the target');
       return [];
@@ -107,7 +108,7 @@ module('RequestStrategy', function(hooks) {
       target: 's2',
       on: 'update',
       action: 'push',
-      filter(transform: Transform) {
+      filter(transform: Transform): boolean {
         assert.strictEqual(this, strategy, 'context is the strategy');
         return (transform === tB);
       }
@@ -118,10 +119,10 @@ module('RequestStrategy', function(hooks) {
       strategies: [strategy]
     });
 
-    s1._update = async function() {
+    s1._update = async function(): Promise<any> {
     };
 
-    s2._push = async function(transform) {
+    s2._push = async function(transform: Transform): Promise<Transform[]> {
       assert.strictEqual(transform, tB, 'argument to _push is expected Transform');
       assert.strictEqual(this, s2, 'context is that of the target');
       return [];
@@ -140,10 +141,10 @@ module('RequestStrategy', function(hooks) {
       target: 's2',
       on: 'update',
       action: 'push',
-      blocking(query) {
+      blocking(transform: Transform): boolean {
         assert.ok(this instanceof RequestStrategy, 'it is bound to the strategy');
-        assert.strictEqual(query, tA, "argument to _update is expected Transform");
-        return;
+        assert.strictEqual(transform, tA, "argument to _update is expected Transform");
+        return false;
       }
     });
 
@@ -152,11 +153,11 @@ module('RequestStrategy', function(hooks) {
       strategies: [strategy]
     });
 
-    s1._update = async function(transform) {
+    s1._update = async function(transform: Transform): Promise<any> {
       assert.strictEqual(transform, tA, 'argument to _update is expected Transform');
     };
 
-    s2._push = async function(transform) {
+    s2._push = async function(transform: Transform): Promise<Transform[]> {
       assert.strictEqual(transform, tA, 'argument to _push is expected Transform');
       assert.strictEqual(this, s2, 'context is that of the target');
       return [];

--- a/packages/@orbit/coordinator/test/strategies/sync-strategy-test.ts
+++ b/packages/@orbit/coordinator/test/strategies/sync-strategy-test.ts
@@ -8,6 +8,7 @@ import {
   syncable,
   buildTransform
 } from '@orbit/data';
+import { Exception } from '@orbit/core';
 
 const { module, test } = QUnit;
 
@@ -16,7 +17,10 @@ module('SyncStrategy', function(hooks) {
   const tA = buildTransform([t.addRecord({ type: 'planet', id: 'a', attributes: { name: 'a' } })], null, 'a');
   const tB = buildTransform([t.addRecord({ type: 'planet', id: 'b', attributes: { name: 'b' } })], null, 'b');
 
-  let strategy, coordinator, s1, s2;
+  let strategy: SyncStrategy;
+  let coordinator: Coordinator;
+  let s1: any;
+  let s2: any;
 
   hooks.beforeEach(function() {
     @syncable
@@ -82,7 +86,7 @@ module('SyncStrategy', function(hooks) {
       strategies: [strategy]
     });
 
-    s2._sync = async function(transform) {
+    s2._sync = async function(transform: Transform): Promise<void> {
       assert.strictEqual(transform, tA, 'argument to _sync is expected Transform');
       assert.strictEqual(this, s2, 'context is that of the target');
     };
@@ -97,7 +101,7 @@ module('SyncStrategy', function(hooks) {
     strategy = new SyncStrategy({
       source: 's1',
       target: 's2',
-      filter(transform: Transform) {
+      filter(transform: Transform): boolean {
         assert.strictEqual(this, strategy, 'context is the strategy');
         return (transform === tB);
       }
@@ -108,7 +112,7 @@ module('SyncStrategy', function(hooks) {
       strategies: [strategy]
     });
 
-    s2._sync = async function(transform) {
+    s2._sync = async function(transform: Transform): Promise<void> {
       assert.strictEqual(transform, tB, 'argument to _sync is expected Transform');
       assert.strictEqual(this, s2, 'context is that of the target');
     };
@@ -124,7 +128,7 @@ module('SyncStrategy', function(hooks) {
       source: 's1',
       target: 's2',
       blocking: true,
-      catch(e, transform: Transform) {
+      catch(e: Exception, transform: Transform) {
         assert.equal(e.message, ':(', 'error matches');
         assert.strictEqual(transform, tA, 'argument to catch is expected Transform');
         assert.strictEqual(this, strategy, 'context is the strategy');
@@ -136,7 +140,7 @@ module('SyncStrategy', function(hooks) {
       strategies: [strategy]
     });
 
-    s2._sync = function(transform) {
+    s2._sync = async function(transform: Transform): Promise<void> {
       assert.strictEqual(transform, tA, 'argument to _sync is expected Transform');
       assert.strictEqual(this, s2, 'context is that of the target');
       throw new Error(':(');
@@ -155,7 +159,7 @@ module('SyncStrategy', function(hooks) {
       source: 's1',
       target: 's2',
       blocking: true,
-      catch(e, transform: Transform) {
+      catch(e: Exception, transform: Transform) {
         assert.equal(e.message, ':(', 'error matches');
         assert.strictEqual(transform, tA, 'argument to catch is expected Transform');
         assert.strictEqual(this, strategy, 'context is the strategy');
@@ -168,7 +172,7 @@ module('SyncStrategy', function(hooks) {
       strategies: [strategy]
     });
 
-    s2._sync = function(transform) {
+    s2._sync = function(transform: Transform): Promise<void> {
       assert.strictEqual(transform, tA, 'argument to _sync is expected Transform');
       assert.strictEqual(this, s2, 'context is that of the target');
       throw new Error(':(');

--- a/packages/@orbit/coordinator/tsconfig.tests.json
+++ b/packages/@orbit/coordinator/tsconfig.tests.json
@@ -8,7 +8,8 @@
     "inlineSourceMap": true,
     "declaration": false,
     "newLine": "LF",
-    "types": ["qunit"]
+    "types": ["qunit"],
+    "noImplicitAny": true
   },
   "include": [
     "src/**/*.ts",

--- a/packages/@orbit/core/src/bucket.ts
+++ b/packages/@orbit/core/src/bucket.ts
@@ -49,7 +49,7 @@ export abstract class Bucket implements Evented {
 
   // Evented interface stubs
   on: (event: BUCKET_EVENTS, listener: Listener) => void;
-  off: (event: BUCKET_EVENTS, listener: Listener) => void;
+  off: (event: BUCKET_EVENTS, listener?: Listener) => void;
   one: (event: BUCKET_EVENTS, listener: Listener) => void;
   emit: (event: BUCKET_EVENTS, ...args: any[]) => void;
   listeners: (event: BUCKET_EVENTS) => Listener[];

--- a/packages/@orbit/core/src/evented.ts
+++ b/packages/@orbit/core/src/evented.ts
@@ -167,7 +167,7 @@ function notifierForEvent(object: any, eventName: string, createIfUndefined = fa
   }
   let notifier = object._eventedNotifiers[eventName];
   if (!notifier && createIfUndefined) {
-    notifier = object._eventedNotifiers[eventName] = new Notifier(object);
+    notifier = object._eventedNotifiers[eventName] = new Notifier();
   }
   return notifier;
 }

--- a/packages/@orbit/core/src/evented.ts
+++ b/packages/@orbit/core/src/evented.ts
@@ -25,7 +25,7 @@ export function isEvented(obj: any): boolean {
  */
 export interface Evented {
   on: (event: string, listener: Listener) => void;
-  off: (event: string, listener: Listener) => void;
+  off: (event: string, listener?: Listener) => void;
   one: (event: string, listener: Listener) => void;
   emit: (event: string, ...args: any[]) => void;
   listeners: (event: string) => Listener[];

--- a/packages/@orbit/core/src/log.ts
+++ b/packages/@orbit/core/src/log.ts
@@ -27,7 +27,7 @@ export default class Log implements Evented {
 
   // Evented interface stubs
   on: (event: string, listener: Listener) => void;
-  off: (event: string, listener: Listener) => void;
+  off: (event: string, listener?: Listener) => void;
   one: (event: string, listener: Listener) => void;
   emit: (event: string, ...args: any[]) => void;
   listeners: (event: string) => Listener[];

--- a/packages/@orbit/core/src/task-queue.ts
+++ b/packages/@orbit/core/src/task-queue.ts
@@ -58,7 +58,7 @@ export default class TaskQueue implements Evented {
 
   // Evented interface stubs
   on: (event: TASK_QUEUE_EVENTS, listener: Listener) => void;
-  off: (event: TASK_QUEUE_EVENTS, listener: Listener) => void;
+  off: (event: TASK_QUEUE_EVENTS, listener?: Listener) => void;
   one: (event: TASK_QUEUE_EVENTS, listener: Listener) => void;
   emit: (event: TASK_QUEUE_EVENTS, ...args: any[]) => void;
   listeners: (event: TASK_QUEUE_EVENTS) => Listener[];

--- a/packages/@orbit/core/test/evented-test.ts
+++ b/packages/@orbit/core/test/evented-test.ts
@@ -1,4 +1,4 @@
-import evented, { isEvented, fulfillInSeries, settleInSeries } from '../src/evented';
+import { evented, isEvented, fulfillInSeries, settleInSeries, Evented, Listener } from '../src/index';
 
 const { module, test } = QUnit;
 
@@ -15,12 +15,18 @@ function failedOperation() {
 }
 
 module('Evented', function(hooks) {
-  let obj;
+  @evented
+  class Foo implements Evented {
+    on: (event: string, listener: Listener) => void;
+    off: (event: string, listener?: Listener) => void;
+    one: (event: string, listener: Listener) => void;
+    emit: (event: string, ...args: any[]) => void;
+    listeners: (event: string) => Listener[];
+  }
+
+  let obj: Foo;
 
   hooks.beforeEach(function() {
-    @evented
-    class Foo {}
-
     obj = new Foo();
   });
 
@@ -35,10 +41,10 @@ module('Evented', function(hooks) {
   test('#emit - notifies listeners when emitting a simple message', function(assert) {
     assert.expect(2);
 
-    let listener1 = function(message) {
+    let listener1: Listener = function(message: string): void {
       assert.equal(message, 'hello', 'notification message should match');
     };
-    let listener2 = function(message) {
+    let listener2: Listener = function(message: string): void {
       assert.equal(message, 'hello', 'notification message should match');
     };
 
@@ -51,10 +57,10 @@ module('Evented', function(hooks) {
   test('#emit - notifies listeners registered with `one` only once each', function(assert) {
     assert.expect(2);
 
-    let listener1 = function(message) {
+    let listener1: Listener = function(message: string): void {
       assert.equal(message, 'hello', 'notification message should match');
     };
-    let listener2 = function(message) {
+    let listener2: Listener = function(message: string): void {
       assert.equal(message, 'hello', 'notification message should match');
     };
 
@@ -69,10 +75,10 @@ module('Evented', function(hooks) {
   test('#off can unregister individual listeners from an event', function(assert) {
     assert.expect(1);
 
-    let listener1 = function() {
+    let listener1: Listener = function(): void {
       assert.ok(false, 'this listener should not be triggered');
     };
-    let listener2 = function(message) {
+    let listener2: Listener = function(message: string): void {
       assert.equal(message, 'hello', 'notification message should match');
     };
 
@@ -110,10 +116,10 @@ module('Evented', function(hooks) {
   test('#emit - allows listeners to be registered for multiple events', function(assert) {
     assert.expect(3);
 
-    let listener1 = function(message) {
+    let listener1 = function(message: string) {
       assert.equal(message, 'hello', 'notification message should match');
     };
-    let listener2 = function(message) {
+    let listener2 = function(message: string) {
       assert.equal(message, 'hello', 'notification message should match');
     };
 
@@ -164,22 +170,22 @@ module('Evented', function(hooks) {
     assert.expect(10);
 
     let order = 0;
-    let listener1 = function(message) {
+    let listener1 = function(message: string) {
       assert.equal(message, 'hello', 'notification message should match');
       assert.equal(++order, 1, 'listener1 triggered first');
       // doesn't return anything
     };
-    let listener2 = function(message) {
+    let listener2 = function(message: string) {
       assert.equal(message, 'hello', 'notification message should match');
       assert.equal(++order, 2, 'listener2 triggered second');
       return failedOperation();
     };
-    let listener3 = function(message) {
+    let listener3 = function(message: string) {
       assert.equal(message, 'hello', 'notification message should match');
       assert.equal(++order, 3, 'listener3 triggered third');
       return successfulOperation();
     };
-    let listener4 = function(message) {
+    let listener4 = function(message: string) {
       assert.equal(message, 'hello', 'notification message should match');
       assert.equal(++order, 4, 'listener4 triggered fourth');
       return failedOperation();
@@ -215,12 +221,12 @@ module('Evented', function(hooks) {
     assert.expect(7);
 
     let order = 0;
-    let listener1 = function(message) {
+    let listener1 = function(message: string) {
       assert.equal(message, 'hello', 'notification message should match');
       assert.equal(++order, 1, 'listener1 triggered first');
       // doesn't return anything
     };
-    let listener2 = function(message) {
+    let listener2 = function(message: string) {
       assert.equal(message, 'hello', 'notification message should match');
       assert.equal(++order, 2, 'listener2 triggered third');
       return successfulOperation();
@@ -243,17 +249,17 @@ module('Evented', function(hooks) {
     assert.expect(8);
 
     let order = 0;
-    let listener1 = function(message) {
+    let listener1 = function(message: string) {
       assert.equal(message, 'hello', 'notification message should match');
       assert.equal(++order, 1, 'listener1 triggered first');
       // doesn't return anything
     };
-    let listener2 = function(message) {
+    let listener2 = function(message: string) {
       assert.equal(message, 'hello', 'notification message should match');
       assert.equal(++order, 2, 'listener2 triggered third');
       return successfulOperation();
     };
-    let listener3 = function(message) {
+    let listener3 = function(message: string) {
       assert.equal(message, 'hello', 'notification message should match');
       assert.equal(++order, 3, 'listener3 triggered second');
       return failedOperation();

--- a/packages/@orbit/core/test/log-test.ts
+++ b/packages/@orbit/core/test/log-test.ts
@@ -1,6 +1,7 @@
 import Log from '../src/log';
 import { NotLoggedException, OutOfRangeException } from '../src/exception';
 import FakeBucket from './support/fake-bucket';
+import { Bucket } from '../src/bucket';
 
 const { module, test } = QUnit;
 
@@ -9,7 +10,7 @@ module('Log', function() {
   const transformBId = '1d12dc84-0d03-4875-a4a6-0e389737d891';
   const transformCId = 'ea054670-8901-45c2-b908-4db2c5bb9c7d';
   const transformDId = '771b25ff-b971-42e0-aac3-c285aef75326';
-  let log;
+  let log: Log;
 
   test('can be instantiated with no params', function(assert) {
     log = new Log();
@@ -125,7 +126,7 @@ module('Log', function() {
     test('#clear', function(assert) {
       assert.expect(3);
 
-      log.on('clear', (removed) => {
+      log.on('clear', (removed: string[]) => {
         assert.deepEqual(removed, [transformAId, transformBId, transformCId], 'clear event emitted');
       });
 
@@ -257,7 +258,7 @@ module('Log', function() {
   });
 
   module('using a bucket', function(hooks) {
-    let bucket;
+    let bucket: Bucket;
 
     hooks.beforeEach(function() {
       bucket = new FakeBucket({ name: 'fake-bucket' });

--- a/packages/@orbit/core/test/notifier-test.ts
+++ b/packages/@orbit/core/test/notifier-test.ts
@@ -3,7 +3,7 @@ import Notifier from '../src/notifier';
 const { module, test } = QUnit;
 
 module('Notifier', function(hooks) {
-  let notifier;
+  let notifier: Notifier;
 
   hooks.beforeEach(function() {
     notifier = new Notifier();
@@ -37,10 +37,10 @@ module('Notifier', function(hooks) {
   test('it notifies listeners when emitting a simple message', function(assert) {
     assert.expect(2);
 
-    let listener1 = function(message) {
+    let listener1 = function(message: string) {
       assert.equal(message, 'hello', 'notification message should match');
     };
-    let listener2 = function(message) {
+    let listener2 = function(message: string) {
       assert.equal(message, 'hello', 'notification message should match');
     };
 

--- a/packages/@orbit/core/test/support/fake-bucket.ts
+++ b/packages/@orbit/core/test/support/fake-bucket.ts
@@ -14,17 +14,15 @@ export default class FakeBucket extends Bucket {
     this.data = {};
   }
 
-  getItem(key) {
-    return Promise.resolve(this.data[key]);
+  async getItem(key: string): Promise<any> {
+    return this.data[key];
   }
 
-  setItem(key, value) {
+  async setItem(key: string, value: any): Promise<void> {
     this.data[key] = value;
-    return Promise.resolve();
   }
 
-  removeItem(key) {
+  async removeItem(key: string): Promise<void> {
     delete this.data[key];
-    return Promise.resolve();
   }
 }

--- a/packages/@orbit/core/tsconfig.tests.json
+++ b/packages/@orbit/core/tsconfig.tests.json
@@ -8,7 +8,8 @@
     "inlineSourceMap": true,
     "declaration": false,
     "newLine": "LF",
-    "types": ["qunit"]
+    "types": ["qunit"],
+    "noImplicitAny": true
   },
   "include": [
     "src/**/*.ts",

--- a/packages/@orbit/data/src/query-expression.ts
+++ b/packages/@orbit/data/src/query-expression.ts
@@ -2,54 +2,63 @@ import { RecordIdentity } from './record';
 
 export type SortOrder = 'ascending' | 'descending';
 
-export interface SortSpecifier {
+export interface BaseSortSpecifier {
   kind: string;
   order: SortOrder;
 }
 
-export interface AttributeSortSpecifier extends SortSpecifier {
+export interface AttributeSortSpecifier extends BaseSortSpecifier {
   kind: 'attribute';
   attribute: string;
 }
 
+export type SortSpecifier = BaseSortSpecifier | AttributeSortSpecifier;
+
 export type ValueComparisonOperator = 'equal' | 'gt' | 'lt' | 'gte' | 'lte';
 export type SetComparisonOperator = 'equal' | 'all' | 'some' | 'none';
 
-export interface FilterSpecifier {
-  op: ValueComparisonOperator | SetComparisonOperator;
+export interface BaseFilterSpecifier {
   kind: string;
+  op: ValueComparisonOperator | SetComparisonOperator;
 }
 
-export interface AttributeFilterSpecifier extends FilterSpecifier {
+export interface AttributeFilterSpecifier extends BaseFilterSpecifier {
+  kind: 'attribute';
   op: ValueComparisonOperator,
-  kind: "attribute";
   attribute: string;
   value: any;
 }
 
-export interface RelatedRecordFilterSpecifier extends FilterSpecifier {
-  op: SetComparisonOperator,
+export interface RelatedRecordFilterSpecifier extends BaseFilterSpecifier {
   kind: 'relatedRecord';
+  op: SetComparisonOperator,
   relation: string;
   record: RecordIdentity | RecordIdentity[] | null;
 }
 
-export interface RelatedRecordsFilterSpecifier extends FilterSpecifier {
-  op: SetComparisonOperator,
+export interface RelatedRecordsFilterSpecifier extends BaseFilterSpecifier {
   kind: 'relatedRecords';
+  op: SetComparisonOperator,
   relation: string;
   records: RecordIdentity[];
 }
 
-export interface PageSpecifier {
+export type FilterSpecifier = BaseFilterSpecifier |
+  AttributeFilterSpecifier |
+  RelatedRecordFilterSpecifier |
+  RelatedRecordsFilterSpecifier;
+
+export interface BasePageSpecifier {
   kind: string;
 }
 
-export interface OffsetLimitPageSpecifier extends PageSpecifier {
+export interface OffsetLimitPageSpecifier extends BasePageSpecifier {
   kind: 'offsetLimit';
   offset?: number;
   limit?: number;
 }
+
+export type PageSpecifier = BasePageSpecifier | OffsetLimitPageSpecifier;
 
 /**
  * An interface to represent a query expression.

--- a/packages/@orbit/data/src/schema.ts
+++ b/packages/@orbit/data/src/schema.ts
@@ -87,7 +87,7 @@ export default class Schema implements Evented, RecordInitializer {
 
   // Evented interface stubs
   on: (event: string, listener: Listener) => void;
-  off: (event: string, listener: Listener) => void;
+  off: (event: string, listener?: Listener) => void;
   one: (event: string, listener: Listener) => void;
   emit: (event: string, ...args: any[]) => void;
   listeners: (event: string) => Listener[];

--- a/packages/@orbit/data/src/source-interfaces/syncable.ts
+++ b/packages/@orbit/data/src/source-interfaces/syncable.ts
@@ -22,6 +22,8 @@ export interface Syncable {
    * of `Transform`s as an argument and applies it to the source.
    */
   sync(transformOrTransforms: Transform | Transform[]): Promise<void>;
+
+  _sync(transform: Transform): Promise<void>;
 }
 
 /**

--- a/packages/@orbit/data/src/source.ts
+++ b/packages/@orbit/data/src/source.ts
@@ -46,7 +46,7 @@ export abstract class Source implements Evented, Performer {
 
   // Evented interface stubs
   on: (event: string, listener: Listener) => void;
-  off: (event: string, listener: Listener) => void;
+  off: (event: string, listener?: Listener) => void;
   one: (event: string, listener: Listener) => void;
   emit: (event: string, ...args: any[]) => void;
   listeners: (event: string) => Listener[];

--- a/packages/@orbit/data/src/transform-builder.ts
+++ b/packages/@orbit/data/src/transform-builder.ts
@@ -14,7 +14,6 @@ import {
   ReplaceRelatedRecordsOperation,
   ReplaceRelatedRecordOperation
 } from './operation';
-import { eq } from '@orbit/utils';
 
 export interface TransformBuilderSettings {
   recordInitializer?: RecordInitializer;

--- a/packages/@orbit/data/test/query-builder-test.ts
+++ b/packages/@orbit/data/test/query-builder-test.ts
@@ -4,7 +4,7 @@ import './test-helper';
 const { module, test } = QUnit;
 
 module('QueryBuilder', function(hooks) {
-  let oqb;
+  let oqb: QueryBuilder;
 
   hooks.beforeEach(function() {
     oqb = new QueryBuilder();
@@ -266,7 +266,7 @@ module('QueryBuilder', function(hooks) {
           .findRecords('planet')
           .sort(null);
       },
-      new Error('Sort expression must be either an object or a string.')
+      new Error('Unrecognized sort param.')
     );
   });
 
@@ -279,7 +279,11 @@ module('QueryBuilder', function(hooks) {
       {
         op: 'findRecords',
         type: 'planet',
-        page: { offset: 1, limit: 10 }
+        page: {
+          kind: 'offsetLimit',
+          offset: 1,
+          limit: 10
+        }
       }
     );
   });
@@ -310,7 +314,11 @@ module('QueryBuilder', function(hooks) {
             value: 23000000
           }
         ],
-        page: { offset: 1, limit: 10 },
+        page: {
+          kind: 'offsetLimit',
+          offset: 1,
+          limit: 10
+        },
         sort: [
           {
             kind: 'attribute',

--- a/packages/@orbit/data/test/record-test.ts
+++ b/packages/@orbit/data/test/record-test.ts
@@ -22,7 +22,7 @@ module('Record', function() {
   });
 
   test('`deserializeRecordIdentity` - deserializes type:id string into an identity object', function(assert) {
-    assert.deepEqual(deserializeRecordIdentity('planet:1'), { type: 'planet', id: '1' }));
+    assert.deepEqual(deserializeRecordIdentity('planet:1'), { type: 'planet', id: '1' });
   });
 
   test('`equalRecordIdentities` compares the type/id identity of two objects', function(assert) {
@@ -78,5 +78,4 @@ module('Record', function() {
     assert.notOk(recordsIncludeAll([{ type: 'planet', id: 'p1' }],
                                    [{ type: 'moon', id: 'm1' }, { type: 'planet', id: 'p1' }]), 'unequal sets 2');
   });
-
 });

--- a/packages/@orbit/data/test/schema-test.ts
+++ b/packages/@orbit/data/test/schema-test.ts
@@ -1,5 +1,6 @@
 import Schema from '../src/schema';
 import './test-helper';
+import { Record } from '../src';
 
 const { module, test } = QUnit;
 
@@ -147,7 +148,7 @@ module('Schema', function() {
       }
     });
 
-    let moon = { type: 'moon', id: undefined };
+    let moon: Record = { type: 'moon', id: undefined };
     schema.initializeRecord(moon);
     assert.equal(moon.id, 'moon-123', 'generates an ID if `id` is undefined');
 

--- a/packages/@orbit/data/test/source-interfaces/pushable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/pushable-test.ts
@@ -1,19 +1,25 @@
 import {
   Source,
+  Pushable,
   pushable, isPushable,
-  buildTransform
+  buildTransform,
+  Transform,
+  TransformOrOperations
 } from '../../src/index';
 import '../test-helper';
 
 const { module, test } = QUnit;
 
 module('@pushable', function(hooks) {
-  let source;
+  @pushable
+  class MySource extends Source implements Pushable {
+    push: (transformOrOperations: TransformOrOperations, options?: object, id?: string) => Promise<Transform[]>;
+    _push: (transform: Transform) => Promise<Transform[]>;
+  }
+
+  let source: MySource;
 
   hooks.beforeEach(function() {
-    @pushable
-    class MySource extends Source {}
-
     source = new MySource({ name: 'src1' });
   });
 
@@ -35,21 +41,22 @@ module('@pushable', function(hooks) {
   //   'assertion raised');
   // });
 
-  test('#push should resolve as a failure when `transform` fails', function(assert) {
+  test('#push should resolve as a failure when `transform` fails', async function(assert) {
     assert.expect(2);
 
     source._push = function() {
       return Promise.reject(':(');
     };
 
-    return source.push({ addRecord: {} })
-      .catch((error) => {
-        assert.ok(true, 'push promise resolved as a failure');
-        assert.equal(error, ':(', 'failure');
-      });
+    try {
+      await source.push({ op: 'addRecord' });
+    } catch(error) {
+      assert.ok(true, 'push promise resolved as a failure');
+      assert.equal(error, ':(', 'failure');
+    }
   });
 
-  test('#push should trigger `push` event after a successful action in which `transform` returns an array of transforms', function(assert) {
+  test('#push should trigger `push` event after a successful action in which `transform` returns an array of transforms', async function(assert) {
     assert.expect(12);
 
     let order = 0;
@@ -85,14 +92,13 @@ module('@pushable', function(hooks) {
       assert.strictEqual(transform, addRecordTransform, 'transform matches');
     });
 
-    return source.push(addRecordTransform)
-      .then((result) => {
-        assert.equal(++order, 6, 'promise resolved last');
-        assert.deepEqual(result, resultingTransforms, 'applied transforms are returned on success');
-      });
+    let result = await source.push(addRecordTransform);
+
+    assert.equal(++order, 6, 'promise resolved last');
+    assert.deepEqual(result, resultingTransforms, 'applied transforms are returned on success');
   });
 
-  test('#push should trigger `pushFail` event after an unsuccessful push', function(assert) {
+  test('#push should trigger `pushFail` event after an unsuccessful push', async function(assert) {
     assert.expect(7);
 
     const addRecordTransform = buildTransform({ op: 'addRecord' });
@@ -115,14 +121,15 @@ module('@pushable', function(hooks) {
       assert.equal(error, ':(', 'error matches');
     });
 
-    return source.push(addRecordTransform)
-      .catch((error) => {
-        assert.equal(++order, 3, 'promise resolved last');
-        assert.equal(error, ':(', 'failure');
-      });
+    try {
+      await source.push(addRecordTransform);
+    } catch(error) {
+      assert.equal(++order, 3, 'promise resolved last');
+      assert.equal(error, ':(', 'failure');
+    }
   });
 
-  test('#push should resolve all promises returned from `beforePush` before calling `_push`', function(assert) {
+  test('#push should resolve all promises returned from `beforePush` before calling `_push`', async function(assert) {
     assert.expect(7);
 
     let order = 0;
@@ -150,23 +157,22 @@ module('@pushable', function(hooks) {
       return Promise.resolve();
     });
 
-    source._push = function() {
+    source._push = async function() {
       assert.equal(++order, 4, '_push invoked after all `beforePush` handlers');
-      return Promise.resolve(resultingTransforms);
+      return resultingTransforms;
     };
 
     source.on('push', () => {
       assert.equal(++order, 5, 'push triggered after action performed successfully');
     });
 
-    return source.push(addRecordTransform)
-      .then((result) => {
-        assert.equal(++order, 6, 'promise resolved last');
-        assert.deepEqual(result, resultingTransforms, 'applied transforms are returned on success');
-      });
+    let result = await source.push(addRecordTransform);
+
+    assert.equal(++order, 6, 'promise resolved last');
+    assert.deepEqual(result, resultingTransforms, 'applied transforms are returned on success');
   });
 
-  test('#push should not call `_push` if the transform has been applied as a result of `beforePush` resolution', function(assert) {
+  test('#push should not call `_push` if the transform has been applied as a result of `beforePush` resolution', async function(assert) {
     assert.expect(2);
 
     let order = 0;
@@ -182,21 +188,21 @@ module('@pushable', function(hooks) {
       return Promise.resolve();
     });
 
-    source._push = function() {
+    source._push = async function(): Promise<Transform[]> {
       assert.ok(false, '_push should not be reached');
+      return [];
     };
 
     source.on('push', () => {
       assert.ok(false, 'push should not be reached');
     });
 
-    return source.push(addRecordTransform)
-      .then(() => {
-        assert.equal(++order, 2, 'promise resolved last');
-      });
+    await source.push(addRecordTransform);
+
+    assert.equal(++order, 2, 'promise resolved last');
   });
 
-  test('#push should resolve all promises returned from `beforePush` and fail if any fail', function(assert) {
+  test('#push should resolve all promises returned from `beforePush` and fail if any fail', async function(assert) {
     assert.expect(5);
 
     let order = 0;
@@ -213,8 +219,9 @@ module('@pushable', function(hooks) {
       return Promise.reject(':(');
     });
 
-    source._push = function() {
+    source._push = async function(): Promise<Transform[]> {
       assert.ok(false, '_push should not be invoked');
+      return [];
     };
 
     source.on('push', () => {
@@ -225,10 +232,11 @@ module('@pushable', function(hooks) {
       assert.equal(++order, 3, 'pushFail triggered after action failed');
     });
 
-    return source.push(addRecordTransform)
-      .catch((error) => {
-        assert.equal(++order, 4, 'promise failed because no actions succeeded');
-        assert.equal(error, ':(', 'failure');
-      });
+    try {
+      await source.push(addRecordTransform);
+    } catch(error) {
+      assert.equal(++order, 4, 'promise failed because no actions succeeded');
+      assert.equal(error, ':(', 'failure');
+    }
   });
 });

--- a/packages/@orbit/data/test/source-interfaces/syncable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/syncable-test.ts
@@ -1,19 +1,24 @@
 import {
   Source,
   syncable, isSyncable,
-  buildTransform
+  Syncable,
+  buildTransform,
+  Transform
 } from '../../src/index';
 import '../test-helper';
 
 const { module, test } = QUnit;
 
 module('@syncable', function(hooks) {
-  let source;
+  @syncable
+  class MySource extends Source implements Syncable {
+    sync: (transformOrTransforms: Transform | Transform[]) => Promise<void>;
+    _sync: (transform: Transform) => Promise<void>;
+  }
+
+  let source: MySource;
 
   hooks.beforeEach(function() {
-    @syncable
-    class MySource extends Source {}
-
     source = new MySource({ name: 'src1' });
   });
 
@@ -35,43 +40,46 @@ module('@syncable', function(hooks) {
   //   'assertion raised');
   // });
 
-  test('#sync accepts a Transform and calls internal method `_sync`', function(assert) {
+  test('#sync accepts a Transform and calls internal method `_sync`', async function(assert) {
     assert.expect(2);
 
     const addPlanet = { op: 'addRecord', record: { type: 'planet', id: 'jupiter' } };
+    const addRecordTransform = buildTransform(addPlanet);
 
-    source._sync = function(transform) {
-      assert.strictEqual(transform, addPlanet, 'argument to _sync is a Transform');
-      return Promise.resolve();
+    source._sync = async function(transform: Transform) {
+      assert.strictEqual(transform, addRecordTransform, 'argument to _sync is a Transform');
     };
 
-    return source.sync(addPlanet)
-      .then(() => {
-        assert.ok(true, 'transformed promise resolved');
-      });
+    await source.sync(addRecordTransform);
+
+    assert.ok(true, 'transformed promise resolved');
   });
 
-  test('#sync should resolve as a failure when `_sync` fails', function(assert) {
+  test('#sync should resolve as a failure when `_sync` fails', async function(assert) {
     assert.expect(2);
 
-    source._sync = function() {
+    const addPlanet = { op: 'addRecord', record: { type: 'planet', id: 'jupiter' } };
+    const addRecordTransform = buildTransform(addPlanet);
+
+    source._sync = async function(transform: Transform) {
       return Promise.reject(':(');
     };
 
-    return source.sync({ addRecord: {} })
-      .catch((error) => {
-        assert.ok(true, 'sync promise resolved as a failure');
-        assert.equal(error, ':(', 'failure');
-      });
+    try {
+      await source.sync(addRecordTransform);
+    } catch(error) {
+      assert.ok(true, 'sync promise resolved as a failure');
+      assert.equal(error, ':(', 'failure');
+    }
   });
 
-
-  test('#sync should trigger `sync` event after a successful action in which `_sync` returns an array of transforms', function(assert) {
+  test('#sync should trigger `sync` event after a successful action in which `_sync` returns an array of transforms', async function(assert) {
     assert.expect(9);
 
     let order = 0;
 
-    const addRecordTransform = buildTransform({ op: 'addRecord' });
+    const addPlanet = { op: 'addRecord', record: { type: 'planet', id: 'jupiter' } };
+    const addRecordTransform = buildTransform(addPlanet);
 
     source.on('beforeSync', (transform) => {
       assert.equal(++order, 1, 'beforeSync triggered first');
@@ -95,20 +103,20 @@ module('@syncable', function(hooks) {
       assert.strictEqual(transform, addRecordTransform, 'sync transform matches');
     });
 
-    return source.sync(addRecordTransform)
-      .then(() => {
-        assert.equal(++order, 5, 'promise resolved last');
-      });
+    await source.sync(addRecordTransform);
+
+    assert.equal(++order, 5, 'promise resolved last');
   });
 
-  test('#sync should trigger `syncFail` event after an unsuccessful sync', function(assert) {
+  test('#sync should trigger `syncFail` event after an unsuccessful sync', async function(assert) {
     assert.expect(7);
 
-    const addRecordTransform = buildTransform({ op: 'addRecord' });
+    const addPlanet = { op: 'addRecord', record: { type: 'planet', id: 'jupiter' } };
+    const addRecordTransform = buildTransform(addPlanet);
 
     let order = 0;
 
-    source._sync = function(transform) {
+    source._sync = async function(transform: Transform) {
       assert.equal(++order, 1, 'action performed first');
       assert.strictEqual(transform, addRecordTransform, 'transform matches');
       throw new Error(':(');
@@ -124,19 +132,21 @@ module('@syncable', function(hooks) {
       assert.equal(error.message, ':(', 'error matches');
     });
 
-    return source.sync(addRecordTransform)
-      .catch((error) => {
-        assert.equal(++order, 3, 'promise resolved last');
-        assert.equal(error.message, ':(', 'failure');
-      });
+    try {
+      await source.sync(addRecordTransform);
+    } catch(error) {
+      assert.equal(++order, 3, 'promise resolved last');
+      assert.equal(error.message, ':(', 'failure');
+    }
   });
 
-  test('#sync should not call `_sync` if the transform has been applied as a result of `beforeSync` resolution', function(assert) {
+  test('#sync should not call `_sync` if the transform has been applied as a result of `beforeSync` resolution', async function(assert) {
     assert.expect(2);
 
     let order = 0;
 
-    const addRecordTransform = buildTransform({ op: 'addRecord' });
+    const addPlanet = { op: 'addRecord', record: { type: 'planet', id: 'jupiter' } };
+    const addRecordTransform = buildTransform(addPlanet);
 
     source.on('beforeSync', () => {
       assert.equal(++order, 1, 'beforeSync triggered first');
@@ -147,7 +157,7 @@ module('@syncable', function(hooks) {
       return Promise.resolve();
     });
 
-    source._sync = function() {
+    source._sync = async function(transform: Transform) {
       assert.ok(false, '_sync should not be reached');
     };
 
@@ -155,18 +165,18 @@ module('@syncable', function(hooks) {
       assert.ok(false, 'sync should not be reached');
     });
 
-    return source.sync(addRecordTransform)
-      .then(() => {
-        assert.equal(++order, 2, 'promise resolved last');
-      });
+    await source.sync(addRecordTransform);
+
+    assert.equal(++order, 2, 'promise resolved last');
   });
 
-  test('#sync should resolve all promises returned from `beforeSync` before calling `_sync`', function(assert) {
+  test('#sync should resolve all promises returned from `beforeSync` before calling `_sync`', async function(assert) {
     assert.expect(6);
 
     let order = 0;
 
-    const addRecordTransform = buildTransform({ op: 'addRecord' });
+    const addPlanet = { op: 'addRecord', record: { type: 'planet', id: 'jupiter' } };
+    const addRecordTransform = buildTransform(addPlanet);
 
     source.on('beforeSync', () => {
       assert.equal(++order, 1, 'beforeSync triggered first');
@@ -183,22 +193,20 @@ module('@syncable', function(hooks) {
       return Promise.resolve();
     });
 
-    source._sync = function() {
+    source._sync = async function(transform: Transform) {
       assert.equal(++order, 4, '_sync invoked after all `beforeSync` handlers');
-      return Promise.resolve();
     };
 
     source.on('sync', () => {
       assert.equal(++order, 5, 'sync triggered after action performed successfully');
     });
 
-    return source.sync(addRecordTransform)
-      .then(() => {
-        assert.equal(++order, 6, 'promise resolved last');
-      });
+    await source.sync(addRecordTransform);
+
+    assert.equal(++order, 6, 'promise resolved last');
   });
 
-  test('#sync should resolve all promises returned from `beforeSync` and fail if any fail', function(assert) {
+  test('#sync should resolve all promises returned from `beforeSync` and fail if any fail', async function(assert) {
     assert.expect(5);
 
     let order = 0;
@@ -215,7 +223,7 @@ module('@syncable', function(hooks) {
       return Promise.reject(':(');
     });
 
-    source._sync = function() {
+    source._sync = async function(transform: Transform) {
       assert.ok(false, '_sync should not be invoked');
     };
 
@@ -227,10 +235,11 @@ module('@syncable', function(hooks) {
       assert.equal(++order, 3, 'syncFail triggered after action failed');
     });
 
-    return source.sync(addRecordTransform)
-      .catch((error) => {
-        assert.equal(++order, 4, 'promise failed because no actions succeeded');
-        assert.equal(error, ':(', 'failure');
-      });
+    try {
+      await source.sync(addRecordTransform);
+    } catch(error) {
+      assert.equal(++order, 4, 'promise failed because no actions succeeded');
+      assert.equal(error, ':(', 'failure');
+    }
   });
 });

--- a/packages/@orbit/data/test/source-test.ts
+++ b/packages/@orbit/data/test/source-test.ts
@@ -2,6 +2,7 @@ import {
   Source,
   Schema,
   buildTransform,
+  Transform,
   TransformBuilder,
   QueryBuilder
 } from '../src/index';
@@ -10,8 +11,8 @@ import { FakeBucket } from './test-helper';
 const { module, test } = QUnit;
 
 module('Source', function(hooks) {
-  let source;
-  let schema;
+  let source: any;
+  let schema: Schema;
 
   class MySource extends Source {}
 
@@ -25,18 +26,19 @@ module('Source', function(hooks) {
     assert.ok(source.transformLog, 'has a transform log');
   });
 
-  test('it can be assigned a schema, which will be observed for upgrades by default', function(assert) {
+  test('it can be assigned a schema, which will be observed for upgrades by default', async function(assert) {
     assert.expect(2);
 
     class MyDynamicSource extends Source {
-      upgrade() {
+      async upgrade() {
         assert.ok(true, 'upgrade called');
-        return Promise.resolve();
       }
     };
 
     source = new MyDynamicSource({ schema });
+
     schema.upgrade({});
+
     assert.ok(true, 'after upgrade');
   });
 
@@ -44,9 +46,8 @@ module('Source', function(hooks) {
     assert.expect(1);
 
     class MyDynamicSource extends Source {
-      upgrade() {
+      async upgrade(): Promise<void> {
         assert.ok(false, 'upgrade should not be called');
-        return Promise.resolve();
       }
     };
 
@@ -128,25 +129,24 @@ module('Source', function(hooks) {
     assert.strictEqual(transformBuilder, source.transformBuilder, 'transformBuilder remains the same');
   });
 
-  test('#_transformed should trigger `transform` event BEFORE resolving', function(assert) {
+  test('#_transformed should trigger `transform` event BEFORE resolving', async function(assert) {
     assert.expect(3);
 
     source = new MySource();
     let order = 0;
     const appliedTransform = buildTransform({ op: 'addRecord' });
 
-    source.on('transform', (transform) => {
+    source.on('transform', (transform: Transform) => {
       assert.equal(++order, 1, '`transform` event triggered after action performed successfully');
       assert.strictEqual(transform, appliedTransform, 'applied transform matches');
     });
 
-    return source._transformed([appliedTransform])
-      .then(() => {
-        assert.equal(++order, 2, '_transformed promise resolved last');
-      });
+    await source._transformed([appliedTransform]);
+
+    assert.equal(++order, 2, '_transformed promise resolved last');
   });
 
-  test('#transformLog contains transforms applied', function(assert) {
+  test('#transformLog contains transforms applied', async function(assert) {
     assert.expect(2);
 
     source = new MySource();
@@ -154,8 +154,8 @@ module('Source', function(hooks) {
 
     assert.ok(!source.transformLog.contains(appliedTransform.id));
 
-    return source
-      ._transformed([appliedTransform])
-      .then(() => assert.ok(source.transformLog.contains(appliedTransform.id)));
+    await source._transformed([appliedTransform]);
+
+    assert.ok(source.transformLog.contains(appliedTransform.id));
   });
 });

--- a/packages/@orbit/data/test/support/fake-bucket.ts
+++ b/packages/@orbit/data/test/support/fake-bucket.ts
@@ -14,17 +14,15 @@ export default class FakeBucket extends Bucket {
     this.data = {};
   }
 
-  getItem(key) {
-    return Promise.resolve(this.data[key]);
+  async getItem(key: string): Promise<any> {
+    return this.data[key];
   }
 
-  setItem(key, value) {
+  async setItem(key: string, value: any): Promise<void> {
     this.data[key] = value;
-    return Promise.resolve();
   }
 
-  removeItem(key) {
+  async removeItem(key: string): Promise<void> {
     delete this.data[key];
-    return Promise.resolve();
   }
 }

--- a/packages/@orbit/data/test/transform-builder-test.ts
+++ b/packages/@orbit/data/test/transform-builder-test.ts
@@ -4,7 +4,7 @@ import './test-helper';
 const { module, test } = QUnit;
 
 module('TransformBuilder', function(hooks) {
-  let tb;
+  let tb: TransformBuilder;
 
   hooks.beforeEach(function() {
     tb = new TransformBuilder();
@@ -109,7 +109,7 @@ module('TransformBuilder', function(hooks) {
     let record = { type: 'planet' };
 
     assert.deepEqual(
-      tb.addRecord(record),
+      tb.addRecord(record as Record),
       { op: 'addRecord', record: { type: 'planet', id: 'abc123' } }
     );
   });

--- a/packages/@orbit/data/tsconfig.tests.json
+++ b/packages/@orbit/data/tsconfig.tests.json
@@ -8,7 +8,8 @@
     "inlineSourceMap": true,
     "declaration": false,
     "newLine": "LF",
-    "types": ["qunit"]
+    "types": ["qunit"],
+    "noImplicitAny": true
   },
   "include": [
     "src/**/*.ts",

--- a/packages/@orbit/immutable/tsconfig.tests.json
+++ b/packages/@orbit/immutable/tsconfig.tests.json
@@ -8,7 +8,8 @@
     "inlineSourceMap": true,
     "declaration": false,
     "newLine": "LF",
-    "types": ["qunit"]
+    "types": ["qunit"],
+    "noImplicitAny": true
   },
   "include": [
     "src/**/*.ts",

--- a/packages/@orbit/indexeddb-bucket/test/bucket-test.ts
+++ b/packages/@orbit/indexeddb-bucket/test/bucket-test.ts
@@ -4,7 +4,7 @@ import IndexedDBBucket from '../src/bucket';
 const { module, test } = QUnit;
 
 module('IndexedDBBucket', function(hooks) {
-  let bucket;
+  let bucket: IndexedDBBucket;
 
   hooks.beforeEach(() => {
     bucket = new IndexedDBBucket();

--- a/packages/@orbit/indexeddb-bucket/tsconfig.tests.json
+++ b/packages/@orbit/indexeddb-bucket/tsconfig.tests.json
@@ -8,7 +8,8 @@
     "inlineSourceMap": true,
     "declaration": false,
     "newLine": "LF",
-    "types": ["qunit"]
+    "types": ["qunit"],
+    "noImplicitAny": true
   },
   "include": [
     "src/**/*.ts",

--- a/packages/@orbit/indexeddb/test/cache-test.ts
+++ b/packages/@orbit/indexeddb/test/cache-test.ts
@@ -1,12 +1,11 @@
+import { getRecordFromIndexedDB } from './support/indexeddb';
 import {
-  verifyIndexedDBContainsRecord,
-  verifyIndexedDBDoesNotContainRecord
-} from './support/indexeddb';
-import {
+  Record,
   Schema,
   KeyMap
 } from '@orbit/data';
 import Cache from '../src/cache';
+import { RelatedRecordIdentity } from '../../record-cache/dist/types';
 
 const { module, test } = QUnit;
 
@@ -148,7 +147,7 @@ module('Cache', function(hooks) {
   test('#patch - addRecord', async function(assert) {
     assert.expect(2);
 
-    let planet = {
+    let planet: Record = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -161,7 +160,8 @@ module('Cache', function(hooks) {
     };
 
     await cache.patch(t => t.addRecord(planet));
-    await verifyIndexedDBContainsRecord(assert, cache, planet);
+
+    assert.deepEqual(await getRecordFromIndexedDB(cache, planet), planet, 'indexeddb contains record');
 
     assert.equal(keyMap.keyToId('planet', 'remoteId', 'j'), 'jupiter', 'key has been mapped');
   });
@@ -169,7 +169,7 @@ module('Cache', function(hooks) {
   test('#patch - replaceRecord', async function(assert) {
     assert.expect(2);
 
-    let original = {
+    let original: Record = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -185,7 +185,7 @@ module('Cache', function(hooks) {
       }
     };
 
-    let updates = {
+    let updates: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -198,7 +198,7 @@ module('Cache', function(hooks) {
       }
     };
 
-    let expected = {
+    let expected: Record = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -220,7 +220,7 @@ module('Cache', function(hooks) {
 
     await cache.patch(t => t.addRecord(original));
     await cache.patch(t => t.replaceRecord(updates));
-    await verifyIndexedDBContainsRecord(assert, cache, expected);
+    assert.deepEqual(await getRecordFromIndexedDB(cache, expected), expected, 'indexeddb contains record');
     assert.equal(keyMap.keyToId('planet', 'remoteId', 'j'), 'jupiter', 'key has been mapped');
   });
 
@@ -238,13 +238,13 @@ module('Cache', function(hooks) {
     };
 
     await cache.patch(t => t.replaceRecord(revised));
-    await verifyIndexedDBContainsRecord(assert, cache, revised);
+    assert.deepEqual(await getRecordFromIndexedDB(cache, revised), revised, 'indexeddb contains record');
   });
 
   test('#patch - removeRecord', async function(assert) {
     assert.expect(1);
 
-    let planet = {
+    let planet: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -255,7 +255,7 @@ module('Cache', function(hooks) {
 
     await cache.patch(t => t.addRecord(planet));
     await cache.patch(t => t.removeRecord(planet));
-    await verifyIndexedDBDoesNotContainRecord(assert, cache, planet);
+    assert.equal(await getRecordFromIndexedDB(cache, planet), null, 'indexeddb does not contain record');
   });
 
   test('#patch - removeRecord - when record does not exist', async function(assert) {
@@ -267,13 +267,13 @@ module('Cache', function(hooks) {
     };
 
     await cache.patch(t => t.removeRecord(planet));
-    await verifyIndexedDBDoesNotContainRecord(assert, cache, planet);
+    assert.equal(await getRecordFromIndexedDB(cache, planet), null, 'indexeddb does not contain record');
   });
 
   test('#patch - replaceKey', async function(assert) {
     assert.expect(2);
 
-    let original = {
+    let original: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -282,7 +282,7 @@ module('Cache', function(hooks) {
       }
     };
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -296,7 +296,7 @@ module('Cache', function(hooks) {
 
     await cache.patch(t => t.addRecord(original));
     await cache.patch(t => t.replaceKey(original, 'remoteId', '123'));
-    await verifyIndexedDBContainsRecord(assert, cache, revised);
+    assert.deepEqual(await getRecordFromIndexedDB(cache, revised), revised, 'indexeddb contains record');
 
     assert.equal(keyMap.keyToId('planet', 'remoteId', '123'), 'jupiter', 'key has been mapped');
   });
@@ -304,7 +304,7 @@ module('Cache', function(hooks) {
   test('#patch - replaceKey - when base record does not exist', async function(assert) {
     assert.expect(2);
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -313,7 +313,7 @@ module('Cache', function(hooks) {
     };
 
     await cache.patch(t => t.replaceKey({ type: 'planet', id: 'jupiter' }, 'remoteId', '123'));
-    await verifyIndexedDBContainsRecord(assert, cache, revised);
+    assert.deepEqual(await getRecordFromIndexedDB(cache, revised), revised, 'indexeddb contains record');
 
     assert.equal(keyMap.keyToId('planet', 'remoteId', '123'), 'jupiter', 'key has been mapped');
   });
@@ -321,7 +321,7 @@ module('Cache', function(hooks) {
   test('#patch - replaceAttribute', async function(assert) {
     assert.expect(1);
 
-    let original = {
+    let original: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -330,7 +330,7 @@ module('Cache', function(hooks) {
       }
     };
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -342,13 +342,13 @@ module('Cache', function(hooks) {
 
     await cache.patch(t => t.addRecord(original));
     await cache.patch(t => t.replaceAttribute(original, 'order', 5));
-    await verifyIndexedDBContainsRecord(assert, cache, revised);
+    assert.deepEqual(await getRecordFromIndexedDB(cache, revised), revised, 'indexeddb contains record');
   });
 
   test('#patch - replaceAttribute - when base record does not exist', async function(assert) {
     assert.expect(1);
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -357,13 +357,13 @@ module('Cache', function(hooks) {
     };
 
     await cache.patch(t => t.replaceAttribute({ type: 'planet', id: 'jupiter' }, 'order', 5));
-    await verifyIndexedDBContainsRecord(assert, cache, revised);
+    assert.deepEqual(await getRecordFromIndexedDB(cache, revised), revised, 'indexeddb contains record');
   });
 
   test('#patch - addToRelatedRecords', async function(assert) {
     assert.expect(1);
 
-    let original = {
+    let original: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -377,7 +377,7 @@ module('Cache', function(hooks) {
       }
     };
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -393,13 +393,13 @@ module('Cache', function(hooks) {
 
     await cache.patch(t => t.addRecord(original));
     await cache.patch(t => t.addToRelatedRecords(original, 'moons', { type: 'moon', id: 'moon1' }));
-    await verifyIndexedDBContainsRecord(assert, cache, revised);
+    assert.deepEqual(await getRecordFromIndexedDB(cache, revised), revised, 'indexeddb contains record');
   });
 
   test('#patch - addToRelatedRecords - when base record does not exist', async function(assert) {
     assert.expect(1);
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -410,13 +410,13 @@ module('Cache', function(hooks) {
     };
 
     await cache.patch(t => t.addToRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons', { type: 'moon', id: 'moon1' }));
-    await verifyIndexedDBContainsRecord(assert, cache, revised);
+    assert.deepEqual(await getRecordFromIndexedDB(cache, revised), revised, 'indexeddb contains record');
   });
 
   test('#patch - removeFromRelatedRecords', async function(assert) {
     assert.expect(1);
 
-    let original = {
+    let original: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -433,7 +433,7 @@ module('Cache', function(hooks) {
       }
     };
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -451,13 +451,13 @@ module('Cache', function(hooks) {
 
     await cache.patch(t => t.addRecord(original));
     await cache.patch(t => t.removeFromRelatedRecords(original, 'moons', { type: 'moon', id: 'moon2' }));
-    await verifyIndexedDBContainsRecord(assert, cache, revised);
+    assert.deepEqual(await getRecordFromIndexedDB(cache, revised), revised, 'indexeddb contains record');
   });
 
   test('#patch - removeFromRelatedRecords - when base record does not exist', async function(assert) {
     assert.expect(1);
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -469,13 +469,13 @@ module('Cache', function(hooks) {
     };
 
     await cache.patch(t => t.removeFromRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons', { type: 'moon', id: 'moon2' }));
-    await verifyIndexedDBDoesNotContainRecord(assert, cache, revised);
+    assert.equal(await getRecordFromIndexedDB(cache, revised), null, 'indexeddb does not contain record');
   });
 
   test('#patch - replaceRelatedRecords', async function(assert) {
     assert.expect(1);
 
-    let original = {
+    let original: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -491,7 +491,7 @@ module('Cache', function(hooks) {
       }
     };
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -510,13 +510,13 @@ module('Cache', function(hooks) {
 
     await cache.patch(t => t.addRecord(original))
     await cache.patch(t => t.replaceRelatedRecords(original, 'moons', [{ type: 'moon', id: 'moon2' }, { type: 'moon', id: 'moon3' }]));
-    await verifyIndexedDBContainsRecord(assert, cache, revised);
+    assert.deepEqual(await getRecordFromIndexedDB(cache, revised), revised, 'indexeddb contains record');
   });
 
   test('#patch - replaceRelatedRecords - when base record does not exist', async function(assert) {
     assert.expect(1);
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -530,13 +530,13 @@ module('Cache', function(hooks) {
     };
 
     await cache.patch(t => t.replaceRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons', [{ type: 'moon', id: 'moon2' }, { type: 'moon', id: 'moon3' }]));
-    await verifyIndexedDBContainsRecord(assert, cache, revised);
+    assert.deepEqual(await getRecordFromIndexedDB(cache, revised), revised, 'indexeddb contains record');
   });
 
   test('#patch - replaceRelatedRecord - with record', async function(assert) {
     assert.expect(1);
 
-    let original = {
+    let original: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -550,7 +550,7 @@ module('Cache', function(hooks) {
       }
     };
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -566,13 +566,13 @@ module('Cache', function(hooks) {
 
     await cache.patch(t => t.addRecord(original));
     await cache.patch(t => t.replaceRelatedRecord(original, 'solarSystem', { type: 'solarSystem', id: 'ss1' }));
-    await verifyIndexedDBContainsRecord(assert, cache, revised);
+    assert.deepEqual(await getRecordFromIndexedDB(cache, revised), revised, 'indexeddb contains record');
   });
 
   test('#patch - replaceRelatedRecord - with record - when base record does not exist', async function(assert) {
     assert.expect(1);
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -583,13 +583,13 @@ module('Cache', function(hooks) {
     };
 
     await cache.patch(t => t.replaceRelatedRecord({ type: 'planet', id: 'jupiter' }, 'solarSystem', { type: 'solarSystem', id: 'ss1' }));
-    await verifyIndexedDBContainsRecord(assert, cache, revised);
+    assert.deepEqual(await getRecordFromIndexedDB(cache, revised), revised, 'indexeddb contains record');
   });
 
   test('#patch - replaceRelatedRecord - with null', async function(assert) {
     assert.expect(1);
 
-    let original = {
+    let original: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -603,7 +603,7 @@ module('Cache', function(hooks) {
       }
     };
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -619,13 +619,13 @@ module('Cache', function(hooks) {
 
     await cache.patch(t => t.addRecord(original));
     await cache.patch(t => t.replaceRelatedRecord(original, 'solarSystem', null));
-    await verifyIndexedDBContainsRecord(assert, cache, revised);
+    assert.deepEqual(await getRecordFromIndexedDB(cache, revised), revised, 'indexeddb contains record');
   });
 
   test('#patch - replaceRelatedRecord - with null - when base record does not exist', async function(assert) {
     assert.expect(1);
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -636,13 +636,13 @@ module('Cache', function(hooks) {
     };
 
     await cache.patch(t => t.replaceRelatedRecord({ type: 'planet', id: 'jupiter' }, 'solarSystem', null));
-    await verifyIndexedDBContainsRecord(assert, cache, revised);
+    assert.deepEqual(await getRecordFromIndexedDB(cache, revised), revised, 'indexeddb contains record');
   });
 
   test('#query - all records', async function(assert) {
     assert.expect(4);
 
-    let earth = {
+    let earth: Record = {
       type: 'planet',
       id: 'earth',
       keys: {
@@ -654,7 +654,7 @@ module('Cache', function(hooks) {
       }
     };
 
-    let jupiter = {
+    let jupiter: Record = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -666,7 +666,7 @@ module('Cache', function(hooks) {
       }
     };
 
-    let io = {
+    let io: Record = {
       type: 'moon',
       id: 'io',
       keys: {
@@ -697,7 +697,7 @@ module('Cache', function(hooks) {
   test('#query - records of one type', async function(assert) {
     assert.expect(1);
 
-    let earth = {
+    let earth: Record = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -706,7 +706,7 @@ module('Cache', function(hooks) {
       }
     };
 
-    let jupiter = {
+    let jupiter: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -715,7 +715,7 @@ module('Cache', function(hooks) {
       }
     };
 
-    let io = {
+    let io: Record = {
       type: 'moon',
       id: 'io',
       attributes: {
@@ -736,7 +736,7 @@ module('Cache', function(hooks) {
   test('#query - a specific record', async function(assert) {
     assert.expect(2);
 
-    let earth = {
+    let earth: Record = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -745,7 +745,7 @@ module('Cache', function(hooks) {
       }
     };
 
-    let jupiter = {
+    let jupiter: Record = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -757,7 +757,7 @@ module('Cache', function(hooks) {
       }
     };
 
-    let io = {
+    let io: Record = {
       type: 'moon',
       id: 'io',
       attributes: {

--- a/packages/@orbit/indexeddb/test/source-test.ts
+++ b/packages/@orbit/indexeddb/test/source-test.ts
@@ -1,8 +1,6 @@
+import { getRecordFromIndexedDB } from './support/indexeddb';
 import {
-  verifyIndexedDBContainsRecord,
-  verifyIndexedDBDoesNotContainRecord
-} from './support/indexeddb';
-import {
+  Record,
   Schema,
   KeyMap,
   AddRecordOperation
@@ -120,7 +118,7 @@ module('IndexedDBSource', function(hooks) {
   test('#push - addRecord', async function(assert) {
     assert.expect(2);
 
-    let planet = {
+    let planet: Record = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -133,7 +131,7 @@ module('IndexedDBSource', function(hooks) {
     };
 
     await source.push(t => t.addRecord(planet));
-    await verifyIndexedDBContainsRecord(assert, source.cache, planet);
+    assert.deepEqual(await getRecordFromIndexedDB(source.cache, planet), planet, 'indexeddb contains record');
 
     assert.equal(keyMap.keyToId('planet', 'remoteId', 'j'), 'jupiter', 'key has been mapped');
   });
@@ -141,7 +139,7 @@ module('IndexedDBSource', function(hooks) {
   test('#push - replaceRecord', async function(assert) {
     assert.expect(2);
 
-    let original = {
+    let original: Record = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -157,7 +155,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    let updates = {
+    let updates: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -170,7 +168,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    let expected = {
+    let expected: Record = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -192,14 +190,14 @@ module('IndexedDBSource', function(hooks) {
 
     await source.push(t => t.addRecord(original));
     await source.push(t => t.replaceRecord(updates));
-    await verifyIndexedDBContainsRecord(assert, source.cache, expected);
+    assert.deepEqual(await getRecordFromIndexedDB(source.cache, expected), expected, 'indexeddb contains record');
     assert.equal(keyMap.keyToId('planet', 'remoteId', 'j'), 'jupiter', 'key has been mapped');
   });
 
   test('#push - replaceRecord - when record does not exist', async function(assert) {
     assert.expect(1);
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -210,13 +208,13 @@ module('IndexedDBSource', function(hooks) {
     };
 
     await source.push(t => t.replaceRecord(revised));
-    await verifyIndexedDBContainsRecord(assert, source.cache, revised);
+    assert.deepEqual(await getRecordFromIndexedDB(source.cache, revised), revised, 'indexeddb contains record');
   });
 
   test('#push - removeRecord', async function(assert) {
     assert.expect(1);
 
-    let planet = {
+    let planet: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -227,25 +225,25 @@ module('IndexedDBSource', function(hooks) {
 
     await source.push(t => t.addRecord(planet));
     await source.push(t => t.removeRecord(planet));
-    await verifyIndexedDBDoesNotContainRecord(assert, source.cache, planet);
+    assert.equal(await getRecordFromIndexedDB(source.cache, planet), undefined, 'indexeddb does not contain record');
   });
 
   test('#push - removeRecord - when record does not exist', async function(assert) {
     assert.expect(1);
 
-    let planet = {
+    let planet: Record = {
       type: 'planet',
       id: 'jupiter'
     };
 
     await source.push(t => t.removeRecord(planet));
-    await verifyIndexedDBDoesNotContainRecord(assert, source.cache, planet);
+    assert.equal(await getRecordFromIndexedDB(source.cache, planet), undefined, 'indexeddb does not contain record');
   });
 
   test('#push - replaceKey', async function(assert) {
     assert.expect(2);
 
-    let original = {
+    let original: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -254,7 +252,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -268,7 +266,7 @@ module('IndexedDBSource', function(hooks) {
 
     await source.push(t => t.addRecord(original));
     await source.push(t => t.replaceKey(original, 'remoteId', '123'));
-    await verifyIndexedDBContainsRecord(assert, source.cache, revised);
+    assert.deepEqual(await getRecordFromIndexedDB(source.cache, revised), revised, 'indexeddb contains record');
 
     assert.equal(keyMap.keyToId('planet', 'remoteId', '123'), 'jupiter', 'key has been mapped');
   });
@@ -276,7 +274,7 @@ module('IndexedDBSource', function(hooks) {
   test('#push - replaceKey - when base record does not exist', async function(assert) {
     assert.expect(2);
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -285,7 +283,7 @@ module('IndexedDBSource', function(hooks) {
     };
 
     await source.push(t => t.replaceKey({ type: 'planet', id: 'jupiter' }, 'remoteId', '123'));
-    await verifyIndexedDBContainsRecord(assert, source.cache, revised);
+    assert.deepEqual(await getRecordFromIndexedDB(source.cache, revised), revised, 'indexeddb contains record');
 
     assert.equal(keyMap.keyToId('planet', 'remoteId', '123'), 'jupiter', 'key has been mapped');
   });
@@ -293,7 +291,7 @@ module('IndexedDBSource', function(hooks) {
   test('#push - replaceAttribute', async function(assert) {
     assert.expect(1);
 
-    let original = {
+    let original: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -302,7 +300,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -314,13 +312,13 @@ module('IndexedDBSource', function(hooks) {
 
     await source.push(t => t.addRecord(original));
     await source.push(t => t.replaceAttribute(original, 'order', 5));
-    await verifyIndexedDBContainsRecord(assert, source.cache, revised);
+    assert.deepEqual(await getRecordFromIndexedDB(source.cache, revised), revised, 'indexeddb contains record');
   });
 
   test('#push - replaceAttribute - when base record does not exist', async function(assert) {
     assert.expect(1);
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -329,13 +327,13 @@ module('IndexedDBSource', function(hooks) {
     };
 
     await source.push(t => t.replaceAttribute({ type: 'planet', id: 'jupiter' }, 'order', 5));
-    await verifyIndexedDBContainsRecord(assert, source.cache, revised);
+    assert.deepEqual(await getRecordFromIndexedDB(source.cache, revised), revised, 'indexeddb contains record');
   });
 
   test('#push - addToRelatedRecords', async function(assert) {
     assert.expect(1);
 
-    let original = {
+    let original: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -349,7 +347,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -365,13 +363,13 @@ module('IndexedDBSource', function(hooks) {
 
     await source.push(t => t.addRecord(original));
     await source.push(t => t.addToRelatedRecords(original, 'moons', { type: 'moon', id: 'moon1' }));
-    await verifyIndexedDBContainsRecord(assert, source.cache, revised);
+    assert.deepEqual(await getRecordFromIndexedDB(source.cache, revised), revised, 'indexeddb contains record');
   });
 
   test('#push - addToRelatedRecords - when base record does not exist', async function(assert) {
     assert.expect(1);
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -382,13 +380,13 @@ module('IndexedDBSource', function(hooks) {
     };
 
     await source.push(t => t.addToRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons', { type: 'moon', id: 'moon1' }));
-    await verifyIndexedDBContainsRecord(assert, source.cache, revised);
+    assert.deepEqual(await getRecordFromIndexedDB(source.cache, revised), revised, 'indexeddb contains record');
   });
 
   test('#push - removeFromRelatedRecords', async function(assert) {
     assert.expect(1);
 
-    let original = {
+    let original: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -405,7 +403,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -423,13 +421,13 @@ module('IndexedDBSource', function(hooks) {
 
     await source.push(t => t.addRecord(original));
     await source.push(t => t.removeFromRelatedRecords(original, 'moons', { type: 'moon', id: 'moon2' }));
-    await verifyIndexedDBContainsRecord(assert, source.cache, revised);
+    assert.deepEqual(await getRecordFromIndexedDB(source.cache, revised), revised, 'indexeddb contains record');
   });
 
   test('#push - removeFromRelatedRecords - when base record does not exist', async function(assert) {
     assert.expect(1);
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -441,13 +439,13 @@ module('IndexedDBSource', function(hooks) {
     };
 
     await source.push(t => t.removeFromRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons', { type: 'moon', id: 'moon2' }));
-    await verifyIndexedDBDoesNotContainRecord(assert, source.cache, revised);
+    assert.equal(await getRecordFromIndexedDB(source.cache, revised), undefined, 'indexeddb does not contain record');
   });
 
   test('#push - replaceRelatedRecords', async function(assert) {
     assert.expect(1);
 
-    let original = {
+    let original: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -463,7 +461,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -482,13 +480,13 @@ module('IndexedDBSource', function(hooks) {
 
     await source.push(t => t.addRecord(original))
     await source.push(t => t.replaceRelatedRecords(original, 'moons', [{ type: 'moon', id: 'moon2' }, { type: 'moon', id: 'moon3' }]));
-    await verifyIndexedDBContainsRecord(assert, source.cache, revised);
+    assert.deepEqual(await getRecordFromIndexedDB(source.cache, revised), revised, 'indexeddb contains record');
   });
 
   test('#push - replaceRelatedRecords - when base record does not exist', async function(assert) {
     assert.expect(1);
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -502,13 +500,13 @@ module('IndexedDBSource', function(hooks) {
     };
 
     await source.push(t => t.replaceRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons', [{ type: 'moon', id: 'moon2' }, { type: 'moon', id: 'moon3' }]));
-    await verifyIndexedDBContainsRecord(assert, source.cache, revised);
+    assert.deepEqual(await getRecordFromIndexedDB(source.cache, revised), revised, 'indexeddb contains record');
   });
 
   test('#push - replaceRelatedRecord - with record', async function(assert) {
     assert.expect(1);
 
-    let original = {
+    let original: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -522,7 +520,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -538,13 +536,13 @@ module('IndexedDBSource', function(hooks) {
 
     await source.push(t => t.addRecord(original));
     await source.push(t => t.replaceRelatedRecord(original, 'solarSystem', { type: 'solarSystem', id: 'ss1' }));
-    await verifyIndexedDBContainsRecord(assert, source.cache, revised);
+    assert.deepEqual(await getRecordFromIndexedDB(source.cache, revised), revised, 'indexeddb contains record');
   });
 
   test('#push - replaceRelatedRecord - with record - when base record does not exist', async function(assert) {
     assert.expect(1);
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -555,13 +553,13 @@ module('IndexedDBSource', function(hooks) {
     };
 
     await source.push(t => t.replaceRelatedRecord({ type: 'planet', id: 'jupiter' }, 'solarSystem', { type: 'solarSystem', id: 'ss1' }));
-    await verifyIndexedDBContainsRecord(assert, source.cache, revised);
-  });
+    assert.deepEqual(await getRecordFromIndexedDB(source.cache, revised), revised, 'indexeddb contains record');
+   });
 
   test('#push - replaceRelatedRecord - with null', async function(assert) {
     assert.expect(1);
 
-    let original = {
+    let original: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -575,7 +573,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -591,13 +589,13 @@ module('IndexedDBSource', function(hooks) {
 
     await source.push(t => t.addRecord(original));
     await source.push(t => t.replaceRelatedRecord(original, 'solarSystem', null));
-    await verifyIndexedDBContainsRecord(assert, source.cache, revised);
-  });
+    assert.deepEqual(await getRecordFromIndexedDB(source.cache, revised), revised, 'indexeddb contains record');
+   });
 
   test('#push - replaceRelatedRecord - with null - when base record does not exist', async function(assert) {
     assert.expect(1);
 
-    let revised = {
+    let revised: Record = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -608,8 +606,8 @@ module('IndexedDBSource', function(hooks) {
     };
 
     await source.push(t => t.replaceRelatedRecord({ type: 'planet', id: 'jupiter' }, 'solarSystem', null));
-    await verifyIndexedDBContainsRecord(assert, source.cache, revised);
-  });
+    assert.deepEqual(await getRecordFromIndexedDB(source.cache, revised), revised, 'indexeddb contains record');
+   });
 
   test('#push - inverse relationships are created', async function(assert) {
     assert.expect(2);
@@ -619,7 +617,7 @@ module('IndexedDBSource', function(hooks) {
       id: 'ss'
     };
 
-    let earth = {
+    let earth: Record = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -633,7 +631,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    let jupiter = {
+    let jupiter: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -647,7 +645,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    let io = {
+    let io: Record = {
       type: 'moon',
       id: 'io',
       attributes: {
@@ -667,7 +665,7 @@ module('IndexedDBSource', function(hooks) {
       t.addRecord(io)
     ]);
 
-    await verifyIndexedDBContainsRecord(assert, source.cache, {
+    let revisedSs = {
       type: 'solarSystem',
       id: 'ss',
       relationships: {
@@ -678,9 +676,11 @@ module('IndexedDBSource', function(hooks) {
           ]
         }
       }
-    });
+    };
 
-    await verifyIndexedDBContainsRecord(assert, source.cache, {
+    assert.deepEqual(await getRecordFromIndexedDB(source.cache, revisedSs), revisedSs, 'indexeddb contains record');
+
+    let revisedJupiter = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -697,13 +697,15 @@ module('IndexedDBSource', function(hooks) {
           data: { type: 'solarSystem', id: 'ss' }
         }
       }
-    });
+    };
+
+    assert.deepEqual(await getRecordFromIndexedDB(source.cache, revisedJupiter), revisedJupiter, 'indexeddb contains record');
   });
 
   test('#pull - all records', async function(assert) {
     assert.expect(5);
 
-    let earth = {
+    let earth: Record = {
       type: 'planet',
       id: 'earth',
       keys: {
@@ -715,7 +717,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    let jupiter = {
+    let jupiter: Record = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -727,7 +729,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    let io = {
+    let io: Record = {
       type: 'moon',
       id: 'io',
       keys: {
@@ -763,7 +765,7 @@ module('IndexedDBSource', function(hooks) {
   test('#pull - records of one type', async function(assert) {
     assert.expect(3);
 
-    let earth = {
+    let earth: Record = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -772,7 +774,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    let jupiter = {
+    let jupiter: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -781,7 +783,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    let io = {
+    let io: Record = {
       type: 'moon',
       id: 'io',
       attributes: {
@@ -813,7 +815,7 @@ module('IndexedDBSource', function(hooks) {
   test('#pull - a specific record', async function(assert) {
     assert.expect(3);
 
-    let earth = {
+    let earth: Record = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -822,7 +824,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    let jupiter = {
+    let jupiter: Record = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -834,7 +836,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    let io = {
+    let io: Record = {
       type: 'moon',
       id: 'io',
       attributes: {

--- a/packages/@orbit/indexeddb/test/support/indexeddb.ts
+++ b/packages/@orbit/indexeddb/test/support/indexeddb.ts
@@ -1,9 +1,12 @@
-async function getRecord(cache, record) {
+import { IndexedDBCache } from '../../src/index';
+import { Record } from '@orbit/data';
+
+export async function getRecordFromIndexedDB(cache: IndexedDBCache, record: Record): Promise<Record> {
   const db = await cache.openDB();
   const transaction = db.transaction([record.type]);
   const objectStore = transaction.objectStore(record.type);
 
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve: (record: Record) => void, reject) => {
     const request = objectStore.get(record.id);
 
     request.onerror = function(/* event */) {
@@ -13,28 +16,7 @@ async function getRecord(cache, record) {
 
     request.onsuccess = function(/* event */) {
       // console.log('success - getRecord', request.result);
-      resolve(request.result);
+      resolve(request.result as Record);
     };
   });
-}
-
-export function verifyIndexedDBContainsRecord(assert, cache, record, ignoreFields?) {
-  return getRecord(cache, record)
-    .then(actual => {
-      if (ignoreFields) {
-        for (let i = 0, l = ignoreFields.length, field; i < l; i++) {
-          field = ignoreFields[i];
-          actual[record.id][field] = record[field];
-        }
-      }
-
-      assert.deepEqual(actual, record, 'indexedDB contains record');
-    });
-}
-
-export function verifyIndexedDBDoesNotContainRecord(assert, cache, record) {
-  return getRecord(cache, record)
-    .then(actual => {
-      assert.equal(actual, null, 'indexedDB does not contain record');
-    });
 }

--- a/packages/@orbit/indexeddb/tsconfig.tests.json
+++ b/packages/@orbit/indexeddb/tsconfig.tests.json
@@ -8,7 +8,8 @@
     "inlineSourceMap": true,
     "declaration": false,
     "newLine": "LF",
-    "types": ["qunit"]
+    "types": ["qunit"],
+    "noImplicitAny": true
   },
   "include": [
     "src/**/*.ts",

--- a/packages/@orbit/jsonapi/Brocfile.js
+++ b/packages/@orbit/jsonapi/Brocfile.js
@@ -9,7 +9,8 @@ let buildOptions = {
   external: [
     '@orbit/utils',
     '@orbit/core',
-    '@orbit/data'
+    '@orbit/data',
+    'sinon'
   ]
 };
 

--- a/packages/@orbit/jsonapi/package-lock.json
+++ b/packages/@orbit/jsonapi/package-lock.json
@@ -1,11 +1,14 @@
 {
-  "requires": true,
+  "name": "@orbit/jsonapi",
+  "version": "0.15.25",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@babel/types": {
       "version": "7.0.0-rc.1",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-rc.1.tgz",
       "integrity": "sha512-MBwO1JQKin9BwKTGydrYe4VDJbStCUy35IhJzeZt3FByOdx/q3CYaqMRrH70qVD2RA7+Xk8e3RN0mzKZkYBYuQ==",
+      "dev": true,
       "requires": {
         "esutils": "^2.0.2",
         "lodash": "^4.17.10",
@@ -15,7 +18,8 @@
         "to-fast-properties": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
         }
       }
     },
@@ -23,6 +27,7 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@glimmer/build/-/build-0.9.0.tgz",
       "integrity": "sha512-mmoYV3lZmQ/itbXhhLqZHXZGGSy0v0zNHaCY76ULC/BsHKDOTB/l4Aqpa4q30FNTuGn11g4twmdRcEHw5ma4Fg==",
+      "dev": true,
       "requires": {
         "@types/qunit": "^2.5.2",
         "amd-name-resolver": "1.2.0",
@@ -65,15 +70,74 @@
         "typescript": "~3.0.1"
       }
     },
+    "@orbit/core": {
+      "version": "0.15.23",
+      "resolved": "https://registry.npmjs.org/@orbit/core/-/core-0.15.23.tgz",
+      "integrity": "sha512-/IDqttFC7eUbyy9NABctYsCrnGIaut4VZfXFQodvd74Rmc1C3+4XbkYmH26zCG/ALQIAhY5odiN9vvzOrHyV0Q==",
+      "requires": {
+        "@orbit/utils": "^0.15.23"
+      }
+    },
+    "@orbit/data": {
+      "version": "0.15.23",
+      "resolved": "https://registry.npmjs.org/@orbit/data/-/data-0.15.23.tgz",
+      "integrity": "sha512-7ZQt9KYCGWIZLpLQHaOVWyMlU5iddPOEfkesY1We4ob+cbWFv4ZvGHuT0Br4ki1LhoAkh1Zz2dB76NR/WQXOBg==",
+      "requires": {
+        "@orbit/core": "^0.15.23",
+        "@orbit/utils": "^0.15.23"
+      }
+    },
+    "@orbit/utils": {
+      "version": "0.15.23",
+      "resolved": "https://registry.npmjs.org/@orbit/utils/-/utils-0.15.23.tgz",
+      "integrity": "sha512-+7l34ROgaq2SISR6uU4/amz8TjG0HxL7XgGEeuxAinhFzO/vI8/G/kER7Jah885esM+ZmGVLrU5c6ddkHm0H3Q=="
+    },
+    "@sinonjs/commons": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
+      "integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
+      "integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/samsam": "^2 || ^3"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.0.2.tgz",
+      "integrity": "sha512-m08g4CS3J6lwRQk1pj1EO+KEVWbrbXsmi9Pw0ySmrIbcVxVaedoFgLvFsV8wHLwh01EpROVz3KvVcD1Jmks9FQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.0.2",
+        "array-from": "^2.1.1",
+        "lodash.get": "^4.4.2"
+      }
+    },
     "@types/qunit": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/@types/qunit/-/qunit-2.5.2.tgz",
-      "integrity": "sha512-bK5HuVLlE0S0stmSHbanLdiB8hBzhdW0LXR8bU/1N+RNW5sbgY+0+YcTlVADyZXFtNgt25ccm9iVpNJheLdbnA=="
+      "integrity": "sha512-bK5HuVLlE0S0stmSHbanLdiB8hBzhdW0LXR8bU/1N+RNW5sbgY+0+YcTlVADyZXFtNgt25ccm9iVpNJheLdbnA==",
+      "dev": true
+    },
+    "@types/sinon": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.0.3.tgz",
+      "integrity": "sha512-cjmJQLx2B5Hp9SzO7rdSivipo3kBqRqeYkTW17nLST1tn5YLWBjTdnzdmeTJXA1+KrrBLsEuvKQ0fUPGrfazQg==",
+      "dev": true
     },
     "accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "dev": true,
       "requires": {
         "mime-types": "~2.1.18",
         "negotiator": "0.6.1"
@@ -82,12 +146,14 @@
     "after": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
+      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
+      "dev": true
     },
     "align-text": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -98,6 +164,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
       "integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
+      "dev": true,
       "requires": {
         "ensure-posix-path": "^1.0.1"
       }
@@ -105,22 +172,26 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
     },
     "anymatch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "dev": true,
       "requires": {
         "micromatch": "^2.1.5",
         "normalize-path": "^2.0.0"
@@ -129,12 +200,14 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "dev": true
     },
     "are-we-there-yet": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "dev": true,
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -144,6 +217,7 @@
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -158,6 +232,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -168,6 +243,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       },
@@ -175,7 +251,8 @@
         "sprintf-js": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+          "dev": true
         }
       }
     },
@@ -183,6 +260,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "dev": true,
       "requires": {
         "arr-flatten": "^1.0.1"
       }
@@ -190,47 +268,62 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
     },
     "arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
     },
     "array-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+      "dev": true
     },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+      "dev": true
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "dev": true
     },
     "array-unique": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "dev": true
     },
     "arraybuffer.slice": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
-      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
+      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
     },
     "async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
     },
     "async-disk-cache": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.3.tgz",
       "integrity": "sha512-GyaWSbDAZCltxSobtj1m1ptXa0+zSdjWs3sM4IqnvhoRwMDHW5786sXQ1RiXbR3ZGuQe6NXMB4N0vUmW163cew==",
+      "dev": true,
       "requires": {
         "debug": "^2.1.3",
         "heimdalljs": "^0.2.3",
@@ -244,17 +337,20 @@
     "async-each": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+      "dev": true
     },
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+      "dev": true
     },
     "async-promise-queue": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/async-promise-queue/-/async-promise-queue-1.0.4.tgz",
       "integrity": "sha512-GQ5X3DT+TefYuFPHdvIPXFTlKnh39U7dwtl+aUBGeKjMea9nBpv3c91DXgeyBQmY07vQ97f3Sr9XHqkamEameQ==",
+      "dev": true,
       "requires": {
         "async": "^2.4.1",
         "debug": "^2.6.8"
@@ -264,6 +360,7 @@
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "dev": true,
           "requires": {
             "lodash": "^4.17.10"
           }
@@ -273,12 +370,14 @@
     "atob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
-      "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
+      "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
+      "dev": true
     },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
       "requires": {
         "chalk": "^1.1.3",
         "esutils": "^2.0.2",
@@ -289,6 +388,7 @@
       "version": "6.26.3",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
       "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+      "dev": true,
       "requires": {
         "babel-code-frame": "^6.26.0",
         "babel-generator": "^6.26.0",
@@ -315,6 +415,7 @@
       "version": "6.26.1",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+      "dev": true,
       "requires": {
         "babel-messages": "^6.23.0",
         "babel-runtime": "^6.26.0",
@@ -330,6 +431,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+      "dev": true,
       "requires": {
         "babel-helper-hoist-variables": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -341,6 +443,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+      "dev": true,
       "requires": {
         "babel-helper-function-name": "^6.24.1",
         "babel-runtime": "^6.26.0",
@@ -352,6 +455,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+      "dev": true,
       "requires": {
         "babel-helper-get-function-arity": "^6.24.1",
         "babel-runtime": "^6.22.0",
@@ -364,6 +468,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
@@ -373,6 +478,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
@@ -382,6 +488,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
@@ -391,6 +498,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+      "dev": true,
       "requires": {
         "babel-helper-optimise-call-expression": "^6.24.1",
         "babel-messages": "^6.23.0",
@@ -404,6 +512,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-template": "^6.24.1"
@@ -413,6 +522,7 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -421,6 +531,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -429,6 +540,7 @@
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.11.tgz",
       "integrity": "sha512-hZw5qNNGAR02Y+yBUrtsnJHh8OXavkayPRqKGAXnIm4t5rWVpj3ArwsC7TWdpZsBguQvHAeyTxZ7s23yY60HHg==",
+      "dev": true,
       "requires": {
         "semver": "^5.3.0"
       }
@@ -437,6 +549,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz",
       "integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -444,12 +557,14 @@
     "babel-plugin-feature-flags": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-feature-flags/-/babel-plugin-feature-flags-0.3.1.tgz",
-      "integrity": "sha1-nIJ8+aTrmhn3JcyyOehcqwIDb8E="
+      "integrity": "sha1-nIJ8+aTrmhn3JcyyOehcqwIDb8E=",
+      "dev": true
     },
     "babel-plugin-filter-imports": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-filter-imports/-/babel-plugin-filter-imports-2.0.0.tgz",
       "integrity": "sha512-QeqMsp9TOUWUmn9fvUeqn5UMLkcUFfOe6n4bJgp6i7wF23fImUaYL72UQOdyx8jekwu+DPjgIaWw1lMjUoUYng==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0-beta.46",
         "lodash": "^4.17.10"
@@ -458,12 +573,14 @@
     "babel-plugin-strip-glimmer-utils": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-strip-glimmer-utils/-/babel-plugin-strip-glimmer-utils-0.1.1.tgz",
-      "integrity": "sha1-33Sko0nQuFIvQ0xFfLbO8gSDyeo="
+      "integrity": "sha1-33Sko0nQuFIvQ0xFfLbO8gSDyeo=",
+      "dev": true
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -472,6 +589,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "babel-template": "^6.26.0",
@@ -484,6 +602,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+      "dev": true,
       "requires": {
         "babel-helper-define-map": "^6.24.1",
         "babel-helper-function-name": "^6.24.1",
@@ -500,6 +619,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-template": "^6.24.1"
@@ -509,6 +629,7 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -517,6 +638,7 @@
       "version": "6.26.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
       "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+      "dev": true,
       "requires": {
         "babel-plugin-transform-strict-mode": "^6.24.1",
         "babel-runtime": "^6.26.0",
@@ -528,6 +650,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+      "dev": true,
       "requires": {
         "babel-helper-call-delegate": "^6.24.1",
         "babel-helper-get-function-arity": "^6.24.1",
@@ -541,6 +664,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
@@ -550,6 +674,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -558,6 +683,7 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
       }
@@ -566,6 +692,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-proto-to-assign/-/babel-plugin-transform-proto-to-assign-6.26.0.tgz",
       "integrity": "sha1-xJPiSmJ0mkT37ellBsDLOhiR9ns=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "lodash": "^4.17.4"
@@ -575,6 +702,7 @@
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
@@ -584,6 +712,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "dev": true,
       "requires": {
         "babel-core": "^6.26.0",
         "babel-runtime": "^6.26.0",
@@ -598,6 +727,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -607,6 +737,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "babel-traverse": "^6.26.0",
@@ -619,6 +750,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "dev": true,
       "requires": {
         "babel-code-frame": "^6.26.0",
         "babel-messages": "^6.23.0",
@@ -635,6 +767,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "esutils": "^2.0.2",
@@ -645,12 +778,14 @@
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true
     },
     "backbone": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.3.3.tgz",
       "integrity": "sha1-TMgOp8sWMaxHSInOQPL4vGg7KZk=",
+      "dev": true,
       "requires": {
         "underscore": ">=1.8.3"
       }
@@ -658,17 +793,20 @@
     "backo2": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
       "requires": {
         "cache-base": "^1.0.1",
         "class-utils": "^0.3.5",
@@ -683,6 +821,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
           "requires": {
             "is-descriptor": "^1.0.0"
           }
@@ -691,6 +830,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -699,6 +839,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -707,6 +848,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -716,29 +858,34 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
         },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
         }
       }
     },
     "base64-arraybuffer": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
+      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
+      "dev": true
     },
     "base64id": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
-      "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
+      "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
+      "dev": true
     },
     "better-assert": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
       "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+      "dev": true,
       "requires": {
         "callsite": "1.0.0"
       }
@@ -746,32 +893,38 @@
     "binary-extensions": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+      "dev": true
     },
     "binaryextensions": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.1.1.tgz",
-      "integrity": "sha512-XBaoWE9RW8pPdPQNibZsW2zh8TW6gcarXp1FZPwT8Uop8ScSNldJEWf2k9l3HeTqdrEwsOsFcq74RiJECW34yA=="
+      "integrity": "sha512-XBaoWE9RW8pPdPQNibZsW2zh8TW6gcarXp1FZPwT8Uop8ScSNldJEWf2k9l3HeTqdrEwsOsFcq74RiJECW34yA==",
+      "dev": true
     },
     "blank-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.2.tgz",
-      "integrity": "sha1-+ZB5P76ajI3QE/syGUIL7IHV9Lk="
+      "integrity": "sha1-+ZB5P76ajI3QE/syGUIL7IHV9Lk=",
+      "dev": true
     },
     "blob": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-      "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
+      "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
+      "dev": true
     },
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "dev": true
     },
     "body-parser": {
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
       "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+      "dev": true,
       "requires": {
         "bytes": "3.0.0",
         "content-type": "~1.0.4",
@@ -789,6 +942,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -798,6 +952,7 @@
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "dev": true,
       "requires": {
         "expand-range": "^1.8.1",
         "preserve": "^0.2.0",
@@ -808,6 +963,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/broccoli/-/broccoli-1.1.4.tgz",
       "integrity": "sha1-sCOwKLhm9EftFDQQB5Ye/QP3JRw=",
+      "dev": true,
       "requires": {
         "broccoli-node-info": "1.1.0",
         "broccoli-slow-trees": "2.0.0",
@@ -830,6 +986,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.0.tgz",
       "integrity": "sha512-c5OLGY40Sdmv6rP230Jt8yoK49BHfOw1LXiDMu9EC9k2U6sqlpNRK78SzvByQ8IzKtBYUfeWCxeZHcvW+gH7VQ==",
+      "dev": true,
       "requires": {
         "babel-core": "^6.26.0",
         "broccoli-funnel": "^2.0.1",
@@ -846,7 +1003,8 @@
         "rsvp": {
           "version": "4.8.3",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.3.tgz",
-          "integrity": "sha512-/OlbK31XtkPnLD2ktmZXj4g/v6q1boTDr6/3lFuDTgxVsrA3h7PH5eYyAxIvDMjRHr/DoOlzNicqDwBEo9xU7g=="
+          "integrity": "sha512-/OlbK31XtkPnLD2ktmZXj4g/v6q1boTDr6/3lFuDTgxVsrA3h7PH5eYyAxIvDMjRHr/DoOlzNicqDwBEo9xU7g==",
+          "dev": true
         }
       }
     },
@@ -854,6 +1012,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/broccoli-cli/-/broccoli-cli-1.0.0.tgz",
       "integrity": "sha1-aURFIaXmMVaTAPvBluheGAl7IqQ=",
+      "dev": true,
       "requires": {
         "resolve": "~0.6.1"
       },
@@ -861,7 +1020,8 @@
         "resolve": {
           "version": "0.6.3",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
-          "integrity": "sha1-3ZV5gufnNt699TtYpN2RdUV13UY="
+          "integrity": "sha1-3ZV5gufnNt699TtYpN2RdUV13UY=",
+          "dev": true
         }
       }
     },
@@ -869,6 +1029,7 @@
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/broccoli-concat/-/broccoli-concat-3.5.1.tgz",
       "integrity": "sha512-CETmWZA+I9c3gt3iLOtHGlpBthQG3I/v0Jtkix7OtB5yoMoQEE08gAEKFeC5FwbRJ8W+xKc118ALzUsdvrn5tQ==",
+      "dev": true,
       "requires": {
         "broccoli-kitchen-sink-helpers": "^0.3.1",
         "broccoli-plugin": "^1.3.0",
@@ -888,6 +1049,7 @@
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.4.tgz",
       "integrity": "sha512-CixMUndBqTljCc26i6ubhBrGbAWXpWBsGJFce6ZOr76Tul2Ev1xxM0tmf7OjSzdYhkr5BrPd/CNbR9VMPi+NBg==",
+      "dev": true,
       "requires": {
         "broccoli-plugin": "^1.2.1",
         "fs-tree-diff": "^0.5.2",
@@ -901,6 +1063,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/broccoli-file-creator/-/broccoli-file-creator-2.1.1.tgz",
       "integrity": "sha512-YpjOExWr92C5vhnK0kmD81kM7U09kdIRZk9w4ZDCDHuHXW+VE/x6AGEOQQW3loBQQ6Jk+k+TSm8dESy4uZsnjw==",
+      "dev": true,
       "requires": {
         "broccoli-plugin": "^1.1.0",
         "mkdirp": "^0.5.1"
@@ -910,6 +1073,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
       "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==",
+      "dev": true,
       "requires": {
         "array-equal": "^1.0.0",
         "blank-object": "^1.0.1",
@@ -930,6 +1094,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz",
       "integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
+      "dev": true,
       "requires": {
         "glob": "^5.0.10",
         "mkdirp": "^0.5.1"
@@ -939,6 +1104,7 @@
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
           "requires": {
             "inflight": "^1.0.4",
             "inherits": "2",
@@ -953,6 +1119,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
       "integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
+      "dev": true,
       "requires": {
         "broccoli-plugin": "^1.3.0",
         "merge-trees": "^1.0.1"
@@ -961,12 +1128,14 @@
     "broccoli-node-info": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/broccoli-node-info/-/broccoli-node-info-1.1.0.tgz",
-      "integrity": "sha1-OqLjHgflvbUW3SUhT3xFuhxFlBI="
+      "integrity": "sha1-OqLjHgflvbUW3SUhT3xFuhxFlBI=",
+      "dev": true
     },
     "broccoli-persistent-filter": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
       "integrity": "sha512-JwNLDvvXJlhUmr+CHcbVhCyp33NbCIAITjQZmJY9e8QzANXh3jpFWlhSFvkWghwKA8rTAKcXkW12agtiZjxr4g==",
+      "dev": true,
       "requires": {
         "async-disk-cache": "^1.2.1",
         "async-promise-queue": "^1.0.3",
@@ -987,6 +1156,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
       "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
+      "dev": true,
       "requires": {
         "promise-map-series": "^0.2.1",
         "quick-temp": "^0.1.3",
@@ -998,6 +1168,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/broccoli-rollup/-/broccoli-rollup-1.3.0.tgz",
       "integrity": "sha1-Q6CneYVVurVCFwCetHCk/1oFbfA=",
+      "dev": true,
       "requires": {
         "broccoli-plugin": "^1.2.1",
         "es6-map": "^0.1.4",
@@ -1016,6 +1187,7 @@
           "version": "0.30.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "jsonfile": "^2.1.0",
@@ -1028,6 +1200,7 @@
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6"
           }
@@ -1037,17 +1210,20 @@
     "broccoli-slow-trees": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/broccoli-slow-trees/-/broccoli-slow-trees-2.0.0.tgz",
-      "integrity": "sha1-l0Gv6ZJ4et1krsf3yCEd/MBYJ40="
+      "integrity": "sha1-l0Gv6ZJ4et1krsf3yCEd/MBYJ40=",
+      "dev": true
     },
     "broccoli-source": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-1.1.0.tgz",
-      "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak="
+      "integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak=",
+      "dev": true
     },
     "broccoli-stew": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/broccoli-stew/-/broccoli-stew-1.6.0.tgz",
       "integrity": "sha512-sUwCJNnYH4Na690By5xcEMAZqKgquUQnMAEuIiL3Z2k63mSw9Xg+7Ew4wCrFrMmXMcLpWjZDOm6Yqnq268N+ZQ==",
+      "dev": true,
       "requires": {
         "broccoli-debug": "^0.6.1",
         "broccoli-funnel": "^2.0.0",
@@ -1069,6 +1245,7 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -1077,6 +1254,7 @@
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -1087,6 +1265,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -1095,6 +1274,7 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
           "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "jsonfile": "^4.0.0",
@@ -1104,12 +1284,14 @@
         "rsvp": {
           "version": "4.8.3",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.3.tgz",
-          "integrity": "sha512-/OlbK31XtkPnLD2ktmZXj4g/v6q1boTDr6/3lFuDTgxVsrA3h7PH5eYyAxIvDMjRHr/DoOlzNicqDwBEo9xU7g=="
+          "integrity": "sha512-/OlbK31XtkPnLD2ktmZXj4g/v6q1boTDr6/3lFuDTgxVsrA3h7PH5eYyAxIvDMjRHr/DoOlzNicqDwBEo9xU7g==",
+          "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -1120,6 +1302,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/broccoli-string-replace/-/broccoli-string-replace-0.1.2.tgz",
       "integrity": "sha1-HtkvhWgK+NUDAjkl51Tk4zZ2uR8=",
+      "dev": true,
       "requires": {
         "broccoli-persistent-filter": "^1.1.5",
         "minimatch": "^3.0.3"
@@ -1129,6 +1312,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/broccoli-typescript-compiler/-/broccoli-typescript-compiler-4.0.1.tgz",
       "integrity": "sha512-3psnblHnaMTfh3sE9lkLTKs8XjK563vbKMh/1mslmabqt9wuAOfTMUNEMbmGCofVoMUd9C/ydrmN5eZ6mJUNpQ==",
+      "dev": true,
       "requires": {
         "broccoli-funnel": "^2.0.1",
         "broccoli-merge-trees": "^3.0.0",
@@ -1144,6 +1328,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.1.tgz",
           "integrity": "sha512-EFPBLbCoyCLdjJx0lxn+acWXK/GAZesXokS4OsF7HuB+WdnV76HVJPdfwp9TaXaUkrtb7eU+ymh9tY9wOGQjMQ==",
+          "dev": true,
           "requires": {
             "broccoli-plugin": "^1.3.0",
             "merge-trees": "^2.0.0"
@@ -1153,6 +1338,7 @@
           "version": "0.3.3",
           "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.3.3.tgz",
           "integrity": "sha1-6S0sb3f9RtW/ULYQ0orTF1UFTQs=",
+          "dev": true,
           "requires": {
             "rsvp": "~3.2.1"
           }
@@ -1161,6 +1347,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
           "integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
+          "dev": true,
           "requires": {
             "md5-o-matic": "^0.1.1"
           }
@@ -1169,6 +1356,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-2.0.0.tgz",
           "integrity": "sha512-5xBbmqYBalWqmhYm51XlohhkmVOua3VAUrrWh8t9iOkaLpS6ifqm/UVuUjQCeDVJ9Vx3g2l6ihfkbLSTeKsHbw==",
+          "dev": true,
           "requires": {
             "fs-updater": "^1.0.4",
             "heimdalljs": "^0.2.5"
@@ -1178,6 +1366,7 @@
               "version": "0.2.5",
               "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.5.tgz",
               "integrity": "sha1-aqVDCO7nk7ZCz/nPlHgURfN3MKw=",
+              "dev": true,
               "requires": {
                 "rsvp": "~3.2.1"
               }
@@ -1187,7 +1376,8 @@
         "rsvp": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
-          "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo="
+          "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
+          "dev": true
         }
       }
     },
@@ -1195,6 +1385,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
       "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+      "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
       }
@@ -1202,17 +1393,20 @@
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
     },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+      "dev": true
     },
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
       "requires": {
         "collection-visit": "^1.0.0",
         "component-emitter": "^1.2.1",
@@ -1228,25 +1422,29 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
         }
       }
     },
     "callsite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
+      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
+      "dev": true
     },
     "camelcase": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "dev": true,
       "optional": true
     },
     "can-symlink": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/can-symlink/-/can-symlink-1.0.0.tgz",
       "integrity": "sha1-l7YH2KhLtsbiKLkC2GTstZS50hk=",
+      "dev": true,
       "requires": {
         "tmp": "0.0.28"
       },
@@ -1255,6 +1453,7 @@
           "version": "0.0.28",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
           "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
+          "dev": true,
           "requires": {
             "os-tmpdir": "~1.0.1"
           }
@@ -1265,6 +1464,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
       "optional": true,
       "requires": {
         "align-text": "^0.1.3",
@@ -1275,6 +1475,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
       "requires": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
@@ -1287,6 +1488,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/charm/-/charm-1.0.2.tgz",
       "integrity": "sha1-it02cVOm2aWBMxBSxAkJkdqZXjU=",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.1"
       }
@@ -1295,6 +1497,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+      "dev": true,
       "requires": {
         "anymatch": "^1.3.0",
         "async-each": "^1.0.0",
@@ -1311,6 +1514,7 @@
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "define-property": "^0.2.5",
@@ -1322,6 +1526,7 @@
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -1329,19 +1534,22 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
         }
       }
     },
     "clean-up-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clean-up-path/-/clean-up-path-1.0.0.tgz",
-      "integrity": "sha512-PHGlEF0Z6976qQyN6gM7kKH6EH0RdfZcc8V+QhFe36eRxV0SMH5OUBZG7Bxa9YcreNzyNbK63cGiZxdSZgosRw=="
+      "integrity": "sha512-PHGlEF0Z6976qQyN6gM7kKH6EH0RdfZcc8V+QhFe36eRxV0SMH5OUBZG7Bxa9YcreNzyNbK63cGiZxdSZgosRw==",
+      "dev": true
     },
     "cliui": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "dev": true,
       "optional": true,
       "requires": {
         "center-align": "^0.1.1",
@@ -1353,6 +1561,7 @@
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true,
           "optional": true
         }
       }
@@ -1360,17 +1569,20 @@
     "clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
       "requires": {
         "map-visit": "^1.0.0",
         "object-visit": "^1.0.0"
@@ -1380,6 +1592,7 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
       "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.1"
       }
@@ -1387,37 +1600,44 @@
     "color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
+      "dev": true
     },
     "commander": {
       "version": "2.17.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+      "dev": true
     },
     "component-bind": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
+      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
+      "dev": true
     },
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
     },
     "component-inherit": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
+      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "connect": {
       "version": "3.6.6",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
       "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
+      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "finalhandler": "1.1.0",
@@ -1428,12 +1648,14 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true
     },
     "consolidate": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.15.1.tgz",
       "integrity": "sha512-DW46nrsMJgy9kqAbPt5rKaCr7uFtpo4mSUvLHIUbJEjm0vo+aY5QLwBUq3FK4tRnJr/X0Psc0C4jf/h+HtXSMw==",
+      "dev": true,
       "requires": {
         "bluebird": "^3.1.1"
       }
@@ -1441,52 +1663,62 @@
     "content-disposition": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+      "dev": true
     },
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "dev": true
     },
     "convert-source-map": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+      "dev": true
     },
     "cookie": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+      "dev": true
     },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
     },
     "copy-dereference": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz",
-      "integrity": "sha1-axMYZUIP2BtBO6mUtE02VTERUrY="
+      "integrity": "sha1-axMYZUIP2BtBO6mUtE02VTERUrY=",
+      "dev": true
     },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
     },
     "core-js": {
       "version": "2.5.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
       "requires": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -1499,6 +1731,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "dev": true,
       "requires": {
         "es5-ext": "^0.10.9"
       }
@@ -1507,6 +1740,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -1515,17 +1749,20 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
       "optional": true
     },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
     },
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
       "requires": {
         "is-descriptor": "^1.0.2",
         "isobject": "^3.0.1"
@@ -1535,6 +1772,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -1543,6 +1781,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -1551,6 +1790,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -1560,34 +1800,40 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
         },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
         }
       }
     },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
     },
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
     },
     "detect-file": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
       "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
+      "dev": true,
       "requires": {
         "fs-exists-sync": "^0.1.0"
       }
@@ -1596,6 +1842,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "dev": true,
       "requires": {
         "repeating": "^2.0.0"
       }
@@ -1603,27 +1850,32 @@
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
     },
     "editions": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
-      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
+      "dev": true
     },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
     },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "dev": true
     },
     "engine.io": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.0.tgz",
       "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
+      "dev": true,
       "requires": {
         "accepts": "~1.3.4",
         "base64id": "1.0.0",
@@ -1637,6 +1889,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -1647,6 +1900,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
       "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
+      "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
@@ -1665,6 +1919,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -1675,6 +1930,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
       "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
+      "dev": true,
       "requires": {
         "after": "0.8.2",
         "arraybuffer.slice": "~0.0.7",
@@ -1686,12 +1942,14 @@
     "ensure-posix-path": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.0.2.tgz",
-      "integrity": "sha1-pls+QtC3HPxYXrd0+ZQ8jZuRsMI="
+      "integrity": "sha1-pls+QtC3HPxYXrd0+ZQ8jZuRsMI=",
+      "dev": true
     },
     "es5-ext": {
       "version": "0.10.45",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.45.tgz",
       "integrity": "sha512-FkfM6Vxxfmztilbxxz5UKSD4ICMf5tSpRFtDNtkAhOxZ0EKtX6qwmXNyH/sFyIbX2P/nU5AMiA9jilWsUGJzCQ==",
+      "dev": true,
       "requires": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.1",
@@ -1702,6 +1960,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -1712,6 +1971,7 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "~0.10.14",
@@ -1725,6 +1985,7 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "~0.10.14",
@@ -1737,6 +1998,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "~0.10.14"
@@ -1745,32 +2007,38 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
     },
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "dev": true
     },
     "event-emitter": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "~0.10.14"
@@ -1779,17 +2047,20 @@
     "eventemitter3": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
-      "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
+      "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
+      "dev": true
     },
     "events-to-array": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
-      "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y="
+      "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
+      "dev": true
     },
     "exec-sh": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
       "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
+      "dev": true,
       "requires": {
         "merge": "^1.2.0"
       }
@@ -1798,6 +2069,7 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
       "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+      "dev": true,
       "requires": {
         "cross-spawn": "^6.0.0",
         "get-stream": "^3.0.0",
@@ -1811,12 +2083,14 @@
     "exists-stat": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/exists-stat/-/exists-stat-1.0.0.tgz",
-      "integrity": "sha1-BmDjUlouidnkRhKUQMJy7foktSk="
+      "integrity": "sha1-BmDjUlouidnkRhKUQMJy7foktSk=",
+      "dev": true
     },
     "expand-brackets": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "dev": true,
       "requires": {
         "is-posix-bracket": "^0.1.0"
       }
@@ -1825,6 +2099,7 @@
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "dev": true,
       "requires": {
         "fill-range": "^2.1.0"
       }
@@ -1833,6 +2108,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
       "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+      "dev": true,
       "requires": {
         "os-homedir": "^1.0.1"
       }
@@ -1841,6 +2117,7 @@
       "version": "4.16.3",
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
+      "dev": true,
       "requires": {
         "accepts": "~1.3.5",
         "array-flatten": "1.1.1",
@@ -1878,6 +2155,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
           "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+          "dev": true,
           "requires": {
             "debug": "2.6.9",
             "encodeurl": "~1.0.2",
@@ -1891,12 +2169,14 @@
         "safe-buffer": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+          "dev": true
         },
         "statuses": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+          "dev": true
         }
       }
     },
@@ -1904,6 +2184,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
       "requires": {
         "assign-symbols": "^1.0.0",
         "is-extendable": "^1.0.1"
@@ -1913,6 +2194,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -1923,6 +2205,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "dev": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }
@@ -1931,6 +2214,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.3.tgz",
       "integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
+      "dev": true,
       "requires": {
         "blank-object": "^1.0.1"
       }
@@ -1939,6 +2223,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-sourcemap-concat/-/fast-sourcemap-concat-1.3.2.tgz",
       "integrity": "sha512-+Eh/O4lYU6JzPY/dt9BR6unKRgxS54Jc5Zg5RSIaKM0pVPmNWny3Q7tdgwm4Sf1sAmyiFwrACqSIYgNLlL9l8Q==",
+      "dev": true,
       "requires": {
         "chalk": "^2.0.0",
         "fs-extra": "^5.0.0",
@@ -1954,6 +2239,7 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -1962,6 +2248,7 @@
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -1972,6 +2259,7 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
           "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "jsonfile": "^4.0.0",
@@ -1982,6 +2270,7 @@
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
           "requires": {
             "amdefine": ">=0.0.4"
           }
@@ -1990,6 +2279,7 @@
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -2000,6 +2290,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+      "dev": true,
       "requires": {
         "bser": "^2.0.0"
       }
@@ -2007,12 +2298,14 @@
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "dev": true
     },
     "fill-range": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
       "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+      "dev": true,
       "requires": {
         "is-number": "^2.1.0",
         "isobject": "^2.0.0",
@@ -2025,6 +2318,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
       "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.1",
@@ -2038,12 +2332,14 @@
     "find-index": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-index/-/find-index-1.1.0.tgz",
-      "integrity": "sha1-UwB8ec0wBA1oFteUWOiDfVxXBe8="
+      "integrity": "sha1-UwB8ec0wBA1oFteUWOiDfVxXBe8=",
+      "dev": true
     },
     "findup-sync": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-1.0.0.tgz",
       "integrity": "sha1-b35LV7buOkA3tEFOrt6j9Y9x4Ow=",
+      "dev": true,
       "requires": {
         "detect-file": "^0.1.0",
         "is-glob": "^2.0.1",
@@ -2055,6 +2351,7 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/fireworm/-/fireworm-0.7.1.tgz",
       "integrity": "sha1-zPIPeUHxCIg/zduZOD2+bhhhx1g=",
+      "dev": true,
       "requires": {
         "async": "~0.2.9",
         "is-type": "0.0.1",
@@ -2066,7 +2363,8 @@
         "async": {
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "dev": true
         }
       }
     },
@@ -2074,6 +2372,7 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.2.tgz",
       "integrity": "sha512-kssLorP/9acIdpQ2udQVTiCS5LQmdEz9mvdIfDcl1gYX2tPKFADHSyFdvJS040XdFsPzemWtgI3q8mFVCxtX8A==",
+      "dev": true,
       "requires": {
         "debug": "^3.1.0"
       },
@@ -2082,6 +2381,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -2091,33 +2391,29 @@
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
     },
     "for-own": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "dev": true,
       "requires": {
         "for-in": "^1.0.1"
-      }
-    },
-    "formatio": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
-      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
-      "requires": {
-        "samsam": "~1.1"
       }
     },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+      "dev": true
     },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
       "requires": {
         "map-cache": "^0.2.2"
       }
@@ -2125,17 +2421,20 @@
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
     },
     "fs-exists-sync": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
+      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
+      "dev": true
     },
     "fs-extra": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
       "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -2146,6 +2445,7 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
       "integrity": "sha512-dJwDX6NBH7IfdfFjZAdHCZ6fIKc8LwR7kzqUhYRFJuX4g9ctG/7cuqJuwegGQsyLEykp6Z4krq+yIFMQlt7d9Q==",
+      "dev": true,
       "requires": {
         "heimdalljs-logger": "^0.1.7",
         "object-assign": "^4.1.0",
@@ -2157,6 +2457,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/fs-updater/-/fs-updater-1.0.4.tgz",
       "integrity": "sha512-0pJX4mJF/qLsNEwTct8CdnnRdagfb+LmjRPJ8sO+nCnAZLW0cTmz4rTgU25n+RvTuWSITiLKrGVJceJPBIPlKg==",
+      "dev": true,
       "requires": {
         "can-symlink": "^1.0.0",
         "clean-up-path": "^1.0.0",
@@ -2168,12 +2469,14 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
       "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "dev": true,
       "optional": true,
       "requires": {
         "nan": "^2.9.2",
@@ -2183,20 +2486,24 @@
         "abbrev": {
           "version": "1.1.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "delegates": "^1.0.0",
@@ -2205,11 +2512,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2218,28 +2527,34 @@
         "chownr": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "ms": "2.0.0"
@@ -2248,21 +2563,25 @@
         "deep-extend": {
           "version": "0.5.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -2271,11 +2590,13 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "aproba": "^1.0.3",
@@ -2291,6 +2612,7 @@
         "glob": {
           "version": "7.1.2",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -2304,11 +2626,13 @@
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "safer-buffer": "^2.1.0"
@@ -2317,6 +2641,7 @@
         "ignore-walk": {
           "version": "3.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -2325,6 +2650,7 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "once": "^1.3.0",
@@ -2333,16 +2659,19 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2350,22 +2679,26 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2374,6 +2707,7 @@
         "minizlib": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "minipass": "^2.2.1"
@@ -2382,6 +2716,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2389,11 +2724,13 @@
         "ms": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "debug": "^2.1.2",
@@ -2404,6 +2741,7 @@
         "node-pre-gyp": {
           "version": "0.10.0",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
@@ -2421,6 +2759,7 @@
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "abbrev": "1",
@@ -2430,11 +2769,13 @@
         "npm-bundled": {
           "version": "1.0.3",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -2444,6 +2785,7 @@
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
@@ -2454,16 +2796,19 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2471,16 +2816,19 @@
         "os-homedir": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "os-homedir": "^1.0.0",
@@ -2490,16 +2838,19 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "deep-extend": "^0.5.1",
@@ -2511,6 +2862,7 @@
             "minimist": {
               "version": "1.2.0",
               "bundled": true,
+              "dev": true,
               "optional": true
             }
           }
@@ -2518,6 +2870,7 @@
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -2532,6 +2885,7 @@
         "rimraf": {
           "version": "2.6.2",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "glob": "^7.0.5"
@@ -2539,36 +2893,43 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2578,6 +2939,7 @@
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -2586,6 +2948,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2593,11 +2956,13 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "chownr": "^1.0.1",
@@ -2612,11 +2977,13 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "string-width": "^1.0.2"
@@ -2624,11 +2991,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         }
       }
     },
@@ -2636,6 +3005,7 @@
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
       "requires": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -2650,17 +3020,20 @@
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
     },
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
     },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2674,6 +3047,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "dev": true,
       "requires": {
         "glob-parent": "^2.0.0",
         "is-glob": "^2.0.0"
@@ -2683,6 +3057,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "dev": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -2691,6 +3066,7 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
       "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+      "dev": true,
       "requires": {
         "global-prefix": "^0.1.4",
         "is-windows": "^0.2.0"
@@ -2700,6 +3076,7 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
       "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+      "dev": true,
       "requires": {
         "homedir-polyfill": "^1.0.0",
         "ini": "^1.3.4",
@@ -2710,22 +3087,26 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true
     },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
     },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "dev": true
     },
     "handlebars": {
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+      "dev": true,
       "requires": {
         "async": "^1.4.0",
         "optimist": "^0.6.1",
@@ -2737,6 +3118,7 @@
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
           "requires": {
             "amdefine": ">=0.0.4"
           }
@@ -2747,6 +3129,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -2755,6 +3138,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
       "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
+      "dev": true,
       "requires": {
         "isarray": "2.0.1"
       },
@@ -2762,29 +3146,34 @@
         "isarray": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+          "dev": true
         }
       }
     },
     "has-cors": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
-      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
+      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
+      "dev": true
     },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "dev": true
     },
     "has-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
       "requires": {
         "get-value": "^2.0.6",
         "has-values": "^1.0.0",
@@ -2794,7 +3183,8 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
         }
       }
     },
@@ -2802,6 +3192,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
       "requires": {
         "is-number": "^3.0.0",
         "kind-of": "^4.0.0"
@@ -2811,6 +3202,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -2819,6 +3211,7 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -2829,6 +3222,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -2839,6 +3233,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.2.3.tgz",
       "integrity": "sha512-NE//rDaCFpWHViw30YM78OAGBShU+g4dnUGY3UWGyEzPOGYg/ptOjk32nEc+bC1xz+RfK5UIs6lOL6eQdrV4Ow==",
+      "dev": true,
       "requires": {
         "broccoli-kitchen-sink-helpers": "^0.3.1",
         "heimdalljs": "^0.2.3",
@@ -2850,6 +3245,7 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.5.tgz",
       "integrity": "sha1-aqVDCO7nk7ZCz/nPlHgURfN3MKw=",
+      "dev": true,
       "requires": {
         "rsvp": "~3.2.1"
       },
@@ -2857,7 +3253,8 @@
         "rsvp": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
-          "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo="
+          "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
+          "dev": true
         }
       }
     },
@@ -2865,6 +3262,7 @@
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.9.tgz",
       "integrity": "sha1-12raTkW3u294b8nAEKaOsuL68XY=",
+      "dev": true,
       "requires": {
         "debug": "^2.2.0",
         "heimdalljs": "^0.2.0"
@@ -2874,6 +3272,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "dev": true,
       "requires": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.1"
@@ -2883,6 +3282,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "dev": true,
       "requires": {
         "parse-passwd": "^1.0.0"
       }
@@ -2891,6 +3291,7 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "dev": true,
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
@@ -2901,7 +3302,8 @@
         "statuses": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+          "dev": true
         }
       }
     },
@@ -2909,6 +3311,7 @@
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
       "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+      "dev": true,
       "requires": {
         "eventemitter3": "^3.0.0",
         "follow-redirects": "^1.0.0",
@@ -2918,17 +3321,20 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+      "dev": true
     },
     "indexof": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -2937,17 +3343,20 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
     },
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -2955,12 +3364,14 @@
     "ipaddr.js": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
-      "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
+      "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
+      "dev": true
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
       }
@@ -2969,6 +3380,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "dev": true,
       "requires": {
         "binary-extensions": "^1.0.0"
       }
@@ -2976,12 +3388,14 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
       }
@@ -2990,6 +3404,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
       "requires": {
         "is-accessor-descriptor": "^0.1.6",
         "is-data-descriptor": "^0.1.4",
@@ -2999,19 +3414,22 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
         }
       }
     },
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+      "dev": true
     },
     "is-equal-shallow": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "dev": true,
       "requires": {
         "is-primitive": "^2.0.0"
       }
@@ -3019,17 +3437,20 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
     },
     "is-extglob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
       "requires": {
         "number-is-nan": "^1.0.0"
       }
@@ -3038,6 +3459,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
       "requires": {
         "number-is-nan": "^1.0.0"
       }
@@ -3046,6 +3468,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "dev": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }
@@ -3054,6 +3477,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
       }
@@ -3062,6 +3486,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
       "requires": {
         "isobject": "^3.0.1"
       },
@@ -3069,29 +3494,34 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
         }
       }
     },
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "dev": true
     },
     "is-primitive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-type": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/is-type/-/is-type-0.0.1.tgz",
       "integrity": "sha1-9lHYXDZdRJVdFKUdjXBh8/a0d5w=",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0"
       }
@@ -3099,22 +3529,26 @@
     "is-windows": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-      "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
+      "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+      "dev": true
     },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "isobject": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "dev": true,
       "requires": {
         "isarray": "1.0.0"
       }
@@ -3123,6 +3557,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
       "integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ=",
+      "dev": true,
       "requires": {
         "binaryextensions": "1 || 2",
         "editions": "^1.1.1",
@@ -3132,17 +3567,20 @@
     "js-reporters": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/js-reporters/-/js-reporters-1.2.1.tgz",
-      "integrity": "sha1-+IxgjjJKM3OpW8xFrTBeXJecRZs="
+      "integrity": "sha1-+IxgjjJKM3OpW8xFrTBeXJecRZs=",
+      "dev": true
     },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -3151,12 +3589,14 @@
     "jsesc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+      "dev": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
       "requires": {
         "jsonify": "~0.0.0"
       }
@@ -3164,12 +3604,14 @@
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "dev": true
     },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -3177,12 +3619,20 @@
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
     },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -3191,6 +3641,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.9"
       }
@@ -3199,22 +3650,26 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true,
       "optional": true
     },
     "loader.js": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/loader.js/-/loader.js-4.7.0.tgz",
-      "integrity": "sha512-9M2KvGT6duzGMgkOcTkWb+PR/Q2Oe54df/tLgHGVmFpAmtqJ553xJh6N63iFYI2yjo2PeJXbS5skHi/QpJq4vA=="
+      "integrity": "sha512-9M2KvGT6duzGMgkOcTkWb+PR/Q2Oe54df/tLgHGVmFpAmtqJ553xJh6N63iFYI2yjo2PeJXbS5skHi/QpJq4vA==",
+      "dev": true
     },
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "dev": true
     },
     "lodash._basebind": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.3.0.tgz",
       "integrity": "sha1-K1vEUqDhBhQ7IYafIzvbWHQX0kg=",
+      "dev": true,
       "requires": {
         "lodash._basecreate": "~2.3.0",
         "lodash._setbinddata": "~2.3.0",
@@ -3225,6 +3680,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.3.0.tgz",
       "integrity": "sha1-m4ioak3P97fzxh2Dovz8BnHsneA=",
+      "dev": true,
       "requires": {
         "lodash._renative": "~2.3.0",
         "lodash.isobject": "~2.3.0",
@@ -3235,6 +3691,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.3.0.tgz",
       "integrity": "sha1-N7KrF1kaM56YjbMln81GAZ16w2I=",
+      "dev": true,
       "requires": {
         "lodash._setbinddata": "~2.3.0",
         "lodash.bind": "~2.3.0",
@@ -3246,6 +3703,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.3.0.tgz",
       "integrity": "sha1-qgxhrZYETDkzN2ExSDqXWcNlEkc=",
+      "dev": true,
       "requires": {
         "lodash._basecreate": "~2.3.0",
         "lodash._setbinddata": "~2.3.0",
@@ -3257,6 +3715,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
       "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
+      "dev": true,
       "requires": {
         "lodash.isarguments": "^3.0.0",
         "lodash.isarray": "^3.0.0"
@@ -3266,6 +3725,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.3.0.tgz",
       "integrity": "sha1-0arhEC2t9EDo4G/BM6bt1/4UYHU=",
+      "dev": true,
       "requires": {
         "lodash._basebind": "~2.3.0",
         "lodash._basecreatewrapper": "~2.3.0",
@@ -3276,6 +3736,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.3.0.tgz",
       "integrity": "sha1-0D2mvYLu3zjcCltQPXQOzQ6JRZI=",
+      "dev": true,
       "requires": {
         "lodash._htmlescapes": "~2.3.0"
       }
@@ -3283,42 +3744,50 @@
     "lodash._escapestringchar": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.3.0.tgz",
-      "integrity": "sha1-zOc65g/G2lXSv4oGecI8orqxSfw="
+      "integrity": "sha1-zOc65g/G2lXSv4oGecI8orqxSfw=",
+      "dev": true
     },
     "lodash._getnative": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
     },
     "lodash._htmlescapes": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.3.0.tgz",
-      "integrity": "sha1-HKmIY8rfH6HYLITzXzHkBVagTzo="
+      "integrity": "sha1-HKmIY8rfH6HYLITzXzHkBVagTzo=",
+      "dev": true
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
     },
     "lodash._objecttypes": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.3.0.tgz",
-      "integrity": "sha1-aj6jmH3W7rgCGy1cnDA1Scwrrh4="
+      "integrity": "sha1-aj6jmH3W7rgCGy1cnDA1Scwrrh4=",
+      "dev": true
     },
     "lodash._reinterpolate": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.3.0.tgz",
-      "integrity": "sha1-A+6dhcDlXL1ZDXFgiilb3aURKOw="
+      "integrity": "sha1-A+6dhcDlXL1ZDXFgiilb3aURKOw=",
+      "dev": true
     },
     "lodash._renative": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._renative/-/lodash._renative-2.3.0.tgz",
-      "integrity": "sha1-d9jt1M7SbdWXH54Vpfdy5OMX+9M="
+      "integrity": "sha1-d9jt1M7SbdWXH54Vpfdy5OMX+9M=",
+      "dev": true
     },
     "lodash._reunescapedhtml": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.3.0.tgz",
       "integrity": "sha1-25ILVax/P/glk5rOubosIxcT0k0=",
+      "dev": true,
       "requires": {
         "lodash._htmlescapes": "~2.3.0",
         "lodash.keys": "~2.3.0"
@@ -3328,6 +3797,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.3.0.tgz",
       "integrity": "sha1-5WEEkKzRMnfVmFjZW18nJ/FQjwQ=",
+      "dev": true,
       "requires": {
         "lodash._renative": "~2.3.0",
         "lodash.noop": "~2.3.0"
@@ -3337,6 +3807,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.3.0.tgz",
       "integrity": "sha1-YR+TFJ4+bHIQlrSHae8pU3rai6k=",
+      "dev": true,
       "requires": {
         "lodash._objecttypes": "~2.3.0"
       }
@@ -3344,17 +3815,20 @@
     "lodash._slice": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.3.0.tgz",
-      "integrity": "sha1-FHGYEyhZly5GgMoppZkshVZpqlw="
+      "integrity": "sha1-FHGYEyhZly5GgMoppZkshVZpqlw=",
+      "dev": true
     },
     "lodash.assignin": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
-      "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI="
+      "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI=",
+      "dev": true
     },
     "lodash.bind": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.3.0.tgz",
       "integrity": "sha1-wqjhi2jl7MFS4rFoJmEW/qWwFsw=",
+      "dev": true,
       "requires": {
         "lodash._createwrapper": "~2.3.0",
         "lodash._renative": "~2.3.0",
@@ -3364,17 +3838,20 @@
     "lodash.castarray": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
-      "integrity": "sha1-wCUTUV4wna3dTCTGDP3c9ZdtkRU="
+      "integrity": "sha1-wCUTUV4wna3dTCTGDP3c9ZdtkRU=",
+      "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
     },
     "lodash.debounce": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.1.tgz",
       "integrity": "sha1-gSIRw3ipTMKdWqTjNGzwv846ffU=",
+      "dev": true,
       "requires": {
         "lodash._getnative": "^3.0.0"
       }
@@ -3383,6 +3860,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.3.0.tgz",
       "integrity": "sha1-qDKwAfE487uXIcKBmip8xa4h7SU=",
+      "dev": true,
       "requires": {
         "lodash._objecttypes": "~2.3.0",
         "lodash.keys": "~2.3.0"
@@ -3392,6 +3870,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.3.0.tgz",
       "integrity": "sha1-hEw4xY+EThNi6+lnJhWbYs9fKlg=",
+      "dev": true,
       "requires": {
         "lodash._escapehtmlchar": "~2.3.0",
         "lodash._reunescapedhtml": "~2.3.0",
@@ -3401,12 +3880,14 @@
     "lodash.find": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
-      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E="
+      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=",
+      "dev": true
     },
     "lodash.flatten": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-3.0.2.tgz",
       "integrity": "sha1-3hz1d1j49EeTGdNcPpzGDEUBk4w=",
+      "dev": true,
       "requires": {
         "lodash._baseflatten": "^3.0.0",
         "lodash._isiterateecall": "^3.0.0"
@@ -3416,6 +3897,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-2.3.0.tgz",
       "integrity": "sha1-CDQEyR6EbudyRf3512UZxosq8Wg=",
+      "dev": true,
       "requires": {
         "lodash._basecreatecallback": "~2.3.0",
         "lodash.forown": "~2.3.0"
@@ -3425,36 +3907,48 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-2.3.0.tgz",
       "integrity": "sha1-JPtKr4ANRfwtxgv+w84EyDajrX8=",
+      "dev": true,
       "requires": {
         "lodash._basecreatecallback": "~2.3.0",
         "lodash._objecttypes": "~2.3.0",
         "lodash.keys": "~2.3.0"
       }
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.identity": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.3.0.tgz",
-      "integrity": "sha1-awGiEMlIU1XCqRO0i2cRIZoXPe0="
+      "integrity": "sha1-awGiEMlIU1XCqRO0i2cRIZoXPe0=",
+      "dev": true
     },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
     },
     "lodash.isarray": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
     },
     "lodash.isfunction": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.3.0.tgz",
-      "integrity": "sha1-aylz5HpkfPEucNZ2rqE2Q3BuUmc="
+      "integrity": "sha1-aylz5HpkfPEucNZ2rqE2Q3BuUmc=",
+      "dev": true
     },
     "lodash.isobject": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.3.0.tgz",
       "integrity": "sha1-LhbT/Fg9qYMZaJU/LY5tc0NPZ5k=",
+      "dev": true,
       "requires": {
         "lodash._objecttypes": "~2.3.0"
       }
@@ -3463,6 +3957,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.3.0.tgz",
       "integrity": "sha1-s1D0+Syqn0WkouzwGEVM8vKK4lM=",
+      "dev": true,
       "requires": {
         "lodash._renative": "~2.3.0",
         "lodash._shimkeys": "~2.3.0",
@@ -3472,22 +3967,26 @@
     "lodash.merge": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
+      "dev": true
     },
     "lodash.noop": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.3.0.tgz",
-      "integrity": "sha1-MFnWKNUbv5N80qC2/Dp/ISpmnCw="
+      "integrity": "sha1-MFnWKNUbv5N80qC2/Dp/ISpmnCw=",
+      "dev": true
     },
     "lodash.omit": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
+      "dev": true
     },
     "lodash.support": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.3.0.tgz",
       "integrity": "sha1-fq8DivTw1qq3drRKptz8gDNMm/0=",
+      "dev": true,
       "requires": {
         "lodash._renative": "~2.3.0"
       }
@@ -3496,6 +3995,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.3.0.tgz",
       "integrity": "sha1-Tj4pxDO0z+pnXsg15vEjkcYf0is=",
+      "dev": true,
       "requires": {
         "lodash._escapestringchar": "~2.3.0",
         "lodash._reinterpolate": "~2.3.0",
@@ -3510,6 +4010,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.3.0.tgz",
       "integrity": "sha1-MD0TLDQnEAQNWhjvqi1XL9A/jNw=",
+      "dev": true,
       "requires": {
         "lodash._reinterpolate": "~2.3.0",
         "lodash.escape": "~2.3.0"
@@ -3518,35 +4019,41 @@
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "dev": true
     },
     "lodash.uniqby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
-      "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
+      "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
+      "dev": true
     },
     "lodash.values": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.3.0.tgz",
       "integrity": "sha1-ypb75gogsLDsK6K6X8anZb0Uo7o=",
+      "dev": true,
       "requires": {
         "lodash.keys": "~2.3.0"
       }
     },
     "lolex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
-      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.0.0.tgz",
+      "integrity": "sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ==",
+      "dev": true
     },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -3555,6 +4062,7 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+      "dev": true,
       "requires": {
         "tmpl": "1.0.x"
       }
@@ -3562,12 +4070,14 @@
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
     },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
       }
@@ -3576,6 +4086,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.5.tgz",
       "integrity": "sha512-nUCmzKipcJEwYsBVAFh5P+d7JBuhJaW1xs85Hara9xuMLqtCVUrW6DSC0JVIkluxEH2W45nPBM/wjHtBXa/tYA==",
+      "dev": true,
       "requires": {
         "minimatch": "^3.0.2"
       }
@@ -3583,12 +4094,14 @@
     "math-random": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+      "dev": true
     },
     "md5-hex": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
       "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+      "dev": true,
       "requires": {
         "md5-o-matic": "^0.1.1"
       }
@@ -3596,17 +4109,20 @@
     "md5-o-matic": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-      "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M="
+      "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
+      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true
     },
     "memory-streams": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/memory-streams/-/memory-streams-0.1.3.tgz",
       "integrity": "sha512-qVQ/CjkMyMInPaaRMrwWNDvf6boRZXaT/DbQeMYcCWuXPEBf1v8qChOc9OlEVQp2uOvRXa1Qu30fLmKhY6NipA==",
+      "dev": true,
       "requires": {
         "readable-stream": "~1.0.2"
       }
@@ -3614,17 +4130,20 @@
     "merge": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
+      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+      "dev": true
     },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
     },
     "merge-trees": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
       "integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
+      "dev": true,
       "requires": {
         "can-symlink": "^1.0.0",
         "fs-tree-diff": "^0.5.4",
@@ -3637,12 +4156,14 @@
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
     },
     "micromatch": {
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "dev": true,
       "requires": {
         "arr-diff": "^2.0.0",
         "array-unique": "^0.2.1",
@@ -3662,17 +4183,20 @@
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true
     },
     "mime-db": {
       "version": "1.35.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
-      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
+      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.19",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
       "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
+      "dev": true,
       "requires": {
         "mime-db": "~1.35.0"
       }
@@ -3681,6 +4205,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -3688,12 +4213,14 @@
     "minimist": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+      "dev": true
     },
     "minipass": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.3.tgz",
       "integrity": "sha512-/jAn9/tEX4gnpyRATxgHEOV6xbcyxgT7iUnxo9Y3+OB0zX00TgKIv/2FZCf5brBbICcwbLqVv2ImjvWWrQMSYw==",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -3703,6 +4230,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "dev": true,
       "requires": {
         "for-in": "^1.0.2",
         "is-extendable": "^1.0.1"
@@ -3712,6 +4240,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -3722,6 +4251,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -3729,35 +4259,41 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
         }
       }
     },
     "mktemp": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.4.0.tgz",
-      "integrity": "sha1-bQUVYRyKjITkhKogABKbmOmB/ws="
+      "integrity": "sha1-bQUVYRyKjITkhKogABKbmOmB/ws=",
+      "dev": true
     },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "mustache": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.1.tgz",
-      "integrity": "sha512-20dW38oeiTzauvbxs1YxQbr3gbu/Lfo15J4V0EqbspYnn/GwSeTSDNtESy2nak28BW0k8qp7dnrFhrsejLPUtw=="
+      "integrity": "sha512-20dW38oeiTzauvbxs1YxQbr3gbu/Lfo15J4V0EqbspYnn/GwSeTSDNtESy2nak28BW0k8qp7dnrFhrsejLPUtw==",
+      "dev": true
     },
     "nan": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
       "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "dev": true,
       "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
       "requires": {
         "arr-diff": "^4.0.0",
         "array-unique": "^0.3.2",
@@ -3775,54 +4311,100 @@
         "arr-diff": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
         },
         "is-windows": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+          "dev": true
         },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
         }
       }
     },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+      "dev": true
     },
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
     },
     "nice-try": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
-      "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA=="
+      "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==",
+      "dev": true
+    },
+    "nise": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.8.tgz",
+      "integrity": "sha512-kGASVhuL4tlAV0tvA34yJYZIVihrUt/5bDwpp4tTluigxUr2bBlJeDXmivb6NuEdFkqvdv/Ybb9dm16PSKUhtw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^3.1.0",
+        "just-extend": "^4.0.2",
+        "lolex": "^2.3.2",
+        "path-to-regexp": "^1.7.0",
+        "text-encoding": "^0.6.4"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "lolex": {
+          "version": "2.7.5",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+          "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+      "dev": true
     },
     "node-modules-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/node-modules-path/-/node-modules-path-1.0.1.tgz",
-      "integrity": "sha1-QAlrCM560OoUaAhjr0ScfHWl0cg="
+      "integrity": "sha1-QAlrCM560OoUaAhjr0ScfHWl0cg=",
+      "dev": true
     },
     "node-notifier": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
       "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+      "dev": true,
       "requires": {
         "growly": "^1.3.0",
         "semver": "^5.4.1",
@@ -3834,6 +4416,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
@@ -3842,6 +4425,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
       "requires": {
         "path-key": "^2.0.0"
       }
@@ -3850,6 +4434,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dev": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -3860,22 +4445,26 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-component": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
-      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
+      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
       "requires": {
         "copy-descriptor": "^0.1.0",
         "define-property": "^0.2.5",
@@ -3886,6 +4475,7 @@
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -3896,6 +4486,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
       "requires": {
         "isobject": "^3.0.0"
       },
@@ -3903,7 +4494,8 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
         }
       }
     },
@@ -3911,6 +4503,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "dev": true,
       "requires": {
         "for-own": "^0.1.4",
         "is-extendable": "^0.1.1"
@@ -3920,6 +4513,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
       "requires": {
         "isobject": "^3.0.1"
       },
@@ -3927,7 +4521,8 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
         }
       }
     },
@@ -3935,6 +4530,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
       "requires": {
         "ee-first": "1.1.1"
       }
@@ -3943,6 +4539,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -3951,6 +4548,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
@@ -3959,22 +4557,26 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
     },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
     },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "dev": true,
       "requires": {
         "glob-base": "^0.3.0",
         "is-dotfile": "^1.0.0",
@@ -3985,12 +4587,14 @@
     "parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
     },
     "parseqs": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+      "dev": true,
       "requires": {
         "better-assert": "~1.0.0"
       }
@@ -3999,6 +4603,7 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+      "dev": true,
       "requires": {
         "better-assert": "~1.0.0"
       }
@@ -4006,67 +4611,80 @@
     "parseurl": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+      "dev": true
     },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
     },
     "path-posix": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz",
-      "integrity": "sha1-BrJhE/Vr6rBCVFojv6iAA8ysJg8="
+      "integrity": "sha1-BrJhE/Vr6rBCVFojv6iAA8ysJg8=",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "dev": true
     },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
     },
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "dev": true
     },
     "printf": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/printf/-/printf-0.3.0.tgz",
-      "integrity": "sha512-DlJSroT2n9nkh47D4T6BHFQvsMR0L41889ECLmdbzk2BlhN0t31/vl5mHvlWiNBCNQrqG9XfpXwqmJQ2utoYwg=="
+      "integrity": "sha512-DlJSroT2n9nkh47D4T6BHFQvsMR0L41889ECLmdbzk2BlhN0t31/vl5mHvlWiNBCNQrqG9XfpXwqmJQ2utoYwg==",
+      "dev": true
     },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
     },
     "promise-map-series": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz",
       "integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
+      "dev": true,
       "requires": {
         "rsvp": "^3.0.14"
       }
@@ -4075,6 +4693,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
       "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
+      "dev": true,
       "requires": {
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.8.0"
@@ -4083,12 +4702,14 @@
     "qs": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+      "dev": true
     },
     "quick-temp": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.8.tgz",
       "integrity": "sha1-urAqJCq4+w3XWKPJd2sy+aXZRAg=",
+      "dev": true,
       "requires": {
         "mktemp": "~0.4.0",
         "rimraf": "^2.5.4",
@@ -4099,6 +4720,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.6.1.tgz",
       "integrity": "sha512-AaILHe41G+fVC8h5wrp8U31iM2tRxLAVwH1tICtDkRbC1HDgJBjjYq0SMCZE8K3Z16MiZq3vhNhLu18KeDtS6Q==",
+      "dev": true,
       "requires": {
         "chokidar": "1.7.0",
         "commander": "2.12.2",
@@ -4112,17 +4734,20 @@
         "arr-diff": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
         },
         "array-unique": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
         },
         "braces": {
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -4140,6 +4765,7 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -4149,17 +4775,20 @@
         "commander": {
           "version": "2.12.2",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
-          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA=="
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
         },
         "detect-file": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
-          "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
+          "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+          "dev": true
         },
         "expand-brackets": {
           "version": "2.1.4",
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
           "requires": {
             "debug": "^2.3.3",
             "define-property": "^0.2.5",
@@ -4174,6 +4803,7 @@
               "version": "0.2.5",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
               "requires": {
                 "is-descriptor": "^0.1.0"
               }
@@ -4182,6 +4812,7 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -4190,6 +4821,7 @@
               "version": "0.1.6",
               "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
               "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
               },
@@ -4198,6 +4830,7 @@
                   "version": "3.2.2",
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -4208,6 +4841,7 @@
               "version": "0.1.4",
               "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
               "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "dev": true,
               "requires": {
                 "kind-of": "^3.0.2"
               },
@@ -4216,6 +4850,7 @@
                   "version": "3.2.2",
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
                   "requires": {
                     "is-buffer": "^1.1.5"
                   }
@@ -4226,6 +4861,7 @@
               "version": "0.1.6",
               "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
               "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
               "requires": {
                 "is-accessor-descriptor": "^0.1.6",
                 "is-data-descriptor": "^0.1.4",
@@ -4235,7 +4871,8 @@
             "kind-of": {
               "version": "5.1.0",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
             }
           }
         },
@@ -4243,6 +4880,7 @@
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
           "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+          "dev": true,
           "requires": {
             "homedir-polyfill": "^1.0.1"
           }
@@ -4251,6 +4889,7 @@
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
           "requires": {
             "array-unique": "^0.3.2",
             "define-property": "^1.0.0",
@@ -4266,6 +4905,7 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
               "requires": {
                 "is-descriptor": "^1.0.0"
               }
@@ -4274,6 +4914,7 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -4284,6 +4925,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -4295,6 +4937,7 @@
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -4305,6 +4948,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
           "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+          "dev": true,
           "requires": {
             "detect-file": "^1.0.0",
             "is-glob": "^3.1.0",
@@ -4316,6 +4960,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
           "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+          "dev": true,
           "requires": {
             "global-prefix": "^1.0.1",
             "is-windows": "^1.0.1",
@@ -4326,6 +4971,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
           "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+          "dev": true,
           "requires": {
             "expand-tilde": "^2.0.2",
             "homedir-polyfill": "^1.0.1",
@@ -4338,6 +4984,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -4346,6 +4993,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -4354,6 +5002,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -4363,12 +5012,14 @@
         "is-extglob": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
         },
         "is-glob": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
           "requires": {
             "is-extglob": "^2.1.0"
           }
@@ -4377,6 +5028,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -4385,6 +5037,7 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -4394,22 +5047,26 @@
         "is-windows": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+          "dev": true
         },
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
         },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
         },
         "micromatch": {
           "version": "3.1.10",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
           "requires": {
             "arr-diff": "^4.0.0",
             "array-unique": "^0.3.2",
@@ -4430,6 +5087,7 @@
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
           "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+          "dev": true,
           "requires": {
             "path-parse": "^1.0.5"
           }
@@ -4438,6 +5096,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
           "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+          "dev": true,
           "requires": {
             "expand-tilde": "^2.0.0",
             "global-modules": "^1.0.0"
@@ -4449,6 +5108,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
       "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
+      "dev": true,
       "requires": {
         "is-number": "^4.0.0",
         "kind-of": "^6.0.0",
@@ -4458,24 +5118,28 @@
         "is-number": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
         },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
         }
       }
     },
     "range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+      "dev": true
     },
     "raw-body": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
       "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+      "dev": true,
       "requires": {
         "bytes": "3.0.0",
         "http-errors": "1.6.2",
@@ -4486,12 +5150,14 @@
         "depd": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+          "dev": true
         },
         "http-errors": {
           "version": "1.6.2",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
           "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+          "dev": true,
           "requires": {
             "depd": "1.1.1",
             "inherits": "2.0.3",
@@ -4502,7 +5168,8 @@
         "setprototypeof": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+          "dev": true
         }
       }
     },
@@ -4510,6 +5177,7 @@
       "version": "1.0.34",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
       "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -4520,7 +5188,8 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
         }
       }
     },
@@ -4528,6 +5197,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "minimatch": "^3.0.2",
@@ -4539,6 +5209,7 @@
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -4553,6 +5224,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -4562,12 +5234,14 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
     },
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "dev": true,
       "requires": {
         "is-equal-shallow": "^0.1.3"
       }
@@ -4576,6 +5250,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
@@ -4584,22 +5259,26 @@
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
     },
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
     },
     "repeating": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
       "requires": {
         "is-finite": "^1.0.0"
       }
@@ -4607,12 +5286,14 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
     },
     "resolve": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "dev": true,
       "requires": {
         "path-parse": "^1.0.5"
       }
@@ -4621,6 +5302,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
       "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+      "dev": true,
       "requires": {
         "expand-tilde": "^1.2.2",
         "global-modules": "^0.2.3"
@@ -4629,17 +5311,20 @@
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
     },
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
     },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
       "optional": true,
       "requires": {
         "align-text": "^0.1.1"
@@ -4649,6 +5334,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
       "requires": {
         "glob": "^7.0.5"
       }
@@ -4657,6 +5343,7 @@
       "version": "0.41.6",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.41.6.tgz",
       "integrity": "sha1-4NBUl4d6OYwQTYFtJzOnGKepTio=",
+      "dev": true,
       "requires": {
         "source-map-support": "^0.4.0"
       }
@@ -4664,30 +5351,29 @@
     "rsvp": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
+      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+      "dev": true
     },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
       "requires": {
         "ret": "~0.1.10"
       }
-    },
-    "samsam": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
-      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc="
     },
     "sane": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/sane/-/sane-1.7.0.tgz",
       "integrity": "sha1-s1ebzLRclM8gNVzIESSZDf00bjA=",
+      "dev": true,
       "requires": {
         "anymatch": "^1.3.0",
         "exec-sh": "^0.2.0",
@@ -4701,19 +5387,22 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
         }
       }
     },
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "dev": true
     },
     "send": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
       "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "depd": "~1.1.2",
@@ -4733,12 +5422,14 @@
         "mime": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+          "dev": true
         },
         "statuses": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+          "dev": true
         }
       }
     },
@@ -4746,6 +5437,7 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "dev": true,
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
@@ -4756,17 +5448,20 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+      "dev": true
     },
     "set-value": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-extendable": "^0.1.1",
@@ -4778,6 +5473,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -4787,12 +5483,14 @@
     "setprototypeof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
       "requires": {
         "shebang-regex": "^1.0.0"
       }
@@ -4800,38 +5498,58 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
     },
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+      "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
     },
     "sinon": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
-      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.2.2.tgz",
+      "integrity": "sha512-WLagdMHiEsrRmee3jr6IIDntOF4kbI6N2pfbi8wkv50qaUQcBglkzkjtoOEbeJ2vf1EsrHhLI+5Ny8//WHdMoA==",
+      "dev": true,
       "requires": {
-        "formatio": "1.1.1",
-        "lolex": "1.3.2",
-        "samsam": "1.1.2",
-        "util": ">=0.10.3 <1"
+        "@sinonjs/commons": "^1.2.0",
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/samsam": "^3.0.2",
+        "diff": "^3.5.0",
+        "lolex": "^3.0.0",
+        "nise": "^1.4.7",
+        "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "dev": true
     },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
       "requires": {
         "base": "^0.11.1",
         "debug": "^2.2.0",
@@ -4847,6 +5565,7 @@
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -4855,6 +5574,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -4865,6 +5585,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
       "requires": {
         "define-property": "^1.0.0",
         "isobject": "^3.0.0",
@@ -4875,6 +5596,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
           "requires": {
             "is-descriptor": "^1.0.0"
           }
@@ -4883,6 +5605,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -4891,6 +5614,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -4899,6 +5623,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -4908,12 +5633,14 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
         },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
         }
       }
     },
@@ -4921,6 +5648,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
       "requires": {
         "kind-of": "^3.2.0"
       }
@@ -4929,6 +5657,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
       "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
+      "dev": true,
       "requires": {
         "debug": "~3.1.0",
         "engine.io": "~3.2.0",
@@ -4942,6 +5671,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -4951,12 +5681,14 @@
     "socket.io-adapter": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
-      "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs="
+      "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs=",
+      "dev": true
     },
     "socket.io-client": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
       "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
+      "dev": true,
       "requires": {
         "backo2": "1.0.2",
         "base64-arraybuffer": "0.1.5",
@@ -4978,6 +5710,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -4988,6 +5721,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
       "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
+      "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
         "debug": "~3.1.0",
@@ -4998,6 +5732,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -5005,19 +5740,22 @@
         "isarray": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+          "dev": true
         }
       }
     },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "dev": true,
       "requires": {
         "atob": "^2.1.1",
         "decode-uri-component": "^0.2.0",
@@ -5029,7 +5767,8 @@
         "source-map-url": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-          "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+          "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+          "dev": true
         }
       }
     },
@@ -5037,6 +5776,7 @@
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "dev": true,
       "requires": {
         "source-map": "^0.5.6"
       }
@@ -5044,12 +5784,14 @@
     "source-map-url": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
-      "integrity": "sha1-fsrxO1e80J2opAxdJp2zN5nUqvk="
+      "integrity": "sha1-fsrxO1e80J2opAxdJp2zN5nUqvk=",
+      "dev": true
     },
     "sourcemap-validator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/sourcemap-validator/-/sourcemap-validator-1.1.0.tgz",
       "integrity": "sha512-Hmdu39KL+EoAAZ69OTk7RXXJdPRRizJvOZOWhCW9jLGfEQflCNPTlSoCXFPdKWFwwf0uzLcGR/fc7EP/PT8vRQ==",
+      "dev": true,
       "requires": {
         "jsesc": "~0.3.x",
         "lodash.foreach": "~2.3.x",
@@ -5060,12 +5802,14 @@
         "jsesc": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.3.0.tgz",
-          "integrity": "sha1-G/XuY7RTn+LibQwemcJAuXpFeXI="
+          "integrity": "sha1-G/XuY7RTn+LibQwemcJAuXpFeXI=",
+          "dev": true
         },
         "source-map": {
           "version": "0.1.43",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "dev": true,
           "requires": {
             "amdefine": ">=0.0.4"
           }
@@ -5075,12 +5819,14 @@
     "spawn-args": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/spawn-args/-/spawn-args-0.2.0.tgz",
-      "integrity": "sha1-+30L0dcP1DFr2ePew4nmX51jYbs="
+      "integrity": "sha1-+30L0dcP1DFr2ePew4nmX51jYbs=",
+      "dev": true
     },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
       "requires": {
         "extend-shallow": "^3.0.0"
       }
@@ -5088,17 +5834,20 @@
     "sprintf-js": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
-      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
+      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw=",
+      "dev": true
     },
     "stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true
     },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
       "requires": {
         "define-property": "^0.2.5",
         "object-copy": "^0.1.0"
@@ -5108,6 +5857,7 @@
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -5117,12 +5867,14 @@
     "statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+      "dev": true
     },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
       "requires": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -5132,12 +5884,14 @@
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -5145,27 +5899,32 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
     },
     "styled_string": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/styled_string/-/styled_string-0.0.1.tgz",
-      "integrity": "sha1-0ieCvYEpVFm8Tx3xjEutjpTdEko="
+      "integrity": "sha1-0ieCvYEpVFm8Tx3xjEutjpTdEko=",
+      "dev": true
     },
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
     },
     "symlink-or-copy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.2.0.tgz",
-      "integrity": "sha512-W31+GLiBmU/ZR02Ii0mVZICuNEN9daZ63xZMPDsYgPgNjMtg+atqLEGI7PPI936jYSQZxoLb/63xos8Adrx4Eg=="
+      "integrity": "sha512-W31+GLiBmU/ZR02Ii0mVZICuNEN9daZ63xZMPDsYgPgNjMtg+atqLEGI7PPI936jYSQZxoLb/63xos8Adrx4Eg==",
+      "dev": true
     },
     "tap-parser": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-7.0.0.tgz",
       "integrity": "sha512-05G8/LrzqOOFvZhhAk32wsGiPZ1lfUrl+iV7+OkKgfofZxiceZWMHkKmow71YsyVQ8IvGBP2EjcIjE5gL4l5lA==",
+      "dev": true,
       "requires": {
         "events-to-array": "^1.0.1",
         "js-yaml": "^3.2.7",
@@ -5176,6 +5935,7 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/testem/-/testem-2.9.2.tgz",
       "integrity": "sha512-cNUi2ETOB1T74wPl0NCDNTN2Sf0zPmTlN5LlXiszLwQThulEPJacfaWFkcKauL0QMm1CF+nH83bLJvu3PPeFcA==",
+      "dev": true,
       "requires": {
         "backbone": "^1.1.2",
         "bluebird": "^3.4.6",
@@ -5206,15 +5966,23 @@
         "xmldom": "^0.1.19"
       }
     },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
+    },
     "textextensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.2.0.tgz",
-      "integrity": "sha512-j5EMxnryTvKxwH2Cq+Pb43tsf6sdEgw6Pdwxk83mPaq0ToeFJt6WE4J3s5BqY7vmjlLgkgXvhtXUxo80FyBhCA=="
+      "integrity": "sha512-j5EMxnryTvKxwH2Cq+Pb43tsf6sdEgw6Pdwxk83mPaq0ToeFJt6WE4J3s5BqY7vmjlLgkgXvhtXUxo80FyBhCA==",
+      "dev": true
     },
     "tmp": {
       "version": "0.0.31",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
       "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
+      "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.1"
       }
@@ -5222,22 +5990,26 @@
     "tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
+      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "dev": true
     },
     "to-array": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
-      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
+      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
+      "dev": true
     },
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
       }
@@ -5246,6 +6018,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
       "requires": {
         "define-property": "^2.0.2",
         "extend-shallow": "^3.0.2",
@@ -5257,6 +6030,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
       "requires": {
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
@@ -5266,6 +6040,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
           "requires": {
             "kind-of": "^3.0.2"
           }
@@ -5276,6 +6051,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-sync/-/tree-sync-1.2.2.tgz",
       "integrity": "sha1-LPdrhYn1n/7bWNtaOsfLAT0BWLc=",
+      "dev": true,
       "requires": {
         "debug": "^2.2.0",
         "fs-tree-diff": "^0.5.6",
@@ -5288,6 +6064,7 @@
           "version": "0.2.7",
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.7.tgz",
           "integrity": "sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=",
+          "dev": true,
           "requires": {
             "ensure-posix-path": "^1.0.0",
             "matcher-collection": "^1.0.0"
@@ -5298,17 +6075,20 @@
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
     },
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
     },
     "tslint": {
       "version": "5.11.0",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
       "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+      "dev": true,
       "requires": {
         "babel-code-frame": "^6.22.0",
         "builtin-modules": "^1.1.1",
@@ -5328,6 +6108,7 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -5336,6 +6117,7 @@
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -5346,6 +6128,7 @@
           "version": "5.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -5356,14 +6139,22 @@
       "version": "2.29.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
       "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+      "dev": true,
       "requires": {
         "tslib": "^1.8.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.16",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+      "dev": true,
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.18"
@@ -5372,12 +6163,14 @@
     "typescript": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.1.tgz",
-      "integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg=="
+      "integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg==",
+      "dev": true
     },
     "uglify-js": {
       "version": "2.8.29",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "dev": true,
       "optional": true,
       "requires": {
         "source-map": "~0.5.1",
@@ -5389,22 +6182,26 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true,
       "optional": true
     },
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+      "dev": true
     },
     "underscore": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
+      "dev": true
     },
     "underscore.string": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
       "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
+      "dev": true,
       "requires": {
         "sprintf-js": "^1.0.3",
         "util-deprecate": "^1.0.2"
@@ -5414,6 +6211,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
@@ -5425,6 +6223,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -5433,6 +6232,7 @@
           "version": "0.4.3",
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "dev": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-extendable": "^0.1.1",
@@ -5445,17 +6245,20 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
       "requires": {
         "has-value": "^0.3.1",
         "isobject": "^3.0.0"
@@ -5465,6 +6268,7 @@
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
           "requires": {
             "get-value": "^2.0.3",
             "has-values": "^0.1.4",
@@ -5475,6 +6279,7 @@
               "version": "2.1.0",
               "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
               "requires": {
                 "isarray": "1.0.0"
               }
@@ -5484,64 +6289,58 @@
         "has-values": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
         },
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
         }
       }
     },
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
     },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
     },
     "username-sync": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/username-sync/-/username-sync-1.0.1.tgz",
-      "integrity": "sha1-HN6H7vz5S4gimE2Ti6K3l0Jtrh8="
-    },
-    "util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-      "requires": {
-        "inherits": "2.0.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
-        }
-      }
+      "integrity": "sha1-HN6H7vz5S4gimE2Ti6K3l0Jtrh8=",
+      "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true
     },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "dev": true
     },
     "walk-sync": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.2.tgz",
       "integrity": "sha512-FMB5VqpLqOCcqrzA9okZFc0wq0Qbmdm396qJxvQZhDpyu0W95G9JCmp74tx7iyYnyOcBtUuKJsgIKAqjozvmmQ==",
+      "dev": true,
       "requires": {
         "ensure-posix-path": "^1.0.0",
         "matcher-collection": "^1.0.0"
@@ -5551,6 +6350,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+      "dev": true,
       "requires": {
         "makeerror": "1.0.x"
       }
@@ -5558,17 +6358,20 @@
     "watch": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz",
-      "integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw="
+      "integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw=",
+      "dev": true
     },
     "whatwg-fetch": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
+      "dev": true
     },
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -5577,6 +6380,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
       }
@@ -5585,17 +6389,20 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "dev": true,
       "optional": true
     },
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
     },
     "workerpool": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.1.tgz",
       "integrity": "sha512-KdF/veTxbGCtJvQv/6ncHEvbFpUqGzkxDMeACnuQrErafJoigxjgv0x4IMq4/SmSPX+AoRf1OdtkjHsmAzhJPQ==",
+      "dev": true,
       "requires": {
         "object-assign": "4.1.1"
       }
@@ -5603,12 +6410,14 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "ws": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
       "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+      "dev": true,
       "requires": {
         "async-limiter": "~1.0.0",
         "safe-buffer": "~5.1.0",
@@ -5618,22 +6427,26 @@
     "xmldom": {
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
-      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
+      "dev": true
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
+      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+      "dev": true
     },
     "yallist": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-      "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+      "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+      "dev": true
     },
     "yargs": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+      "dev": true,
       "optional": true,
       "requires": {
         "camelcase": "^1.0.2",
@@ -5645,7 +6458,8 @@
     "yeast": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
-      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
+      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
+      "dev": true
     }
   }
 }

--- a/packages/@orbit/jsonapi/package.json
+++ b/packages/@orbit/jsonapi/package.json
@@ -32,7 +32,8 @@
   },
   "devDependencies": {
     "@glimmer/build": "^0.9.0",
-    "sinon": "^1.17.7",
+    "sinon": "^7.2.2",
+    "@types/sinon": "7.0.3",
     "whatwg-fetch": "^2.0.3"
   }
 }

--- a/packages/@orbit/jsonapi/src/jsonapi-serializer.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-serializer.ts
@@ -3,8 +3,7 @@ import {
   Schema,
   KeyMap,
   Record,
-  RecordIdentity,
-  RecordRelationship
+  RecordIdentity
 } from '@orbit/data';
 import {
   Resource,

--- a/packages/@orbit/jsonapi/src/jsonapi-source.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-source.ts
@@ -184,8 +184,10 @@ export default class JSONAPISource extends Source implements Pullable, Pushable,
       delete settings.params;
     }
 
-    // console.log('fetch', fullUrl, mergedSettings, 'polyfill', fetch.polyfill);
-    let fetchFn = (Orbit as any).fetch || fetch;
+    let fetchFn = (Orbit as any).fetch || Orbit.globals.fetch;
+
+    // console.log('fetch', fullUrl, settings, 'polyfill', fetchFn.polyfill);
+
     if (settings.timeout) {
       let timeout = settings.timeout;
       delete settings.timeout;

--- a/packages/@orbit/jsonapi/src/lib/query-operators.ts
+++ b/packages/@orbit/jsonapi/src/lib/query-operators.ts
@@ -1,4 +1,4 @@
-import { Dict, toArray, merge } from '@orbit/utils';
+import { Dict, toArray, merge, clone } from '@orbit/utils';
 import {
   Query,
   QueryExpressionParseError,
@@ -17,7 +17,8 @@ import {
   AttributeFilterSpecifier,
   RelatedRecordFilterSpecifier,
   AttributeSortSpecifier,
-  RelatedRecordsFilterSpecifier
+  RelatedRecordsFilterSpecifier,
+  PageSpecifier
 } from '@orbit/data';
 import JSONAPISource from '../jsonapi-source';
 import { DeserializedDocument } from '../jsonapi-serializer';
@@ -81,7 +82,7 @@ export const QueryOperators: Dict<QueryOperator> = {
     }
 
     if (expression.page) {
-      requestOptions.page = expression.page;
+      requestOptions.page = buildPageParam(source, expression.page);
     }
 
     let customOptions = customRequestOptions(source, query);
@@ -194,4 +195,10 @@ function buildSortParam(source: JSONAPISource, sortSpecifiers: SortSpecifier[]):
     }
     throw new QueryExpressionParseError(`Sort specifier ${sortSpecifier.kind} not recognized for JSONAPISource.`, sortSpecifier);
   }).join(',');
+}
+
+function buildPageParam(source: JSONAPISource, pageSpecifier: PageSpecifier): object {
+  let pageParam = clone(pageSpecifier);
+  delete pageParam.kind;
+  return pageParam;
 }

--- a/packages/@orbit/jsonapi/test/jsonapi-serializer-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-serializer-test.ts
@@ -2,6 +2,7 @@ import { Dict } from '@orbit/utils';
 import {
   KeyMap,
   ModelDefinition,
+  Record,
   Schema
 } from '@orbit/data';
 import JSONAPISerializer from '../src/jsonapi-serializer';
@@ -48,7 +49,7 @@ module('JSONAPISerializer', function(hooks) {
   };
 
   module('Using local ids', function(hooks) {
-    let serializer;
+    let serializer: JSONAPISerializer;
     let keyMap: KeyMap;
 
     hooks.beforeEach(function() {
@@ -119,6 +120,7 @@ module('JSONAPISerializer', function(hooks) {
         serializer.serializeDocument(
           {
             type: 'planet',
+            id: 'jupiter',
             attributes: {
               name: 'Jupiter',
               classification: 'gas giant'
@@ -265,7 +267,7 @@ module('JSONAPISerializer', function(hooks) {
           }
         }
       );
-      let record = result.data;
+      let record = result.data as Record;
 
       assert.deepEqual(
         record,
@@ -281,7 +283,11 @@ module('JSONAPISerializer', function(hooks) {
     });
 
     test('#deserialize - can deserialize a simple resource and associate it with a local record', function (assert) {
-      let localRecord = { id: '1a2b3c' };
+      let localRecord = {
+        id: '1a2b3c',
+        type: 'planet'
+      };
+
       let result = serializer.deserializeDocument(
         {
           data: {
@@ -291,6 +297,7 @@ module('JSONAPISerializer', function(hooks) {
         },
         localRecord
       );
+
       let record = result.data;
 
       assert.deepEqual(
@@ -343,7 +350,7 @@ module('JSONAPISerializer', function(hooks) {
         }
       );
 
-      let planet = result.data;
+      let planet = result.data as Record;
       let moon = result.included[0];
       let solarSystem = result.included[1];
 
@@ -428,7 +435,7 @@ module('JSONAPISerializer', function(hooks) {
           ]
         }
       );
-      let records = result.data;
+      let records = result.data as Record[];
 
       assert.deepEqual(
         records,
@@ -457,9 +464,9 @@ module('JSONAPISerializer', function(hooks) {
             { type: 'planets', id: '234' }
           ]
         },
-        localRecords
+        localRecords as Record[]
       );
-      let records = result.data;
+      let records = result.data as Record[];
 
       assert.deepEqual(
         records,
@@ -481,7 +488,7 @@ module('JSONAPISerializer', function(hooks) {
   });
 
   module('Using shared UUIDs', function(hooks) {
-    let serializer;
+    let serializer: JSONAPISerializer;
 
     hooks.beforeEach(function() {
       let schema = new Schema({ models: modelDefinitions });

--- a/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
@@ -7,17 +7,24 @@ import Orbit, {
   ReplaceRecordOperation,
   TransformNotAllowed,
   Schema,
-  Source
+  Source,
+  SchemaSettings,
+  ReplaceKeyOperation,
+  RecordOperation,
+  ReplaceRelatedRecordOperation,
+  ReplaceRelatedRecordsOperation,
+  Transform
 } from '@orbit/data';
 import JSONAPISource from '../src/jsonapi-source';
 import { jsonapiResponse } from './support/jsonapi';
+import { Resource } from '../src/jsonapi-document';
+import { SinonStatic, SinonStub} from 'sinon';
 
-declare const sinon: any;
-
+declare const sinon: SinonStatic;
 const { module, test } = QUnit;
 
-module('JSONAPISource', function(hooks) {
-  let fetchStub;
+module('JSONAPISource', function() {
+  let fetchStub: SinonStub;
   let keyMap: KeyMap;
   let schema: Schema;
   let source: JSONAPISource;
@@ -89,11 +96,13 @@ module('JSONAPISource', function(hooks) {
 
     test('source saves options', function(assert) {
       assert.expect(5);
-      let schema = new Schema({});
+      let schema = new Schema({} as SchemaSettings);
       source = new JSONAPISource({ schema, keyMap, host: '127.0.0.1:8888', namespace: 'api', defaultFetchSettings: { headers: { 'User-Agent': 'CERN-LineMode/2.15 libwww/2.17b3' } } });
       assert.equal(source.namespace, 'api', 'Namespace should be defined');
       assert.equal(source.host, '127.0.0.1:8888', 'Host should be defined');
-      assert.equal(source.defaultFetchSettings.headers['User-Agent'], 'CERN-LineMode/2.15 libwww/2.17b3', 'Headers should be defined');
+
+      const headers = source.defaultFetchSettings.headers as any;
+      assert.equal(headers['User-Agent'], 'CERN-LineMode/2.15 libwww/2.17b3', 'Headers should be defined');
       assert.equal(source.resourceNamespace(), source.namespace, 'Default namespace should be used by default');
       assert.equal(source.resourceHost(), source.host, 'Default host should be used by default');
     });
@@ -245,9 +254,9 @@ module('JSONAPISource', function(hooks) {
         record: { type: 'planet', id: planet.id },
         key: 'remoteId',
         value: '12345'
-      };
+      } as ReplaceKeyOperation;
 
-      source.on('transform', function(transform) {
+      source.on('transform', function(transform: Transform) {
         transformCount++;
 
         if (transformCount === 1) {
@@ -294,13 +303,12 @@ module('JSONAPISource', function(hooks) {
       );
     });
 
-    test('#push - can add sideloaded records', function (assert) {
+    test('#push - can add sideloaded records', async function (assert) {
       assert.expect(8);
 
       let transformCount = 0;
 
       let planet: Record = source.serializer.deserializeResource({ type: 'planet', attributes: { name: 'Jupiter', classification: 'gas giant' } });
-      let moon: Record = source.serializer.deserializeResource({ type: 'moon', attributes: { name: 'Europa' } });
 
       let addPlanetOp = {
         op: 'addRecord',
@@ -334,7 +342,7 @@ module('JSONAPISource', function(hooks) {
         }
       };
 
-      source.on('transform', <() => void>function (transform) {
+      source.on('transform', (transform: Transform) => {
         transformCount++;
 
         if (transformCount === 1) {
@@ -352,7 +360,7 @@ module('JSONAPISource', function(hooks) {
           );
         } else if (transformCount === 3) {
           let operationsWithoutId = transform.operations.map(op => {
-            let clonedOp = Object.assign({}, op);
+            let clonedOp = Object.assign({}, op) as RecordOperation;
             delete clonedOp.record.id;
             return clonedOp;
           });
@@ -382,30 +390,28 @@ module('JSONAPISource', function(hooks) {
           }]
         }));
 
-      return source.push(t => t.addRecord(planet))
-        .then(function () {
-          assert.ok(true, 'transform resolves successfully');
+      await source.push(t => t.addRecord(planet));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, 'POST', 'fetch called with expected method');
-          assert.equal(fetchStub.getCall(0).args[1].headers['Content-Type'], 'application/vnd.api+json', 'fetch called with expected content type');
-          assert.deepEqual(
-            JSON.parse(fetchStub.getCall(0).args[1].body),
-            {
-              data: {
-                type: 'planets',
-                attributes: {
-                  name: 'Jupiter',
-                  classification: 'gas giant'
-                }
-              }
-            },
-            'fetch called with expected data'
-          );
-        });
+      assert.ok(true, 'transform resolves successfully');
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, 'POST', 'fetch called with expected method');
+      assert.equal(fetchStub.getCall(0).args[1].headers['Content-Type'], 'application/vnd.api+json', 'fetch called with expected content type');
+      assert.deepEqual(
+        JSON.parse(fetchStub.getCall(0).args[1].body),
+        {
+          data: {
+            type: 'planets',
+            attributes: {
+              name: 'Jupiter',
+              classification: 'gas giant'
+            }
+          }
+        },
+        'fetch called with expected data'
+      );
     });
 
-    test('#push - can transform records', function(assert) {
+    test('#push - can transform records', async function(assert) {
       assert.expect(6);
 
       let transformCount = 0;
@@ -434,7 +440,7 @@ module('JSONAPISource', function(hooks) {
         }
       };
 
-      source.on('transform', <() => void>function(transform) {
+      source.on('transform', (transform: Transform) => {
         transformCount++;
 
         if (transformCount === 1) {
@@ -455,31 +461,30 @@ module('JSONAPISource', function(hooks) {
           )
         );
 
-      return source.push(t => t.replaceRecord(planet))
-        .then(() => {
-          assert.ok(true, 'transform resolves successfully');
+      await source.push(t => t.replaceRecord(planet));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, 'PATCH', 'fetch called with expected method');
-          assert.equal(fetchStub.getCall(0).args[1].headers['Content-Type'], 'application/vnd.api+json', 'fetch called with expected content type');
-          assert.deepEqual(
-            JSON.parse(fetchStub.getCall(0).args[1].body),
-            {
-              data: {
-                type: 'planets',
-                id: '12345',
-                attributes: {
-                  name: 'Jupiter',
-                  classification: 'gas giant'
-                }
-              }
-            },
-            'fetch called with expected data'
-          );
-        });
+      assert.ok(true, 'transform resolves successfully');
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, 'PATCH', 'fetch called with expected method');
+      assert.equal(fetchStub.getCall(0).args[1].headers['Content-Type'], 'application/vnd.api+json', 'fetch called with expected content type');
+      assert.deepEqual(
+        JSON.parse(fetchStub.getCall(0).args[1].body),
+        {
+          data: {
+            type: 'planets',
+            id: '12345',
+            attributes: {
+              name: 'Jupiter',
+              classification: 'gas giant'
+            }
+          }
+        },
+        'fetch called with expected data'
+      );
     });
 
-    test('#push - can replace a single attribute', function(assert) {
+    test('#push - can replace a single attribute', async function(assert) {
       assert.expect(5);
 
       let planet = source.serializer.deserializeResource({
@@ -495,30 +500,29 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/12345')
         .returns(jsonapiResponse(200));
 
-      return source.push(t => t.replaceAttribute(planet, 'classification', 'terrestrial'))
-        .then(() => {
-          assert.ok(true, 'record patched');
+      await source.push(t => t.replaceAttribute(planet, 'classification', 'terrestrial'));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, 'PATCH', 'fetch called with expected method');
-          assert.equal(fetchStub.getCall(0).args[1].headers['Content-Type'], 'application/vnd.api+json', 'fetch called with expected content type');
-          assert.deepEqual(
-            JSON.parse(fetchStub.getCall(0).args[1].body),
-            {
-              data: {
-                type: 'planets',
-                id: '12345',
-                attributes: {
-                  classification: 'terrestrial'
-                }
-              }
-            },
-            'fetch called with expected data'
-          );
-        });
+      assert.ok(true, 'record patched');
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, 'PATCH', 'fetch called with expected method');
+      assert.equal(fetchStub.getCall(0).args[1].headers['Content-Type'], 'application/vnd.api+json', 'fetch called with expected content type');
+      assert.deepEqual(
+        JSON.parse(fetchStub.getCall(0).args[1].body),
+        {
+          data: {
+            type: 'planets',
+            id: '12345',
+            attributes: {
+              classification: 'terrestrial'
+            }
+          }
+        },
+        'fetch called with expected data'
+      );
     });
 
-    test('#push - can accept remote changes', function(assert) {
+    test('#push - can accept remote changes', async function(assert) {
       assert.expect(2);
 
       let planet = source.serializer.deserializeResource({
@@ -543,14 +547,13 @@ module('JSONAPISource', function(hooks) {
           }
         }));
 
-      return source.push(t => t.replaceAttribute(planet, 'classification', 'terrestrial'))
-        .then((transforms) => {
-          assert.deepEqual(transforms[1].operations.map(o => o.op), ['replaceAttribute', 'replaceKey']);
-          assert.deepEqual(transforms[1].operations.map((o: ReplaceRecordOperation) => o.value), ['Mars', 'remote-id-123']);
-        });
+      let transforms = await source.push(t => t.replaceAttribute(planet, 'classification', 'terrestrial'));
+
+      assert.deepEqual(transforms[1].operations.map(o => o.op), ['replaceAttribute', 'replaceKey']);
+      assert.deepEqual(transforms[1].operations.map((o: ReplaceKeyOperation) => o.value), ['Mars', 'remote-id-123']);
     });
 
-    test('#push - can delete records', function(assert) {
+    test('#push - can delete records', async function(assert) {
       assert.expect(4);
 
       let planet = source.serializer.deserializeResource({
@@ -562,17 +565,15 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/12345')
         .returns(jsonapiResponse(200));
 
-      return source.push(t => t.removeRecord(planet))
-        .then(() => {
-          assert.ok(true, 'record deleted');
+      await source.push(t => t.removeRecord(planet));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, 'DELETE', 'fetch called with expected method');
-          assert.equal(fetchStub.getCall(0).args[1].body, null, 'fetch called with no data');
-        });
+      assert.ok(true, 'record deleted');
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, 'DELETE', 'fetch called with expected method');
+      assert.equal(fetchStub.getCall(0).args[1].body, null, 'fetch called with no data');
     });
 
-    test('#push - can add a hasMany relationship with POST', function(assert) {
+    test('#push - can add a hasMany relationship with POST', async function(assert) {
       assert.expect(5);
 
       let planet = source.serializer.deserializeResource({
@@ -589,22 +590,20 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/12345/relationships/moons')
         .returns(jsonapiResponse(204));
 
-      return source.push(t => t.addToRelatedRecords(planet, 'moons', moon))
-        .then(() => {
-          assert.ok(true, 'records linked');
+      await source.push(t => t.addToRelatedRecords(planet, 'moons', moon));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, 'POST', 'fetch called with expected method');
-          assert.equal(fetchStub.getCall(0).args[1].headers['Content-Type'], 'application/vnd.api+json', 'fetch called with expected content type');
-          assert.deepEqual(
-            JSON.parse(fetchStub.getCall(0).args[1].body),
-            { data: [{ type: 'moons', id: '987' }] },
-            'fetch called with expected data'
-          );
-        });
+      assert.ok(true, 'records linked');
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, 'POST', 'fetch called with expected method');
+      assert.equal(fetchStub.getCall(0).args[1].headers['Content-Type'], 'application/vnd.api+json', 'fetch called with expected content type');
+      assert.deepEqual(
+        JSON.parse(fetchStub.getCall(0).args[1].body),
+        { data: [{ type: 'moons', id: '987' }] },
+        'fetch called with expected data'
+      );
     });
 
-    test('#push - can remove a relationship with DELETE', function(assert) {
+    test('#push - can remove a relationship with DELETE', async function(assert) {
       assert.expect(4);
 
       let planet = source.serializer.deserializeResource({
@@ -621,21 +620,19 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/12345/relationships/moons')
         .returns(jsonapiResponse(200));
 
-      return source.push(t => t.removeFromRelatedRecords(planet, 'moons', moon))
-        .then(function() {
-          assert.ok(true, 'records unlinked');
+      await source.push(t => t.removeFromRelatedRecords(planet, 'moons', moon));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, 'DELETE', 'fetch called with expected method');
-          assert.deepEqual(
-            JSON.parse(fetchStub.getCall(0).args[1].body),
-            { data: [{ type: 'moons', id: '987' }] },
-            'fetch called with expected data'
-          );
-        });
+      assert.ok(true, 'records unlinked');
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, 'DELETE', 'fetch called with expected method');
+      assert.deepEqual(
+        JSON.parse(fetchStub.getCall(0).args[1].body),
+        { data: [{ type: 'moons', id: '987' }] },
+        'fetch called with expected data'
+      );
     });
 
-    test('#push - can update a hasOne relationship with PATCH', function(assert) {
+    test('#push - can update a hasOne relationship with PATCH', async function(assert) {
       assert.expect(5);
 
       let planet = source.serializer.deserializeResource({
@@ -652,22 +649,21 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/moons/987')
         .returns(jsonapiResponse(200));
 
-      return source.push(t => t.replaceRelatedRecord(moon, 'planet', planet))
-        .then(function() {
-          assert.ok(true, 'relationship replaced');
+      await source.push(t => t.replaceRelatedRecord(moon, 'planet', planet));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, 'PATCH', 'fetch called with expected method');
-          assert.equal(fetchStub.getCall(0).args[1].headers['Content-Type'], 'application/vnd.api+json', 'fetch called with expected content type');
-          assert.deepEqual(
-            JSON.parse(fetchStub.getCall(0).args[1].body),
-            { data: { type: 'moons', id: '987', relationships: { planet: { data: { type: 'planets', id: '12345' } } } } },
-            'fetch called with expected data'
-          );
-        });
+      assert.ok(true, 'relationship replaced');
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, 'PATCH', 'fetch called with expected method');
+      assert.equal(fetchStub.getCall(0).args[1].headers['Content-Type'], 'application/vnd.api+json', 'fetch called with expected content type');
+      assert.deepEqual(
+        JSON.parse(fetchStub.getCall(0).args[1].body),
+        { data: { type: 'moons', id: '987', relationships: { planet: { data: { type: 'planets', id: '12345' } } } } },
+        'fetch called with expected data'
+      );
     });
 
-    test('#push - can update a hasOne relationship with PATCH with newly created record', function(assert) {
+    test('#push - can update a hasOne relationship with PATCH with newly created record', async function(assert) {
       assert.expect(5);
 
       let planet = {
@@ -691,24 +687,24 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/moons/987')
         .returns(jsonapiResponse(200));
 
-      return source.push(t => [
+      await source.push(t => [
         t.addRecord(planet),
         t.replaceRelatedRecord(moon, 'planet', planet)
-      ]).then(function() {
-          assert.ok(true, 'relationship replaced');
+      ]);
 
-          assert.equal(fetchStub.callCount, 2, 'fetch called twice');
-          assert.equal(fetchStub.getCall(1).args[1].method, 'PATCH', 'fetch called with expected method');
-          assert.equal(fetchStub.getCall(1).args[1].headers['Content-Type'], 'application/vnd.api+json', 'fetch called with expected content type');
-          assert.deepEqual(
-            JSON.parse(fetchStub.getCall(1).args[1].body),
-            { data: { type: 'moons', id: '987', relationships: { planet: { data: { type: 'planets', id: 'planet-remote-id' } } } } },
-            'fetch called with expected data'
-          );
-        });
+      assert.ok(true, 'relationship replaced');
+
+      assert.equal(fetchStub.callCount, 2, 'fetch called twice');
+      assert.equal(fetchStub.getCall(1).args[1].method, 'PATCH', 'fetch called with expected method');
+      assert.equal(fetchStub.getCall(1).args[1].headers['Content-Type'], 'application/vnd.api+json', 'fetch called with expected content type');
+      assert.deepEqual(
+        JSON.parse(fetchStub.getCall(1).args[1].body),
+        { data: { type: 'moons', id: '987', relationships: { planet: { data: { type: 'planets', id: 'planet-remote-id' } } } } },
+        'fetch called with expected data'
+      );
     });
 
-    test('#push - can clear a hasOne relationship with PATCH', function(assert) {
+    test('#push - can clear a hasOne relationship with PATCH', async function(assert) {
       assert.expect(5);
 
       let moon = source.serializer.deserializeResource({
@@ -720,22 +716,21 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/moons/987')
         .returns(jsonapiResponse(200));
 
-      return source.push(t => t.replaceRelatedRecord(moon, 'planet', null))
-        .then(function() {
-          assert.ok(true, 'relationship replaced');
+      await source.push(t => t.replaceRelatedRecord(moon, 'planet', null));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, 'PATCH', 'fetch called with expected method');
-          assert.equal(fetchStub.getCall(0).args[1].headers['Content-Type'], 'application/vnd.api+json', 'fetch called with expected content type');
-          assert.deepEqual(
-            JSON.parse(fetchStub.getCall(0).args[1].body),
-            { data: { type: 'moons', id: '987', relationships: { planet: { data: null } } } },
-            'fetch called with expected data'
-          );
-        });
+      assert.ok(true, 'relationship replaced');
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, 'PATCH', 'fetch called with expected method');
+      assert.equal(fetchStub.getCall(0).args[1].headers['Content-Type'], 'application/vnd.api+json', 'fetch called with expected content type');
+      assert.deepEqual(
+        JSON.parse(fetchStub.getCall(0).args[1].body),
+        { data: { type: 'moons', id: '987', relationships: { planet: { data: null } } } },
+        'fetch called with expected data'
+      );
     });
 
-    test('#push - can replace a hasMany relationship with PATCH', function(assert) {
+    test('#push - can replace a hasMany relationship with PATCH', async function(assert) {
       assert.expect(5);
 
       let planet = source.serializer.deserializeResource({
@@ -752,22 +747,21 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/12345')
         .returns(jsonapiResponse(200));
 
-      return source.push(t => t.replaceRelatedRecords(planet, 'moons', [moon]))
-        .then(function() {
-          assert.ok(true, 'relationship replaced');
+      await source.push(t => t.replaceRelatedRecords(planet, 'moons', [moon]));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, 'PATCH', 'fetch called with expected method');
-          assert.equal(fetchStub.getCall(0).args[1].headers['Content-Type'], 'application/vnd.api+json', 'fetch called with expected content type');
-          assert.deepEqual(
-            JSON.parse(fetchStub.getCall(0).args[1].body),
-            { data: { type: 'planets', id: '12345', relationships: { moons: { data: [{ type: 'moons', id: '987' }] } } } },
-            'fetch called with expected data'
-          );
-        });
+      assert.ok(true, 'relationship replaced');
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, 'PATCH', 'fetch called with expected method');
+      assert.equal(fetchStub.getCall(0).args[1].headers['Content-Type'], 'application/vnd.api+json', 'fetch called with expected content type');
+      assert.deepEqual(
+        JSON.parse(fetchStub.getCall(0).args[1].body),
+        { data: { type: 'planets', id: '12345', relationships: { moons: { data: [{ type: 'moons', id: '987' }] } } } },
+        'fetch called with expected data'
+      );
     });
 
-    test('#push - a single transform can result in multiple requests', function(assert) {
+    test('#push - a single transform can result in multiple requests', async function(assert) {
       assert.expect(6);
 
       let planet1 = source.serializer.deserializeResource({ type: 'planet', id: '1' });
@@ -781,24 +775,23 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/2')
         .returns(jsonapiResponse(200));
 
-      return source.push(t => [
+      await source.push(t => [
         t.removeRecord(planet1),
         t.removeRecord(planet2)
-      ])
-        .then(() => {
-          assert.ok(true, 'records deleted');
+      ]);
 
-          assert.equal(fetchStub.callCount, 2, 'fetch called twice');
+      assert.ok(true, 'records deleted');
 
-          assert.equal(fetchStub.getCall(0).args[1].method, 'DELETE', 'fetch called with expected method');
-          assert.equal(fetchStub.getCall(0).args[1].body, null, 'fetch called with no data');
+      assert.equal(fetchStub.callCount, 2, 'fetch called twice');
 
-          assert.equal(fetchStub.getCall(1).args[1].method, 'DELETE', 'fetch called with expected method');
-          assert.equal(fetchStub.getCall(1).args[1].body, null, 'fetch called with no data');
-        });
+      assert.equal(fetchStub.getCall(0).args[1].method, 'DELETE', 'fetch called with expected method');
+      assert.equal(fetchStub.getCall(0).args[1].body, null, 'fetch called with no data');
+
+      assert.equal(fetchStub.getCall(1).args[1].method, 'DELETE', 'fetch called with expected method');
+      assert.equal(fetchStub.getCall(1).args[1].body, null, 'fetch called with no data');
     });
 
-    test('#push - source can limit the number of allowed requests per transform with `maxRequestsPerTransform`', function(assert) {
+    test('#push - source can limit the number of allowed requests per transform with `maxRequestsPerTransform`', async function(assert) {
       assert.expect(1);
 
       let planet1 = source.serializer.deserializeResource({ type: 'planet', id: '1' });
@@ -806,16 +799,17 @@ module('JSONAPISource', function(hooks) {
 
       source.maxRequestsPerTransform = 1;
 
-      return source.push(t => [
-        t.removeRecord(planet1),
-        t.removeRecord(planet2)
-      ])
-        .catch(e => {
-          assert.ok(e instanceof TransformNotAllowed, 'TransformNotAllowed thrown');
-        });
+      try {
+        await source.push(t => [
+          t.removeRecord(planet1),
+          t.removeRecord(planet2)
+        ]);
+      } catch(e) {
+        assert.ok(e instanceof TransformNotAllowed, 'TransformNotAllowed thrown');
+      }
     });
 
-    test('#push - request can timeout', function(assert) {
+    test('#push - request can timeout', async function(assert) {
       assert.expect(2);
 
       let planet = source.serializer.deserializeResource({
@@ -834,17 +828,16 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/12345')
         .returns(jsonapiResponse(200, null, 20)); // 20ms delay
 
-      return source.push(t => t.replaceAttribute(planet, 'classification', 'terrestrial'))
-        .then(() => {
-          assert.ok(false, 'should not be reached');
-        })
-        .catch(e => {
-          assert.ok(e instanceof NetworkError, 'Network error raised');
-          assert.equal(e.description, 'No fetch response within 10ms.')
-        });
+      try {
+        await source.push(t => t.replaceAttribute(planet, 'classification', 'terrestrial'));
+        assert.ok(false, 'should not be reached');
+      } catch(e) {
+        assert.ok(e instanceof NetworkError, 'Network error raised');
+        assert.equal(e.description, 'No fetch response within 10ms.')
+      }
     });
 
-    test('#push - allowed timeout can be specified per-request', function(assert) {
+    test('#push - allowed timeout can be specified per-request', async function(assert) {
       assert.expect(2);
 
       let planet = source.serializer.deserializeResource({
@@ -870,17 +863,16 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/12345')
         .returns(jsonapiResponse(200, null, 20)); // 20ms delay
 
-      return source.push(t => t.replaceAttribute(planet, 'classification', 'terrestrial'), options)
-        .then(() => {
-          assert.ok(false, 'should not be reached');
-        })
-        .catch(e => {
-          assert.ok(e instanceof NetworkError, 'Network error raised');
-          assert.equal(e.description, 'No fetch response within 10ms.')
-        });
+      try {
+        await source.push(t => t.replaceAttribute(planet, 'classification', 'terrestrial'), options);
+        assert.ok(false, 'should not be reached');
+      } catch(e) {
+        assert.ok(e instanceof NetworkError, 'Network error raised');
+        assert.equal(e.description, 'No fetch response within 10ms.')
+      }
     });
 
-    test('#push - fetch can reject with a NetworkError', function(assert) {
+    test('#push - fetch can reject with a NetworkError', async function(assert) {
       assert.expect(2);
 
       let planet = source.serializer.deserializeResource({
@@ -896,17 +888,16 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/12345')
         .returns(Promise.reject(':('));
 
-      return source.push(t => t.replaceAttribute(planet, 'classification', 'terrestrial'))
-        .then(() => {
-          assert.ok(false, 'should not be reached');
-        })
-        .catch(e => {
-          assert.ok(e instanceof NetworkError, 'Network error raised');
-          assert.equal(e.description, ':(')
-        });
+      try {
+        await source.push(t => t.replaceAttribute(planet, 'classification', 'terrestrial'));
+        assert.ok(false, 'should not be reached');
+      } catch(e) {
+        assert.ok(e instanceof NetworkError, 'Network error raised');
+        assert.equal(e.description, ':(')
+      }
     });
 
-    test('#push - response can trigger a ClientError', function(assert) {
+    test('#push - response can trigger a ClientError', async function(assert) {
       assert.expect(3);
 
       let planet = source.serializer.deserializeResource({
@@ -927,21 +918,20 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/12345')
         .returns(jsonapiResponse(422, { errors }));
 
-      return source.push(t => t.replaceAttribute(planet, 'classification', 'terrestrial'))
-        .then(() => {
-          assert.ok(false, 'should not be reached');
-        })
-        .catch(e => {
-          assert.ok(e instanceof ClientError, 'Client error raised');
-          assert.equal(e.description, 'Unprocessable Entity');
-          assert.deepEqual(e.data, { errors }, 'Error data included');
-        });
+      try {
+        await source.push(t => t.replaceAttribute(planet, 'classification', 'terrestrial'));
+        assert.ok(false, 'should not be reached');
+      } catch(e) {
+        assert.ok(e instanceof ClientError, 'Client error raised');
+        assert.equal(e.description, 'Unprocessable Entity');
+        assert.deepEqual(e.data, { errors }, 'Error data included');
+      }
     });
 
-    test('#pull - record', function(assert) {
+    test('#pull - record', async function(assert) {
       assert.expect(5);
 
-      const data = { type: 'planets', id: '12345', attributes: { name: 'Jupiter', classification: 'gas giant' } };
+      const data: Resource = { type: 'planets', id: '12345', attributes: { name: 'Jupiter', classification: 'gas giant' } };
 
       const planet = source.serializer.deserializeResource({
         type: 'planet',
@@ -952,21 +942,20 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/12345')
         .returns(jsonapiResponse(200, { data }));
 
-      return source.pull(q => q.findRecord({ type: 'planet', id: planet.id }))
-        .then(transforms => {
-          assert.equal(transforms.length, 1, 'one transform returned');
-          assert.deepEqual(transforms[0].operations.map(o => o.op), ['replaceRecord']);
-          assert.deepEqual(transforms[0].operations.map((o: ReplaceRecordOperation) => o.record.attributes.name), ['Jupiter']);
+      let transforms = await source.pull(q => q.findRecord({ type: 'planet', id: planet.id }));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      assert.equal(transforms.length, 1, 'one transform returned');
+      assert.deepEqual(transforms[0].operations.map(o => o.op), ['replaceRecord']);
+      assert.deepEqual(transforms[0].operations.map((o: ReplaceRecordOperation) => o.record.attributes.name), ['Jupiter']);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#pull - request can timeout', function(assert) {
+    test('#pull - request can timeout', async function(assert) {
       assert.expect(2);
 
-      const data = {
+      const data: Resource = {
         type: 'planets',
         id: '12345',
         attributes: { name: 'Jupiter', classification: 'gas giant' } ,
@@ -985,20 +974,19 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/12345')
         .returns(jsonapiResponse(200, { data }, 20)); // 20ms delay
 
-      return source.pull(q => q.findRecord({ type: 'planet', id: planet.id }))
-        .then(() => {
-          assert.ok(false, 'should not be reached');
-        })
-        .catch(e => {
-          assert.ok(e instanceof NetworkError, 'Network error raised');
-          assert.equal(e.description, 'No fetch response within 10ms.')
-        });
+      try {
+        await source.pull(q => q.findRecord({ type: 'planet', id: planet.id }));
+        assert.ok(false, 'should not be reached');
+      } catch(e) {
+        assert.ok(e instanceof NetworkError, 'Network error raised');
+        assert.equal(e.description, 'No fetch response within 10ms.')
+      }
     });
 
-    test('#pull - allowed timeout can be specified per-request', function(assert) {
+    test('#pull - allowed timeout can be specified per-request', async function(assert) {
       assert.expect(2);
 
-      const data = {
+      const data: Resource = {
         type: 'planets',
         id: '12345',
         attributes: { name: 'Jupiter', classification: 'gas giant' } ,
@@ -1024,25 +1012,18 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/12345')
         .returns(jsonapiResponse(200, { data }, 20)); // 20ms delay
 
-      return source.pull(q => q.findRecord({ type: 'planet', id: planet.id }), options)
-        .then(() => {
-          assert.ok(false, 'should not be reached');
-        })
-        .catch(e => {
-          assert.ok(e instanceof NetworkError, 'Network error raised');
-          assert.equal(e.description, 'No fetch response within 10ms.')
-        });
+
+      try {
+        await source.pull(q => q.findRecord({ type: 'planet', id: planet.id }), options)
+        assert.ok(false, 'should not be reached');
+      } catch(e) {
+        assert.ok(e instanceof NetworkError, 'Network error raised');
+        assert.equal(e.description, 'No fetch response within 10ms.')
+      }
     });
 
-    test('#pull - fetch can reject with a NetworkError', function(assert) {
+    test('#pull - fetch can reject with a NetworkError', async function(assert) {
       assert.expect(2);
-
-      const data = {
-        type: 'planets',
-        id: '12345',
-        attributes: { name: 'Jupiter', classification: 'gas giant' } ,
-        relationships: { moons: { data: [] } }
-      };
 
       const planet = source.serializer.deserializeResource({
         type: 'planet',
@@ -1053,20 +1034,19 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/12345')
         .returns(Promise.reject(':('));
 
-      return source.pull(q => q.findRecord({ type: 'planet', id: planet.id }))
-        .then(() => {
-          assert.ok(false, 'should not be reached');
-        })
-        .catch(e => {
-          assert.ok(e instanceof NetworkError, 'Network error raised');
-          assert.equal(e.description, ':(')
-        });
+      try {
+        await source.pull(q => q.findRecord({ type: 'planet', id: planet.id }));
+        assert.ok(false, 'should not be reached');
+      } catch(e) {
+        assert.ok(e instanceof NetworkError, 'Network error raised');
+        assert.equal(e.description, ':(')
+      }
     });
 
-    test('#pull - record with include', function(assert) {
+    test('#pull - record with include', async function(assert) {
       assert.expect(2);
 
-      const data = {
+      const data: Resource = {
         type: 'planets',
         id: '12345',
         attributes: { name: 'Jupiter', classification: 'gas giant' } ,
@@ -1090,17 +1070,16 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/12345?include=moons')
         .returns(jsonapiResponse(200, { data }));
 
-      return source.pull(q => q.findRecord({ type: 'planet', id: planet.id }), options)
-        .then(() => {
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      await source.pull(q => q.findRecord({ type: 'planet', id: planet.id }), options);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#pull - records', function(assert) {
+    test('#pull - records', async function(assert) {
       assert.expect(5);
 
-      const data = [
+      const data: Resource[] = [
         { type: 'planets', attributes: { name: 'Jupiter', classification: 'gas giant' } },
         { type: 'planets', attributes: { name: 'Earth', classification: 'terrestrial' } },
         { type: 'planets', attributes: { name: 'Saturn', classification: 'gas giant' } }
@@ -1110,21 +1089,20 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets')
         .returns(jsonapiResponse(200, { data }));
 
-      return source.pull(q => q.findRecords('planet'))
-        .then(transforms => {
-          assert.equal(transforms.length, 1, 'one transform returned');
-          assert.deepEqual(transforms[0].operations.map(o => o.op), ['replaceRecord', 'replaceRecord', 'replaceRecord']);
-          assert.deepEqual(transforms[0].operations.map((o: ReplaceRecordOperation) => o.record.attributes.name), ['Jupiter', 'Earth', 'Saturn']);
+      let transforms = await source.pull(q => q.findRecords('planet'));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      assert.equal(transforms.length, 1, 'one transform returned');
+      assert.deepEqual(transforms[0].operations.map(o => o.op), ['replaceRecord', 'replaceRecord', 'replaceRecord']);
+      assert.deepEqual(transforms[0].operations.map((o: ReplaceRecordOperation) => o.record.attributes.name), ['Jupiter', 'Earth', 'Saturn']);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#pull - records with attribute filter', function(assert) {
+    test('#pull - records with attribute filter', async function(assert) {
       assert.expect(5);
 
-      const data = [
+      const data: Resource[] = [
         { type: 'planets', attributes: { name: 'Earth', classification: 'terrestrial', lengthOfDay: 24 } }
       ];
 
@@ -1132,23 +1110,21 @@ module('JSONAPISource', function(hooks) {
         .withArgs(`/planets?${encodeURIComponent('filter[length-of-day]')}=24`)
         .returns(jsonapiResponse(200, { data }));
 
-      return source.pull(q => q.findRecords('planet')
-                               .filter({ attribute: 'lengthOfDay', value: 24 }))
-        .then(transforms => {
-          assert.equal(transforms.length, 1, 'one transform returned');
-          assert.deepEqual(transforms[0].operations.map(o => o.op), ['replaceRecord']);
-          assert.deepEqual(transforms[0].operations.map((o: ReplaceRecordOperation) => o.record.attributes.name), ['Earth']);
+      let transforms = await source.pull(q => q.findRecords('planet')
+                                   .filter({ attribute: 'lengthOfDay', value: 24 }));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      assert.equal(transforms.length, 1, 'one transform returned');
+      assert.deepEqual(transforms[0].operations.map(o => o.op), ['replaceRecord']);
+      assert.deepEqual(transforms[0].operations.map((o: ReplaceRecordOperation) => o.record.attributes.name), ['Earth']);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-
-    test('#pull - records with attribute filters', function(assert) {
+    test('#pull - records with attribute filters', async function(assert) {
       assert.expect(5);
 
-      const data = [
+      const data: Resource[] = [
         { type: 'planets', attributes: { name: 'Earth', classification: 'terrestrial', lengthOfDay: 24 } }
       ];
 
@@ -1161,22 +1137,21 @@ module('JSONAPISource', function(hooks) {
         .withArgs(expectedUrl)
         .returns(jsonapiResponse(200, { data }));
 
-      return source.pull(q => q.findRecords('planet')
-                               .filter({ attribute: 'lengthOfDay', value: 'le:24' }, { attribute: 'lengthOfDay', value: 'ge:24' }))
-        .then(transforms => {
-          assert.equal(transforms.length, 1, 'one transform returned');
-          assert.deepEqual(transforms[0].operations.map(o => o.op), ['replaceRecord']);
-          assert.deepEqual(transforms[0].operations.map((o: ReplaceRecordOperation) => o.record.attributes.name), ['Earth']);
+      let transforms = await source.pull(q => q.findRecords('planet')
+                                   .filter({ attribute: 'lengthOfDay', value: 'le:24' }, { attribute: 'lengthOfDay', value: 'ge:24' }));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      assert.equal(transforms.length, 1, 'one transform returned');
+      assert.deepEqual(transforms[0].operations.map(o => o.op), ['replaceRecord']);
+      assert.deepEqual(transforms[0].operations.map((o: ReplaceRecordOperation) => o.record.attributes.name), ['Earth']);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#pull - records with relatedRecord filter (single value)', function(assert) {
+    test('#pull - records with relatedRecord filter (single value)', async function(assert) {
       assert.expect(5);
 
-      const data = [
+      const data: Resource[] = [
         {
           id: 'moon',
           type: 'moons',
@@ -1191,22 +1166,21 @@ module('JSONAPISource', function(hooks) {
         .withArgs(`/moons?${encodeURIComponent('filter[planet]')}=earth`)
         .returns(jsonapiResponse(200, { data }));
 
-      return source.pull(q => q.findRecords('moon')
-                               .filter({ relation: 'planet', record: { id: 'earth', type: 'planets' } }))
-        .then(transforms => {
-          assert.equal(transforms.length, 1, 'one transform returned');
-          assert.deepEqual(transforms[0].operations.map(o => o.op), ['replaceRecord']);
-          assert.deepEqual(transforms[0].operations.map((o: ReplaceRecordOperation) => o.record.attributes.name), ['Moon']);
+      let transforms = await source.pull(q => q.findRecords('moon')
+                                   .filter({ relation: 'planet', record: { id: 'earth', type: 'planets' } }));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      assert.equal(transforms.length, 1, 'one transform returned');
+      assert.deepEqual(transforms[0].operations.map(o => o.op), ['replaceRecord']);
+      assert.deepEqual(transforms[0].operations.map((o: ReplaceRecordOperation) => o.record.attributes.name), ['Moon']);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#pull - records with relatedRecord filter (multiple values)', function(assert) {
+    test('#pull - records with relatedRecord filter (multiple values)', async function(assert) {
       assert.expect(5);
 
-      const data = [
+      const data: Resource[] = [
         {
           id: 'moon',
           type: 'moons',
@@ -1237,26 +1211,25 @@ module('JSONAPISource', function(hooks) {
         .withArgs(`/moons?${encodeURIComponent('filter[planet]')}=${encodeURIComponent('earth,mars')}`)
         .returns(jsonapiResponse(200, { data }));
 
-      return source.pull(q => q.findRecords('moon')
-                               .filter({ relation: 'planet', record: [{ id: 'earth', type: 'planets' }, { id: 'mars', type: 'planets' }] }))
-        .then(transforms => {
-          assert.equal(transforms.length, 1, 'one transform returned');
-          assert.deepEqual(transforms[0].operations.map(o => o.op), [
-            'replaceRecord',
-            'replaceRecord',
-            'replaceRecord'
-          ]);
-          assert.deepEqual(transforms[0].operations.map((o: ReplaceRecordOperation) => o.record.attributes.name), ['Moon', 'Phobos', 'Deimos']);
+      let transforms = await source.pull(q => q.findRecords('moon')
+                                   .filter({ relation: 'planet', record: [{ id: 'earth', type: 'planets' }, { id: 'mars', type: 'planets' }] }));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      assert.equal(transforms.length, 1, 'one transform returned');
+      assert.deepEqual(transforms[0].operations.map(o => o.op), [
+        'replaceRecord',
+        'replaceRecord',
+        'replaceRecord'
+      ]);
+      assert.deepEqual(transforms[0].operations.map((o: ReplaceRecordOperation) => o.record.attributes.name), ['Moon', 'Phobos', 'Deimos']);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#pull - records with relatedRecords filter', function(assert) {
+    test('#pull - records with relatedRecords filter', async function(assert) {
       assert.expect(5);
 
-      const data = [
+      const data: Resource[] = [
         {
           id: 'mars',
           type: 'planets',
@@ -1271,26 +1244,25 @@ module('JSONAPISource', function(hooks) {
         .withArgs(`/planets?${encodeURIComponent('filter[moons]')}=${encodeURIComponent('phobos,deimos')}`)
         .returns(jsonapiResponse(200, { data }));
 
-      return source.pull(q => q.findRecords('planet')
+      let transforms = await source.pull(q => q.findRecords('planet')
         .filter({
           relation: 'moons',
           records: [{ id: 'phobos', type: 'moons' }, { id: 'deimos', type: 'moons' }],
           op: 'equal'
-        }))
-        .then(transforms => {
-          assert.equal(transforms.length, 1, 'one transform returned');
-          assert.deepEqual(transforms[0].operations.map(o => o.op), ['replaceRecord']);
-          assert.deepEqual(transforms[0].operations.map((o: ReplaceRecordOperation) => o.record.attributes.name), ['Mars']);
+        }));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      assert.equal(transforms.length, 1, 'one transform returned');
+      assert.deepEqual(transforms[0].operations.map(o => o.op), ['replaceRecord']);
+      assert.deepEqual(transforms[0].operations.map((o: ReplaceRecordOperation) => o.record.attributes.name), ['Mars']);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#pull - records with sort by an attribute in ascending order', function(assert) {
+    test('#pull - records with sort by an attribute in ascending order', async function(assert) {
       assert.expect(5);
 
-      const data = [
+      const data: Resource[] = [
         { type: 'planets', attributes: { name: 'Earth', classification: 'terrestrial' } },
         { type: 'planets', attributes: { name: 'Jupiter', classification: 'gas giant' } },
         { type: 'planets', attributes: { name: 'Saturn', classification: 'gas giant' } }
@@ -1300,21 +1272,20 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets?sort=name')
         .returns(jsonapiResponse(200, { data }));
 
-      return source.pull(q => q.findRecords('planet').sort('name'))
-        .then(transforms => {
-          assert.equal(transforms.length, 1, 'one transform returned');
-          assert.deepEqual(transforms[0].operations.map(o => o.op), ['replaceRecord', 'replaceRecord', 'replaceRecord']);
-          assert.deepEqual(transforms[0].operations.map((o: ReplaceRecordOperation) => o.record.attributes.name), ['Earth', 'Jupiter', 'Saturn']);
+      let transforms = await source.pull(q => q.findRecords('planet').sort('name'));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      assert.equal(transforms.length, 1, 'one transform returned');
+      assert.deepEqual(transforms[0].operations.map(o => o.op), ['replaceRecord', 'replaceRecord', 'replaceRecord']);
+      assert.deepEqual(transforms[0].operations.map((o: ReplaceRecordOperation) => o.record.attributes.name), ['Earth', 'Jupiter', 'Saturn']);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#pull - records with sort by an attribute in descending order', function(assert) {
+    test('#pull - records with sort by an attribute in descending order', async function(assert) {
       assert.expect(5);
 
-      const data = [
+      const data: Resource[] = [
         { type: 'planets', attributes: { name: 'Saturn', classification: 'gas giant' } },
         { type: 'planets', attributes: { name: 'Jupiter', classification: 'gas giant' } },
         { type: 'planets', attributes: { name: 'Earth', classification: 'terrestrial' } }
@@ -1324,21 +1295,20 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets?sort=-name')
         .returns(jsonapiResponse(200, { data }));
 
-      return source.pull(q => q.findRecords('planet').sort('-name'))
-        .then(transforms => {
-          assert.equal(transforms.length, 1, 'one transform returned');
-          assert.deepEqual(transforms[0].operations.map(o => o.op), ['replaceRecord', 'replaceRecord', 'replaceRecord']);
-          assert.deepEqual(transforms[0].operations.map((o: ReplaceRecordOperation) => o.record.attributes.name), ['Saturn', 'Jupiter', 'Earth']);
+      let transforms = await source.pull(q => q.findRecords('planet').sort('-name'))
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      assert.equal(transforms.length, 1, 'one transform returned');
+      assert.deepEqual(transforms[0].operations.map(o => o.op), ['replaceRecord', 'replaceRecord', 'replaceRecord']);
+      assert.deepEqual(transforms[0].operations.map((o: ReplaceRecordOperation) => o.record.attributes.name), ['Saturn', 'Jupiter', 'Earth']);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#pull - records with sort by multiple fields', function(assert) {
+    test('#pull - records with sort by multiple fields', async function(assert) {
       assert.expect(5);
 
-      const data = [
+      const data: Resource[] = [
         { type: 'planets', attributes: { name: 'Jupiter', classification: 'gas giant', lengthOfDay: 9.9 } },
         { type: 'planets', attributes: { name: 'Saturn', classification: 'gas giant', lengthOfDay: 10.7 } },
         { type: 'planets', attributes: { name: 'Earth', classification: 'terrestrial', lengthOfDay: 24.0 } }
@@ -1348,21 +1318,20 @@ module('JSONAPISource', function(hooks) {
         .withArgs(`/planets?sort=${encodeURIComponent('length-of-day,name')}`)
         .returns(jsonapiResponse(200, { data }));
 
-      return source.pull(q => q.findRecords('planet').sort('lengthOfDay', 'name'))
-        .then(transforms => {
-          assert.equal(transforms.length, 1, 'one transform returned');
-          assert.deepEqual(transforms[0].operations.map(o => o.op), ['replaceRecord', 'replaceRecord', 'replaceRecord']);
-          assert.deepEqual(transforms[0].operations.map((o: ReplaceRecordOperation) => o.record.attributes.name), ['Jupiter', 'Saturn', 'Earth']);
+      let transforms = await source.pull(q => q.findRecords('planet').sort('lengthOfDay', 'name'))
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      assert.equal(transforms.length, 1, 'one transform returned');
+      assert.deepEqual(transforms[0].operations.map(o => o.op), ['replaceRecord', 'replaceRecord', 'replaceRecord']);
+      assert.deepEqual(transforms[0].operations.map((o: ReplaceRecordOperation) => o.record.attributes.name), ['Jupiter', 'Saturn', 'Earth']);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#pull - records with pagination', function(assert) {
+    test('#pull - records with pagination', async function(assert) {
       assert.expect(5);
 
-      const data = [
+      const data: Resource[] = [
         { type: 'planets', attributes: { name: 'Jupiter', classification: 'gas giant' } },
         { type: 'planets', attributes: { name: 'Earth', classification: 'terrestrial' } },
         { type: 'planets', attributes: { name: 'Saturn', classification: 'gas giant' } }
@@ -1372,19 +1341,18 @@ module('JSONAPISource', function(hooks) {
         .withArgs(`/planets?${encodeURIComponent('page[offset]')}=1&${encodeURIComponent('page[limit]')}=10`)
         .returns(jsonapiResponse(200, { data }));
 
-      return source.pull(q => q.findRecords('planet')
-                               .page({ offset: 1, limit: 10 }))
-        .then(transforms => {
-          assert.equal(transforms.length, 1, 'one transform returned');
-          assert.deepEqual(transforms[0].operations.map(o => o.op), ['replaceRecord', 'replaceRecord', 'replaceRecord']);
-          assert.deepEqual(transforms[0].operations.map((o: ReplaceRecordOperation) => o.record.attributes.name), ['Jupiter', 'Earth', 'Saturn']);
+      let transforms = await source.pull(q => q.findRecords('planet')
+                                               .page({ offset: 1, limit: 10 }));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      assert.equal(transforms.length, 1, 'one transform returned');
+      assert.deepEqual(transforms[0].operations.map(o => o.op), ['replaceRecord', 'replaceRecord', 'replaceRecord']);
+      assert.deepEqual(transforms[0].operations.map((o: ReplaceRecordOperation) => o.record.attributes.name), ['Jupiter', 'Earth', 'Saturn']);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#pull - records with include', function(assert) {
+    test('#pull - records with include', async function(assert) {
       assert.expect(2);
 
       const options = {
@@ -1399,14 +1367,13 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets?include=moons')
         .returns(jsonapiResponse(200, { data: [] }));
 
-      return source.pull(q => q.findRecords('planet'), options)
-        .then(() => {
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      await source.pull(q => q.findRecords('planet'), options);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#pull - records with include many relationships', function(assert) {
+    test('#pull - records with include many relationships', async function(assert) {
       assert.expect(2);
 
       const options = {
@@ -1421,14 +1388,13 @@ module('JSONAPISource', function(hooks) {
         .withArgs(`/planets?include=${encodeURIComponent('moons,solar-systems')}`)
         .returns(jsonapiResponse(200, { data: [] }));
 
-      return source.pull(q => q.findRecords('planet'), options)
-        .then(() => {
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      await source.pull(q => q.findRecords('planet'), options);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#pull - relatedRecord', function(assert) {
+    test('#pull - relatedRecord', async function(assert) {
       assert.expect(12);
 
       const planetRecord: Record = <Record>source.serializer.deserializeDocument({
@@ -1438,7 +1404,7 @@ module('JSONAPISource', function(hooks) {
         }
       }).data;
 
-      const data = {
+      const data: Resource = {
         type: 'solar-systems',
         id: 'ours',
         attributes: {
@@ -1450,31 +1416,33 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/jupiter/solar-system')
         .returns(jsonapiResponse(200, { data }));
 
-      return source.pull(q => q.findRelatedRecord(planetRecord, 'solarSystem')).then((transforms) => {
-        assert.equal(transforms.length, 1, 'one transform returned');
-        const operations = transforms[0].operations;
+      let transforms = await source.pull(q => q.findRelatedRecord(planetRecord, 'solarSystem'));
 
-        const planetId = keyMap.keyToId('planet', 'remoteId', 'jupiter');
-        const ssId = keyMap.keyToId('solarSystem', 'remoteId', 'ours');
+      assert.equal(transforms.length, 1, 'one transform returned');
+      const operations = transforms[0].operations as RecordOperation[];
 
-        assert.deepEqual(operations.map(o => o.op), ['replaceRecord', 'replaceRelatedRecord']);
+      const planetId = keyMap.keyToId('planet', 'remoteId', 'jupiter');
+      const ssId = keyMap.keyToId('solarSystem', 'remoteId', 'ours');
 
-        assert.equal(operations[0].record.type, 'solarSystem');
-        assert.equal(operations[0].record.id, ssId);
-        assert.equal(operations[0].record.attributes.name, 'Our Solar System');
+      assert.deepEqual(operations.map(o => o.op), ['replaceRecord', 'replaceRelatedRecord']);
 
-        assert.equal(operations[1].record.type, 'planet');
-        assert.equal(operations[1].record.id, planetId);
-        assert.equal(operations[1].relationship, 'solarSystem');
-        assert.equal(operations[1].relatedRecord.type, 'solarSystem');
-        assert.equal(operations[1].relatedRecord.id, ssId);
+      const op1 = operations[0] as ReplaceRecordOperation;
+      assert.equal(op1.record.type, 'solarSystem');
+      assert.equal(op1.record.id, ssId);
+      assert.equal(op1.record.attributes.name, 'Our Solar System');
 
-        assert.equal(fetchStub.callCount, 1, 'fetch called once');
-        assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-      });
+      const op2 = operations[1] as ReplaceRelatedRecordOperation;
+      assert.equal(op2.record.type, 'planet');
+      assert.equal(op2.record.id, planetId);
+      assert.equal(op2.relationship, 'solarSystem');
+      assert.equal(op2.relatedRecord.type, 'solarSystem');
+      assert.equal(op2.relatedRecord.id, ssId);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#pull - relatedRecords', function(assert) {
+    test('#pull - relatedRecords', async function(assert) {
       assert.expect(8);
 
       let planetRecord: Record = <Record>source.serializer.deserializeDocument({
@@ -1496,21 +1464,24 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/jupiter/moons')
         .returns(jsonapiResponse(200, { data }));
 
-      return source.pull(q => q.findRelatedRecords(planetRecord, 'moons')).then((transforms) => {
-        assert.equal(transforms.length, 1, 'one transform returned');
-        assert.deepEqual(transforms[0].operations.map(o => o.op), ['replaceRecord', 'replaceRelatedRecords']);
+      let transforms = await source.pull(q => q.findRelatedRecords(planetRecord, 'moons'));
 
-        assert.equal(transforms[0].operations[0].record.attributes.name, 'Io');
-        assert.equal(transforms[0].operations[1].record.id, planetRecord.id);
-        assert.equal(transforms[0].operations[1].relationship, 'moons');
-        assert.deepEqual(transforms[0].operations[1].relatedRecords.map(r => r.id),  [transforms[0].operations[0].record.id]);
+      assert.equal(transforms.length, 1, 'one transform returned');
+      assert.deepEqual(transforms[0].operations.map(o => o.op), ['replaceRecord', 'replaceRelatedRecords']);
 
-        assert.equal(fetchStub.callCount, 1, 'fetch called once');
-        assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-      });
+      const op1 = transforms[0].operations[0] as ReplaceRecordOperation;
+      assert.equal(op1.record.attributes.name, 'Io');
+
+      const op2 = transforms[0].operations[1] as ReplaceRelatedRecordsOperation;
+      assert.equal(op2.record.id, planetRecord.id);
+      assert.equal(op2.relationship, 'moons');
+      assert.deepEqual(op2.relatedRecords.map(r => r.id),  [op1.record.id]);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#pull - relatedRecords with include', function(assert) {
+    test('#pull - relatedRecords with include', async function(assert) {
       assert.expect(2);
 
       const planetRecord = source.serializer.deserializeDocument({
@@ -1532,17 +1503,16 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/jupiter/moons?include=planet')
         .returns(jsonapiResponse(200, { data: [] }));
 
-      return source.pull(q => q.findRelatedRecords(<RecordIdentity>planetRecord, 'moons'), options)
-        .then(() => {
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      await source.pull(q => q.findRelatedRecords(<RecordIdentity>planetRecord, 'moons'), options);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#query - record', function(assert) {
+    test('#query - record', async function(assert) {
       assert.expect(4);
 
-      const data = { type: 'planets', id: '12345', attributes: { name: 'Jupiter', classification: 'gas giant' } };
+      const data: Resource = { type: 'planets', id: '12345', attributes: { name: 'Jupiter', classification: 'gas giant' } };
 
       const planet = source.serializer.deserializeResource({
         type: 'planet',
@@ -1553,20 +1523,19 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/12345')
         .returns(jsonapiResponse(200, { data }));
 
-      return source.query(q => q.findRecord({ type: 'planet', id: planet.id }))
-        .then(data => {
-          assert.ok(!Array.isArray(data), 'only a single primary recored returned');
-          assert.equal((data as Record).attributes.name, 'Jupiter');
+      let record = await source.query(q => q.findRecord({ type: 'planet', id: planet.id }));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      assert.ok(!Array.isArray(record), 'only a single primary recored returned');
+      assert.equal((record as Record).attributes.name, 'Jupiter');
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#query - request can timeout', function(assert) {
+    test('#query - request can timeout', async function(assert) {
       assert.expect(2);
 
-      const data = {
+      const data: Resource = {
         type: 'planets',
         id: '12345',
         attributes: { name: 'Jupiter', classification: 'gas giant' } ,
@@ -1585,20 +1554,19 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/12345')
         .returns(jsonapiResponse(200, { data }, 20)); // 20ms delay
 
-      return source.query(q => q.findRecord({ type: 'planet', id: planet.id }))
-        .then(() => {
-          assert.ok(false, 'should not be reached');
-        })
-        .catch(e => {
-          assert.ok(e instanceof NetworkError, 'Network error raised');
-          assert.equal(e.description, 'No fetch response within 10ms.')
-        });
+      try {
+        await source.query(q => q.findRecord({ type: 'planet', id: planet.id }));
+        assert.ok(false, 'should not be reached');
+      } catch(e) {
+        assert.ok(e instanceof NetworkError, 'Network error raised');
+        assert.equal(e.description, 'No fetch response within 10ms.')
+      }
     });
 
-    test('#query - allowed timeout can be specified per-request', function(assert) {
+    test('#query - allowed timeout can be specified per-request', async function(assert) {
       assert.expect(2);
 
-      const data = {
+      const data: Resource = {
         type: 'planets',
         id: '12345',
         attributes: { name: 'Jupiter', classification: 'gas giant' } ,
@@ -1624,17 +1592,16 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/12345')
         .returns(jsonapiResponse(200, { data }, 20)); // 20ms delay
 
-      return source.query(q => q.findRecord({ type: 'planet', id: planet.id }), options)
-        .then(() => {
-          assert.ok(false, 'should not be reached');
-        })
-        .catch(e => {
-          assert.ok(e instanceof NetworkError, 'Network error raised');
-          assert.equal(e.description, 'No fetch response within 10ms.')
-        });
+      try {
+        await source.query(q => q.findRecord({ type: 'planet', id: planet.id }), options);
+        assert.ok(false, 'should not be reached');
+      } catch(e) {
+        assert.ok(e instanceof NetworkError, 'Network error raised');
+        assert.equal(e.description, 'No fetch response within 10ms.')
+      }
     });
 
-    test('#query - fetch can reject with a NetworkError', function(assert) {
+    test('#query - fetch can reject with a NetworkError', async function(assert) {
       assert.expect(2);
 
       const planet = source.serializer.deserializeResource({
@@ -1646,20 +1613,19 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/12345')
         .returns(Promise.reject(':('));
 
-      return source.query(q => q.findRecord({ type: 'planet', id: planet.id }))
-        .then(() => {
-          assert.ok(false, 'should not be reached');
-        })
-        .catch(e => {
-          assert.ok(e instanceof NetworkError, 'Network error raised');
-          assert.equal(e.description, ':(')
-        });
+      try {
+        await source.query(q => q.findRecord({ type: 'planet', id: planet.id }));
+        assert.ok(false, 'should not be reached');
+      } catch(e) {
+        assert.ok(e instanceof NetworkError, 'Network error raised');
+        assert.equal(e.description, ':(')
+      }
     });
 
-    test('#query - record with include', function(assert) {
+    test('#query - record with include', async function(assert) {
       assert.expect(2);
 
-      const data = {
+      const data: Resource = {
         type: 'planets',
         id: '12345',
         attributes: { name: 'Jupiter', classification: 'gas giant' } ,
@@ -1683,17 +1649,16 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/12345?include=moons')
         .returns(jsonapiResponse(200, { data }));
 
-      return source.query(q => q.findRecord({ type: 'planet', id: planet.id }), options)
-        .then(() => {
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      await source.query(q => q.findRecord({ type: 'planet', id: planet.id }), options);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#query - records', function(assert) {
+    test('#query - records', async function(assert) {
       assert.expect(5);
 
-      const data = [
+      const data: Resource[] = [
         { type: 'planets', attributes: { name: 'Jupiter', classification: 'gas giant' } },
         { type: 'planets', attributes: { name: 'Earth', classification: 'terrestrial' } },
         { type: 'planets', attributes: { name: 'Saturn', classification: 'gas giant' } }
@@ -1703,21 +1668,20 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets')
         .returns(jsonapiResponse(200, { data }));
 
-      return source.query(q => q.findRecords('planet'))
-        .then((data) => {
-          assert.ok(Array.isArray(data), 'returned an array of data');
-          assert.equal(data.length, 3, 'three objects in data returned');
-          assert.deepEqual(data.map((o) => o.attributes.name), ['Jupiter', 'Earth', 'Saturn']);
+      let records: Record[] = await source.query(q => q.findRecords('planet'));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      assert.ok(Array.isArray(records), 'returned an array of data');
+      assert.equal(records.length, 3, 'three objects in data returned');
+      assert.deepEqual(records.map((o) => o.attributes.name), ['Jupiter', 'Earth', 'Saturn']);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#query - records with attribute filter', function(assert) {
+    test('#query - records with attribute filter', async function(assert) {
       assert.expect(5);
 
-      const data = [
+      const data: Resource[] = [
         { type: 'planets', attributes: { name: 'Earth', classification: 'terrestrial', lengthOfDay: 24 } }
       ];
 
@@ -1725,22 +1689,21 @@ module('JSONAPISource', function(hooks) {
         .withArgs(`/planets?${encodeURIComponent('filter[length-of-day]')}=24`)
         .returns(jsonapiResponse(200, { data }));
 
-      return source.query(q => q.findRecords('planet')
-                               .filter({ attribute: 'lengthOfDay', value: 24 }))
-        .then(data => {
-          assert.ok(Array.isArray(data), 'returned an array of data');
-          assert.equal(data.length, 1, 'one objects in data returned');
-          assert.deepEqual(data.map((o) => o.attributes.name), ['Earth']);
+      let records: Record[] = await source.query(q => q.findRecords('planet')
+                                          .filter({ attribute: 'lengthOfDay', value: 24 }));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      assert.ok(Array.isArray(records), 'returned an array of data');
+      assert.equal(records.length, 1, 'one objects in data returned');
+      assert.deepEqual(records.map((o) => o.attributes.name), ['Earth']);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#query - records with relatedRecord filter (single value)', function(assert) {
+    test('#query - records with relatedRecord filter (single value)', async function(assert) {
       assert.expect(5);
 
-      const data = [
+      const data: Resource[] = [
         {
           id: 'moon',
           type: 'moons',
@@ -1755,22 +1718,21 @@ module('JSONAPISource', function(hooks) {
         .withArgs(`/moons?${encodeURIComponent('filter[planet]')}=earth`)
         .returns(jsonapiResponse(200, { data }));
 
-      return source.query(q => q.findRecords('moon')
-                               .filter({ relation: 'planet', record: { id: 'earth', type: 'planets' } }))
-        .then(data => {
-          assert.ok(Array.isArray(data), 'returned an array of data');
-          assert.equal(data.length, 1, 'one objects in data returned');
-          assert.deepEqual(data.map((o) => o.attributes.name), ['Moon']);
+      let records: Record[] = await source.query(q => q.findRecords('moon')
+                                          .filter({ relation: 'planet', record: { id: 'earth', type: 'planets' } }));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      assert.ok(Array.isArray(records), 'returned an array of data');
+      assert.equal(records.length, 1, 'one objects in data returned');
+      assert.deepEqual(records.map((o) => o.attributes.name), ['Moon']);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#query - records with relatedRecord filter (multiple values)', function(assert) {
+    test('#query - records with relatedRecord filter (multiple values)', async function(assert) {
       assert.expect(5);
 
-      const data = [
+      const data: Resource[] = [
         {
           id: 'moon',
           type: 'moons',
@@ -1801,22 +1763,21 @@ module('JSONAPISource', function(hooks) {
         .withArgs(`/moons?${encodeURIComponent('filter[planet]')}=${encodeURIComponent('earth,mars')}`)
         .returns(jsonapiResponse(200, { data }));
 
-      return source.query(q => q.findRecords('moon')
-                               .filter({ relation: 'planet', record: [{ id: 'earth', type: 'planets' }, { id: 'mars', type: 'planets' }] }))
-        .then(data => {
-          assert.ok(Array.isArray(data), 'returned an array of data');
-          assert.equal(data.length, 3, 'three objects in data returned');
-          assert.deepEqual(data.map((o) => o.attributes.name), ['Moon', 'Phobos', 'Deimos']);
+      let records: Record[] = await source.query(q => q.findRecords('moon')
+                                          .filter({ relation: 'planet', record: [{ id: 'earth', type: 'planets' }, { id: 'mars', type: 'planets' }] }))
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      assert.ok(Array.isArray(records), 'returned an array of data');
+      assert.equal(records.length, 3, 'three objects in data returned');
+      assert.deepEqual(records.map((o) => o.attributes.name), ['Moon', 'Phobos', 'Deimos']);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#query - records with relatedRecords filter', function(assert) {
+    test('#query - records with relatedRecords filter', async function(assert) {
       assert.expect(5);
 
-      const data = [
+      const data: Resource[] = [
         {
           id: 'mars',
           type: 'planets',
@@ -1831,26 +1792,25 @@ module('JSONAPISource', function(hooks) {
         .withArgs(`/planets?${encodeURIComponent('filter[moons]')}=${encodeURIComponent('phobos,deimos')}`)
         .returns(jsonapiResponse(200, { data }));
 
-      return source.query(q => q.findRecords('planet')
+      let records: Record[] = await source.query(q => q.findRecords('planet')
         .filter({
           relation: 'moons',
           records: [{ id: 'phobos', type: 'moons' }, { id: 'deimos', type: 'moons' }],
           op: 'equal'
-        }))
-        .then(data => {
-          assert.ok(Array.isArray(data), 'returned an array of data');
-          assert.equal(data.length, 1, 'one objects in data returned');
-          assert.deepEqual(data.map((o) => o.attributes.name), ['Mars']);
+        }));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      assert.ok(Array.isArray(records), 'returned an array of data');
+      assert.equal(records.length, 1, 'one objects in data returned');
+      assert.deepEqual(records.map((o) => o.attributes.name), ['Mars']);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#query - records with sort by an attribute in ascending order', function(assert) {
+    test('#query - records with sort by an attribute in ascending order', async function(assert) {
       assert.expect(5);
 
-      const data = [
+      const data: Resource[] = [
         { type: 'planets', attributes: { name: 'Earth', classification: 'terrestrial' } },
         { type: 'planets', attributes: { name: 'Jupiter', classification: 'gas giant' } },
         { type: 'planets', attributes: { name: 'Saturn', classification: 'gas giant' } }
@@ -1860,21 +1820,20 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets?sort=name')
         .returns(jsonapiResponse(200, { data }));
 
-      return source.query(q => q.findRecords('planet').sort('name'))
-        .then(data => {
-          assert.ok(Array.isArray(data), 'returned an array of data');
-          assert.equal(data.length, 3, 'three objects in data returned');
-          assert.deepEqual(data.map((o) => o.attributes.name), ['Earth', 'Jupiter', 'Saturn']);
+      let records: Record[] = await source.query(q => q.findRecords('planet').sort('name'));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      assert.ok(Array.isArray(records), 'returned an array of data');
+      assert.equal(records.length, 3, 'three objects in data returned');
+      assert.deepEqual(records.map((o) => o.attributes.name), ['Earth', 'Jupiter', 'Saturn']);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#query - records with sort by an attribute in descending order', function(assert) {
+    test('#query - records with sort by an attribute in descending order', async function(assert) {
       assert.expect(5);
 
-      const data = [
+      const data: Resource[] = [
         { type: 'planets', attributes: { name: 'Saturn', classification: 'gas giant' } },
         { type: 'planets', attributes: { name: 'Jupiter', classification: 'gas giant' } },
         { type: 'planets', attributes: { name: 'Earth', classification: 'terrestrial' } }
@@ -1884,21 +1843,20 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets?sort=-name')
         .returns(jsonapiResponse(200, { data }));
 
-      return source.query(q => q.findRecords('planet').sort('-name'))
-        .then(data => {
-          assert.ok(Array.isArray(data), 'returned an array of data');
-          assert.equal(data.length, 3, 'three objects in data returned');
-          assert.deepEqual(data.map((o) => o.attributes.name), ['Saturn', 'Jupiter', 'Earth']);
+      let records: Record[] = await source.query(q => q.findRecords('planet').sort('-name'));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      assert.ok(Array.isArray(records), 'returned an array of data');
+      assert.equal(records.length, 3, 'three objects in data returned');
+      assert.deepEqual(records.map((o) => o.attributes.name), ['Saturn', 'Jupiter', 'Earth']);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#query - records with sort by multiple fields', function(assert) {
+    test('#query - records with sort by multiple fields', async function(assert) {
       assert.expect(5);
 
-      const data = [
+      const data: Resource[] = [
         { type: 'planets', attributes: { name: 'Jupiter', classification: 'gas giant', lengthOfDay: 9.9 } },
         { type: 'planets', attributes: { name: 'Saturn', classification: 'gas giant', lengthOfDay: 10.7 } },
         { type: 'planets', attributes: { name: 'Earth', classification: 'terrestrial', lengthOfDay: 24.0 } }
@@ -1908,21 +1866,20 @@ module('JSONAPISource', function(hooks) {
         .withArgs(`/planets?sort=${encodeURIComponent('length-of-day,name')}`)
         .returns(jsonapiResponse(200, { data }));
 
-      return source.query(q => q.findRecords('planet').sort('lengthOfDay', 'name'))
-        .then(data => {
-          assert.ok(Array.isArray(data), 'returned an array of data');
-          assert.equal(data.length, 3, 'three objects in data returned');
-          assert.deepEqual(data.map((o) => o.attributes.name), ['Jupiter', 'Saturn', 'Earth']);
+      let records: Record[] = await source.query(q => q.findRecords('planet').sort('lengthOfDay', 'name'));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      assert.ok(Array.isArray(records), 'returned an array of data');
+      assert.equal(records.length, 3, 'three objects in data returned');
+      assert.deepEqual(records.map((o) => o.attributes.name), ['Jupiter', 'Saturn', 'Earth']);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#query - records with pagination', function(assert) {
+    test('#query - records with pagination', async function(assert) {
       assert.expect(5);
 
-      const data = [
+      const data: Resource[] = [
         { type: 'planets', attributes: { name: 'Jupiter', classification: 'gas giant' } },
         { type: 'planets', attributes: { name: 'Earth', classification: 'terrestrial' } },
         { type: 'planets', attributes: { name: 'Saturn', classification: 'gas giant' } }
@@ -1932,19 +1889,18 @@ module('JSONAPISource', function(hooks) {
         .withArgs(`/planets?${encodeURIComponent('page[offset]')}=1&${encodeURIComponent('page[limit]')}=10`)
         .returns(jsonapiResponse(200, { data }));
 
-      return source.query(q => q.findRecords('planet')
-                               .page({ offset: 1, limit: 10 }))
-        .then(data => {
-          assert.ok(Array.isArray(data), 'returned an array of data');
-          assert.equal(data.length, 3, 'three objects in data returned');
-          assert.deepEqual(data.map((o) => o.attributes.name), ['Jupiter', 'Earth', 'Saturn']);
+      let records: Record[] = await source.query(q => q.findRecords('planet')
+                                                       .page({ offset: 1, limit: 10 }));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      assert.ok(Array.isArray(records), 'returned an array of data');
+      assert.equal(records.length, 3, 'three objects in data returned');
+      assert.deepEqual(records.map((o) => o.attributes.name), ['Jupiter', 'Earth', 'Saturn']);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#query - records with include', function(assert) {
+    test('#query - records with include', async function(assert) {
       assert.expect(2);
 
       const options = {
@@ -1959,14 +1915,13 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets?include=moons')
         .returns(jsonapiResponse(200, { data: [] }));
 
-      return source.query(q => q.findRecords('planet'), options)
-        .then(() => {
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      await source.query(q => q.findRecords('planet'), options);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#query - records with include: verify only primary data array is returned', function(assert) {
+    test('#query - records with include: verify only primary data array is returned', async function(assert) {
       assert.expect(6);
 
       const options = {
@@ -1984,19 +1939,18 @@ module('JSONAPISource', function(hooks) {
           included: [{ type: "moons", id: 1 }, { type: "moons", id: 2 }]
         }));
 
-      return source.query(q => q.findRecords('planet'), options)
-        .then((result) => {
-          assert.ok(Array.isArray(result), 'query result is an array, like primary data');
-          assert.equal(result.length, 2, 'query result length equals primary data length');
-          assert.deepEqual(result.map(planet => planet.type), ["planet", "planet"]);
-          assert.deepEqual(result.map(planet => planet.keys.remoteId), [1, 2], "returned IDs match primary data (including sorting)");
+      let records: Record[] = await source.query(q => q.findRecords('planet'), options);
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      assert.ok(Array.isArray(records), 'query result is an array, like primary data');
+      assert.equal(records.length, 2, 'query result length equals primary data length');
+      assert.deepEqual(records.map(planet => planet.type), ["planet", "planet"]);
+      assert.deepEqual(records.map(planet => planet.keys.remoteId), [1, 2], "returned IDs match primary data (including sorting)");
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#query - records with include many relationships', function(assert) {
+    test('#query - records with include many relationships', async function(assert) {
       assert.expect(2);
 
       const options = {
@@ -2011,14 +1965,13 @@ module('JSONAPISource', function(hooks) {
         .withArgs(`/planets?include=${encodeURIComponent('moons,solar-systems')}`)
         .returns(jsonapiResponse(200, { data: [] }));
 
-      return source.query(q => q.findRecords('planet'), options)
-        .then(() => {
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      await source.query(q => q.findRecords('planet'), options);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#query - relatedRecords', function(assert) {
+    test('#query - relatedRecords', async function(assert) {
       assert.expect(5);
 
       let planetRecord: Record = <Record>source.serializer.deserializeDocument({
@@ -2040,18 +1993,17 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/jupiter/moons')
         .returns(jsonapiResponse(200, { data }));
 
-      return source.query(q => q.findRelatedRecords(planetRecord, 'moons'))
-        .then((data) => {
-          assert.ok(Array.isArray(data), 'returned an array of data');
-          assert.equal(data.length, 1, 'one objects in data returned');
-          assert.deepEqual(data.map((o) => o.attributes.name), ['Io']);
+      let records: Record[] = await source.query(q => q.findRelatedRecords(planetRecord, 'moons'));
 
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      assert.ok(Array.isArray(records), 'returned an array of data');
+      assert.equal(records.length, 1, 'one objects in data returned');
+      assert.deepEqual(records.map((o) => o.attributes.name), ['Io']);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
 
-    test('#query - relatedRecords with include', function(assert) {
+    test('#query - relatedRecords with include', async function(assert) {
       assert.expect(2);
 
       const planetRecord = source.serializer.deserializeDocument({
@@ -2073,11 +2025,10 @@ module('JSONAPISource', function(hooks) {
         .withArgs('/planets/jupiter/moons?include=planet')
         .returns(jsonapiResponse(200, { data: [] }));
 
-      return source.query(q => q.findRelatedRecords(<RecordIdentity>planetRecord, 'moons'), options)
-        .then(() => {
-          assert.equal(fetchStub.callCount, 1, 'fetch called once');
-          assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
-        });
+      await source.query(q => q.findRelatedRecords(<RecordIdentity>planetRecord, 'moons'), options);
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+      assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
     });
   });
 
@@ -2138,7 +2089,7 @@ module('JSONAPISource', function(hooks) {
         }
       };
 
-      source.on('transform', <() => void>function(transform) {
+      source.on('transform', (transform: Transform) => {
         transformCount++;
 
         if (transformCount === 1) {

--- a/packages/@orbit/jsonapi/test/support/jsonapi.ts
+++ b/packages/@orbit/jsonapi/test/support/jsonapi.ts
@@ -1,8 +1,8 @@
 import Orbit from '@orbit/core';
 
-export function jsonapiResponse(_options, body?, timeout?) {
-  let options;
-  let response;
+export function jsonapiResponse(_options: any, body?: any, timeout?: number): Promise<Response> {
+  let options: any;
+  let response: Response;
 
   if (typeof _options === 'number') {
     options = { status: _options };
@@ -22,7 +22,7 @@ export function jsonapiResponse(_options, body?, timeout?) {
   // console.log('jsonapiResponse', body, options, response.headers.get('Content-Type'));
 
   if (timeout) {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve: (response: Response) => void) => {
         let timer = Orbit.globals.setTimeout(() => {
           Orbit.globals.clearTimeout(timer);
           resolve(response);
@@ -33,7 +33,7 @@ export function jsonapiResponse(_options, body?, timeout?) {
   }
 }
 
-function statusText(code) {
+function statusText(code: number): string {
   switch (code) {
     case 200:
       return 'OK';

--- a/packages/@orbit/jsonapi/tsconfig.tests.json
+++ b/packages/@orbit/jsonapi/tsconfig.tests.json
@@ -8,7 +8,8 @@
     "inlineSourceMap": true,
     "declaration": false,
     "newLine": "LF",
-    "types": ["qunit"]
+    "types": ["qunit"],
+    "noImplicitAny": true
   },
   "include": [
     "src/**/*.ts",

--- a/packages/@orbit/local-storage-bucket/test/bucket-test.ts
+++ b/packages/@orbit/local-storage-bucket/test/bucket-test.ts
@@ -4,7 +4,7 @@ import LocalStorageBucket from '../src/bucket';
 const { module, test } = QUnit;
 
 module('LocalStorageBucket', function(hooks) {
-  let bucket;
+  let bucket: LocalStorageBucket;
 
   hooks.beforeEach(() => {
     bucket = new LocalStorageBucket();
@@ -24,7 +24,7 @@ module('LocalStorageBucket', function(hooks) {
     assert.equal(bucket.delimiter, '/', '`delimiter` is `/` by default');
   });
 
-  test('#setItem sets a value, #getItem gets a value, #removeItem removes a value', function(assert) {
+  test('#setItem sets a value, #getItem gets a value, #removeItem removes a value', async function(assert) {
     assert.expect(3);
 
     let planet = {
@@ -36,13 +36,15 @@ module('LocalStorageBucket', function(hooks) {
       }
     };
 
-    return bucket.getItem('planet')
-      .then(item => assert.equal(item, null, 'bucket does not contain item'))
-      .then(() => bucket.setItem('planet', planet))
-      .then(() => bucket.getItem('planet'))
-      .then(item => assert.deepEqual(item, planet, 'bucket contains item'))
-      .then(() => bucket.removeItem('planet'))
-      .then(() => bucket.getItem('planet'))
-      .then(item => assert.equal(item, null, 'bucket does not contain item'));
+    let item = await bucket.getItem('planet');
+    assert.equal(item, null, 'bucket does not contain item');
+
+    await bucket.setItem('planet', planet);
+    item = await bucket.getItem('planet');
+    assert.deepEqual(item, planet, 'bucket contains item');
+
+    await bucket.removeItem('planet');
+    item = await bucket.getItem('planet');
+    assert.equal(item, null, 'bucket does not contain item');
   });
 });

--- a/packages/@orbit/local-storage-bucket/tsconfig.tests.json
+++ b/packages/@orbit/local-storage-bucket/tsconfig.tests.json
@@ -8,7 +8,8 @@
     "inlineSourceMap": true,
     "declaration": false,
     "newLine": "LF",
-    "types": ["qunit"]
+    "types": ["qunit"],
+    "noImplicitAny": true
   },
   "include": [
     "src/**/*.ts",

--- a/packages/@orbit/local-storage/test/support/local-storage.ts
+++ b/packages/@orbit/local-storage/test/support/local-storage.ts
@@ -1,31 +1,13 @@
 import Orbit from '@orbit/core';
+import LocalStorageSource from '../../src/source';
+import { Record } from '@orbit/data';
 
-function getRecord(source, record) {
-  let recordKey = [source.namespace, record.type, record.id].join(source.delimiter);
-
+export function getRecordFromLocalStorage(source: LocalStorageSource, record: Record): Record {
+  const recordKey = [source.namespace, record.type, record.id].join(source.delimiter);
   return JSON.parse(Orbit.globals.localStorage.getItem(recordKey));
 }
 
-export function verifyLocalStorageContainsRecord(assert, source, record, ignoreFields?) {
-  let actual = getRecord(source, record);
-
-  if (ignoreFields) {
-    for (let i = 0, l = ignoreFields.length, field; i < l; i++) {
-      field = ignoreFields[i];
-      actual[record.id][field] = record[field];
-    }
-  }
-
-  assert.deepEqual(actual, record, 'local storage contains record');
-}
-
-export function verifyLocalStorageDoesNotContainRecord(assert, source, record) {
-  let actual = getRecord(source, record);
-
-  assert.equal(actual, null, 'local storage does not contain record');
-}
-
-export function verifyLocalStorageIsEmpty(assert, source) {
+export function isLocalStorageEmpty(source: LocalStorageSource) {
   let isEmpty = true;
   for (let key in Orbit.globals.localStorage) {
     if (key.indexOf(source.namespace + source.delimiter) === 0) {
@@ -33,5 +15,5 @@ export function verifyLocalStorageIsEmpty(assert, source) {
       break;
     }
   }
-  assert.ok(isEmpty, 'local storage does not contain records for source');
+  return isEmpty;
 }

--- a/packages/@orbit/local-storage/tsconfig.tests.json
+++ b/packages/@orbit/local-storage/tsconfig.tests.json
@@ -8,7 +8,8 @@
     "inlineSourceMap": true,
     "declaration": false,
     "newLine": "LF",
-    "types": ["qunit"]
+    "types": ["qunit"],
+    "noImplicitAny": true
   },
   "include": [
     "src/**/*.ts",

--- a/packages/@orbit/record-cache/src/async-record-cache.ts
+++ b/packages/@orbit/record-cache/src/async-record-cache.ts
@@ -52,7 +52,7 @@ export abstract class AsyncRecordCache implements Evented, AsyncRecordAccessor {
 
   // Evented interface stubs
   on: (event: string, listener: Listener) => void;
-  off: (event: string, listener: Listener) => void;
+  off: (event: string, listener?: Listener) => void;
   one: (event: string, listener: Listener) => void;
   emit: (event: string, ...args: any[]) => void;
   listeners: (event: string) => Listener[];

--- a/packages/@orbit/record-cache/src/sync-record-cache.ts
+++ b/packages/@orbit/record-cache/src/sync-record-cache.ts
@@ -52,7 +52,7 @@ export abstract class SyncRecordCache implements Evented, SyncRecordAccessor {
 
   // Evented interface stubs
   on: (event: string, listener: Listener) => void;
-  off: (event: string, listener: Listener) => void;
+  off: (event: string, listener?: Listener) => void;
   one: (event: string, listener: Listener) => void;
   emit: (event: string, ...args: any[]) => void;
   listeners: (event: string) => Listener[];

--- a/packages/@orbit/record-cache/test/async-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/async-record-cache-test.ts
@@ -1,5 +1,6 @@
 import {
   KeyMap,
+  Record,
   RecordNotFoundException,
   Schema,
   equalRecordIdentities,
@@ -49,7 +50,7 @@ module('AsyncRecordCache', function(hooks) {
   });
 
   test('it exists', async function(assert) {
-    let cache = new Cache({ schema });
+    const cache = new Cache({ schema });
 
     assert.ok(cache);
     assert.equal(cache.processors.length, 3, 'processors are assigned by default');
@@ -69,7 +70,7 @@ module('AsyncRecordCache', function(hooks) {
   test('#patch sets data and #records retrieves it', async function(assert) {
     assert.expect(4);
 
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
     const earth = { type: 'planet', id: '1', attributes: { name: 'Earth' }, keys: { remoteId: 'a' } };
 
@@ -90,7 +91,7 @@ module('AsyncRecordCache', function(hooks) {
   test('#patch can replace records', async function(assert) {
     assert.expect(4);
 
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
     const earth = { type: 'planet', id: '1', attributes: { name: 'Earth' }, keys: { remoteId: 'a' } };
 
@@ -111,7 +112,7 @@ module('AsyncRecordCache', function(hooks) {
   test('#patch can replace keys', async function(assert) {
     assert.expect(4);
 
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
     const earth = { type: 'planet', id: '1' };
 
@@ -132,7 +133,7 @@ module('AsyncRecordCache', function(hooks) {
   });
 
   test('#patch updates the cache and returns arrays of primary data and inverse ops', async function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
     let p1 = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
     let p2 = { type: 'planet', id: '2' };
@@ -158,11 +159,11 @@ module('AsyncRecordCache', function(hooks) {
   });
 
   test('#patch tracks refs and clears them from hasOne relationships when a referenced record is removed', async function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const jupiter = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' }, relationships: { moons: { data: undefined } } };
-    const io = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
-    const europa = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
+    const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' }, relationships: { moons: { data: undefined } } };
+    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
+    const europa: Record = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
 
     await cache.patch(t => [
       t.addRecord(jupiter),
@@ -182,11 +183,11 @@ module('AsyncRecordCache', function(hooks) {
   });
 
   test('#patch tracks refs and clears them from hasMany relationships when a referenced record is removed', async function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    var io = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: null } } };
-    var europa = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: null } } };
-    var jupiter = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' }, relationships: { moons: { data: [{ type: 'moon', id: 'm1' }, { type: 'moon', id: 'm2' }] } } };
+    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: null } } };
+    const europa: Record = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: null } } };
+    const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' }, relationships: { moons: { data: [{ type: 'moon', id: 'm1' }, { type: 'moon', id: 'm2' }] } } };
 
     await cache.patch(t => [
       t.addRecord(io),
@@ -204,12 +205,11 @@ module('AsyncRecordCache', function(hooks) {
 
     assert.equal(await cache.getRecordAsync({ type: 'moon', id: 'm2' }), null, 'Europa is GONE');
 
-    assert.equal((await cache.getRecordAsync({ type: 'planet', id: 'p1' })).relationships.moons.data['moon:m1'], null, 'Io has been cleared from Jupiter');
-    assert.equal((await cache.getRecordAsync({ type: 'planet', id: 'p1' })).relationships.moons.data['moon:m2'], null, 'Europa has been cleared from Jupiter');
+    assert.deepEqual((await cache.getRelatedRecordsAsync({ type: 'planet', id: 'p1' }, 'moons')), [], 'Io and Europa have been cleared from Jupiter');
   });
 
   test('#patch adds link to hasMany if record doesn\'t exist', async function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
     await cache.patch(t => t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', { type: 'moon', id: 'm1' }));
 
@@ -219,7 +219,7 @@ module('AsyncRecordCache', function(hooks) {
   test('#patch does not remove hasMany relationship if record doesn\'t exist', async function(assert) {
     assert.expect(1);
 
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
     cache.on('patch', () => {
       assert.ok(false, 'no operations were applied');
@@ -233,7 +233,7 @@ module('AsyncRecordCache', function(hooks) {
   test('#patch adds hasOne if record doesn\'t exist', async function(assert) {
     assert.expect(2);
 
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
     const tb = cache.transformBuilder;
     const replacePlanet = tb.replaceRelatedRecord(
@@ -264,7 +264,7 @@ module('AsyncRecordCache', function(hooks) {
   test('#patch will add empty hasOne link if record doesn\'t exist', async function(assert) {
     assert.expect(2);
 
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
     const tb = cache.transformBuilder;
     const clearPlanet = tb.replaceRelatedRecord(
@@ -290,9 +290,9 @@ module('AsyncRecordCache', function(hooks) {
   test('#patch does not add link to hasMany if link already exists', async function(assert) {
     assert.expect(1);
 
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const jupiter = { id: 'p1', type: 'planet', attributes: { name: 'Jupiter' }, relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } } };
+    const jupiter: Record = { id: 'p1', type: 'planet', attributes: { name: 'Jupiter' }, relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } } };
 
     await cache.patch(t => t.addRecord(jupiter));
 
@@ -308,9 +308,9 @@ module('AsyncRecordCache', function(hooks) {
   test('#patch does not remove relationship from hasMany if relationship doesn\'t exist', async function(assert) {
     assert.expect(1);
 
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const jupiter = { id: 'p1', type: 'planet', attributes: { name: 'Jupiter' } };
+    const jupiter: Record = { id: 'p1', type: 'planet', attributes: { name: 'Jupiter' } };
 
     await cache.patch(t => t.addRecord(jupiter));
 
@@ -326,9 +326,9 @@ module('AsyncRecordCache', function(hooks) {
   test('#patch can add and remove to has-many relationship', async function(assert) {
     assert.expect(2);
 
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const jupiter = { id: 'jupiter', type: 'planet' };
+    const jupiter: Record = { id: 'jupiter', type: 'planet' };
     await cache.patch(t => t.addRecord(jupiter));
 
     const callisto = { id: 'callisto', type: 'moon' };
@@ -346,9 +346,9 @@ module('AsyncRecordCache', function(hooks) {
   test('#patch can add and clear has-one relationship', async function(assert) {
     assert.expect(2);
 
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const jupiter = { id: 'jupiter', type: 'planet' };
+    const jupiter: Record = { id: 'jupiter', type: 'planet' };
     await cache.patch(t => t.addRecord(jupiter));
 
     const callisto = { id: 'callisto', type: 'moon' };
@@ -366,9 +366,9 @@ module('AsyncRecordCache', function(hooks) {
   test('does not replace hasOne if relationship already exists', async function(assert) {
     assert.expect(1);
 
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const europa = { id: 'm1', type: 'moon', attributes: { name: 'Europa' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
+    const europa: Record = { id: 'm1', type: 'moon', attributes: { name: 'Europa' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
 
     await cache.patch(t => t.addRecord(europa));
 
@@ -384,9 +384,9 @@ module('AsyncRecordCache', function(hooks) {
   test('does not remove hasOne if relationship doesn\'t exist', async function(assert) {
     assert.expect(1);
 
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const europa = { type: 'moon', id: 'm1', attributes: { name: 'Europa' }, relationships: { planet: { data: null } } };
+    const europa: Record = { type: 'moon', id: 'm1', attributes: { name: 'Europa' }, relationships: { planet: { data: null } } };
 
     await cache.patch(t => t.addRecord(europa));
 
@@ -417,7 +417,7 @@ module('AsyncRecordCache', function(hooks) {
       }
     });
 
-    let cache = new Cache({ schema: hasOneSchema, keyMap });
+    const cache = new Cache({ schema: hasOneSchema, keyMap });
 
     await cache.patch(t => [
       t.addRecord({
@@ -464,11 +464,11 @@ module('AsyncRecordCache', function(hooks) {
       }
     });
 
-    let cache = new Cache({ schema: dependentSchema, keyMap });
+    const cache = new Cache({ schema: dependentSchema, keyMap });
 
-    const jupiter = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' } };
-    const io = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
-    const europa = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
+    const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' } };
+    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
+    const europa: Record = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
 
     await cache.patch(t => [
       t.addRecord(jupiter),
@@ -501,11 +501,11 @@ module('AsyncRecordCache', function(hooks) {
       }
     });
 
-    let cache = new Cache({ schema: dependentSchema, keyMap });
+    const cache = new Cache({ schema: dependentSchema, keyMap });
 
-    const jupiter = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' } };
-    const io = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: { type: 'planet', id: 'p1' } } } };
-    const europa = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: { type: 'planet', id: 'p1' } } } };
+    const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' } };
+    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: { type: 'planet', id: 'p1' } } } };
+    const europa: Record = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: { type: 'planet', id: 'p1' } } } };
 
     await cache.patch(t => [
       t.addRecord(jupiter),
@@ -524,7 +524,7 @@ module('AsyncRecordCache', function(hooks) {
   });
 
   test('#patch merges records when "replacing" and will not stomp on attributes and relationships that are not replaced', async function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
     await cache.patch(t => [
@@ -567,7 +567,7 @@ module('AsyncRecordCache', function(hooks) {
   });
 
   test('#patch can replace related records but only if they are different', async function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
     await cache.patch(t => [
@@ -632,16 +632,16 @@ module('AsyncRecordCache', function(hooks) {
   });
 
   test('#patch merges records when "replacing" and _will_ replace specified attributes and relationships', async function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
-    let earth = {
+    const earth: Record = {
       type: 'planet', id: '1',
       attributes: { name: 'Earth' },
       relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
     };
 
-    let jupiter = {
+    const jupiter: Record = {
       type: 'planet', id: '1',
       attributes: { name: 'Jupiter', classification: 'terrestrial' },
       relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
@@ -709,9 +709,9 @@ module('AsyncRecordCache', function(hooks) {
   });
 
   test('#query can retrieve an individual record with `record`', async function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    let jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
+    const jupiter: Record = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
     await cache.patch(t => [t.addRecord(jupiter)]);
 
     assert.deepEqual(
@@ -721,13 +721,12 @@ module('AsyncRecordCache', function(hooks) {
   });
 
   test('#query can perform a simple attribute filter by value equality', async function(assert) {
-    let cache = new Cache({ schema, keyMap });
-    const tb = cache.transformBuilder;
+    const cache = new Cache({ schema, keyMap });
 
-    let jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
-    let earth = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
-    let venus = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
-    let mercury = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
+    const jupiter: Record = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
+    const earth: Record = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
+    const venus: Record = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
+    const mercury: Record = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
 
     await cache.patch(t => [
       t.addRecord(jupiter),
@@ -745,12 +744,12 @@ module('AsyncRecordCache', function(hooks) {
   });
 
   test('#query can perform a simple attribute filter by value comparison (gt, lt, gte & lte)', async function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    let jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', sequence: 5, classification: 'gas giant', atmosphere: true } };
-    let earth = { type: 'planet', id: 'earth', attributes: { name: 'Earth', sequence: 3, classification: 'terrestrial', atmosphere: true } };
-    let venus = { type: 'planet', id: 'venus', attributes: { name: 'Venus', sequence: 2, classification: 'terrestrial', atmosphere: true } };
-    let mercury = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', sequence: 1, classification: 'terrestrial', atmosphere: false } };
+    const jupiter: Record = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', sequence: 5, classification: 'gas giant', atmosphere: true } };
+    const earth: Record = { type: 'planet', id: 'earth', attributes: { name: 'Earth', sequence: 3, classification: 'terrestrial', atmosphere: true } };
+    const venus: Record = { type: 'planet', id: 'venus', attributes: { name: 'Venus', sequence: 2, classification: 'terrestrial', atmosphere: true } };
+    const mercury: Record = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', sequence: 1, classification: 'terrestrial', atmosphere: false } };
 
     await cache.patch(t => [
       t.addRecord(jupiter),
@@ -760,10 +759,8 @@ module('AsyncRecordCache', function(hooks) {
     ]);
     arrayMembershipMatches(
       assert,
-      await cache.query(q => {
-        let tmp = q.findRecords('planet')
-        return tmp.filter({ attribute: 'sequence', value: 2, op: 'gt' })
-      }),
+      await cache.query(q => q.findRecords('planet')
+                              .filter({ attribute: 'sequence', value: 2, op: 'gt' })),
       [earth, jupiter]
     );
     arrayMembershipMatches(
@@ -793,9 +790,9 @@ module('AsyncRecordCache', function(hooks) {
   });
 
   test('#query can perform relatedRecords filters with operators `equal`, `all`, `some` and `none`', async function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    let jupiter = {
+    const jupiter: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: { name: 'Jupiter', sequence: 5, classification: 'gas giant', atmosphere: true },
@@ -809,54 +806,54 @@ module('AsyncRecordCache', function(hooks) {
         }
       }
     };
-    let earth = {
+    const earth: Record = {
       type: 'planet',
       id: 'earth',
       attributes: { name: 'Earth', sequence: 3, classification: 'terrestrial', atmosphere: true },
       relationships: { moons: { data: [{ type: 'moon', id: 'moon' }] } }
     };
-    let mars = {
+    const mars: Record = {
       type: 'planet',
       id: 'mars',
       attributes: { name: 'Mars', sequence: 4, classification: 'terrestrial', atmosphere: true },
       relationships: { moons: { data: [{ type: 'moon', id: 'phobos' }, { type: 'moon', id: 'deimos' }] } }
     };
-    let mercury = {
+    const mercury: Record = {
       type: 'planet',
       id: 'mercury',
       attributes: { name: 'Mercury', sequence: 1, classification: 'terrestrial', atmosphere: false }
     };
-    let theMoon = {
+    const theMoon: Record = {
       id: 'moon', type: 'moon',
       attributes: { name: 'The moon' },
       relationships: { planet: { data: { type: 'planet', id: 'earth' } } }
     };
-    let europa = {
+    const europa: Record = {
       id: 'europa', type: 'moon',
       attributes: { name: 'Europa' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    let ganymede = {
+    const ganymede: Record = {
       id: 'ganymede', type: 'moon',
       attributes: { name: 'Ganymede' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    let callisto = {
+    const callisto: Record = {
       id: 'callisto', type: 'moon',
       attributes: { name: 'Callisto' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    let phobos = {
+    const phobos: Record = {
       id: 'phobos', type: 'moon',
       attributes: { name: 'Phobos' },
       relationships: { planet: { data: { type: 'planet', id: 'mars' } } }
     };
-    let deimos = {
+    const deimos: Record = {
       id: 'deimos', type: 'moon',
       attributes: { name: 'Deimos' },
       relationships: { planet: { data: { type: 'planet', id: 'mars' } } }
     };
-    let titan = {
+    const titan: Record = {
       id: 'titan', type: 'moon',
       attributes: { name: 'titan' },
       relationships: {}
@@ -920,9 +917,9 @@ module('AsyncRecordCache', function(hooks) {
   });
 
   test('#query can perform relatedRecord filters', async function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    let jupiter = {
+    const jupiter: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: { name: 'Jupiter', sequence: 5, classification: 'gas giant', atmosphere: true },
@@ -936,54 +933,54 @@ module('AsyncRecordCache', function(hooks) {
         }
       }
     };
-    let earth = {
+    const earth: Record = {
       type: 'planet',
       id: 'earth',
       attributes: { name: 'Earth', sequence: 3, classification: 'terrestrial', atmosphere: true },
       relationships: { moons: { data: [{ type: 'moon', id: 'moon' }] } }
     };
-    let mars = {
+    const mars: Record = {
       type: 'planet',
       id: 'mars',
       attributes: { name: 'Mars', sequence: 4, classification: 'terrestrial', atmosphere: true },
       relationships: { moons: { data: [{ type: 'moon', id: 'phobos' }, { type: 'moon', id: 'deimos' }] } }
     };
-    let mercury = {
+    const mercury: Record = {
       type: 'planet',
       id: 'mercury',
       attributes: { name: 'Mercury', sequence: 1, classification: 'terrestrial', atmosphere: false }
     };
-    let theMoon = {
+    const theMoon: Record = {
       id: 'moon', type: 'moon',
       attributes: { name: 'The moon' },
       relationships: { planet: { data: { type: 'planet', id: 'earth' } } }
     };
-    let europa = {
+    const europa: Record = {
       id: 'europa', type: 'moon',
       attributes: { name: 'Europa' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    let ganymede = {
+    const ganymede: Record = {
       id: 'ganymede', type: 'moon',
       attributes: { name: 'Ganymede' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    let callisto = {
+    const callisto: Record = {
       id: 'callisto', type: 'moon',
       attributes: { name: 'Callisto' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    let phobos = {
+    const phobos: Record = {
       id: 'phobos', type: 'moon',
       attributes: { name: 'Phobos' },
       relationships: { planet: { data: { type: 'planet', id: 'mars' } } }
     };
-    let deimos = {
+    const deimos: Record = {
       id: 'deimos', type: 'moon',
       attributes: { name: 'Deimos' },
       relationships: { planet: { data: { type: 'planet', id: 'mars' } } }
     };
-    let titan = {
+    const titan: Record = {
       id: 'titan', type: 'moon',
       attributes: { name: 'titan' },
       relationships: {}
@@ -1029,12 +1026,12 @@ module('AsyncRecordCache', function(hooks) {
   });
 
   test('#query can perform a complex attribute filter by value', async function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    let jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
-    let earth = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
-    let venus = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
-    let mercury = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
+    const jupiter: Record = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
+    const earth: Record = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
+    const venus: Record = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
+    const mercury: Record = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
 
     await cache.patch(t => [
       t.addRecord(jupiter),
@@ -1056,12 +1053,12 @@ module('AsyncRecordCache', function(hooks) {
   });
 
   test('#query can perform a filter on attributes, even when a particular record has none', async function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    let jupiter = { type: 'planet', id: 'jupiter' };
-    let earth = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
-    let venus = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
-    let mercury = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
+    const jupiter: Record = { type: 'planet', id: 'jupiter' };
+    const earth: Record = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
+    const venus: Record = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
+    const mercury: Record = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
 
     await cache.patch(t => [
       t.addRecord(jupiter),
@@ -1083,12 +1080,12 @@ module('AsyncRecordCache', function(hooks) {
   });
 
   test('#query can sort by an attribute', async function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    let jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
-    let earth = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
-    let venus = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
-    let mercury = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
+    const jupiter: Record = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
+    const earth: Record = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
+    const venus: Record = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
+    const mercury: Record = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
 
     await cache.patch(t => [
       t.addRecord(jupiter),
@@ -1110,12 +1107,12 @@ module('AsyncRecordCache', function(hooks) {
   });
 
   test('#query can sort by an attribute, even when a particular record has none', async function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    let jupiter = { type: 'planet', id: 'jupiter' };
-    let earth = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
-    let venus = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
-    let mercury = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
+    const jupiter: Record = { type: 'planet', id: 'jupiter' };
+    const earth: Record = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
+    const venus: Record = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
+    const mercury: Record = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
 
     await cache.patch(t => [
       t.addRecord(jupiter),
@@ -1137,12 +1134,12 @@ module('AsyncRecordCache', function(hooks) {
   });
 
   test('#query can filter and sort by attributes', async function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    let jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
-    let earth = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
-    let venus = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
-    let mercury = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
+    const jupiter: Record = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
+    const earth: Record = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
+    const venus: Record = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
+    const mercury: Record = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
 
     await cache.patch(t => [
       t.addRecord(jupiter),
@@ -1164,12 +1161,12 @@ module('AsyncRecordCache', function(hooks) {
   });
 
   test('#query can sort by an attribute in descending order', async function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    let jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
-    let earth = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
-    let venus = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
-    let mercury = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
+    const jupiter: Record = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
+    const earth: Record = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
+    const venus: Record = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
+    const mercury: Record = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
 
     await cache.patch(t => [
       t.addRecord(jupiter),
@@ -1191,12 +1188,12 @@ module('AsyncRecordCache', function(hooks) {
   });
 
   test('#query can sort by according to multiple criteria', async function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    let jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
-    let earth = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
-    let venus = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
-    let mercury = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
+    const jupiter: Record = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
+    const earth: Record = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
+    const venus: Record = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
+    const mercury: Record = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
 
     await cache.patch(t => [
       t.addRecord(jupiter),
@@ -1218,9 +1215,9 @@ module('AsyncRecordCache', function(hooks) {
   });
 
   test('#query - findRecord - finds record', async function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const jupiter = {
+    const jupiter: Record = {
       id: 'jupiter', type: 'planet',
       attributes: { name: 'Jupiter' },
       relationships: { moons: { data: [{ type: 'moon', id: 'callisto' }] } } };
@@ -1236,7 +1233,7 @@ module('AsyncRecordCache', function(hooks) {
   });
 
   test('#query - findRecord - throws RecordNotFoundException if record doesn\'t exist', async function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
     try {
       await cache.query(q => q.findRecord({ type: 'planet', id: 'jupiter' }));
@@ -1246,9 +1243,9 @@ module('AsyncRecordCache', function(hooks) {
   });
 
   test('#query - findRecords - finds matching records', async function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const jupiter = {
+    const jupiter: Record = {
       id: 'jupiter', type: 'planet',
       attributes: { name: 'Jupiter' },
       relationships: { moons: { data: [{ type: 'moon', id: 'callisto' }] } } };
@@ -1270,9 +1267,9 @@ module('AsyncRecordCache', function(hooks) {
   });
 
   test('#query - page - can paginate records by offset and limit', async function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const jupiter = {
+    const jupiter: Record = {
       id: 'jupiter', type: 'planet',
       attributes: { name: 'Jupiter' } };
 
@@ -1312,9 +1309,9 @@ module('AsyncRecordCache', function(hooks) {
   });
 
   test('#query - findRelatedRecords', async function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const jupiter = {
+    const jupiter: Record = {
       id: 'jupiter', type: 'planet',
       attributes: { name: 'Jupiter' },
       relationships: { moons: { data: [{ type: 'moon', id: 'callisto' }] } } };
@@ -1336,9 +1333,9 @@ module('AsyncRecordCache', function(hooks) {
   });
 
   test('#query - findRelatedRecord', async function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const jupiter = {
+    const jupiter: Record = {
       id: 'jupiter', type: 'planet',
       attributes: { name: 'Jupiter' },
       relationships: { moons: { data: [{ type: 'moon', id: 'callisto' }] } } };

--- a/packages/@orbit/record-cache/test/operation-processors/cache-integrity-processor-test.ts
+++ b/packages/@orbit/record-cache/test/operation-processors/cache-integrity-processor-test.ts
@@ -1,7 +1,13 @@
 import {
   Schema,
   SchemaSettings,
-  KeyMap
+  KeyMap,
+  ReplaceRelatedRecordOperation,
+  ReplaceRelatedRecordsOperation,
+  AddToRelatedRecordsOperation,
+  RemoveFromRelatedRecordsOperation,
+  RemoveRecordOperation,
+  ReplaceRecordOperation
 } from '@orbit/data';
 import { SyncCacheIntegrityProcessor } from '../../src/index';
 import Cache from '../support/example-sync-record-cache';
@@ -9,7 +15,9 @@ import Cache from '../support/example-sync-record-cache';
 const { module, test } = QUnit;
 
 module('CacheIntegrityProcessor', function(hooks) {
-  let schema, cache, processor;
+  let schema: Schema;
+  let cache: Cache;
+  let processor: SyncCacheIntegrityProcessor;
 
   const schemaDefinition: SchemaSettings = {
     models: {
@@ -55,7 +63,7 @@ module('CacheIntegrityProcessor', function(hooks) {
     let keyMap = new KeyMap();
     schema = new Schema(schemaDefinition);
     cache = new Cache({ schema, keyMap, processors: [SyncCacheIntegrityProcessor] });
-    processor = cache._processors[0];
+    processor = cache.processors[0] as SyncCacheIntegrityProcessor;
   });
 
   hooks.afterEach(function() {
@@ -161,7 +169,7 @@ module('CacheIntegrityProcessor', function(hooks) {
       relatedRecord: saturnId
     }]);
 
-    const addPlanetOp = {
+    const addPlanetOp: ReplaceRelatedRecordOperation = {
       op: 'replaceRelatedRecord',
       record: europaId,
       relationship: 'planet',
@@ -256,7 +264,7 @@ module('CacheIntegrityProcessor', function(hooks) {
       relatedRecord: saturnId
     }]);
 
-    const replacePlanetOp = {
+    const replacePlanetOp: ReplaceRelatedRecordOperation = {
       op: 'replaceRelatedRecord',
       record: europaId,
       relationship: 'planet',
@@ -331,7 +339,7 @@ module('CacheIntegrityProcessor', function(hooks) {
       relatedRecord: saturnId
     }]);
 
-    const clearMoonsOp = {
+    const clearMoonsOp: ReplaceRelatedRecordsOperation = {
       op: 'replaceRelatedRecords',
       record: saturn,
       relationship: 'moons',
@@ -392,7 +400,7 @@ module('CacheIntegrityProcessor', function(hooks) {
       relatedRecord: saturnId
     }]);
 
-    const replaceMoonsOp = {
+    const replaceMoonsOp: ReplaceRelatedRecordsOperation = {
       op: 'replaceRelatedRecords',
       record: saturn,
       relationship: 'moons',
@@ -475,7 +483,7 @@ module('CacheIntegrityProcessor', function(hooks) {
       relatedRecord: saturnId
     }]);
 
-    const replaceMoonsOp = {
+    const replaceMoonsOp: ReplaceRelatedRecordsOperation = {
       op: 'replaceRelatedRecords',
       record: saturn,
       relationship: 'moons',
@@ -543,7 +551,7 @@ module('CacheIntegrityProcessor', function(hooks) {
       relatedRecord: humanId
     }]);
 
-    const clearInhabitantsOp = {
+    const clearInhabitantsOp: ReplaceRelatedRecordsOperation = {
       op: 'replaceRelatedRecords',
       record: earth,
       relationship: 'inhabitants',
@@ -617,7 +625,7 @@ module('CacheIntegrityProcessor', function(hooks) {
       relatedRecord: saturnId
     }]);
 
-    const removePlanetOp = {
+    const removePlanetOp: ReplaceRelatedRecordOperation = {
       op: 'replaceRelatedRecord',
       record: europa,
       relationship: 'planet',
@@ -690,7 +698,7 @@ module('CacheIntegrityProcessor', function(hooks) {
       relatedRecord: saturnId
     }]);
 
-    const changePlanetOp = {
+    const changePlanetOp: ReplaceRelatedRecordOperation = {
       op: 'replaceRelatedRecord',
       record: earthId,
       relationship: 'next',
@@ -760,7 +768,7 @@ module('CacheIntegrityProcessor', function(hooks) {
       relatedRecord: saturnId
     }]);
 
-    const changePlanetOp = {
+    const changePlanetOp: ReplaceRelatedRecordOperation = {
       op: 'replaceRelatedRecord',
       record: earthId,
       relationship: 'next',
@@ -811,7 +819,7 @@ module('CacheIntegrityProcessor', function(hooks) {
     assert.deepEqual(cache.getInverseRelationshipsSync(earth), []);
     assert.deepEqual(cache.getInverseRelationshipsSync(human), []);
 
-    const addPlanetOp = {
+    const addPlanetOp: AddToRelatedRecordsOperation = {
       op: 'addToRelatedRecords',
       record: humanId,
       relationship: 'planets',
@@ -861,7 +869,7 @@ module('CacheIntegrityProcessor', function(hooks) {
       relatedRecord: humanId
     }]);
 
-    const removePlanetOp = {
+    const removePlanetOp: RemoveFromRelatedRecordsOperation = {
       op: 'removeFromRelatedRecords',
       record: human,
       relationship: 'planets',
@@ -913,7 +921,7 @@ module('CacheIntegrityProcessor', function(hooks) {
       relatedRecord: humanId
     }]);
 
-    const removeInhabitantOp = {
+    const removeInhabitantOp: RemoveRecordOperation = {
       op: 'removeRecord',
       record: human
     };
@@ -988,7 +996,7 @@ module('CacheIntegrityProcessor', function(hooks) {
       }
     };
 
-    const replaceHumanOp = {
+    const replaceHumanOp: ReplaceRecordOperation = {
       op: 'replaceRecord',
       record: humanOnEarth
     };

--- a/packages/@orbit/record-cache/test/operation-processors/schema-consistency-processor-test.ts
+++ b/packages/@orbit/record-cache/test/operation-processors/schema-consistency-processor-test.ts
@@ -2,7 +2,12 @@ import {
   cloneRecordIdentity as identity,
   KeyMap,
   Schema,
-  SchemaSettings
+  SchemaSettings,
+  AddToRelatedRecordsOperation,
+  ReplaceRelatedRecordOperation,
+  ReplaceRelatedRecordsOperation,
+  RemoveFromRelatedRecordsOperation,
+  ReplaceRecordOperation
 } from '@orbit/data';
 import { SyncCacheIntegrityProcessor, SyncSchemaConsistencyProcessor } from '../../src/index';
 import Cache from '../support/example-sync-record-cache';
@@ -10,7 +15,9 @@ import Cache from '../support/example-sync-record-cache';
 const { module, test } = QUnit;
 
 module('SchemaConsistencyProcessor', function(hooks) {
-  let schema, cache, processor;
+  let schema: Schema;
+  let cache: Cache;
+  let processor: SyncSchemaConsistencyProcessor;
 
   const schemaDefinition: SchemaSettings = {
     models: {
@@ -49,7 +56,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
     let keyMap = new KeyMap();
     schema = new Schema(schemaDefinition);
     cache = new Cache({ schema, keyMap, processors: [SyncCacheIntegrityProcessor, SyncSchemaConsistencyProcessor] });
-    processor = cache._processors[1];
+    processor = cache.processors[1] as SyncSchemaConsistencyProcessor;
   });
 
   hooks.afterEach(function() {
@@ -82,7 +89,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       t.addRecord(europa)
     ]);
 
-    const addPlanetOp = {
+    const addPlanetOp: AddToRelatedRecordsOperation = {
       op: 'addToRelatedRecords',
       record: { type: 'moon', id: europa.id },
       relationship: 'planet',
@@ -136,7 +143,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       t.addRecord(europa)
     ]);
 
-    const replacePlanetOp = {
+    const replacePlanetOp: ReplaceRelatedRecordOperation = {
       op: 'replaceRelatedRecord',
       record: identity(europa),
       relationship: 'planet',
@@ -187,7 +194,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       t.addRecord(titan)
     ]);
 
-    const clearMoonsOp = {
+    const clearMoonsOp: ReplaceRelatedRecordsOperation = {
       op: 'replaceRelatedRecords',
       record: identity(saturn),
       relationship: 'moons',
@@ -235,7 +242,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       t.addRecord(titan)
     ]);
 
-    const replaceMoonsOp = {
+    const replaceMoonsOp: ReplaceRelatedRecordsOperation = {
       op: 'replaceRelatedRecords',
       record: identity(jupiter),
       relationship: 'moons',
@@ -289,7 +296,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       t.addRecord(europa)
     ]);
 
-    const replaceMoonsOp = {
+    const replaceMoonsOp: ReplaceRelatedRecordsOperation = {
       op: 'replaceRelatedRecords',
       record: identity(saturn),
       relationship: 'moons',
@@ -334,7 +341,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       t.addRecord(human)
     ]);
 
-    const clearInhabitantsOp = {
+    const clearInhabitantsOp: ReplaceRelatedRecordsOperation = {
       op: 'replaceRelatedRecords',
       record: identity(earth),
       relationship: 'inhabitants',
@@ -372,7 +379,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       t.addRecord(dog)
     ]);
 
-    const clearInhabitantsOp = {
+    const clearInhabitantsOp: ReplaceRelatedRecordsOperation = {
       op: 'replaceRelatedRecords',
       record: identity(earth),
       relationship: 'inhabitants',
@@ -427,7 +434,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       t.addRecord(europa)
     ]);
 
-    const removePlanetOp = {
+    const removePlanetOp: ReplaceRelatedRecordOperation = {
       op: 'replaceRelatedRecord',
       record: identity(europa),
       relationship: 'planet',
@@ -475,7 +482,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       t.addRecord(earth)
     ]);
 
-    const changePlanetOp = {
+    const changePlanetOp: ReplaceRelatedRecordOperation = {
       op: 'replaceRelatedRecord',
       record: identity(earth),
       relationship: 'next',
@@ -523,7 +530,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       t.addRecord(earth)
     ]);
 
-    const changePlanetOp = {
+    const changePlanetOp: ReplaceRelatedRecordOperation = {
       op: 'replaceRelatedRecord',
       record: identity(earth),
       relationship: 'next',
@@ -571,7 +578,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       t.addRecord(earth)
     ]);
 
-    const changePlanetOp = {
+    const changePlanetOp: ReplaceRelatedRecordOperation = {
       op: 'replaceRelatedRecord',
       record: identity(saturn),
       relationship: 'next',
@@ -603,7 +610,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       t.addRecord(human)
     ]);
 
-    const addPlanetOp = {
+    const addPlanetOp: AddToRelatedRecordsOperation = {
       op: 'addToRelatedRecords',
       record: identity(human),
       relationship: 'planets',
@@ -642,7 +649,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       t.addRecord(human)
     ]);
 
-    const removePlanetOp = {
+    const removePlanetOp: RemoveFromRelatedRecordsOperation = {
       op: 'removeFromRelatedRecords',
       record: identity(human),
       relationship: 'planets',
@@ -723,7 +730,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       t.addRecord(dog)
     ]);
 
-    const clearInhabitantsOp = {
+    const clearInhabitantsOp: ReplaceRecordOperation = {
       op: 'replaceRecord',
       record: earth2
     };

--- a/packages/@orbit/record-cache/test/operation-processors/schema-validation-processor-test.ts
+++ b/packages/@orbit/record-cache/test/operation-processors/schema-validation-processor-test.ts
@@ -10,7 +10,8 @@ import { SyncSchemaValidationProcessor } from '../../src/index';
 const { module, test } = QUnit;
 
 module('SchemaValidationProcessor', function(hooks) {
-  let schema, cache;
+  let schema: Schema;
+  let cache: Cache;
 
   const schemaDefinition: SchemaSettings = {
     models: {

--- a/packages/@orbit/record-cache/test/support/example-async-record-cache.ts
+++ b/packages/@orbit/record-cache/test/support/example-async-record-cache.ts
@@ -76,7 +76,7 @@ export default class ExampleAsyncRecordCache extends AsyncRecordCache {
 
   async addInverseRelationshipsAsync(relationships: RecordRelationshipIdentity[]): Promise<void> {
     for (let relationship of relationships) {
-      let rels = deepGet(this._inverseRelationships, [relationship.relatedRecord.type, relationship.relatedRecord.id]);
+      let rels: any = deepGet(this._inverseRelationships, [relationship.relatedRecord.type, relationship.relatedRecord.id]);
       rels = rels ? clone(rels) : [];
       rels.push(relationship);
       deepSet(this._inverseRelationships, [relationship.relatedRecord.type, relationship.relatedRecord.id], rels);
@@ -85,10 +85,10 @@ export default class ExampleAsyncRecordCache extends AsyncRecordCache {
 
   async removeInverseRelationshipsAsync(relationships: RecordRelationshipIdentity[]): Promise<void> {
     for (let relationship of relationships) {
-      let rels = deepGet(this._inverseRelationships, [relationship.relatedRecord.type, relationship.relatedRecord.id]);
+      let rels: any = deepGet(this._inverseRelationships, [relationship.relatedRecord.type, relationship.relatedRecord.id]);
       if (rels) {
-        let newRels = rels.filter(rel => !(equalRecordIdentities(rel.record, relationship.record) &&
-                                           rel.relationship === relationship.relationship));
+        let newRels: any = rels.filter((rel: any) => !(equalRecordIdentities(rel.record, relationship.record) &&
+                                                     rel.relationship === relationship.relationship));
         deepSet(this._inverseRelationships, [relationship.relatedRecord.type, relationship.relatedRecord.id], newRels);
       }
     }

--- a/packages/@orbit/record-cache/test/support/example-sync-record-cache.ts
+++ b/packages/@orbit/record-cache/test/support/example-sync-record-cache.ts
@@ -8,7 +8,8 @@ import {
 import {
   RecordRelationshipIdentity,
   SyncRecordCache,
-  SyncRecordCacheSettings
+  SyncRecordCacheSettings,
+  SyncOperationProcessor
 } from '../../src/index';
 
 /**
@@ -76,7 +77,7 @@ export default class ExampleSyncRecordCache extends SyncRecordCache {
 
   addInverseRelationshipsSync(relationships: RecordRelationshipIdentity[]): void {
     for (let relationship of relationships) {
-      let rels = deepGet(this._inverseRelationships, [relationship.relatedRecord.type, relationship.relatedRecord.id]);
+      let rels: any = deepGet(this._inverseRelationships, [relationship.relatedRecord.type, relationship.relatedRecord.id]);
       rels = rels ? clone(rels) : [];
       rels.push(relationship);
       deepSet(this._inverseRelationships, [relationship.relatedRecord.type, relationship.relatedRecord.id], rels);
@@ -85,10 +86,10 @@ export default class ExampleSyncRecordCache extends SyncRecordCache {
 
   removeInverseRelationshipsSync(relationships: RecordRelationshipIdentity[]): void {
     for (let relationship of relationships) {
-      let rels = deepGet(this._inverseRelationships, [relationship.relatedRecord.type, relationship.relatedRecord.id]);
+      let rels: any = deepGet(this._inverseRelationships, [relationship.relatedRecord.type, relationship.relatedRecord.id]);
       if (rels) {
-        let newRels = rels.filter(rel => !(equalRecordIdentities(rel.record, relationship.record) &&
-                                           rel.relationship === relationship.relationship));
+        let newRels: any = rels.filter((rel: any) => !(equalRecordIdentities(rel.record, relationship.record) &&
+                                                     rel.relationship === relationship.relationship));
         deepSet(this._inverseRelationships, [relationship.relatedRecord.type, relationship.relatedRecord.id], newRels);
       }
     }

--- a/packages/@orbit/record-cache/test/support/matchers.ts
+++ b/packages/@orbit/record-cache/test/support/matchers.ts
@@ -1,4 +1,4 @@
-export function arrayMembershipMatches(assert, actual, expected) {
+export function arrayMembershipMatches(assert: any, actual: any, expected: any) {
   assert.equal(actual.length, expected.length, 'array lengths match');
   for (let i = 0, l = actual.length; i < l; i++) {
     assert.ok(expected.indexOf(actual[i]) > -1, 'array contains member');

--- a/packages/@orbit/record-cache/test/sync-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/sync-record-cache-test.ts
@@ -4,7 +4,8 @@ import {
   Schema,
   equalRecordIdentities,
   recordsInclude,
-  recordsIncludeAll
+  recordsIncludeAll,
+  Record
 } from '@orbit/data';
 import {
   SyncSchemaValidationProcessor
@@ -49,7 +50,7 @@ module('SyncRecordCache', function(hooks) {
   });
 
   test('it exists', function(assert) {
-    let cache = new Cache({ schema });
+    const cache = new Cache({ schema });
 
     assert.ok(cache);
     assert.equal(cache.processors.length, 3, 'processors are assigned by default');
@@ -69,9 +70,9 @@ module('SyncRecordCache', function(hooks) {
   test('#patch sets data and #records retrieves it', function(assert) {
     assert.expect(4);
 
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const earth = { type: 'planet', id: '1', attributes: { name: 'Earth' }, keys: { remoteId: 'a' } };
+    const earth: Record = { type: 'planet', id: '1', attributes: { name: 'Earth' }, keys: { remoteId: 'a' } };
 
     cache.on('patch', (operation, data) => {
       assert.deepEqual(operation, {
@@ -90,9 +91,9 @@ module('SyncRecordCache', function(hooks) {
   test('#patch can replace records', function(assert) {
     assert.expect(4);
 
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const earth = { type: 'planet', id: '1', attributes: { name: 'Earth' }, keys: { remoteId: 'a' } };
+    const earth: Record = { type: 'planet', id: '1', attributes: { name: 'Earth' }, keys: { remoteId: 'a' } };
 
     cache.on('patch', (operation, data) => {
       assert.deepEqual(operation, {
@@ -111,9 +112,9 @@ module('SyncRecordCache', function(hooks) {
   test('#patch can replace keys', function(assert) {
     assert.expect(4);
 
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const earth = { type: 'planet', id: '1' };
+    const earth: Record = { type: 'planet', id: '1' };
 
     cache.on('patch', (operation, data) => {
       assert.deepEqual(operation, {
@@ -132,7 +133,7 @@ module('SyncRecordCache', function(hooks) {
   });
 
   test('#patch updates the cache and returns arrays of primary data and inverse ops', function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
     let p1 = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
     let p2 = { type: 'planet', id: '2' };
@@ -158,11 +159,11 @@ module('SyncRecordCache', function(hooks) {
   });
 
   test('#patch tracks refs and clears them from hasOne relationships when a referenced record is removed', function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const jupiter = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' }, relationships: { moons: { data: undefined } } };
-    const io = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
-    const europa = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
+    const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' }, relationships: { moons: { data: undefined } } };
+    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
+    const europa: Record = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
 
     cache.patch(t => [
       t.addRecord(jupiter),
@@ -182,11 +183,11 @@ module('SyncRecordCache', function(hooks) {
   });
 
   test('#patch tracks refs and clears them from hasMany relationships when a referenced record is removed', function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    var io = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: null } } };
-    var europa = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: null } } };
-    var jupiter = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' }, relationships: { moons: { data: [{ type: 'moon', id: 'm1' }, { type: 'moon', id: 'm2' }] } } };
+    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: null } } };
+    const europa: Record = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: null } } };
+    const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' }, relationships: { moons: { data: [{ type: 'moon', id: 'm1' }, { type: 'moon', id: 'm2' }] } } };
 
     cache.patch(t => [
       t.addRecord(io),
@@ -204,12 +205,11 @@ module('SyncRecordCache', function(hooks) {
 
     assert.equal(cache.getRecordSync({ type: 'moon', id: 'm2' }), null, 'Europa is GONE');
 
-    assert.equal(cache.getRecordSync({ type: 'planet', id: 'p1' }).relationships.moons.data['moon:m1'], null, 'Io has been cleared from Jupiter');
-    assert.equal(cache.getRecordSync({ type: 'planet', id: 'p1' }).relationships.moons.data['moon:m2'], null, 'Europa has been cleared from Jupiter');
+    assert.deepEqual(cache.getRelatedRecordsSync({ type: 'planet', id: 'p1' }, 'moons'), [], 'moons have been cleared from Jupiter');
   });
 
   test('#patch adds link to hasMany if record doesn\'t exist', function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
     cache.patch(t => t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', { type: 'moon', id: 'm1' }));
 
@@ -219,7 +219,7 @@ module('SyncRecordCache', function(hooks) {
   test('#patch does not remove hasMany relationship if record doesn\'t exist', function(assert) {
     assert.expect(1);
 
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
     cache.on('patch', () => {
       assert.ok(false, 'no operations were applied');
@@ -233,7 +233,7 @@ module('SyncRecordCache', function(hooks) {
   test('#patch adds hasOne if record doesn\'t exist', function(assert) {
     assert.expect(2);
 
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
     const tb = cache.transformBuilder;
     const replacePlanet = tb.replaceRelatedRecord(
@@ -264,7 +264,7 @@ module('SyncRecordCache', function(hooks) {
   test('#patch will add empty hasOne link if record doesn\'t exist', function(assert) {
     assert.expect(2);
 
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
     const tb = cache.transformBuilder;
     const clearPlanet = tb.replaceRelatedRecord(
@@ -290,9 +290,9 @@ module('SyncRecordCache', function(hooks) {
   test('#patch does not add link to hasMany if link already exists', function(assert) {
     assert.expect(1);
 
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const jupiter = { id: 'p1', type: 'planet', attributes: { name: 'Jupiter' }, relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } } };
+    const jupiter: Record = { id: 'p1', type: 'planet', attributes: { name: 'Jupiter' }, relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } } };
 
     cache.patch(t => t.addRecord(jupiter));
 
@@ -308,9 +308,9 @@ module('SyncRecordCache', function(hooks) {
   test('#patch does not remove relationship from hasMany if relationship doesn\'t exist', function(assert) {
     assert.expect(1);
 
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const jupiter = { id: 'p1', type: 'planet', attributes: { name: 'Jupiter' } };
+    const jupiter: Record = { id: 'p1', type: 'planet', attributes: { name: 'Jupiter' } };
 
     cache.patch(t => t.addRecord(jupiter));
 
@@ -326,12 +326,12 @@ module('SyncRecordCache', function(hooks) {
   test('#patch can add and remove to has-many relationship', function(assert) {
     assert.expect(2);
 
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const jupiter = { id: 'jupiter', type: 'planet' };
+    const jupiter: Record = { id: 'jupiter', type: 'planet' };
     cache.patch(t => t.addRecord(jupiter));
 
-    const callisto = { id: 'callisto', type: 'moon' };
+    const callisto: Record = { id: 'callisto', type: 'moon' };
     cache.patch(t => t.addRecord(callisto));
 
     cache.patch(t => t.addToRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'callisto' }));
@@ -346,12 +346,12 @@ module('SyncRecordCache', function(hooks) {
   test('#patch can add and clear has-one relationship', function(assert) {
     assert.expect(2);
 
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const jupiter = { id: 'jupiter', type: 'planet' };
+    const jupiter: Record = { id: 'jupiter', type: 'planet' };
     cache.patch(t => t.addRecord(jupiter));
 
-    const callisto = { id: 'callisto', type: 'moon' };
+    const callisto: Record = { id: 'callisto', type: 'moon' };
     cache.patch(t => t.addRecord(callisto));
 
     cache.patch(t => t.replaceRelatedRecord(callisto, 'planet', { type: 'planet', id: 'jupiter' }));
@@ -366,9 +366,9 @@ module('SyncRecordCache', function(hooks) {
   test('does not replace hasOne if relationship already exists', function(assert) {
     assert.expect(1);
 
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const europa = { id: 'm1', type: 'moon', attributes: { name: 'Europa' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
+    const europa: Record = { id: 'm1', type: 'moon', attributes: { name: 'Europa' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
 
     cache.patch(t => t.addRecord(europa));
 
@@ -384,9 +384,9 @@ module('SyncRecordCache', function(hooks) {
   test('does not remove hasOne if relationship doesn\'t exist', function(assert) {
     assert.expect(1);
 
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const europa = { type: 'moon', id: 'm1', attributes: { name: 'Europa' }, relationships: { planet: { data: null } } };
+    const europa: Record = { type: 'moon', id: 'm1', attributes: { name: 'Europa' }, relationships: { planet: { data: null } } };
 
     cache.patch(t => t.addRecord(europa));
 
@@ -417,7 +417,7 @@ module('SyncRecordCache', function(hooks) {
       }
     });
 
-    let cache = new Cache({ schema: hasOneSchema, keyMap });
+    const cache = new Cache({ schema: hasOneSchema, keyMap });
 
     cache.patch(t => [
       t.addRecord({
@@ -464,11 +464,11 @@ module('SyncRecordCache', function(hooks) {
       }
     });
 
-    let cache = new Cache({ schema: dependentSchema, keyMap });
+    const cache = new Cache({ schema: dependentSchema, keyMap });
 
-    const jupiter = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' } };
-    const io = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
-    const europa = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
+    const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' } };
+    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
+    const europa: Record = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
 
     cache.patch(t => [
       t.addRecord(jupiter),
@@ -501,11 +501,11 @@ module('SyncRecordCache', function(hooks) {
       }
     });
 
-    let cache = new Cache({ schema: dependentSchema, keyMap });
+    const cache = new Cache({ schema: dependentSchema, keyMap });
 
-    const jupiter = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' } };
-    const io = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: { type: 'planet', id: 'p1' } } } };
-    const europa = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: { type: 'planet', id: 'p1' } } } };
+    const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' } };
+    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: { type: 'planet', id: 'p1' } } } };
+    const europa: Record = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: { type: 'planet', id: 'p1' } } } };
 
     cache.patch(t => [
       t.addRecord(jupiter),
@@ -524,7 +524,7 @@ module('SyncRecordCache', function(hooks) {
   });
 
   test('#patch merges records when "replacing" and will not stomp on attributes and relationships that are not replaced', function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
     cache.patch(t => [
@@ -567,7 +567,7 @@ module('SyncRecordCache', function(hooks) {
   });
 
   test('#patch can replace related records but only if they are different', function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
     cache.patch(t => [
@@ -632,16 +632,16 @@ module('SyncRecordCache', function(hooks) {
   });
 
   test('#patch merges records when "replacing" and _will_ replace specified attributes and relationships', function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
-    let earth = {
+    const earth: Record = {
       type: 'planet', id: '1',
       attributes: { name: 'Earth' },
       relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
     };
 
-    let jupiter = {
+    const jupiter: Record = {
       type: 'planet', id: '1',
       attributes: { name: 'Jupiter', classification: 'terrestrial' },
       relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
@@ -709,9 +709,9 @@ module('SyncRecordCache', function(hooks) {
   });
 
   test('#query can retrieve an individual record with `record`', function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    let jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
+    const jupiter: Record = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
     cache.patch(t => [t.addRecord(jupiter)]);
 
     assert.deepEqual(
@@ -721,13 +721,12 @@ module('SyncRecordCache', function(hooks) {
   });
 
   test('#query can perform a simple attribute filter by value equality', function(assert) {
-    let cache = new Cache({ schema, keyMap });
-    const tb = cache.transformBuilder;
+    const cache = new Cache({ schema, keyMap });
 
-    let jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
-    let earth = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
-    let venus = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
-    let mercury = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
+    const jupiter: Record = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
+    const earth: Record = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
+    const venus: Record = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
+    const mercury: Record = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
 
     cache.patch(t => [
       t.addRecord(jupiter),
@@ -745,12 +744,12 @@ module('SyncRecordCache', function(hooks) {
   });
 
   test('#query can perform a simple attribute filter by value comparison (gt, lt, gte & lte)', function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    let jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', sequence: 5, classification: 'gas giant', atmosphere: true } };
-    let earth = { type: 'planet', id: 'earth', attributes: { name: 'Earth', sequence: 3, classification: 'terrestrial', atmosphere: true } };
-    let venus = { type: 'planet', id: 'venus', attributes: { name: 'Venus', sequence: 2, classification: 'terrestrial', atmosphere: true } };
-    let mercury = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', sequence: 1, classification: 'terrestrial', atmosphere: false } };
+    const jupiter: Record = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', sequence: 5, classification: 'gas giant', atmosphere: true } };
+    const earth: Record = { type: 'planet', id: 'earth', attributes: { name: 'Earth', sequence: 3, classification: 'terrestrial', atmosphere: true } };
+    const venus: Record = { type: 'planet', id: 'venus', attributes: { name: 'Venus', sequence: 2, classification: 'terrestrial', atmosphere: true } };
+    const mercury: Record = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', sequence: 1, classification: 'terrestrial', atmosphere: false } };
 
     cache.patch(t => [
       t.addRecord(jupiter),
@@ -793,9 +792,9 @@ module('SyncRecordCache', function(hooks) {
   });
 
   test('#query can perform relatedRecords filters with operators `equal`, `all`, `some` and `none`', function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    let jupiter = {
+    const jupiter: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: { name: 'Jupiter', sequence: 5, classification: 'gas giant', atmosphere: true },
@@ -809,54 +808,54 @@ module('SyncRecordCache', function(hooks) {
         }
       }
     };
-    let earth = {
+    const earth: Record = {
       type: 'planet',
       id: 'earth',
       attributes: { name: 'Earth', sequence: 3, classification: 'terrestrial', atmosphere: true },
       relationships: { moons: { data: [{ type: 'moon', id: 'moon' }] } }
     };
-    let mars = {
+    const mars: Record = {
       type: 'planet',
       id: 'mars',
       attributes: { name: 'Mars', sequence: 4, classification: 'terrestrial', atmosphere: true },
       relationships: { moons: { data: [{ type: 'moon', id: 'phobos' }, { type: 'moon', id: 'deimos' }] } }
     };
-    let mercury = {
+    const mercury: Record = {
       type: 'planet',
       id: 'mercury',
       attributes: { name: 'Mercury', sequence: 1, classification: 'terrestrial', atmosphere: false }
     };
-    let theMoon = {
+    const theMoon: Record = {
       id: 'moon', type: 'moon',
       attributes: { name: 'The moon' },
       relationships: { planet: { data: { type: 'planet', id: 'earth' } } }
     };
-    let europa = {
+    const europa: Record = {
       id: 'europa', type: 'moon',
       attributes: { name: 'Europa' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    let ganymede = {
+    const ganymede: Record = {
       id: 'ganymede', type: 'moon',
       attributes: { name: 'Ganymede' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    let callisto = {
+    const callisto: Record = {
       id: 'callisto', type: 'moon',
       attributes: { name: 'Callisto' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    let phobos = {
+    const phobos: Record = {
       id: 'phobos', type: 'moon',
       attributes: { name: 'Phobos' },
       relationships: { planet: { data: { type: 'planet', id: 'mars' } } }
     };
-    let deimos = {
+    const deimos: Record = {
       id: 'deimos', type: 'moon',
       attributes: { name: 'Deimos' },
       relationships: { planet: { data: { type: 'planet', id: 'mars' } } }
     };
-    let titan = {
+    const titan: Record = {
       id: 'titan', type: 'moon',
       attributes: { name: 'titan' },
       relationships: {}
@@ -920,9 +919,9 @@ module('SyncRecordCache', function(hooks) {
   });
 
   test('#query can perform relatedRecord filters', function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    let jupiter = {
+    const jupiter: Record = {
       type: 'planet',
       id: 'jupiter',
       attributes: { name: 'Jupiter', sequence: 5, classification: 'gas giant', atmosphere: true },
@@ -936,54 +935,54 @@ module('SyncRecordCache', function(hooks) {
         }
       }
     };
-    let earth = {
+    const earth: Record = {
       type: 'planet',
       id: 'earth',
       attributes: { name: 'Earth', sequence: 3, classification: 'terrestrial', atmosphere: true },
       relationships: { moons: { data: [{ type: 'moon', id: 'moon' }] } }
     };
-    let mars = {
+    const mars: Record = {
       type: 'planet',
       id: 'mars',
       attributes: { name: 'Mars', sequence: 4, classification: 'terrestrial', atmosphere: true },
       relationships: { moons: { data: [{ type: 'moon', id: 'phobos' }, { type: 'moon', id: 'deimos' }] } }
     };
-    let mercury = {
+    const mercury: Record = {
       type: 'planet',
       id: 'mercury',
       attributes: { name: 'Mercury', sequence: 1, classification: 'terrestrial', atmosphere: false }
     };
-    let theMoon = {
+    const theMoon: Record = {
       id: 'moon', type: 'moon',
       attributes: { name: 'The moon' },
       relationships: { planet: { data: { type: 'planet', id: 'earth' } } }
     };
-    let europa = {
+    const europa: Record = {
       id: 'europa', type: 'moon',
       attributes: { name: 'Europa' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    let ganymede = {
+    const ganymede: Record = {
       id: 'ganymede', type: 'moon',
       attributes: { name: 'Ganymede' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    let callisto = {
+    const callisto: Record = {
       id: 'callisto', type: 'moon',
       attributes: { name: 'Callisto' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    let phobos = {
+    const phobos: Record = {
       id: 'phobos', type: 'moon',
       attributes: { name: 'Phobos' },
       relationships: { planet: { data: { type: 'planet', id: 'mars' } } }
     };
-    let deimos = {
+    const deimos: Record = {
       id: 'deimos', type: 'moon',
       attributes: { name: 'Deimos' },
       relationships: { planet: { data: { type: 'planet', id: 'mars' } } }
     };
-    let titan = {
+    const titan: Record = {
       id: 'titan', type: 'moon',
       attributes: { name: 'titan' },
       relationships: {}
@@ -1029,12 +1028,12 @@ module('SyncRecordCache', function(hooks) {
   });
 
   test('#query can perform a complex attribute filter by value', function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    let jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
-    let earth = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
-    let venus = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
-    let mercury = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
+    const jupiter: Record = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
+    const earth: Record = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
+    const venus: Record = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
+    const mercury: Record = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
 
     cache.patch(t => [
       t.addRecord(jupiter),
@@ -1056,12 +1055,12 @@ module('SyncRecordCache', function(hooks) {
   });
 
   test('#query can perform a filter on attributes, even when a particular record has none', function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    let jupiter = { type: 'planet', id: 'jupiter' };
-    let earth = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
-    let venus = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
-    let mercury = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
+    const jupiter: Record = { type: 'planet', id: 'jupiter' };
+    const earth: Record = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
+    const venus: Record = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
+    const mercury: Record = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
 
     cache.patch(t => [
       t.addRecord(jupiter),
@@ -1083,12 +1082,12 @@ module('SyncRecordCache', function(hooks) {
   });
 
   test('#query can sort by an attribute', function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    let jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
-    let earth = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
-    let venus = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
-    let mercury = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
+    const jupiter: Record = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
+    const earth: Record = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
+    const venus: Record = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
+    const mercury: Record = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
 
     cache.patch(t => [
       t.addRecord(jupiter),
@@ -1110,12 +1109,12 @@ module('SyncRecordCache', function(hooks) {
   });
 
   test('#query can sort by an attribute, even when a particular record has none', function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    let jupiter = { type: 'planet', id: 'jupiter' };
-    let earth = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
-    let venus = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
-    let mercury = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
+    const jupiter: Record = { type: 'planet', id: 'jupiter' };
+    const earth: Record = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
+    const venus: Record = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
+    const mercury: Record = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
 
     cache.patch(t => [
       t.addRecord(jupiter),
@@ -1137,12 +1136,12 @@ module('SyncRecordCache', function(hooks) {
   });
 
   test('#query can filter and sort by attributes', function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    let jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
-    let earth = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
-    let venus = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
-    let mercury = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
+    const jupiter: Record = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
+    const earth: Record = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
+    const venus: Record = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
+    const mercury: Record = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
 
     cache.patch(t => [
       t.addRecord(jupiter),
@@ -1164,12 +1163,12 @@ module('SyncRecordCache', function(hooks) {
   });
 
   test('#query can sort by an attribute in descending order', function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    let jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
-    let earth = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
-    let venus = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
-    let mercury = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
+    const jupiter: Record = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
+    const earth: Record = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
+    const venus: Record = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
+    const mercury: Record = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
 
     cache.patch(t => [
       t.addRecord(jupiter),
@@ -1191,12 +1190,12 @@ module('SyncRecordCache', function(hooks) {
   });
 
   test('#query can sort by according to multiple criteria', function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    let jupiter = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
-    let earth = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
-    let venus = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
-    let mercury = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
+    const jupiter: Record = { type: 'planet', id: 'jupiter', attributes: { name: 'Jupiter', classification: 'gas giant', atmosphere: true } };
+    const earth: Record = { type: 'planet', id: 'earth', attributes: { name: 'Earth', classification: 'terrestrial', atmosphere: true } };
+    const venus: Record = { type: 'planet', id: 'venus', attributes: { name: 'Venus', classification: 'terrestrial', atmosphere: true } };
+    const mercury: Record = { type: 'planet', id: 'mercury', attributes: { name: 'Mercury', classification: 'terrestrial', atmosphere: false } };
 
     cache.patch(t => [
       t.addRecord(jupiter),
@@ -1218,9 +1217,9 @@ module('SyncRecordCache', function(hooks) {
   });
 
   test('#query - findRecord - finds record', function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const jupiter = {
+    const jupiter: Record = {
       id: 'jupiter', type: 'planet',
       attributes: { name: 'Jupiter' },
       relationships: { moons: { data: [{ type: 'moon', id: 'callisto' }] } } };
@@ -1236,7 +1235,7 @@ module('SyncRecordCache', function(hooks) {
   });
 
   test('#query - findRecord - throws RecordNotFoundException if record doesn\'t exist', function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
     assert.throws(
       () => cache.query(q => q.findRecord({ type: 'planet', id: 'jupiter' })),
@@ -1245,14 +1244,14 @@ module('SyncRecordCache', function(hooks) {
   });
 
   test('#query - findRecords - finds matching records', function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const jupiter = {
+    const jupiter: Record = {
       id: 'jupiter', type: 'planet',
       attributes: { name: 'Jupiter' },
       relationships: { moons: { data: [{ type: 'moon', id: 'callisto' }] } } };
 
-    const callisto = {
+    const callisto: Record = {
       id: 'callisto', type: 'moon',
       attributes: { name: 'Callisto' },
       relationships: { planet: { data: [{ type: 'planet', id: 'jupiter' }] } } };
@@ -1269,21 +1268,21 @@ module('SyncRecordCache', function(hooks) {
   });
 
   test('#query - page - can paginate records by offset and limit', function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const jupiter = {
+    const jupiter: Record = {
       id: 'jupiter', type: 'planet',
       attributes: { name: 'Jupiter' } };
 
-    const earth = {
+    const earth: Record = {
       id: 'earth', type: 'planet',
       attributes: { name: 'Earth' } };
 
-    const venus = {
+    const venus: Record = {
       id: 'venus', type: 'planet',
       attributes: { name: 'Venus' } };
 
-    const mars = {
+    const mars: Record = {
       id: 'mars', type: 'planet',
       attributes: { name: 'Mars' } };
 
@@ -1311,14 +1310,14 @@ module('SyncRecordCache', function(hooks) {
   });
 
   test('#query - findRelatedRecords', function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const jupiter = {
+    const jupiter: Record = {
       id: 'jupiter', type: 'planet',
       attributes: { name: 'Jupiter' },
       relationships: { moons: { data: [{ type: 'moon', id: 'callisto' }] } } };
 
-    const callisto = {
+    const callisto: Record = {
       id: 'callisto', type: 'moon',
       attributes: { name: 'Callisto' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } } };
@@ -1335,14 +1334,14 @@ module('SyncRecordCache', function(hooks) {
   });
 
   test('#query - findRelatedRecord', function(assert) {
-    let cache = new Cache({ schema, keyMap });
+    const cache = new Cache({ schema, keyMap });
 
-    const jupiter = {
+    const jupiter: Record = {
       id: 'jupiter', type: 'planet',
       attributes: { name: 'Jupiter' },
       relationships: { moons: { data: [{ type: 'moon', id: 'callisto' }] } } };
 
-    const callisto = {
+    const callisto: Record = {
       id: 'callisto', type: 'moon',
       attributes: { name: 'Callisto' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } } };

--- a/packages/@orbit/record-cache/tsconfig.tests.json
+++ b/packages/@orbit/record-cache/tsconfig.tests.json
@@ -8,7 +8,8 @@
     "inlineSourceMap": true,
     "declaration": false,
     "newLine": "LF",
-    "types": ["qunit"]
+    "types": ["qunit"],
+    "noImplicitAny": true
   },
   "include": [
     "src/**/*.ts",

--- a/packages/@orbit/store/test/cache-test.ts
+++ b/packages/@orbit/store/test/cache-test.ts
@@ -1,5 +1,6 @@
 import {
   KeyMap,
+  Record,
   RecordNotFoundException,
   Schema,
   equalRecordIdentities,
@@ -13,8 +14,8 @@ import { arrayMembershipMatches } from './support/matchers';
 const { module, test } = QUnit;
 
 module('Cache', function(hooks) {
-  let schema: Schema,
-      keyMap: KeyMap;
+  let schema: Schema;
+  let keyMap: KeyMap;
 
   hooks.beforeEach(function() {
     schema = new Schema({
@@ -68,7 +69,7 @@ module('Cache', function(hooks) {
 
     let cache = new Cache({ schema, keyMap });
 
-    const earth = { type: 'planet', id: '1', attributes: { name: 'Earth' }, keys: { remoteId: 'a' } };
+    const earth: Record = { type: 'planet', id: '1', attributes: { name: 'Earth' }, keys: { remoteId: 'a' } };
 
     cache.on('patch', (operation, data) => {
       assert.deepEqual(operation, {
@@ -89,7 +90,7 @@ module('Cache', function(hooks) {
 
     let cache = new Cache({ schema, keyMap });
 
-    const earth = { type: 'planet', id: '1', attributes: { name: 'Earth' }, keys: { remoteId: 'a' } };
+    const earth: Record = { type: 'planet', id: '1', attributes: { name: 'Earth' }, keys: { remoteId: 'a' } };
 
     cache.on('patch', (operation, data) => {
       assert.deepEqual(operation, {
@@ -110,7 +111,7 @@ module('Cache', function(hooks) {
 
     let cache = new Cache({ schema, keyMap });
 
-    const earth = { type: 'planet', id: '1' };
+    const earth: Record = { type: 'planet', id: '1' };
 
     cache.on('patch', (operation, data) => {
       assert.deepEqual(operation, {
@@ -208,9 +209,9 @@ module('Cache', function(hooks) {
   test('#patch tracks refs and clears them from hasOne relationships when a referenced record is removed', function(assert) {
     let cache = new Cache({ schema, keyMap });
 
-    const jupiter = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' }, relationships: { moons: { data: undefined } } };
+    const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' }, relationships: { moons: { data: undefined } } };
     const io = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
-    const europa = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
+    const europa: Record = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
 
     cache.patch(t => [
       t.addRecord(jupiter),
@@ -232,9 +233,9 @@ module('Cache', function(hooks) {
   test('#patch tracks refs and clears them from hasMany relationships when a referenced record is removed', function(assert) {
     let cache = new Cache({ schema, keyMap });
 
-    var io = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: null } } };
-    var europa = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: null } } };
-    var jupiter = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' }, relationships: { moons: { data: [{ type: 'moon', id: 'm1' }, { type: 'moon', id: 'm2' }] } } };
+    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: null } } };
+    const europa: Record = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: null } } };
+    const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' }, relationships: { moons: { data: [{ type: 'moon', id: 'm1' }, { type: 'moon', id: 'm2' }] } } };
 
     cache.patch(t => [
       t.addRecord(io),
@@ -252,8 +253,7 @@ module('Cache', function(hooks) {
 
     assert.equal(cache.getRecordSync({ type: 'moon', id: 'm2' }), null, 'Europa is GONE');
 
-    assert.equal(cache.getRecordSync({ type: 'planet', id: 'p1' }).relationships.moons.data['moon:m1'], null, 'Io has been cleared from Jupiter');
-    assert.equal(cache.getRecordSync({ type: 'planet', id: 'p1' }).relationships.moons.data['moon:m2'], null, 'Europa has been cleared from Jupiter');
+    assert.deepEqual(cache.getRelatedRecordsSync({ type: 'planet', id: 'p1' }, 'moons'), [], 'Europa and Io have been cleared from Jupiter');
   });
 
   test('#patch adds link to hasMany if record doesn\'t exist', function(assert) {
@@ -261,7 +261,7 @@ module('Cache', function(hooks) {
 
     cache.patch(t => t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', { type: 'moon', id: 'm1' }));
 
-    assert.deepEqual(cache.getRecordSync({ type: 'planet', id: 'p1' }).relationships.moons.data, [{ type: 'moon', id: 'm1' }], 'relationship was added');
+    assert.deepEqual(cache.getRelatedRecordsSync({ type: 'planet', id: 'p1' }, 'moons'), [{ type: 'moon', id: 'm1' }], 'relationship was added');
   });
 
   test('#patch does not remove hasMany relationship if record doesn\'t exist', function(assert) {
@@ -340,7 +340,7 @@ module('Cache', function(hooks) {
 
     let cache = new Cache({ schema, keyMap });
 
-    const jupiter = { id: 'p1', type: 'planet', attributes: { name: 'Jupiter' }, relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } } };
+    const jupiter: Record = { id: 'p1', type: 'planet', attributes: { name: 'Jupiter' }, relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } } };
 
     cache.patch(t => t.addRecord(jupiter));
 
@@ -358,7 +358,7 @@ module('Cache', function(hooks) {
 
     let cache = new Cache({ schema, keyMap });
 
-    const jupiter = { id: 'p1', type: 'planet', attributes: { name: 'Jupiter' } };
+    const jupiter: Record = { id: 'p1', type: 'planet', attributes: { name: 'Jupiter' } };
 
     cache.patch(t => t.addRecord(jupiter));
 
@@ -376,7 +376,7 @@ module('Cache', function(hooks) {
 
     let cache = new Cache({ schema, keyMap });
 
-    const jupiter = { id: 'jupiter', type: 'planet' };
+    const jupiter: Record = { id: 'jupiter', type: 'planet' };
     cache.patch(t => t.addRecord(jupiter));
 
     const callisto = { id: 'callisto', type: 'moon' };
@@ -396,7 +396,7 @@ module('Cache', function(hooks) {
 
     let cache = new Cache({ schema, keyMap });
 
-    const jupiter = { id: 'jupiter', type: 'planet' };
+    const jupiter: Record = { id: 'jupiter', type: 'planet' };
     cache.patch(t => t.addRecord(jupiter));
 
     const callisto = { id: 'callisto', type: 'moon' };
@@ -416,7 +416,7 @@ module('Cache', function(hooks) {
 
     let cache = new Cache({ schema, keyMap });
 
-    const europa = { id: 'm1', type: 'moon', attributes: { name: 'Europa' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
+    const europa: Record = { id: 'm1', type: 'moon', attributes: { name: 'Europa' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
 
     cache.patch(t => t.addRecord(europa));
 
@@ -434,7 +434,7 @@ module('Cache', function(hooks) {
 
     let cache = new Cache({ schema, keyMap });
 
-    const europa = { type: 'moon', id: 'm1', attributes: { name: 'Europa' }, relationships: { planet: { data: null } } };
+    const europa: Record = { type: 'moon', id: 'm1', attributes: { name: 'Europa' }, relationships: { planet: { data: null } } };
 
     cache.patch(t => t.addRecord(europa));
 
@@ -514,9 +514,9 @@ module('Cache', function(hooks) {
 
     let cache = new Cache({ schema: dependentSchema, keyMap });
 
-    const jupiter = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' } };
+    const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' } };
     const io = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
-    const europa = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
+    const europa: Record = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
 
     cache.patch(t => [
       t.addRecord(jupiter),
@@ -551,9 +551,9 @@ module('Cache', function(hooks) {
 
     let cache = new Cache({ schema: dependentSchema, keyMap });
 
-    const jupiter = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' } };
+    const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' } };
     const io = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: { type: 'planet', id: 'p1' } } } };
-    const europa = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: { type: 'planet', id: 'p1' } } } };
+    const europa: Record = { type: 'moon', id: 'm2', attributes: { name: 'Europa' }, relationships: { planet: { data: { type: 'planet', id: 'p1' } } } };
 
     cache.patch(t => [
       t.addRecord(jupiter),
@@ -1271,7 +1271,7 @@ module('Cache', function(hooks) {
   test('#query - findRecord - finds record', function(assert) {
     let cache = new Cache({ schema, keyMap });
 
-    const jupiter = {
+    const jupiter: Record = {
       id: 'jupiter', type: 'planet',
       attributes: { name: 'Jupiter' },
       relationships: { moons: { data: [{ type: 'moon', id: 'callisto' }] } } };
@@ -1298,7 +1298,7 @@ module('Cache', function(hooks) {
   test('#query - findRecords - finds matching records', function(assert) {
     let cache = new Cache({ schema, keyMap });
 
-    const jupiter = {
+    const jupiter: Record = {
       id: 'jupiter', type: 'planet',
       attributes: { name: 'Jupiter' },
       relationships: { moons: { data: [{ type: 'moon', id: 'callisto' }] } } };
@@ -1322,11 +1322,11 @@ module('Cache', function(hooks) {
   test('#query - page - can paginate records by offset and limit', function(assert) {
     let cache = new Cache({ schema, keyMap });
 
-    const jupiter = {
+    const jupiter: Record = {
       id: 'jupiter', type: 'planet',
       attributes: { name: 'Jupiter' } };
 
-    const earth = {
+    const earth: Record = {
       id: 'earth', type: 'planet',
       attributes: { name: 'Earth' } };
 
@@ -1364,7 +1364,7 @@ module('Cache', function(hooks) {
   test('#query - findRelatedRecords', function(assert) {
     let cache = new Cache({ schema, keyMap });
 
-    const jupiter = {
+    const jupiter: Record = {
       id: 'jupiter', type: 'planet',
       attributes: { name: 'Jupiter' },
       relationships: { moons: { data: [{ type: 'moon', id: 'callisto' }] } } };
@@ -1388,7 +1388,7 @@ module('Cache', function(hooks) {
   test('#query - findRelatedRecord', function(assert) {
     let cache = new Cache({ schema, keyMap });
 
-    const jupiter = {
+    const jupiter: Record = {
       id: 'jupiter', type: 'planet',
       attributes: { name: 'Jupiter' },
       relationships: { moons: { data: [{ type: 'moon', id: 'callisto' }] } } };

--- a/packages/@orbit/store/test/cache/operation-processors/sync-cache-integrity-processor-test.ts
+++ b/packages/@orbit/store/test/cache/operation-processors/sync-cache-integrity-processor-test.ts
@@ -1,7 +1,14 @@
 import {
+  Record,
   Schema,
   SchemaSettings,
-  KeyMap
+  KeyMap,
+  ReplaceRelatedRecordOperation,
+  ReplaceRelatedRecordsOperation,
+  AddToRelatedRecordsOperation,
+  RemoveFromRelatedRecordsOperation,
+  RemoveRecordOperation,
+  ReplaceRecordOperation
 } from '@orbit/data';
 import { SyncCacheIntegrityProcessor } from '@orbit/record-cache';
 import Cache from '../../../src/cache';
@@ -9,7 +16,9 @@ import Cache from '../../../src/cache';
 const { module, test } = QUnit;
 
 module('SyncCacheIntegrityProcessor', function(hooks) {
-  let schema, cache, processor;
+  let schema: Schema;
+  let cache: Cache;
+  let processor: SyncCacheIntegrityProcessor;
 
   const schemaDefinition: SchemaSettings = {
     models: {
@@ -55,7 +64,7 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
     let keyMap = new KeyMap();
     schema = new Schema(schemaDefinition);
     cache = new Cache({ schema, keyMap, processors: [SyncCacheIntegrityProcessor] });
-    processor = cache._processors[0];
+    processor = cache.processors[0] as SyncCacheIntegrityProcessor;
   });
 
   hooks.afterEach(function() {
@@ -65,19 +74,19 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
   });
 
   test('reset empty cache', function(assert) {
-    const saturn = { type: 'planet', id: 'saturn',
+    const saturn: Record = { type: 'planet', id: 'saturn',
                     attributes: { name: 'Saturn' },
                     relationships: { moons: { data: [titanId] } } };
 
-    const jupiter = { type: 'planet', id: 'jupiter',
+    const jupiter: Record = { type: 'planet', id: 'jupiter',
                       attributes: { name: 'Jupiter' },
                       relationships: { moons: { data: [europaId] } } };
 
-    const titan = { type: 'moon', id: 'titan',
+    const titan: Record = { type: 'moon', id: 'titan',
                     attributes: { name: 'Titan' },
                     relationships: { planet: { data: saturnId } } };
 
-    const europa = { type: 'moon', id: 'europa',
+    const europa: Record = { type: 'moon', id: 'europa',
                     attributes: { name: 'Europa' },
                     relationships: { planet: { data: jupiterId } } };
 
@@ -114,19 +123,19 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
   });
 
   test('add to hasOne => hasMany', function(assert) {
-    const saturn = { type: 'planet', id: 'saturn',
+    const saturn: Record = { type: 'planet', id: 'saturn',
                     attributes: { name: 'Saturn' },
                     relationships: { moons: { data: [titanId] } } };
 
-    const jupiter = { type: 'planet', id: 'jupiter',
+    const jupiter: Record = { type: 'planet', id: 'jupiter',
                       attributes: { name: 'Jupiter' },
                       relationships: { moons: { data: [europaId] } } };
 
-    const titan = { type: 'moon', id: 'titan',
+    const titan: Record = { type: 'moon', id: 'titan',
                     attributes: { name: 'Titan' },
                     relationships: { planet: { data: saturnId} } };
 
-    const europa = { type: 'moon', id: 'europa',
+    const europa: Record = { type: 'moon', id: 'europa',
                     attributes: { name: 'Europa' },
                     relationships: { planet: { data: jupiterId } } };
 
@@ -161,7 +170,7 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
       relatedRecord: saturnId
     }]);
 
-    const addPlanetOp = {
+    const addPlanetOp: ReplaceRelatedRecordOperation = {
       op: 'replaceRelatedRecord',
       record: europaId,
       relationship: 'planet',
@@ -209,19 +218,19 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
   });
 
   test('replace hasOne => hasMany', function(assert) {
-    const saturn = { type: 'planet', id: 'saturn',
+    const saturn: Record = { type: 'planet', id: 'saturn',
                     attributes: { name: 'Saturn' },
                     relationships: { moons: { data: [titanId] } } };
 
-    const jupiter = { type: 'planet', id: 'jupiter',
+    const jupiter: Record = { type: 'planet', id: 'jupiter',
                       attributes: { name: 'Jupiter' },
                       relationships: { moons: { data: [europaId] } } };
 
-    const titan = { type: 'moon', id: 'titan',
+    const titan: Record = { type: 'moon', id: 'titan',
                     attributes: { name: 'Titan' },
                     relationships: { planet: { data: saturnId} } };
 
-    const europa = { type: 'moon', id: 'europa',
+    const europa: Record = { type: 'moon', id: 'europa',
                     attributes: { name: 'Europa' },
                     relationships: { planet: { data: jupiterId } } };
 
@@ -256,7 +265,7 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
       relatedRecord: saturnId
     }]);
 
-    const replacePlanetOp = {
+    const replacePlanetOp: ReplaceRelatedRecordOperation = {
       op: 'replaceRelatedRecord',
       record: europaId,
       relationship: 'planet',
@@ -306,11 +315,11 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
   });
 
   test('replace hasMany => hasOne with empty array', function(assert) {
-    const saturn = { type: 'planet', id: 'saturn',
+    const saturn: Record = { type: 'planet', id: 'saturn',
                     attributes: { name: 'Saturn' },
                     relationships: { moons: { data: [titanId] } } };
 
-    const titan = { type: 'moon', id: 'titan',
+    const titan: Record = { type: 'moon', id: 'titan',
                     attributes: { name: 'Titan' },
                     relationships: { planet: { data: saturnId} } };
 
@@ -331,7 +340,7 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
       relatedRecord: saturnId
     }]);
 
-    const clearMoonsOp = {
+    const clearMoonsOp: ReplaceRelatedRecordsOperation = {
       op: 'replaceRelatedRecords',
       record: saturn,
       relationship: 'moons',
@@ -363,14 +372,14 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
   });
 
   test('replace hasMany => hasOne with populated array', function(assert) {
-    const saturn = { type: 'planet', id: 'saturn',
+    const saturn: Record = { type: 'planet', id: 'saturn',
                     attributes: { name: 'Saturn' },
                     relationships: { moons: { data: [titanId] } } };
 
-    const jupiter = { type: 'planet', id: 'jupiter',
+    const jupiter: Record = { type: 'planet', id: 'jupiter',
                       attributes: { name: 'Jupiter' } };
 
-    const titan = { type: 'moon', id: 'titan',
+    const titan: Record = { type: 'moon', id: 'titan',
                     attributes: { name: 'Titan' },
                     relationships: { planet: { data: saturnId} } };
 
@@ -392,7 +401,7 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
       relatedRecord: saturnId
     }]);
 
-    const replaceMoonsOp = {
+    const replaceMoonsOp: ReplaceRelatedRecordsOperation = {
       op: 'replaceRelatedRecords',
       record: saturn,
       relationship: 'moons',
@@ -428,19 +437,19 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
   });
 
   test('replace hasMany => hasOne with populated array, when already populated', function(assert) {
-    const saturn = { type: 'planet', id: 'saturn',
+    const saturn: Record = { type: 'planet', id: 'saturn',
                     attributes: { name: 'Saturn' },
                     relationships: { moons: { data: [titanId] } } };
 
-    const jupiter = { type: 'planet', id: 'jupiter',
+    const jupiter: Record = { type: 'planet', id: 'jupiter',
                       attributes: { name: 'Jupiter' },
                       relationships: { moons: { data: [europaId] } } };
 
-    const titan = { type: 'moon', id: 'titan',
+    const titan: Record = { type: 'moon', id: 'titan',
                     attributes: { name: 'Titan' },
                     relationships: { planet: { data: saturnId } } };
 
-    const europa = { type: 'moon', id: 'europa',
+    const europa: Record = { type: 'moon', id: 'europa',
                     attributes: { name: 'Europa' },
                     relationships: { planet: { data: jupiterId } } };
 
@@ -475,7 +484,7 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
       relatedRecord: saturnId
     }]);
 
-    const replaceMoonsOp = {
+    const replaceMoonsOp: ReplaceRelatedRecordsOperation = {
       op: 'replaceRelatedRecords',
       record: saturn,
       relationship: 'moons',
@@ -524,7 +533,7 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
 
   test('replace hasMany => hasMany', function(assert) {
     const human = { type: 'inhabitant', id: 'human', relationships: { planets: { data: [earthId] } } };
-    const earth = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: [humanId] } } };
+    const earth: Record = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: [humanId] } } };
 
     cache.patch(t => [
       t.addRecord(human),
@@ -543,7 +552,7 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
       relatedRecord: humanId
     }]);
 
-    const clearInhabitantsOp = {
+    const clearInhabitantsOp: ReplaceRelatedRecordsOperation = {
       op: 'replaceRelatedRecords',
       record: earth,
       relationship: 'inhabitants',
@@ -570,19 +579,19 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
   });
 
   test('remove hasOne => hasMany', function(assert) {
-    const saturn = { type: 'planet', id: 'saturn',
+    const saturn: Record = { type: 'planet', id: 'saturn',
                     attributes: { name: 'Saturn' },
                     relationships: { moons: { data: [titanId] } } };
 
-    const jupiter = { type: 'planet', id: 'jupiter',
+    const jupiter: Record = { type: 'planet', id: 'jupiter',
                     attributes: { name: 'Jupiter' },
                     relationships: { moons: { data: [europaId] } } };
 
-    const titan = { type: 'moon', id: 'titan',
+    const titan: Record = { type: 'moon', id: 'titan',
                   attributes: { name: 'Titan' },
                   relationships: { planet: { data: saturnId} } };
 
-    const europa = { type: 'moon', id: 'europa',
+    const europa: Record = { type: 'moon', id: 'europa',
                     attributes: { name: 'Europa' },
                     relationships: { planet: { data: jupiterId } } };
 
@@ -617,7 +626,7 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
       relatedRecord: saturnId
     }]);
 
-    const removePlanetOp = {
+    const removePlanetOp: ReplaceRelatedRecordOperation = {
       op: 'replaceRelatedRecord',
       record: europa,
       relationship: 'planet',
@@ -661,15 +670,15 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
   });
 
   test('add to hasOne => hasOne', function(assert) {
-    const saturn = { type: 'planet', id: 'saturn',
+    const saturn: Record = { type: 'planet', id: 'saturn',
                     attributes: { name: 'Saturn' },
                     relationships: { next: { data: jupiterId } } };
 
-    const jupiter = { type: 'planet', id: 'jupiter',
+    const jupiter: Record = { type: 'planet', id: 'jupiter',
                       attributes: { name: 'Jupiter' },
                       relationships: { previous: { data: saturnId} } };
 
-    const earth = { type: 'planet', id: 'earth',
+    const earth: Record = { type: 'planet', id: 'earth',
                     attributes: { name: 'Earth' } };
 
     cache.patch(t => [
@@ -690,7 +699,7 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
       relatedRecord: saturnId
     }]);
 
-    const changePlanetOp = {
+    const changePlanetOp: ReplaceRelatedRecordOperation = {
       op: 'replaceRelatedRecord',
       record: earthId,
       relationship: 'next',
@@ -731,15 +740,15 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
   });
 
   test('replace hasOne => hasOne with existing value', function(assert) {
-    const saturn = { type: 'planet', id: 'saturn',
+    const saturn: Record = { type: 'planet', id: 'saturn',
                     attributes: { name: 'Saturn' },
                     relationships: { next: { data: jupiterId } } };
 
-    const jupiter = { type: 'planet', id: 'jupiter',
+    const jupiter: Record = { type: 'planet', id: 'jupiter',
                       attributes: { name: 'Jupiter' },
                       relationships: { previous: { data: saturnId} } };
 
-    const earth = { type: 'planet', id: 'earth',
+    const earth: Record = { type: 'planet', id: 'earth',
                     attributes: { name: 'Earth' } };
 
     cache.patch(t => [
@@ -760,7 +769,7 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
       relatedRecord: saturnId
     }]);
 
-    const changePlanetOp = {
+    const changePlanetOp: ReplaceRelatedRecordOperation = {
       op: 'replaceRelatedRecord',
       record: earthId,
       relationship: 'next',
@@ -811,7 +820,7 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
     assert.deepEqual(cache.getInverseRelationshipsSync(earth), []);
     assert.deepEqual(cache.getInverseRelationshipsSync(human), []);
 
-    const addPlanetOp = {
+    const addPlanetOp: AddToRelatedRecordsOperation = {
       op: 'addToRelatedRecords',
       record: humanId,
       relationship: 'planets',
@@ -841,7 +850,7 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
   });
 
   test('remove from hasMany => hasMany', function(assert) {
-    const earth = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: [humanId] } } };
+    const earth: Record = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: [humanId] } } };
     const human = { type: 'inhabitant', id: 'human', relationships: { planets: { data: [earthId] } } };
 
     cache.patch(t => [
@@ -861,7 +870,7 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
       relatedRecord: humanId
     }]);
 
-    const removePlanetOp = {
+    const removePlanetOp: RemoveFromRelatedRecordsOperation = {
       op: 'removeFromRelatedRecords',
       record: human,
       relationship: 'planets',
@@ -893,7 +902,7 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
   });
 
   test('remove record with hasMany relationships - verify processor', function(assert) {
-    const earth = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: [humanId] } } };
+    const earth: Record = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: [humanId] } } };
     const human = { type: 'inhabitant', id: 'human', relationships: { planets: { data: [earthId] } } };
 
     cache.patch(t => [
@@ -913,7 +922,7 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
       relatedRecord: humanId
     }]);
 
-    const removeInhabitantOp = {
+    const removeInhabitantOp: RemoveRecordOperation = {
       op: 'removeRecord',
       record: human
     };
@@ -942,7 +951,7 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
   });
 
   test('remove record with hasMany relationships - verify inverse relationships are cleared', function(assert) {
-    const earth = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: [humanId] } } };
+    const earth: Record = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: [humanId] } } };
     const human = { type: 'inhabitant', id: 'human', relationships: { planets: { data: [earthId] } } };
 
     cache.patch(t => [
@@ -988,7 +997,7 @@ module('SyncCacheIntegrityProcessor', function(hooks) {
       }
     };
 
-    const replaceHumanOp = {
+    const replaceHumanOp: ReplaceRecordOperation = {
       op: 'replaceRecord',
       record: humanOnEarth
     };

--- a/packages/@orbit/store/test/cache/operation-processors/sync-schema-consistency-processor-test.ts
+++ b/packages/@orbit/store/test/cache/operation-processors/sync-schema-consistency-processor-test.ts
@@ -1,8 +1,14 @@
 import {
   cloneRecordIdentity as identity,
   KeyMap,
+  Record,
   Schema,
-  SchemaSettings
+  SchemaSettings,
+  AddToRelatedRecordsOperation,
+  ReplaceRelatedRecordOperation,
+  ReplaceRelatedRecordsOperation,
+  RemoveFromRelatedRecordsOperation,
+  ReplaceRecordOperation
 } from '@orbit/data';
 import Cache from '../../../src/cache';
 import {
@@ -13,7 +19,9 @@ import {
 const { module, test } = QUnit;
 
 module('SyncSchemaConsistencyProcessor', function(hooks) {
-  let schema, cache, processor;
+  let schema: Schema;
+  let cache: Cache;
+  let processor: SyncSchemaConsistencyProcessor;
 
   const schemaDefinition: SchemaSettings = {
     models: {
@@ -52,7 +60,7 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
     let keyMap = new KeyMap();
     schema = new Schema(schemaDefinition);
     cache = new Cache({ schema, keyMap, processors: [SyncCacheIntegrityProcessor, SyncSchemaConsistencyProcessor] });
-    processor = cache._processors[1];
+    processor = cache.processors[1];
   });
 
   hooks.afterEach(function() {
@@ -62,19 +70,19 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
   });
 
   test('add to hasOne => hasMany', function(assert) {
-    const saturn = { type: 'planet', id: 'saturn',
+    const saturn: Record = { type: 'planet', id: 'saturn',
                     attributes: { name: 'Saturn' },
                     relationships: { moons: { data: [{ type: 'moon', id: 'titan' }] } } };
 
-    const jupiter = { type: 'planet', id: 'jupiter',
+    const jupiter: Record = { type: 'planet', id: 'jupiter',
                       attributes: { name: 'Jupiter' },
                       relationships: { moons: { data: [{ type: 'moon', id: 'europa' }] } } };
 
-    const titan = { type: 'moon', id: 'titan',
+    const titan: Record = { type: 'moon', id: 'titan',
                     attributes: { name: 'Titan' },
                     relationships: { planet: { data: { type: 'planet', id: 'saturn' } } } };
 
-    const europa = { type: 'moon', id: 'europa',
+    const europa: Record = { type: 'moon', id: 'europa',
                     attributes: { name: 'Europa' },
                     relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } } };
 
@@ -85,7 +93,7 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
       t.addRecord(europa)
     ]);
 
-    const addPlanetOp = {
+    const addPlanetOp: AddToRelatedRecordsOperation = {
       op: 'addToRelatedRecords',
       record: { type: 'moon', id: europa.id },
       relationship: 'planet',
@@ -116,19 +124,19 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
   });
 
   test('replace hasOne => hasMany', function(assert) {
-    const saturn = { type: 'planet', id: 'saturn',
+    const saturn: Record = { type: 'planet', id: 'saturn',
                     attributes: { name: 'Saturn' },
                     relationships: { moons: { data: [{ type: 'moon', id: 'titan' }] } } };
 
-    const jupiter = { type: 'planet', id: 'jupiter',
+    const jupiter: Record = { type: 'planet', id: 'jupiter',
                       attributes: { name: 'Jupiter' },
                       relationships: { moons: { data: [{ type: 'moon', id: 'europa' }] } } };
 
-    const titan = { type: 'moon', id: 'titan',
+    const titan: Record = { type: 'moon', id: 'titan',
                     attributes: { name: 'Titan' },
                     relationships: { planet: { data: { type: 'planet', id: 'saturn' } } } };
 
-    const europa = { type: 'moon', id: 'europa',
+    const europa: Record = { type: 'moon', id: 'europa',
                     attributes: { name: 'Europa' },
                     relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } } };
 
@@ -139,7 +147,7 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
       t.addRecord(europa)
     ]);
 
-    const replacePlanetOp = {
+    const replacePlanetOp: ReplaceRelatedRecordOperation = {
       op: 'replaceRelatedRecord',
       record: identity(europa),
       relationship: 'planet',
@@ -177,11 +185,11 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
   });
 
   test('replace hasMany => hasOne with empty array', function(assert) {
-    const saturn = { type: 'planet', id: 'saturn',
+    const saturn: Record = { type: 'planet', id: 'saturn',
                     attributes: { name: 'Saturn' },
                     relationships: { moons: { data: [{ type: 'moon', id: 'titan' }] } } };
 
-    const titan = { type: 'moon', id: 'titan',
+    const titan: Record = { type: 'moon', id: 'titan',
                     attributes: { name: 'Titan' },
                     relationships: { planet: { data: { type: 'planet', id: 'saturn' } } } };
 
@@ -190,7 +198,7 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
       t.addRecord(titan)
     ]);
 
-    const clearMoonsOp = {
+    const clearMoonsOp: ReplaceRelatedRecordsOperation = {
       op: 'replaceRelatedRecords',
       record: identity(saturn),
       relationship: 'moons',
@@ -221,15 +229,15 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
   });
 
   test('replace hasMany => hasOne with populated array', function(assert) {
-    const saturn = { type: 'planet', id: 'saturn',
+    const saturn: Record = { type: 'planet', id: 'saturn',
                     attributes: { name: 'Saturn' },
                     relationships: { moons: { data: [{ type: 'moon', id: 'titan' }] } } };
 
-    const titan = { type: 'moon', id: 'titan',
+    const titan: Record = { type: 'moon', id: 'titan',
                     attributes: { name: 'Titan' },
                     relationships: { planet: { data: { type: 'planet', id: 'saturn' } } } };
 
-    const jupiter = { type: 'planet', id: 'jupiter',
+    const jupiter: Record = { type: 'planet', id: 'jupiter',
                       attributes: { name: 'Jupiter' } };
 
     cache.patch(t => [
@@ -238,7 +246,7 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
       t.addRecord(titan)
     ]);
 
-    const replaceMoonsOp = {
+    const replaceMoonsOp: ReplaceRelatedRecordsOperation = {
       op: 'replaceRelatedRecords',
       record: identity(jupiter),
       relationship: 'moons',
@@ -269,19 +277,19 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
   });
 
   test('replace hasMany => hasOne with populated array, when already populated', function(assert) {
-    const saturn = { type: 'planet', id: 'saturn',
+    const saturn: Record = { type: 'planet', id: 'saturn',
                   attributes: { name: 'Saturn' },
                   relationships: { moons: { data: [{ type: 'moon', id: 'titan' }] } } };
 
-    const jupiter = { type: 'planet', id: 'jupiter',
+    const jupiter: Record = { type: 'planet', id: 'jupiter',
                     attributes: { name: 'Jupiter' },
                     relationships: { moons: { data: [{ type: 'moon', id: 'europa' }] } } };
 
-    const titan = { type: 'moon', id: 'titan',
+    const titan: Record = { type: 'moon', id: 'titan',
                   attributes: { name: 'Titan' },
                   relationships: { planet: { data: { type: 'planet', id: 'saturn' } } } };
 
-    const europa = { type: 'moon', id: 'europa',
+    const europa: Record = { type: 'moon', id: 'europa',
                   attributes: { name: 'Europa' },
                   relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } } };
 
@@ -292,7 +300,7 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
       t.addRecord(europa)
     ]);
 
-    const replaceMoonsOp = {
+    const replaceMoonsOp: ReplaceRelatedRecordsOperation = {
       op: 'replaceRelatedRecords',
       record: identity(saturn),
       relationship: 'moons',
@@ -330,14 +338,14 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
 
   test('replace hasMany => hasMany, clearing records', function(assert) {
     const human = { type: 'inhabitant', id: 'human', relationships: { planets: { data: [{ type: 'planet', id: 'earth' }] } } };
-    const earth = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: [{ type: 'inhabitant', id: 'human' }] } } };
+    const earth: Record = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: [{ type: 'inhabitant', id: 'human' }] } } };
 
     cache.patch(t => [
       t.addRecord(earth),
       t.addRecord(human)
     ]);
 
-    const clearInhabitantsOp = {
+    const clearInhabitantsOp: ReplaceRelatedRecordsOperation = {
       op: 'replaceRelatedRecords',
       record: identity(earth),
       relationship: 'inhabitants',
@@ -366,7 +374,7 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
     const human = { type: 'inhabitant', id: 'human', relationships: { planets: { data: [{ type: 'planet', id: 'earth' }] } } };
     const cat = { type: 'inhabitant', id: 'cat' };
     const dog = { type: 'inhabitant', id: 'dog' };
-    const earth = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: [{ type: 'inhabitant', id: 'human' }] } } };
+    const earth: Record = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: [{ type: 'inhabitant', id: 'human' }] } } };
 
     cache.patch(t => [
       t.addRecord(earth),
@@ -375,7 +383,7 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
       t.addRecord(dog)
     ]);
 
-    const clearInhabitantsOp = {
+    const clearInhabitantsOp: ReplaceRelatedRecordsOperation = {
       op: 'replaceRelatedRecords',
       record: identity(earth),
       relationship: 'inhabitants',
@@ -407,19 +415,19 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
   });
 
   test('remove hasOne => hasMany', function(assert) {
-    const saturn = { type: 'planet', id: 'saturn',
+    const saturn: Record = { type: 'planet', id: 'saturn',
                   attributes: { name: 'Saturn' },
                   relationships: { moons: { data: [{ type: 'moon', id: 'titan' }] } } };
 
-    const jupiter = { type: 'planet', id: 'jupiter',
+    const jupiter: Record = { type: 'planet', id: 'jupiter',
                     attributes: { name: 'Jupiter' },
                     relationships: { moons: { data: [{ type: 'moon', id: 'europa' }] } } };
 
-    const titan = { type: 'moon', id: 'titan',
+    const titan: Record = { type: 'moon', id: 'titan',
                   attributes: { name: 'Titan' },
                   relationships: { planet: { data: { type: 'planet', id: 'saturn' } } } };
 
-    const europa = { type: 'moon', id: 'europa',
+    const europa: Record = { type: 'moon', id: 'europa',
                   attributes: { name: 'Europa' },
                   relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } } };
 
@@ -430,7 +438,7 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
       t.addRecord(europa)
     ]);
 
-    const removePlanetOp = {
+    const removePlanetOp: ReplaceRelatedRecordOperation = {
       op: 'replaceRelatedRecord',
       record: identity(europa),
       relationship: 'planet',
@@ -461,15 +469,15 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
   });
 
   test('add to hasOne => hasOne', function(assert) {
-    const saturn = { type: 'planet', id: 'saturn',
+    const saturn: Record = { type: 'planet', id: 'saturn',
                   attributes: { name: 'Saturn' },
                   relationships: { next: { data: { type: 'planet', id: 'jupiter' } } } };
 
-    const jupiter = { type: 'planet', id: 'jupiter',
+    const jupiter: Record = { type: 'planet', id: 'jupiter',
                     attributes: { name: 'Jupiter' },
                     relationships: { previous: { data: { type: 'planet', id: 'saturn' } } } };
 
-    const earth = { type: 'planet', id: 'earth',
+    const earth: Record = { type: 'planet', id: 'earth',
                   attributes: { name: 'Earth' } };
 
     cache.patch(t => [
@@ -478,7 +486,7 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
       t.addRecord(earth)
     ]);
 
-    const changePlanetOp = {
+    const changePlanetOp: ReplaceRelatedRecordOperation = {
       op: 'replaceRelatedRecord',
       record: identity(earth),
       relationship: 'next',
@@ -509,15 +517,15 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
   });
 
   test('replace hasOne => hasOne with existing value', function(assert) {
-    const saturn = { type: 'planet', id: 'saturn',
+    const saturn: Record = { type: 'planet', id: 'saturn',
                   attributes: { name: 'Saturn' },
                   relationships: { next: { data: { type: 'planet', id: 'jupiter' } } } };
 
-    const jupiter = { type: 'planet', id: 'jupiter',
+    const jupiter: Record = { type: 'planet', id: 'jupiter',
                     attributes: { name: 'Jupiter' },
                     relationships: { previous: { data: { type: 'planet', id: 'saturn' } } } };
 
-    const earth = { type: 'planet', id: 'earth',
+    const earth: Record = { type: 'planet', id: 'earth',
                   attributes: { name: 'Earth' } };
 
     cache.patch(t => [
@@ -526,7 +534,7 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
       t.addRecord(earth)
     ]);
 
-    const changePlanetOp = {
+    const changePlanetOp: ReplaceRelatedRecordOperation = {
       op: 'replaceRelatedRecord',
       record: identity(earth),
       relationship: 'next',
@@ -557,15 +565,15 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
   });
 
   test('replace hasOne => hasOne with current existing value', function(assert) {
-    const saturn = { type: 'planet', id: 'saturn',
+    const saturn: Record = { type: 'planet', id: 'saturn',
                   attributes: { name: 'Saturn' },
                   relationships: { next: { data: { type: 'planet', id: 'jupiter' } } } };
 
-    const jupiter = { type: 'planet', id: 'jupiter',
+    const jupiter: Record = { type: 'planet', id: 'jupiter',
                     attributes: { name: 'Jupiter' },
                     relationships: { previous: { data: { type: 'planet', id: 'saturn' } } } };
 
-    const earth = { type: 'planet', id: 'earth',
+    const earth: Record = { type: 'planet', id: 'earth',
                   attributes: { name: 'Earth' } };
 
     cache.patch(t => [
@@ -574,7 +582,7 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
       t.addRecord(earth)
     ]);
 
-    const changePlanetOp = {
+    const changePlanetOp: ReplaceRelatedRecordOperation = {
       op: 'replaceRelatedRecord',
       record: identity(saturn),
       relationship: 'next',
@@ -598,7 +606,7 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
   });
 
   test('add to hasMany => hasMany', function(assert) {
-    const earth = { type: 'planet', id: 'earth' };
+    const earth: Record = { type: 'planet', id: 'earth' };
     const human = { type: 'inhabitant', id: 'human' };
 
     cache.patch(t => [
@@ -606,7 +614,7 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
       t.addRecord(human)
     ]);
 
-    const addPlanetOp = {
+    const addPlanetOp: AddToRelatedRecordsOperation = {
       op: 'addToRelatedRecords',
       record: identity(human),
       relationship: 'planets',
@@ -637,7 +645,7 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
   });
 
   test('remove from hasMany => hasMany', function(assert) {
-    const earth = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: [{ type: 'inhabitant', id: 'human' }] } } };
+    const earth: Record = { type: 'planet', id: 'earth', relationships: { inhabitants: { data: [{ type: 'inhabitant', id: 'human' }] } } };
     const human = { type: 'inhabitant', id: 'human', relationships: { planets: { data: [{ type: 'planet', id: 'earth' }] } } };
 
     cache.patch(t => [
@@ -645,7 +653,7 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
       t.addRecord(human)
     ]);
 
-    const removePlanetOp = {
+    const removePlanetOp: RemoveFromRelatedRecordsOperation = {
       op: 'removeFromRelatedRecords',
       record: identity(human),
       relationship: 'planets',
@@ -680,13 +688,13 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
     const cat = { type: 'inhabitant', id: 'cat' };
     const dog = { type: 'inhabitant', id: 'dog' };
     const moon = { type: 'moon', id: 'themoon' };
-    const saturn = { type: 'planet', id: 'saturn',
+    const saturn: Record = { type: 'planet', id: 'saturn',
                   attributes: { name: 'Saturn' },
                   relationships: { next: { data: { type: 'planet', id: 'jupiter' } } } };
-    const jupiter = { type: 'planet', id: 'jupiter',
+    const jupiter: Record = { type: 'planet', id: 'jupiter',
                     attributes: { name: 'Jupiter' },
                     relationships: { previous: { data: { type: 'planet', id: 'saturn' } } } };
-    const earth = {
+    const earth: Record = {
       type: 'planet', id: 'earth',
       relationships: {
         inhabitants: {
@@ -726,7 +734,7 @@ module('SyncSchemaConsistencyProcessor', function(hooks) {
       t.addRecord(dog)
     ]);
 
-    const clearInhabitantsOp = {
+    const clearInhabitantsOp: ReplaceRecordOperation = {
       op: 'replaceRecord',
       record: earth2
     };

--- a/packages/@orbit/store/test/cache/operation-processors/sync-schema-validation-processor-test.ts
+++ b/packages/@orbit/store/test/cache/operation-processors/sync-schema-validation-processor-test.ts
@@ -10,7 +10,8 @@ import { SyncSchemaValidationProcessor } from '@orbit/record-cache';
 const { module, test } = QUnit;
 
 module('SyncSchemaValidationProcessor', function(hooks) {
-  let schema, cache;
+  let schema: Schema;
+  let cache: Cache;
 
   const schemaDefinition: SchemaSettings = {
     models: {

--- a/packages/@orbit/store/test/support/matchers.ts
+++ b/packages/@orbit/store/test/support/matchers.ts
@@ -1,4 +1,4 @@
-export function arrayMembershipMatches(assert, actual, expected) {
+export function arrayMembershipMatches(assert: any, actual: any, expected: any) {
   assert.equal(actual.length, expected.length, 'array lengths match');
   for (let i = 0, l = actual.length; i < l; i++) {
     assert.ok(expected.indexOf(actual[i]) > -1, 'array contains member');

--- a/packages/@orbit/store/tsconfig.tests.json
+++ b/packages/@orbit/store/tsconfig.tests.json
@@ -8,7 +8,8 @@
     "inlineSourceMap": true,
     "declaration": false,
     "newLine": "LF",
-    "types": ["qunit"]
+    "types": ["qunit"],
+    "noImplicitAny": true
   },
   "include": [
     "src/**/*.ts",

--- a/packages/@orbit/utils/tsconfig.tests.json
+++ b/packages/@orbit/utils/tsconfig.tests.json
@@ -9,7 +9,8 @@
     "inlineSourceMap": true,
     "declaration": false,
     "newLine": "LF",
-    "types": ["qunit"] 
+    "types": ["qunit"],
+    "noImplicitAny": true
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
The bulk of this PR contains typing improvements for tests, which are driven by setting `noImplicitAny` for test builds (as was previously done for src builds). Improvements to tests also include some modernizations, such as increased use of async/await.

In addition, several interfaces were refined in preparation for v0.16:
* [core] The `listener` arg is optional for Evented#off
* [data] More flexible interfaces were introduced for query builder params. Query builder param interfaces are defined with a `QBParam` suffix to distinguish them from specifiers, which have a `Specifier` suffix. QB params can be less verbose and more friendly, as long as they can be converted into the more verbose specifier forms.
