### PR TITLE
[jsonapi] Consider application/json to be valid content

### DIFF
--- a/packages/@orbit/jsonapi/src/jsonapi-source.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-source.ts
@@ -279,7 +279,9 @@ export default class JSONAPISource extends Source implements Pullable, Pushable,
 
   responseHasContent(response: any): boolean {
     let contentType = response.headers.get('Content-Type');
-    return contentType && contentType.indexOf('application/vnd.api+json') > -1;
+    return contentType &&
+           (contentType.indexOf('application/vnd.api+json') > -1 ||
+            contentType.indexOf('application/json') > -1);
   }
 
   resourceNamespace(type?: string): string {

--- a/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
@@ -219,15 +219,18 @@ module('JSONAPISource', function() {
         });
     });
 
-    test('#responseHasContent - returns true if JSONAPI media type appears anywhere in Content-Type header', function(assert) {
+    test('#responseHasContent - returns true if application/json OR application/vnd.api+json appears anywhere in Content-Type header', function(assert) {
       let response = new Orbit.globals.Response('{ data: null }', { headers: { 'Content-Type': 'application/vnd.api+json' } });
       assert.equal(source.responseHasContent(response), true, 'Accepts content that is _only_ the JSONAPI media type.');
 
-      response = new Orbit.globals.Response('{ data: null }', { headers: { 'Content-Type': 'application/json,application/vnd.api+json; charset=utf-8' } });
+      response = new Orbit.globals.Response('{ data: null }', { headers: { 'Content-Type': 'multipart,application/vnd.api+json; charset=utf-8' } });
       assert.equal(source.responseHasContent(response), true, 'Position of JSONAPI media type is not important.');
 
       response = new Orbit.globals.Response('{ data: null }', { headers: { 'Content-Type': 'application/json' } });
-      assert.equal(source.responseHasContent(response), false, 'Plain json can not be parsed by default.');
+      assert.equal(source.responseHasContent(response), true, 'Source will attempt to parse plain json.');
+
+      response = new Orbit.globals.Response('{ data: null }', { headers: { 'Content-Type': 'application/xml' } });
+      assert.equal(source.responseHasContent(response), false, 'XML is not acceptable.');
     });
 
     test('#push - can add records', async function(assert) {


### PR DESCRIPTION
In an attempt to be more forgiving of server responses, the JSONAPISource will attempt to parse `Content-Type: application/json` as if it is compliant JSON:API. This eliminates a common error developers hit when using the JSONAPISource.

In order to be more strict and revert to the previous behavior, override the `responseHasContent` method.

Closes #487