### PR TITLE
[BREAKING] Expose assert + deprecate only on OrbitGlobal

### DIFF
--- a/packages/@orbit/coordinator/src/coordinator.ts
+++ b/packages/@orbit/coordinator/src/coordinator.ts
@@ -1,6 +1,8 @@
-import { Source } from '@orbit/data';
-import { Dict, assert, objectValues } from '@orbit/utils';
+import Orbit, { Source } from '@orbit/data';
+import { Dict, objectValues } from '@orbit/utils';
 import { Strategy } from './strategy';
+
+const { assert } = Orbit;
 
 export interface CoordinatorOptions {
   sources?: Source[];

--- a/packages/@orbit/coordinator/src/strategies/connection-strategy.ts
+++ b/packages/@orbit/coordinator/src/strategies/connection-strategy.ts
@@ -1,8 +1,9 @@
 import Coordinator, { ActivationOptions } from '../coordinator';
 import { Strategy, StrategyOptions } from '../strategy';
-import { Listener } from '@orbit/core';
+import Orbit, { Listener } from '@orbit/core';
 import { Source } from '@orbit/data';
-import { assert } from '@orbit/utils';
+
+const { assert } = Orbit;
 
 export interface ConnectionStrategyOptions extends StrategyOptions {
   /**

--- a/packages/@orbit/coordinator/src/strategies/sync-strategy.ts
+++ b/packages/@orbit/coordinator/src/strategies/sync-strategy.ts
@@ -1,6 +1,8 @@
 import { StrategyOptions } from '../strategy';
 import { ConnectionStrategy, ConnectionStrategyOptions } from './connection-strategy';
-import { assert } from '@orbit/utils';
+import Orbit from '@orbit/core';
+
+const { assert } = Orbit;
 
 export interface SyncStrategyOptions extends StrategyOptions {
   /**

--- a/packages/@orbit/coordinator/src/strategy.ts
+++ b/packages/@orbit/coordinator/src/strategy.ts
@@ -2,7 +2,8 @@ import Coordinator, { ActivationOptions, LogLevel } from './coordinator';
 import Orbit, {
   Source
 } from '@orbit/data';
-import { assert } from '@orbit/utils';
+
+const { assert } = Orbit;
 
 export interface StrategyOptions {
   /**

--- a/packages/@orbit/core/src/assert.ts
+++ b/packages/@orbit/core/src/assert.ts
@@ -1,9 +1,5 @@
 /**
  * Throw an exception if `test` is not truthy.
- * 
- * @export
- * @param {string} description Description of the error thrown
- * @param {boolean} test Value that should be truthy for assertion to pass
  */
 export function assert(description: string, test: boolean): void {
   if (!test) { throw new Error('Assertion failed: ' + description); }

--- a/packages/@orbit/core/src/deprecate.ts
+++ b/packages/@orbit/core/src/deprecate.ts
@@ -3,11 +3,6 @@ declare const console: any;
 /**
  * Display a deprecation warning with the provided message if the
  * provided `test` evaluates to a falsy value (or is missing).
- *
- * @export
- * @param {string} message Description of the deprecation
- * @param {(boolean | (() => boolean))} test An optional boolean or function that evaluates to a boolean.
- * @returns
  */
 export function deprecate(message: string, test?: boolean | (() => boolean) ): void {
   if (typeof test === 'function') {

--- a/packages/@orbit/core/src/evented.ts
+++ b/packages/@orbit/core/src/evented.ts
@@ -1,5 +1,7 @@
+import Orbit from './main';
 import Notifier, { Listener } from './notifier';
-import { deprecate } from '@orbit/utils';
+
+const { deprecate } = Orbit;
 
 export const EVENTED = '__evented__';
 

--- a/packages/@orbit/core/src/log.ts
+++ b/packages/@orbit/core/src/log.ts
@@ -1,8 +1,10 @@
-import { assert } from '@orbit/utils';
+import Orbit from './main';
 import evented, { Evented } from './evented';
 import { Listener } from './notifier';
 import { Bucket } from './bucket';
 import { NotLoggedException, OutOfRangeException } from './exception';
+
+const { assert } = Orbit;
 
 export interface LogOptions {
   name?: string;

--- a/packages/@orbit/core/src/main.ts
+++ b/packages/@orbit/core/src/main.ts
@@ -1,3 +1,5 @@
+import { assert } from './assert';
+import { deprecate } from './deprecate';
 import { uuid } from '@orbit/utils';
 
 declare const self: any;
@@ -5,6 +7,8 @@ declare const global: any;
 
 export interface OrbitGlobal {
   globals: any;
+  assert: (description: string, test: boolean) => void;
+  deprecate: (message: string, test?: boolean | (() => boolean) ) => void;
   uuid: () => string;
 }
 
@@ -23,6 +27,8 @@ const globals = typeof self == 'object' && self.self === self && self ||
 
 const Orbit: OrbitGlobal = {
   globals,
+  assert,
+  deprecate,
   uuid
 };
 

--- a/packages/@orbit/core/src/notifier.ts
+++ b/packages/@orbit/core/src/notifier.ts
@@ -1,4 +1,6 @@
-import { deprecate } from '@orbit/utils';
+import Orbit from './main';
+
+const { deprecate } = Orbit;
 
 export type Listener = (...args: any[]) => any;
 

--- a/packages/@orbit/core/src/task-queue.ts
+++ b/packages/@orbit/core/src/task-queue.ts
@@ -1,9 +1,11 @@
+import Orbit from './main';
 import { Task, Performer } from './task';
 import TaskProcessor from './task-processor';
 import { Bucket } from './bucket';
 import evented, { Evented, settleInSeries } from './evented';
 import { Listener } from './notifier';
-import { assert } from '@orbit/utils';
+
+const { assert } = Orbit;
 
 /**
  * Settings for a `TaskQueue`.

--- a/packages/@orbit/data/src/source-interfaces/pullable.ts
+++ b/packages/@orbit/data/src/source-interfaces/pullable.ts
@@ -1,8 +1,9 @@
-import { assert } from '@orbit/utils';
-import { settleInSeries, fulfillInSeries } from '@orbit/core';
+import Orbit, { settleInSeries, fulfillInSeries } from '@orbit/core';
 import { Source, SourceClass } from '../source';
 import { Query, QueryOrExpression, buildQuery } from '../query';
 import { Transform } from '../transform';
+
+const { assert } = Orbit;
 
 export const PULLABLE = '__pullable__';
 

--- a/packages/@orbit/data/src/source-interfaces/pushable.ts
+++ b/packages/@orbit/data/src/source-interfaces/pushable.ts
@@ -1,7 +1,8 @@
-import { assert } from '@orbit/utils';
-import { settleInSeries, fulfillInSeries } from '@orbit/core';
+import Orbit, { settleInSeries, fulfillInSeries } from '@orbit/core';
 import { Source, SourceClass } from '../source';
 import { Transform, TransformOrOperations, buildTransform } from '../transform';
+
+const { assert } = Orbit;
 
 export const PUSHABLE = '__pushable__';
 

--- a/packages/@orbit/data/src/source-interfaces/queryable.ts
+++ b/packages/@orbit/data/src/source-interfaces/queryable.ts
@@ -1,7 +1,8 @@
-import { assert } from '@orbit/utils';
-import { settleInSeries, fulfillInSeries } from '@orbit/core';
+import Orbit, { settleInSeries, fulfillInSeries } from '@orbit/core';
 import { Query, QueryOrExpression, buildQuery } from '../query';
 import { Source, SourceClass } from '../source';
+
+const { assert } = Orbit;
 
 export const QUERYABLE = '__queryable__';
 

--- a/packages/@orbit/data/src/source-interfaces/syncable.ts
+++ b/packages/@orbit/data/src/source-interfaces/syncable.ts
@@ -1,7 +1,9 @@
-import { assert, isArray } from '@orbit/utils';
-import { fulfillInSeries, settleInSeries } from '@orbit/core';
+import { isArray } from '@orbit/utils';
+import Orbit, { fulfillInSeries, settleInSeries } from '@orbit/core';
 import { Source, SourceClass } from '../source';
 import { Transform } from '../transform';
+
+const { assert } = Orbit;
 
 export const SYNCABLE = '__syncable__';
 

--- a/packages/@orbit/data/src/source-interfaces/updatable.ts
+++ b/packages/@orbit/data/src/source-interfaces/updatable.ts
@@ -1,7 +1,8 @@
-import { assert } from '@orbit/utils';
-import { settleInSeries, fulfillInSeries } from '@orbit/core';
+import Orbit, { settleInSeries, fulfillInSeries } from '@orbit/core';
 import { Source, SourceClass } from '../source';
 import { Transform, TransformOrOperations, buildTransform } from '../transform';
+
+const { assert } = Orbit;
 
 export const UPDATABLE = '__updatable__';
 

--- a/packages/@orbit/data/src/source.ts
+++ b/packages/@orbit/data/src/source.ts
@@ -1,5 +1,4 @@
-import Orbit from './main';
-import {
+import Orbit, {
   evented, Evented, settleInSeries,
   Bucket,
   TaskQueue,
@@ -13,7 +12,8 @@ import Schema from './schema';
 import QueryBuilder from './query-builder';
 import { Transform } from './transform';
 import TransformBuilder from './transform-builder';
-import { assert } from '@orbit/utils';
+
+const { assert } = Orbit;
 
 export interface SourceSettings {
   name?: string;

--- a/packages/@orbit/indexeddb-bucket/src/bucket.ts
+++ b/packages/@orbit/indexeddb-bucket/src/bucket.ts
@@ -1,8 +1,9 @@
 import Orbit, {
   Bucket, BucketSettings
 } from '@orbit/core';
-import { assert } from '@orbit/utils';
 import { supportsIndexedDB } from './lib/indexeddb';
+
+const { assert } = Orbit;
 
 declare const console: any;
 

--- a/packages/@orbit/indexeddb/src/cache.ts
+++ b/packages/@orbit/indexeddb/src/cache.ts
@@ -1,5 +1,3 @@
-/* eslint-disable valid-jsdoc */
-import { assert } from '@orbit/utils';
 import Orbit, {
   serializeRecordIdentity,
   deserializeRecordIdentity,
@@ -17,6 +15,8 @@ import {
   QueryResultData
 } from '@orbit/record-cache';
 import { supportsIndexedDB } from './lib/indexeddb';
+
+const { assert } = Orbit;
 
 const INVERSE_RELS = '__inverseRels__';
 

--- a/packages/@orbit/indexeddb/src/source.ts
+++ b/packages/@orbit/indexeddb/src/source.ts
@@ -14,9 +14,10 @@ import Orbit, {
   ReplaceRecordOperation,
   Record
 } from '@orbit/data';
-import { assert } from '@orbit/utils';
 import { supportsIndexedDB } from './lib/indexeddb';
 import IndexedDBCache, { IndexedDBCacheSettings } from './cache';
+
+const { assert } = Orbit;
 
 export interface IndexedDBSourceSettings extends SourceSettings {
   namespace?: string;

--- a/packages/@orbit/jsonapi/src/jsonapi-source.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-source.ts
@@ -13,12 +13,14 @@ import Orbit, {
   Queryable, queryable,
   Record
 } from '@orbit/data';
-import { assert, deepMerge, deprecate } from '@orbit/utils';
+import { deepMerge } from '@orbit/utils';
 import JSONAPISerializer, { JSONAPISerializerSettings } from './jsonapi-serializer';
 import { appendQueryParams } from './lib/query-params';
 import { getTransformRequests, TransformRequestProcessors } from './lib/transform-requests';
 import { InvalidServerResponse } from './lib/exceptions';
 import { QueryOperator, QueryOperators } from "./lib/query-operators";
+
+const { assert, deprecate } = Orbit;
 
 export interface FetchSettings {
   headers?: object;

--- a/packages/@orbit/jsonapi/src/lib/request-settings.ts
+++ b/packages/@orbit/jsonapi/src/lib/request-settings.ts
@@ -1,6 +1,8 @@
-import { clone, deepGet, deepMerge, deepSet, deprecate, isArray } from '@orbit/utils';
+import { clone, deepGet, deepMerge, deepSet, isArray } from '@orbit/utils';
 import { FetchSettings } from '../jsonapi-source';
-import { Source, Query, Transform } from '@orbit/data';
+import Orbit, { Source, Query, Transform } from '@orbit/data';
+
+const { deprecate } = Orbit;
 
 export interface Filter {
   [filterOn: string]: any;

--- a/packages/@orbit/local-storage-bucket/src/bucket.ts
+++ b/packages/@orbit/local-storage-bucket/src/bucket.ts
@@ -1,8 +1,9 @@
 import Orbit, {
   Bucket, BucketSettings
 } from '@orbit/core';
-import { assert } from '@orbit/utils';
 import { supportsLocalStorage } from './lib/local-storage';
+
+const { assert } = Orbit;
 
 export interface LocalStorageBucketSettings extends BucketSettings {
   delimiter?: string;

--- a/packages/@orbit/local-storage/src/source.ts
+++ b/packages/@orbit/local-storage/src/source.ts
@@ -1,4 +1,4 @@
-import {
+import Orbit, {
   buildTransform,
   Operation,
   pullable, Pullable,
@@ -15,9 +15,10 @@ import {
   RecordOperation,
   ReplaceRecordOperation
 } from '@orbit/data';
-import { assert } from '@orbit/utils';
 import { supportsLocalStorage } from './lib/local-storage';
 import LocalStorageCache, { LocalStorageCacheSettings } from './cache';
+
+const { assert } = Orbit;
 
 export interface LocalStorageSourceSettings extends SourceSettings {
   delimiter?: string;

--- a/packages/@orbit/record-cache/src/async-record-cache.ts
+++ b/packages/@orbit/record-cache/src/async-record-cache.ts
@@ -1,9 +1,9 @@
-import {
+import Orbit, {
   evented,
   Evented,
   Listener
 } from '@orbit/core';
-import { assert, isArray, deepGet, Dict } from '@orbit/utils';
+import { isArray, deepGet, Dict } from '@orbit/utils';
 import {
   KeyMap,
   Record,
@@ -27,6 +27,8 @@ import { AsyncInversePatchOperators, AsyncInversePatchOperator } from './operato
 import { AsyncRecordAccessor, RecordRelationshipIdentity } from './record-accessor';
 import { PatchResult } from './patch-result';
 import { QueryResultData } from './query-result';
+
+const { assert } = Orbit;
 
 export interface AsyncRecordCacheSettings {
   schema?: Schema;

--- a/packages/@orbit/record-cache/src/sync-record-cache.ts
+++ b/packages/@orbit/record-cache/src/sync-record-cache.ts
@@ -1,9 +1,9 @@
-import {
+import Orbit, {
   evented,
   Evented,
   Listener
 } from '@orbit/core';
-import { assert, isArray, deepGet, Dict } from '@orbit/utils';
+import { isArray, deepGet, Dict } from '@orbit/utils';
 import {
   KeyMap,
   Record,
@@ -27,6 +27,8 @@ import { SyncInversePatchOperators, SyncInversePatchOperator } from './operators
 import { SyncRecordAccessor, RecordRelationshipIdentity } from './record-accessor';
 import { PatchResult } from './patch-result';
 import { QueryResultData } from './query-result';
+
+const { assert } = Orbit;
 
 export interface SyncRecordCacheSettings {
   schema?: Schema;

--- a/packages/@orbit/store/src/store.ts
+++ b/packages/@orbit/store/src/store.ts
@@ -12,9 +12,11 @@ import Orbit, {
   coalesceRecordOperations,
   buildTransform
 } from '@orbit/data';
-import { assert, Dict } from '@orbit/utils';
+import { Dict } from '@orbit/utils';
 import Cache, { CacheSettings } from './cache';
 import { PatchResultData } from '@orbit/record-cache';
+
+const { assert } = Orbit;
 
 export interface StoreSettings extends SourceSettings {
   base?: Store;

--- a/packages/@orbit/utils/src/index.ts
+++ b/packages/@orbit/utils/src/index.ts
@@ -1,6 +1,4 @@
 export * from './arrays';
-export * from './assert';
-export * from './deprecate';
 export * from './dict';
 export * from './eq';
 export * from './objects';


### PR DESCRIPTION
By exposing `assert` and `deprecate` only on the global `Orbit` atom, these methods can be more easily overridden and tested for specific builds.

Correct usage is now:

```ts
import Orbit from '@orbit/core'; // or '@orbit/data'

const { assert, deprecate } = Orbit;
```

[BREAKING] Removes `assert` and `deprecate` exports from `@orbit/utils` to avoid potential confusion.
