### PR TITLE
Introduce "hints" for requests

### DIFF
--- a/packages/@orbit/coordinator/src/strategies/connection-strategy.ts
+++ b/packages/@orbit/coordinator/src/strategies/connection-strategy.ts
@@ -100,7 +100,7 @@ export class ConnectionStrategy extends Strategy {
 
   async activate(coordinator: Coordinator, options: ActivationOptions = {}): Promise<void> {
     await super.activate(coordinator, options);
-    this._listener = this._generateListener();
+    this._listener = this.generateListener();
     this.source.on(this._event, this._listener);
   }
 
@@ -110,7 +110,7 @@ export class ConnectionStrategy extends Strategy {
     this._listener = null;
   }
 
-  protected _generateListener(): Listener {
+  protected generateListener(): Listener {
     const target = this.target as any;
 
     return (...args: any[]) => {

--- a/packages/@orbit/coordinator/src/strategies/request-strategy.ts
+++ b/packages/@orbit/coordinator/src/strategies/request-strategy.ts
@@ -1,9 +1,79 @@
 import { ConnectionStrategy, ConnectionStrategyOptions } from './connection-strategy';
+import { Listener } from '@orbit/core';
 
-export interface RequestStrategyOptions extends ConnectionStrategyOptions {}
+export interface RequestStrategyOptions extends ConnectionStrategyOptions {
+  /**
+   * Should results returned from calling `action` on the `target` source be
+   * passed as hint data back to the `source`?
+   *
+   * This can allow hints to inform the processing of subsequent actions on the
+   * source. For instance, a `beforeQuery` event might invoke `query` on a
+   * target, and those results could inform how the originating source performs
+   * `_query`. This might allow a target source's sorting and filtering of
+   * results to affect how the originating source processes the query.
+   *
+   * This setting is only effective for `blocking` strategies, since only in
+   * those scenarios is processing delayed.
+   */
+  passHints?: boolean;
+}
 
 export class RequestStrategy extends ConnectionStrategy {
+  public passHints: boolean;
+
   constructor(options: RequestStrategyOptions) {
     super(options);
+
+    this.passHints = options.passHints;
+  }
+
+  protected generateListener(): Listener {
+    const target = this.target as any;
+
+    return (data: any, hints: any): any => {
+      let result;
+
+      if (this._filter) {
+        if (!this._filter(data, hints)) {
+          return;
+        }
+      }
+
+      if (typeof this._action === 'string') {
+        result = target[this._action](data);
+      } else {
+        result = this._action(data);
+      }
+
+      if (this._catch && result && result.catch) {
+        result = result.catch((e: Error) => {
+          return this._catch(e, data);
+        });
+      }
+
+      if (result && result.then) {
+        let blocking = false;
+        if (typeof this._blocking === 'function') {
+          if (this._blocking(data)) {
+            blocking = true;
+          }
+        } else if (this._blocking) {
+          blocking = true;
+        }
+
+        if (blocking) {
+          if (this.passHints && typeof hints === 'object') {
+            return this.applyHint(hints, result);
+          } else {
+            return result;
+          }
+        }
+      }
+    };
+  }
+
+  protected async applyHint(hints: any, result: Promise<any>): Promise<void> {
+    return hints.data = await result;
   }
 }
+

--- a/packages/@orbit/data/src/source-interfaces/pullable.ts
+++ b/packages/@orbit/data/src/source-interfaces/pullable.ts
@@ -27,7 +27,7 @@ export interface Pullable {
    */
   pull(queryOrExpression: QueryOrExpression, options?: object, id?: string): Promise<Transform[]>;
 
-  _pull(query: Query): Promise<Transform[]>;
+  _pull(query: Query, hints?: any): Promise<Transform[]>;
 }
 
 /**
@@ -71,8 +71,9 @@ export default function pullable(Klass: SourceClass): void {
   }
 
   proto.__pull__ = function(query: Query): Promise<Transform[]> {
-    return fulfillInSeries(this, 'beforePull', query)
-      .then(() => this._pull(query))
+    const hints: any = {};
+    return fulfillInSeries(this, 'beforePull', query, hints)
+      .then(() => this._pull(query, hints))
       .then(result => this._transformed(result))
       .then(result => {
         return settleInSeries(this, 'pull', query, result)

--- a/packages/@orbit/data/src/source-interfaces/pushable.ts
+++ b/packages/@orbit/data/src/source-interfaces/pushable.ts
@@ -30,7 +30,7 @@ export interface Pushable {
    */
   push(transformOrOperations: TransformOrOperations, options?: object, id?: string): Promise<Transform[]>;
 
-  _push(transform: Transform): Promise<Transform[]>;
+  _push(transform: Transform, hints?: any): Promise<Transform[]>;
 }
 
 /**
@@ -83,12 +83,13 @@ export default function pushable(Klass: SourceClass): void {
       return Promise.resolve([]);
     }
 
-    return fulfillInSeries(this, 'beforePush', transform)
+    const hints: any = {};
+    return fulfillInSeries(this, 'beforePush', transform, hints)
       .then(() => {
         if (this.transformLog.contains(transform.id)) {
           return Promise.resolve([]);
         } else {
-          return this._push(transform)
+          return this._push(transform, hints)
             .then((result: Transform[]) => {
               return this._transformed(result)
                 .then(() => settleInSeries(this, 'push', transform, result))

--- a/packages/@orbit/data/src/source-interfaces/queryable.ts
+++ b/packages/@orbit/data/src/source-interfaces/queryable.ts
@@ -24,7 +24,7 @@ export interface Queryable {
    */
   query(queryOrExpression: QueryOrExpression, options?: object, id?: string): Promise<any>;
 
-  _query(query: Query): Promise<any>;
+  _query(query: Query, hints?: any): Promise<any>;
 }
 
 /**
@@ -67,8 +67,9 @@ export default function queryable(Klass: SourceClass): void {
   }
 
   proto.__query__ = function(query: Query): Promise<any> {
-    return fulfillInSeries(this, 'beforeQuery', query)
-      .then(() => this._query(query))
+    const hints: any = {};
+    return fulfillInSeries(this, 'beforeQuery', query, hints)
+      .then(() => this._query(query, hints))
       .then((result: any) => {
         return settleInSeries(this, 'query', query, result)
           .then(() => result);

--- a/packages/@orbit/data/src/source-interfaces/updatable.ts
+++ b/packages/@orbit/data/src/source-interfaces/updatable.ts
@@ -25,7 +25,7 @@ export interface Updatable {
    */
   update(transformOrOperations: TransformOrOperations, options?: object, id?: string): Promise<any>;
 
-  _update(transform: Transform): Promise<any>;
+  _update(transform: Transform, hints?: any): Promise<any>;
 }
 
 /**
@@ -77,12 +77,13 @@ export default function updatable(Klass: SourceClass): void {
       return Promise.resolve();
     }
 
-    return fulfillInSeries(this, 'beforeUpdate', transform)
+    const hints: any = {};
+    return fulfillInSeries(this, 'beforeUpdate', transform, hints)
       .then(() => {
         if (this.transformLog.contains(transform.id)) {
           return Promise.resolve();
         } else {
-          return this._update(transform)
+          return this._update(transform, hints)
             .then((result: any) => {
               return this._transformed([transform])
                 .then(() => settleInSeries(this, 'update', transform, result))


### PR DESCRIPTION
Request "hints" are a new feature that allows event listeners to influence how an action is performed by a primary source. For instance, hints could allow `store.query()` to return results with the precise order and filtering dictated by another source, such as the `JSONAPISource`.

Hints are now available to every interface that participates in the [request flow](https://orbitjs.com/v0.15/guide/data-flows.html), including: `Pullable`, `Pushable`, `Queryable`, and `Updatable`.

A new `hints` argument, initialized as an empty object, is now passed to every `before` listener as a second argument. Listeners can provide “hints” by adding members to this object that will enable the source to fulfill the request. The `hints` object is then passed as a second argument to the source's internal action processor, such as `_query` or `_pull`.

Hints have also been incorporated as an option for `RequestStrategy`. Request strategies that are created with both `blocking: true` and `passHints: true` will now pass the results of invoking a request on the `target` source back on the `hints` object as a `data` member.

For the next phase of this work, select sources will be updated to change their processing based upon hints. For instance, `Store#query` will use any hints provided to return a specified set of records in the order specified. More PRs to follow soon ...