### PR TITLE
Expand areas in which meta data is allowed

### DIFF
--- a/packages/@orbit/data/src/record.ts
+++ b/packages/@orbit/data/src/record.ts
@@ -2,7 +2,7 @@ import { Dict, isObject, isNone, merge } from '@orbit/utils';
 
 export interface LinkObject {
   href: string;
-  meta?: any;
+  meta?: Dict<any>;
 }
 
 export type Link = string | LinkObject;
@@ -15,11 +15,13 @@ export interface RecordIdentity {
 export interface RecordHasOneRelationship {
   data?: RecordIdentity | null;
   links?: Dict<Link>;
+  meta?: Dict<any>;
 }
 
 export interface RecordHasManyRelationship {
   data?: RecordIdentity[];
   links?: Dict<Link>;
+  meta?: Dict<any>;
 }
 
 export type RecordRelationship = RecordHasOneRelationship | RecordHasManyRelationship;
@@ -29,6 +31,7 @@ export interface Record extends RecordIdentity {
   attributes?: Dict<any>;
   relationships?: Dict<RecordRelationship>;
   links?: Dict<Link>;
+  meta?: Dict<any>;
 }
 
 export interface RecordInitializer {

--- a/packages/@orbit/jsonapi/src/jsonapi-document.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-document.ts
@@ -8,13 +8,13 @@ export interface ResourceIdentity {
 
 export interface ResourceHasOneRelationship {
   data?: ResourceIdentity | null;
-  meta?: any;
+  meta?: Dict<any>;
   links?: Dict<Link>;
 }
 
 export interface ResourceHasManyRelationship {
   data?: ResourceIdentity[];
-  meta?: any;
+  meta?: Dict<any>;
   links?: Dict<Link>;
 }
 
@@ -25,13 +25,13 @@ export interface Resource {
   type: string;
   attributes?: Dict<any>;
   relationships?: Dict<ResourceRelationship>;
-  meta?: any;
+  meta?: Dict<any>;
   links?: Dict<Link>;
 }
 
 export interface JSONAPIDocument {
   data: Resource | Resource[] | ResourceIdentity | ResourceIdentity[];
   included?: Resource[];
-  meta?: any;
+  meta?: Dict<any>;
   links?: Dict<Link>;
 }

--- a/packages/@orbit/jsonapi/src/jsonapi-serializer.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-serializer.ts
@@ -1,5 +1,6 @@
 import { isArray, dasherize, camelize, deepSet, Dict } from '@orbit/utils';
 import {
+  Link,
   Schema,
   KeyMap,
   Record,
@@ -13,8 +14,10 @@ import {
 } from './jsonapi-document';
 
 export interface DeserializedDocument {
-  data: Record | Record[]
-  included?: Record[]
+  data: Record | Record[];
+  included?: Record[];
+  links?: Dict<Link>;
+  meta?: Dict<any>;
 }
 
 export interface JSONAPISerializerSettings {
@@ -209,6 +212,14 @@ export default class JSONAPISerializer {
       result.included = document.included.map(e => this.deserializeResource(e));
     }
 
+    if (document.links) {
+      result.links = document.links;
+    }
+
+    if (document.meta) {
+      result.meta = document.meta;
+    }
+
     return result;
   }
 
@@ -246,6 +257,7 @@ export default class JSONAPISerializer {
     this.deserializeAttributes(record, resource);
     this.deserializeRelationships(record, resource);
     this.deserializeLinks(record, resource);
+    this.deserializeMeta(record, resource);
 
     if (this.keyMap) {
       this.keyMap.pushRecord(record);
@@ -300,16 +312,26 @@ export default class JSONAPISerializer {
       deepSet(record, ['relationships', relationship, 'data'], data);
     }
 
-    let resourceLinks = value.links;
+    let { links, meta } = value;
 
-    if (resourceLinks !== undefined) {
-      deepSet(record, ['relationships', relationship, 'links'], resourceLinks);
+    if (links !== undefined) {
+      deepSet(record, ['relationships', relationship, 'links'], links);
+    }
+
+    if (meta !== undefined) {
+      deepSet(record, ['relationships', relationship, 'meta'], meta);
     }
   }
 
   deserializeLinks(record: Record, resource: Resource) {
     if (resource.links) {
       record.links = resource.links;
+    }
+  }
+
+  deserializeMeta(record: Record, resource: Resource) {
+    if (resource.meta) {
+      record.meta = resource.meta;
     }
   }
 

--- a/packages/@orbit/jsonapi/test/jsonapi-serializer-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-serializer-test.ts
@@ -668,8 +668,8 @@ module('JSONAPISerializer', function(hooks) {
       );
     });
   });
-  
-  module('Deserialize links',function(hooks){
+
+  module('Deserialize links and meta',function(hooks){
     let serializer;
 
     hooks.beforeEach(function() {
@@ -685,7 +685,33 @@ module('JSONAPISerializer', function(hooks) {
       assert.ok(serializer);
     });
 
-    test('it deserializes links in records', function (assert) {
+    test('it deserializes links and meta at the document-level', function (assert) {
+      let result = serializer.deserializeDocument(
+        {
+          links: {
+            self: "https://example.com/planets/12345/moons"
+          },
+          meta: {
+            abc: "123",
+            def: "456"
+          },
+          data: []
+        }
+      );
+
+      assert.deepEqual(result, {
+        links: {
+          self: "https://example.com/planets/12345/moons"
+        },
+        meta: {
+          abc: "123",
+          def: "456"
+        },
+        data: []
+      })
+    });
+
+    test('it deserializes links and meta in records', function (assert) {
       let result = serializer.deserializeDocument(
         {
           data: {
@@ -697,6 +723,10 @@ module('JSONAPISerializer', function(hooks) {
             },
             links: {
               self: "https://example.com/api/planets/12345"
+            },
+            meta: {
+              abc: "123",
+              def: "456"
             },
             relationships: {
               moons: { data: [{ type: 'moons', id: '5' }] },
@@ -716,6 +746,10 @@ module('JSONAPISerializer', function(hooks) {
           links: {
             self: "https://example.com/api/planets/12345"
           },
+          meta: {
+            abc: "123",
+            def: "456"
+          },
           relationships: {
             moons: {
               data: [
@@ -730,7 +764,7 @@ module('JSONAPISerializer', function(hooks) {
       })
     });
 
-    test('it deserializes links in hasOne relationship', function (assert) {
+    test('it deserializes links and meta in hasOne relationship', function (assert) {
       let result = serializer.deserializeDocument(
         {
           data: {
@@ -745,10 +779,16 @@ module('JSONAPISerializer', function(hooks) {
             },
             relationships: {
               moons: { data: [{ type: 'moons', id: '5' }] },
-              'solar-system': { data: { type: 'solar-systems', id: '6' }, links: {
-                self: "https://example.com/api/planets/12345/relationships/solarsystem",
-                related: "https://example.com/api/planets/12345/solarsystem"
-              } }
+              'solar-system': { data: { type: 'solar-systems', id: '6' },
+                links: {
+                  self: "https://example.com/api/planets/12345/relationships/solarsystem",
+                  related: "https://example.com/api/planets/12345/solarsystem"
+                },
+                meta: {
+                  abc: "123",
+                  def: "456"
+                }
+              }
             }
           }
         });
@@ -775,6 +815,10 @@ module('JSONAPISerializer', function(hooks) {
               links: {
                 self: "https://example.com/api/planets/12345/relationships/solarsystem",
                 related: "https://example.com/api/planets/12345/solarsystem"
+              },
+              meta: {
+                abc: "123",
+                def: "456"
               }
             }
           }
@@ -782,7 +826,7 @@ module('JSONAPISerializer', function(hooks) {
       })
     });
 
-    test('it deserializes links in hasMany relationship', function (assert) {
+    test('it deserializes links and meta in hasMany relationship', function (assert) {
       let result = serializer.deserializeDocument(
         {
           data: {
@@ -797,14 +841,19 @@ module('JSONAPISerializer', function(hooks) {
             },
             relationships: {
               moons: { data: [{ type: 'moons', id: '5' }],
-               links: {
-                self: "https://example.com/api/planets/12345/relationships/moons",
-                related: "https://example.com/api/planets/12345/moons"
-              } 
-            },
-              'solar-system': { data: { type: 'solar-systems', id: '6' }
-            
-            }}
+                links: {
+                  self: "https://example.com/api/planets/12345/relationships/moons",
+                  related: "https://example.com/api/planets/12345/moons"
+                },
+                meta: {
+                  abc: "123",
+                  def: "456"
+                }
+              },
+              'solar-system': {
+                data: { type: 'solar-systems', id: '6' }
+              }
+          }
           }
         });
       let planet = result.data;
@@ -827,6 +876,10 @@ module('JSONAPISerializer', function(hooks) {
               links: {
                 self: "https://example.com/api/planets/12345/relationships/moons",
                 related: "https://example.com/api/planets/12345/moons"
+              },
+              meta: {
+                abc: "123",
+                def: "456"
               }
             },
             solarSystem: {
@@ -837,7 +890,7 @@ module('JSONAPISerializer', function(hooks) {
       })
     });
 
-    test('it deserializes links in hasOne relationship without data', function (assert) {
+    test('it deserializes links and meta in hasOne relationship without data', function (assert) {
       let result = serializer.deserializeDocument(
         {
           data: {
@@ -852,10 +905,16 @@ module('JSONAPISerializer', function(hooks) {
             },
             relationships: {
               moons: { data: [{ type: 'moons', id: '5' }] },
-              'solar-system': {  links: {
-                self: "https://example.com/api/planets/12345/relationships/solarsystem",
-                related: "https://example.com/api/planets/12345/solarsystem"
-              } }
+              'solar-system': {
+                links: {
+                  self: "https://example.com/api/planets/12345/relationships/solarsystem",
+                  related: "https://example.com/api/planets/12345/solarsystem"
+                },
+                meta: {
+                  abc: "123",
+                  def: "456"
+                }
+              }
             }
           }
         });
@@ -881,6 +940,10 @@ module('JSONAPISerializer', function(hooks) {
               links: {
                 self: "https://example.com/api/planets/12345/relationships/solarsystem",
                 related: "https://example.com/api/planets/12345/solarsystem"
+              },
+              meta: {
+                abc: "123",
+                def: "456"
               }
             }
           }
@@ -903,14 +966,17 @@ module('JSONAPISerializer', function(hooks) {
             },
             relationships: {
               moons: {
-               links: {
-                self: "https://example.com/api/planets/12345/relationships/moons",
-                related: "https://example.com/api/planets/12345/moons"
-              } 
-            },
-              'solar-system': { data: { type: 'solar-systems', id: '6' }
-            
-            }}
+                links: {
+                  self: "https://example.com/api/planets/12345/relationships/moons",
+                  related: "https://example.com/api/planets/12345/moons"
+                },
+                meta: {
+                  abc: "123",
+                  def: "456"
+                }
+              },
+              'solar-system': { data: { type: 'solar-systems', id: '6' } }
+            }
           }
         });
       let planet = result.data;
@@ -930,6 +996,10 @@ module('JSONAPISerializer', function(hooks) {
               links: {
                 self: "https://example.com/api/planets/12345/relationships/moons",
                 related: "https://example.com/api/planets/12345/moons"
+              },
+              meta: {
+                abc: "123",
+                def: "456"
               }
             },
             solarSystem: {


### PR DESCRIPTION
Allow meta data everywhere it is allowed in JSON:API: the top-level document, records, relationships, and links.

Where `meta` is allowed, ensure it is properly typed as a dictionary object (rather than just `any`).

Additional work will be needed to add operations that mutate individual meta data members.