### PR TITLE
Always treat a 204 response as having no content

### DIFF
--- a/packages/@orbit/jsonapi/src/jsonapi-source.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-source.ts
@@ -283,6 +283,10 @@ export default class JSONAPISource extends Source implements Pullable, Pushable,
   }
 
   responseHasContent(response: Response): boolean {
+    if (response.status === 204) {
+      return false;
+    }
+
     let contentType = response.headers.get('Content-Type');
     if (contentType) {
       for (let allowedContentType of this.allowedContentTypes) {

--- a/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
@@ -257,6 +257,12 @@ module('JSONAPISource', function() {
       assert.equal(source.responseHasContent(response), true, 'Source will accept custom content type if specifically allowed.');
     });
 
+    test('#responseHasContent - returns false if response has status code 204', function(assert) {
+      let response = new Orbit.globals.Response(null, { status: 204, headers: { 'Content-Type': 'application/vnd.api+json' } });
+
+      assert.equal(source.responseHasContent(response), false, 'A 204 - No Content response has no content.');
+    });
+
     test('#push - can add records', async function(assert) {
       assert.expect(7);
 


### PR DESCRIPTION
A "204 No Content" response has by definition no content, even if the response includes a supported Content-Type header.

FWIW, I came across this because Mirage was returning a `DELETE` request by default with a 204 response with `Content-Type` set to `application/json`. This lead to a `JSON.parse` error, trying to parse an empty body. Probably doesn't make too much sense to return a `Content-Type` for a 204 response (filed https://github.com/samselikoff/ember-cli-mirage/pull/1481), but also I didn't find any reference stating that this is against the spec...