### PR TITLE
JSONAPISerializer implements new Serializer interface

### DIFF
--- a/packages/@orbit/jsonapi/package.json
+++ b/packages/@orbit/jsonapi/package.json
@@ -28,7 +28,8 @@
   "dependencies": {
     "@orbit/core": "^0.15.23",
     "@orbit/data": "^0.15.23",
-    "@orbit/utils": "^0.15.23"
+    "@orbit/utils": "^0.15.23",
+    "@orbit/serializers": "^0.15.23"
   },
   "devDependencies": {
     "@glimmer/build": "^0.9.0",

--- a/packages/@orbit/jsonapi/src/index.ts
+++ b/packages/@orbit/jsonapi/src/index.ts
@@ -1,3 +1,4 @@
 export { default } from './jsonapi-source';
-export { default as JSONAPISerializer } from './jsonapi-serializer';
-export * from './jsonapi-document';
+export * from './jsonapi-serializer';
+export * from './record-document';
+export * from './resource-document';

--- a/packages/@orbit/jsonapi/src/jsonapi-source.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-source.ts
@@ -14,7 +14,7 @@ import Orbit, {
   Record
 } from '@orbit/data';
 import { deepMerge } from '@orbit/utils';
-import JSONAPISerializer, { JSONAPISerializerSettings } from './jsonapi-serializer';
+import { JSONAPISerializer, JSONAPISerializerSettings } from './jsonapi-serializer';
 import { appendQueryParams } from './lib/query-params';
 import { getTransformRequests, TransformRequestProcessors } from './lib/transform-requests';
 import { InvalidServerResponse } from './lib/exceptions';

--- a/packages/@orbit/jsonapi/src/lib/query-operators.ts
+++ b/packages/@orbit/jsonapi/src/lib/query-operators.ts
@@ -21,10 +21,10 @@ import {
   PageSpecifier
 } from '@orbit/data';
 import JSONAPISource from '../jsonapi-source';
-import { DeserializedDocument } from '../jsonapi-serializer';
+import { RecordDocument } from '../record-document';
 import { Filter, RequestOptions, buildFetchSettings, customRequestOptions } from './request-settings';
 
-function operationsFromDeserializedDocument(deserialized: DeserializedDocument): Operation[] {
+function operationsFromDeserializedDocument(deserialized: RecordDocument): Operation[] {
   const records: Record[] = [];
   Array.prototype.push.apply(records, toArray(deserialized.data));
 
@@ -58,7 +58,7 @@ export const QueryOperators: Dict<QueryOperator> = {
 
     const document = await source.fetch(source.resourceURL(record.type, record.id), settings);
 
-    const deserialized = source.serializer.deserializeDocument(document);
+    const deserialized = source.serializer.deserialize(document);
     const operations = operationsFromDeserializedDocument(deserialized);
 
     const transforms = [buildTransform(operations)];
@@ -94,7 +94,7 @@ export const QueryOperators: Dict<QueryOperator> = {
 
     const document = await source.fetch(source.resourceURL(type), settings);
 
-    const deserialized = source.serializer.deserializeDocument(document);
+    const deserialized = source.serializer.deserialize(document);
     const operations = operationsFromDeserializedDocument(deserialized);
 
     const transforms = [buildTransform(operations)];
@@ -111,7 +111,7 @@ export const QueryOperators: Dict<QueryOperator> = {
 
     const document = await source.fetch(source.relatedResourceURL(record.type, record.id, relationship), settings);
 
-    const deserialized = source.serializer.deserializeDocument(document);
+    const deserialized = source.serializer.deserialize(document);
     const relatedRecord = deserialized.data;
     const operations = operationsFromDeserializedDocument(deserialized);
     operations.push({
@@ -135,7 +135,7 @@ export const QueryOperators: Dict<QueryOperator> = {
 
     const document = await source.fetch(source.relatedResourceURL(record.type, record.id, relationship), settings);
 
-    const deserialized = source.serializer.deserializeDocument(document);
+    const deserialized = source.serializer.deserialize(document);
     const relatedRecords = deserialized.data;
 
     const operations = operationsFromDeserializedDocument(deserialized);

--- a/packages/@orbit/jsonapi/src/record-document.ts
+++ b/packages/@orbit/jsonapi/src/record-document.ts
@@ -1,0 +1,17 @@
+import { Dict } from '@orbit/utils';
+import {
+  Link,
+  Record
+} from '@orbit/data';
+
+export interface RecordDocument {
+  data: Record | Record[];
+  included?: Record[];
+  links?: Dict<Link>;
+  meta?: Dict<any>;
+}
+
+/**
+ * @deprecated
+ */
+export interface DeserializedDocument extends RecordDocument {};

--- a/packages/@orbit/jsonapi/src/resource-document.ts
+++ b/packages/@orbit/jsonapi/src/resource-document.ts
@@ -29,9 +29,14 @@ export interface Resource {
   links?: Dict<Link>;
 }
 
-export interface JSONAPIDocument {
+export interface ResourceDocument {
   data: Resource | Resource[] | ResourceIdentity | ResourceIdentity[];
   included?: Resource[];
   meta?: Dict<any>;
   links?: Dict<Link>;
 }
+
+/**
+ * @deprecated
+ */
+export interface JSONAPIDocument extends ResourceDocument {};

--- a/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
@@ -15,9 +15,8 @@ import Orbit, {
   ReplaceRelatedRecordsOperation,
   Transform
 } from '@orbit/data';
-import JSONAPISource from '../src/jsonapi-source';
 import { jsonapiResponse } from './support/jsonapi';
-import { Resource } from '../src/jsonapi-document';
+import JSONAPISource, { Resource } from '../src/index';
 import { SinonStatic, SinonStub} from 'sinon';
 
 declare const sinon: SinonStatic;
@@ -399,7 +398,7 @@ module('JSONAPISource', function() {
           });
           assert.deepEqual(
             operationsWithoutId,
-            [addMoonOp],
+            [addMoonOp as any],
             'transform event to add included records'
           );
         }
@@ -1430,12 +1429,12 @@ module('JSONAPISource', function() {
     test('#pull - relatedRecord', async function(assert) {
       assert.expect(12);
 
-      const planetRecord: Record = <Record>source.serializer.deserializeDocument({
+      const planetRecord: Record = source.serializer.deserialize({
         data: {
           type: 'planets',
           id: 'jupiter'
         }
-      }).data;
+      }).data as Record;
 
       const data: Resource = {
         type: 'solar-systems',
@@ -1478,12 +1477,12 @@ module('JSONAPISource', function() {
     test('#pull - relatedRecords', async function(assert) {
       assert.expect(8);
 
-      let planetRecord: Record = <Record>source.serializer.deserializeDocument({
+      let planetRecord: Record = source.serializer.deserialize({
         data: {
           type: 'planets',
           id: 'jupiter'
         }
-      }).data;
+      }).data as Record;
 
       let data = [{
         type: 'moons',
@@ -1517,12 +1516,12 @@ module('JSONAPISource', function() {
     test('#pull - relatedRecords with include', async function(assert) {
       assert.expect(2);
 
-      const planetRecord = source.serializer.deserializeDocument({
+      const planetRecord = source.serializer.deserialize({
         data: {
           type: 'planets',
           id: 'jupiter'
         }
-      }).data;
+      }).data as RecordIdentity;
 
       const options = {
         sources: {
@@ -1536,7 +1535,7 @@ module('JSONAPISource', function() {
         .withArgs('/planets/jupiter/moons?include=planet')
         .returns(jsonapiResponse(200, { data: [] }));
 
-      await source.pull(q => q.findRelatedRecords(<RecordIdentity>planetRecord, 'moons'), options);
+      await source.pull(q => q.findRelatedRecords(planetRecord, 'moons'), options);
 
       assert.equal(fetchStub.callCount, 1, 'fetch called once');
       assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
@@ -1968,16 +1967,16 @@ module('JSONAPISource', function() {
       fetchStub
         .withArgs('/planets?include=moons')
         .returns(jsonapiResponse(200, {
-          data: [{ type: "planets", id: 1 }, { type: "planets", id: 2 }],
-          included: [{ type: "moons", id: 1 }, { type: "moons", id: 2 }]
+          data: [{ type: 'planets', id: '1' }, { type: 'planets', id: '2' }],
+          included: [{ type: 'moons', id: '1' }, { type: 'moons', id: '2' }]
         }));
 
       let records: Record[] = await source.query(q => q.findRecords('planet'), options);
 
       assert.ok(Array.isArray(records), 'query result is an array, like primary data');
       assert.equal(records.length, 2, 'query result length equals primary data length');
-      assert.deepEqual(records.map(planet => planet.type), ["planet", "planet"]);
-      assert.deepEqual(records.map(planet => planet.keys.remoteId), [1, 2], "returned IDs match primary data (including sorting)");
+      assert.deepEqual(records.map(planet => planet.type), ['planet', 'planet']);
+      assert.deepEqual(records.map(planet => planet.keys.remoteId), ['1', '2'], 'returned IDs match primary data (including sorting)');
 
       assert.equal(fetchStub.callCount, 1, 'fetch called once');
       assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');
@@ -2007,12 +2006,12 @@ module('JSONAPISource', function() {
     test('#query - relatedRecords', async function(assert) {
       assert.expect(5);
 
-      let planetRecord: Record = <Record>source.serializer.deserializeDocument({
+      let planetRecord: Record = source.serializer.deserialize({
         data: {
           type: 'planets',
           id: 'jupiter'
         }
-      }).data;
+      }).data as Record;
 
       let data = [{
         type: 'moons',
@@ -2039,12 +2038,12 @@ module('JSONAPISource', function() {
     test('#query - relatedRecords with include', async function(assert) {
       assert.expect(2);
 
-      const planetRecord = source.serializer.deserializeDocument({
+      const planetRecord = source.serializer.deserialize({
         data: {
           type: 'planets',
           id: 'jupiter'
         }
-      }).data;
+      }).data as RecordIdentity;
 
       const options = {
         sources: {
@@ -2058,7 +2057,7 @@ module('JSONAPISource', function() {
         .withArgs('/planets/jupiter/moons?include=planet')
         .returns(jsonapiResponse(200, { data: [] }));
 
-      await source.query(q => q.findRelatedRecords(<RecordIdentity>planetRecord, 'moons'), options);
+      await source.query(q => q.findRelatedRecords(planetRecord, 'moons'), options);
 
       assert.equal(fetchStub.callCount, 1, 'fetch called once');
       assert.equal(fetchStub.getCall(0).args[1].method, undefined, 'fetch called with no method (equivalent to GET)');

--- a/packages/@orbit/serializers/src/serializer.ts
+++ b/packages/@orbit/serializers/src/serializer.ts
@@ -1,4 +1,4 @@
 export interface Serializer<From, To> {
-  serialize(arg: From): To;
-  deserialize(arg: To): From;
+  serialize(arg: From, options?: any): To;
+  deserialize(arg: To, options?: any): From;
 }


### PR DESCRIPTION
* `JSONAPISerializer#serializeDocument` is deprecated in favor of `serialize`
* `JSONAPISerializer#deserializeDocument` is deprecated in favor of `deserialize`
* `DeserializedDocument` interface is deprecated in favor of `RecordDocument`
* `JSONAPIDocument` interface is deprecated in favor of `ResourceDocument`