### PR TITLE
[jsonapi] Use new serializers for serializing / deserializing attribute values

### DIFF
--- a/packages/@orbit/data/src/schema.ts
+++ b/packages/@orbit/data/src/schema.ts
@@ -7,6 +7,8 @@ import { Record, RecordInitializer } from './record';
 
 export interface AttributeDefinition {
   type?: string;
+  serializationOptions?: Dict<any>;
+  deserializationOptions?: Dict<any>;
 }
 
 export interface RelationshipDefinition {

--- a/packages/@orbit/jsonapi/Brocfile.js
+++ b/packages/@orbit/jsonapi/Brocfile.js
@@ -10,6 +10,7 @@ let buildOptions = {
     '@orbit/utils',
     '@orbit/core',
     '@orbit/data',
+    '@orbit/serializers',
     'sinon'
   ]
 };
@@ -19,6 +20,7 @@ if (process.env.BROCCOLI_ENV === 'tests') {
     packageDist('@orbit/utils'),
     packageDist('@orbit/core'),
     packageDist('@orbit/data'),
+    packageDist('@orbit/serializers'),
     funnel(path.join(require.resolve('rsvp'), '..'), { include: ['rsvp.js'] }),
     funnel(path.join(require.resolve('sinon'), '../../pkg'), { include: ['sinon.js'] }),
     funnel(path.join(require.resolve('whatwg-fetch'), '../'), { include: ['fetch.js'] })


### PR DESCRIPTION
Serializers can now be registered in the JSONAPISerializer and will be used to serialize/deserialize attribute values according to the `type` in the schema.

By default, all the standard serializers from `@orbit/serializers` are registered. In addition, custom serializers can be registered.

Furthermore, the `AttributeDefinition` interface (used within the `Schema`) has been expanded to include:
* `serializationOptions`
* `deserializationOptions`

These options can help specialize a serializer for the given attribute `type`.

Here's an example usage, taken from the tests:

```ts
const modelDefinitions: Dict<ModelDefinition> = {
  person: {
    attributes: {
      name: { type: 'string' },
      birthday: { type: 'date' },
      birthtime: { type: 'datetime' },
      height: { 
        type: 'distance', 
        serializationOptions: { format: 'cm', digits: 2 }, 
        deserializationOptions: { format: 'cm' }
      },
      isAdult: { type: 'boolean' }
    }
  }
};

// Custom serializer
class DistanceSerializer implements Serializer<number,string> {
  serialize(arg: number, options?: any): string {
    let distance = arg;
    const format = options && options.format;
    const digits = options && options.digits || 0;
    if (format === 'cm') {
      distance *= 100;
    } else if (format) {
      throw new Error('Unknown format');
    }
    return distance.toFixed(digits);
  }

  deserialize(arg: string, options?: any): number {
    const format = options && options.format;
    let distance = parseFloat(arg);
    if (format === 'cm') {
      distance /= 100;
    } else if (format) {
      throw new Error('Unknown format');
    }
    return distance;
  }
}

let serializer: JSONAPISerializer;

let schema: Schema = new Schema({ models: modelDefinitions });

// Create a serializer that uses our custom DistanceSerializer
serializer = new JSONAPISerializer({ schema, serializers: {
  distance: new DistanceSerializer()
}});

// Example test confirming serialization works
assert.deepEqual(
  serializer.serialize({
    data: {
      type: 'person',
      id: '123',
      attributes: {
        name: 'Joe',
        birthday: new Date(2000, 11, 31),
        birthtime: new Date('2000-12-31T10:00:00.000Z'),
        height: 1.0, // meters
        isAdult: true
      }
    }
  }),
  {
    data: {
      type: 'persons',
      id: '123',
      attributes: {
        name: 'Joe',
        birthday: '2000-12-31',
        birthtime: '2000-12-31T10:00:00.000Z',
        height: '100.00', // cm (with 2 digits)
        'is-adult': true
      }
    }
  },
  'serialized document matches'
);

```