### PR TITLE
Return empty array when querying for non-existing relationships with findRelatedRecords

### DIFF
--- a/packages/@orbit/record-cache/src/operators/sync-query-operators.ts
+++ b/packages/@orbit/record-cache/src/operators/sync-query-operators.ts
@@ -48,6 +48,10 @@ export const SyncQueryOperators: Dict<SyncQueryOperator> = {
   findRelatedRecords(cache: SyncRecordAccessor, expression: FindRelatedRecords): Record[] {
     const { record, relationship } = expression;
     const relatedIds = cache.getRelatedRecordsSync(record, relationship);
+    if (!relatedIds) {
+      return [];
+    }
+  
     return cache.getRecordsSync(relatedIds);
   },
 

--- a/packages/@orbit/record-cache/test/sync-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/sync-record-cache-test.ts
@@ -1381,6 +1381,22 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
+  test('#query - findRelatedRecords - returns empty array if there are no related records', function (assert) {
+    const cache = new Cache({ schema, keyMap });
+
+    const jupiter: Record = {
+      id: 'jupiter', type: 'planet',
+      attributes: { name: 'Jupiter' }
+    };
+
+    cache.patch(t => [t.addRecord(jupiter)]);
+
+    assert.deepEqual(
+      cache.query(q => q.findRelatedRecords({ type: 'planet', id: 'jupiter'}, 'moons')),
+      []
+    );
+  });
+
   test('#query - findRelatedRecord', function(assert) {
     const cache = new Cache({ schema, keyMap });
 
@@ -1402,6 +1418,22 @@ module('SyncRecordCache', function(hooks) {
     assert.deepEqual(
       cache.query(q => q.findRelatedRecord({ type: 'moon', id: 'callisto' }, 'planet')),
       jupiter
+    );
+  });
+  
+  test('#query - findRelatedRecord', function(assert) {
+    const cache = new Cache({ schema, keyMap });
+
+    const jupiter: Record = {
+      id: 'jupiter', type: 'planet',
+      attributes: { name: 'Jupiter' }
+    };
+
+    cache.patch(t => [t.addRecord(jupiter)]);
+
+    assert.deepEqual(
+      cache.query(q => q.findRelatedRecord({ type: 'moon', id: 'callisto' }, 'planet')),
+      null
     );
   });
 });

--- a/packages/@orbit/record-cache/test/sync-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/sync-record-cache-test.ts
@@ -1421,7 +1421,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
   
-  test('#query - findRelatedRecord', function(assert) {
+  test('#query - findRelatedRecord - return null if no related record is found', function(assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {


### PR DESCRIPTION
Was in the process of updating ember-orbit to 0.16 and the following test failed:

```
test('add to hasMany', async function(assert) {
  const jupiter = await store.addRecord({type: 'planet', name: 'Jupiter'});
  const callisto = await store.addRecord({type: 'moon', name: 'Callisto'});

  await jupiter.get('moons').pushObject(callisto);

  assert.ok(jupiter.get('moons').includes(callisto), 'added record to hasMany');
  assert.equal(callisto.get('planet'), jupiter, 'updated inverse');
});
```

The `get('moons')`call on jupiter would trigger a findRelatedRecords query, which would error out as there were no related ids (moons) yet on the planet, and those related ids would be passed to `Cache.getRecordsSync` which expects either a string or array, not null - as in this case.

This PR simply makes it so an empty array is returned if there are no relatedIds.