### PR TITLE
Extends #603 to fix related errors

### DIFF
--- a/packages/@orbit/record-cache/src/operators/async-query-operators.ts
+++ b/packages/@orbit/record-cache/src/operators/async-query-operators.ts
@@ -48,15 +48,28 @@ export const AsyncQueryOperators: Dict<AsyncQueryOperator> = {
   async findRelatedRecords(cache: AsyncRecordAccessor, expression: FindRelatedRecords): Promise<Record[]> {
     const { record, relationship } = expression;
     const relatedIds = await cache.getRelatedRecordsAsync(record, relationship);
+    if (!relatedIds) {
+      if (!(await cache.getRecordAsync(record))) {
+        throw new RecordNotFoundException(record.type, record.id);
+      }
+
+      return [];
+    }
+
     return cache.getRecordsAsync(relatedIds);
   },
 
   async findRelatedRecord(cache: AsyncRecordAccessor, expression: FindRelatedRecord): Promise<Record> {
     const { record, relationship } = expression;
     const relatedId = await cache.getRelatedRecordAsync(record, relationship);
+
     if (relatedId) {
       return await cache.getRecordAsync(relatedId);
     } else {
+      if (!(await cache.getRecordAsync(record))) {
+        throw new RecordNotFoundException(record.type, record.id);
+      }
+
       return null;
     }
   }

--- a/packages/@orbit/record-cache/src/operators/sync-query-operators.ts
+++ b/packages/@orbit/record-cache/src/operators/sync-query-operators.ts
@@ -48,6 +48,10 @@ export const SyncQueryOperators: Dict<SyncQueryOperator> = {
   findRelatedRecords(cache: SyncRecordAccessor, expression: FindRelatedRecords): Record[] {
     const { record, relationship } = expression;
     const relatedIds = cache.getRelatedRecordsSync(record, relationship);
+    if (!relatedIds) {
+      return [];
+    }
+  
     return cache.getRecordsSync(relatedIds);
   },
 

--- a/packages/@orbit/record-cache/src/operators/sync-query-operators.ts
+++ b/packages/@orbit/record-cache/src/operators/sync-query-operators.ts
@@ -49,9 +49,13 @@ export const SyncQueryOperators: Dict<SyncQueryOperator> = {
     const { record, relationship } = expression;
     const relatedIds = cache.getRelatedRecordsSync(record, relationship);
     if (!relatedIds) {
+      if (!cache.getRecordSync(record)) {
+        throw new RecordNotFoundException(record.type, record.id);
+      }
+
       return [];
     }
-  
+
     return cache.getRecordsSync(relatedIds);
   },
 
@@ -61,6 +65,10 @@ export const SyncQueryOperators: Dict<SyncQueryOperator> = {
     if (relatedId) {
       return cache.getRecordSync(relatedId);
     } else {
+      if (!cache.getRecordSync(record)) {
+        throw new RecordNotFoundException(record.type, record.id);
+      }
+
       return null;
     }
   }

--- a/packages/@orbit/record-cache/test/async-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/async-record-cache-test.ts
@@ -1380,6 +1380,32 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
+  test('#query - findRelatedRecords - returns empty array if there are no related records', async function (assert) {
+    const cache = new Cache({ schema, keyMap });
+
+    const jupiter: Record = {
+      id: 'jupiter', type: 'planet',
+      attributes: { name: 'Jupiter' }
+    };
+
+    await cache.patch(t => [t.addRecord(jupiter)]);
+
+    assert.deepEqual(
+      await cache.query(q => q.findRelatedRecords({ type: 'planet', id: 'jupiter'}, 'moons')),
+      []
+    );
+  });
+
+  test('#query - findRelatedRecords - throws RecordNotFoundException if primary record doesn\'t exist', async function (assert) {
+    const cache = new Cache({ schema, keyMap });
+
+    try {
+      await cache.query(q => q.findRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons'));
+    } catch(e) {
+      assert.ok(e instanceof RecordNotFoundException);
+    }
+  });
+
   test('#query - findRelatedRecord', async function(assert) {
     const cache = new Cache({ schema, keyMap });
 
@@ -1402,5 +1428,31 @@ module('AsyncRecordCache', function(hooks) {
       await cache.query(q => q.findRelatedRecord({ type: 'moon', id: 'callisto' }, 'planet')),
       jupiter
     );
+  });
+
+  test('#query - findRelatedRecord - return null if no related record is found', async function(assert) {
+    const cache = new Cache({ schema, keyMap });
+
+    const callisto: Record = {
+      id: 'callisto', type: 'moon',
+      attributes: { name: 'Callisto' }
+    };
+
+    await cache.patch(t => [t.addRecord(callisto)]);
+
+    assert.deepEqual(
+      await cache.query(q => q.findRelatedRecord({ type: 'moon', id: 'callisto' }, 'planet')),
+      null
+    );
+  });
+
+  test('#query - findRelatedRecord - throws RecordNotFoundException if primary record doesn\'t exist', async function (assert) {
+    const cache = new Cache({ schema, keyMap });
+
+    try {
+      await cache.query(q => q.findRelatedRecord({ type: 'moon', id: 'callisto' }, 'planet'));
+    } catch(e) {
+      assert.ok(e instanceof RecordNotFoundException);
+    }
   });
 });

--- a/packages/@orbit/record-cache/test/sync-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/sync-record-cache-test.ts
@@ -1397,6 +1397,15 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
+  test('#query - findRelatedRecords - throws RecordNotFoundException if primary record doesn\'t exist', function (assert) {
+    const cache = new Cache({ schema, keyMap });
+
+    assert.throws(
+      () => cache.query(q => q.findRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons')),
+      RecordNotFoundException
+    );
+  });
+
   test('#query - findRelatedRecord', function(assert) {
     const cache = new Cache({ schema, keyMap });
 
@@ -1420,20 +1429,29 @@ module('SyncRecordCache', function(hooks) {
       jupiter
     );
   });
-  
+
   test('#query - findRelatedRecord - return null if no related record is found', function(assert) {
     const cache = new Cache({ schema, keyMap });
 
-    const jupiter: Record = {
-      id: 'jupiter', type: 'planet',
-      attributes: { name: 'Jupiter' }
+    const callisto: Record = {
+      id: 'callisto', type: 'moon',
+      attributes: { name: 'Callisto' }
     };
 
-    cache.patch(t => [t.addRecord(jupiter)]);
+    cache.patch(t => [t.addRecord(callisto)]);
 
     assert.deepEqual(
       cache.query(q => q.findRelatedRecord({ type: 'moon', id: 'callisto' }, 'planet')),
       null
+    );
+  });
+
+  test('#query - findRelatedRecord - throws RecordNotFoundException if primary record doesn\'t exist', function (assert) {
+    const cache = new Cache({ schema, keyMap });
+
+    assert.throws(
+      () => cache.query(q => q.findRelatedRecord({ type: 'moon', id: 'callisto' }, 'planet')),
+      RecordNotFoundException
     );
   });
 });

--- a/packages/@orbit/record-cache/test/sync-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/sync-record-cache-test.ts
@@ -1381,6 +1381,22 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
+  test('#query - findRelatedRecords - returns empty array if there are no related records', function (assert) {
+    const cache = new Cache({ schema, keyMap });
+
+    const jupiter: Record = {
+      id: 'jupiter', type: 'planet',
+      attributes: { name: 'Jupiter' }
+    };
+
+    cache.patch(t => [t.addRecord(jupiter)]);
+
+    assert.deepEqual(
+      cache.query(q => q.findRelatedRecords({ type: 'planet', id: 'jupiter'}, 'moons')),
+      []
+    );
+  });
+
   test('#query - findRelatedRecord', function(assert) {
     const cache = new Cache({ schema, keyMap });
 
@@ -1402,6 +1418,22 @@ module('SyncRecordCache', function(hooks) {
     assert.deepEqual(
       cache.query(q => q.findRelatedRecord({ type: 'moon', id: 'callisto' }, 'planet')),
       jupiter
+    );
+  });
+  
+  test('#query - findRelatedRecord', function(assert) {
+    const cache = new Cache({ schema, keyMap });
+
+    const jupiter: Record = {
+      id: 'jupiter', type: 'planet',
+      attributes: { name: 'Jupiter' }
+    };
+
+    cache.patch(t => [t.addRecord(jupiter)]);
+
+    assert.deepEqual(
+      cache.query(q => q.findRelatedRecord({ type: 'moon', id: 'callisto' }, 'planet')),
+      null
     );
   });
 });

--- a/packages/@orbit/record-cache/test/sync-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/sync-record-cache-test.ts
@@ -1421,7 +1421,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
   
-  test('#query - findRelatedRecord', function(assert) {
+  test('#query - findRelatedRecord - return null if no related record is found', function(assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {


### PR DESCRIPTION
This PR is based on #603 and extends the fix for `SyncRecordCache` to apply to `AsyncRecordCache` as well.

Furthermore, a related set of bugs is resolved, in which `findRelatedRecord` and `findRelatedRecords` should throw a `RecordNotFoundException` when the _primary_ record can not be found in a cache. This makes them consistent with `findRecord`.

Closes #603 