### PR TITLE
Do not reset persisting sources on initalize

### DIFF
--- a/packages/@orbit/indexeddb/src/cache.ts
+++ b/packages/@orbit/indexeddb/src/cache.ts
@@ -49,8 +49,6 @@ export default class IndexedDBCache extends AsyncRecordCache {
     super(settings);
 
     this._namespace = settings.namespace || 'orbit';
-
-    this.reset();
   }
 
   async query(queryOrExpression: QueryOrExpression, options?: object, id?: string): Promise<QueryResultData> {

--- a/packages/@orbit/local-storage/src/cache.ts
+++ b/packages/@orbit/local-storage/src/cache.ts
@@ -30,8 +30,6 @@ export default class LocalStorageCache extends SyncRecordCache {
 
     this._namespace = settings.namespace || 'orbit';
     this._delimiter = settings.delimiter || '/';
-
-    this.reset();
   }
 
   get namespace(): string {


### PR DESCRIPTION
Persisting sources should not drop all data on initialize. Introduced in the following commit
https://github.com/orbitjs/orbit/commit/838dcc6b74297b647e64256b74dfa444ca2fbae2