### PR TITLE
RemoveRecord when part of has many relationship should not clobber the whole relationship in IndexedDB source

### DIFF
--- a/packages/@orbit/indexeddb/src/cache.ts
+++ b/packages/@orbit/indexeddb/src/cache.ts
@@ -5,8 +5,7 @@ import Orbit, {
   Record,
   RecordIdentity,
   RecordOperation,
-  TransformBuilderFunc,
-  recordsInclude
+  TransformBuilderFunc
 } from '@orbit/data';
 import {
   RecordRelationshipIdentity,
@@ -155,6 +154,7 @@ export default class IndexedDBCache extends AsyncRecordCache {
   createInverseRelationshipStore(db: IDBDatabase): void {
     let objectStore = db.createObjectStore(INVERSE_RELS, { keyPath: 'id' });
     objectStore.createIndex('type', 'type', { unique: false });
+    objectStore.createIndex('recordIdentity', 'recordIdentity', { unique: false });
     objectStore.createIndex('relatedType', 'relatedType', { unique: false });
     objectStore.createIndex('relatedIdentity', 'relatedIdentity', { unique: false });
   }
@@ -443,7 +443,8 @@ export default class IndexedDBCache extends AsyncRecordCache {
       const transaction = this._db.transaction([INVERSE_RELS]);
       const objectStore = transaction.objectStore(INVERSE_RELS);
       const results: RecordRelationshipIdentity[] = [];
-      const request = objectStore.openCursor();
+      const keyRange = IDBKeyRange.only(serializeRecordIdentity(recordIdentity));
+      const request = objectStore.index('recordIdentity').openCursor(keyRange);
 
       request.onerror = function(/* event */) {
         // console.error('error - getRecords', request.error);

--- a/packages/@orbit/indexeddb/test/source-test.ts
+++ b/packages/@orbit/indexeddb/test/source-test.ts
@@ -252,6 +252,34 @@ module('IndexedDBSource', function(hooks) {
     assert.equal(await getRecordFromIndexedDB(source.cache, planet), undefined, 'indexeddb does not contain record');
   });
 
+  test('#push - removeRecord when part of has many relationship', async function(assert) {
+    assert.expect(2);
+
+    let moon1 = { type: 'moon', id: 'moon1' };
+    let moon2 = { type: 'moon', id: 'moon2' }
+    let planet: Record = {
+      type: 'planet',
+      id: 'jupiter',
+      attributes: {
+        name: 'Jupiter',
+        classification: 'gas giant'
+      },
+      relationships: {
+        moons: {
+          data: [
+            moon1,
+            moon2
+          ]
+        }
+      }
+    };
+
+    await source.push(t => [t.addRecord(moon1),t.addRecord(moon2),t.addRecord(planet)]);
+    assert.deepEqual((await getRecordFromIndexedDB(source.cache, planet)).relationships.moons.data.length, 2, 'record has 2 moons');
+    await source.push(t => t.removeRecord(moon1));
+    assert.deepEqual((await getRecordFromIndexedDB(source.cache, planet)).relationships.moons.data.length, 1, 'record has 1 moon');
+  });
+
   test('#push - removeRecord - when record does not exist', async function(assert) {
     assert.expect(1);
 

--- a/packages/@orbit/local-storage/test/source-test.ts
+++ b/packages/@orbit/local-storage/test/source-test.ts
@@ -216,6 +216,34 @@ module('LocalStorageSource', function(hooks) {
     assert.deepEqual(getRecordFromLocalStorage(source, planet), null, 'local storage does not contain record');
   });
 
+  test('#push - removeRecord when part of has many relationship', async function(assert) {
+    assert.expect(2);
+
+    let moon1 = { type: 'moon', id: 'moon1' };
+    let moon2 = { type: 'moon', id: 'moon2' }
+    let planet: Record = {
+      type: 'planet',
+      id: 'jupiter',
+      attributes: {
+        name: 'Jupiter',
+        classification: 'gas giant'
+      },
+      relationships: {
+        moons: {
+          data: [
+            moon1,
+            moon2
+          ]
+        }
+      }
+    };
+
+    await source.push(t => [t.addRecord(moon1),t.addRecord(moon2),t.addRecord(planet)]);
+    assert.deepEqual((await getRecordFromLocalStorage(source, planet)).relationships.moons.data.length, 2, 'record has 2 moons');
+    await source.push(t => t.removeRecord(moon1));
+    assert.deepEqual((await getRecordFromLocalStorage(source, planet)).relationships.moons.data.length, 1, 'record has 1 moon');
+  });
+
   test('#push - removeRecord - when record does not exist', async function(assert) {
     assert.expect(1);
 

--- a/packages/@orbit/record-cache/test/async-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/async-record-cache-test.ts
@@ -201,6 +201,8 @@ module('AsyncRecordCache', function(hooks) {
 
     assert.equal(await cache.getRecordAsync({ type: 'moon', id: 'm1' }), null, 'Io is GONE');
 
+    assert.deepEqual((await cache.getRelatedRecordsAsync({ type: 'planet', id: 'p1' }, 'moons')), [{ type: 'moon', id: 'm2' }], 'Io have been cleared from Jupiter');
+
     await cache.patch(t => t.removeRecord(europa));
 
     assert.equal(await cache.getRecordAsync({ type: 'moon', id: 'm2' }), null, 'Europa is GONE');


### PR DESCRIPTION
`IndexedDB` source clobber parent record relationship when one of the members of the given relationship is removed. I added a `record-cache` and `local-storage` tests to show that the problem is scoped to `IndexedDB` source.