### PR TITLE
Add integration-tests package

### DIFF
--- a/packages/@orbit/integration-tests/.npmignore
+++ b/packages/@orbit/integration-tests/.npmignore
@@ -1,0 +1,12 @@
+docs
+node_modules
+test
+tests
+tmp
+*.log
+*.DS_Store
+*.editorconfig
+*.gitignore
+*.travis.yml
+Brocfile.js
+testem.json

--- a/packages/@orbit/integration-tests/Brocfile.js
+++ b/packages/@orbit/integration-tests/Brocfile.js
@@ -1,0 +1,48 @@
+"use strict";
+
+const build = require('@glimmer/build');
+const packageDist = require('@glimmer/build/lib/package-dist');
+const funnel = require('broccoli-funnel');
+const path = require('path');
+
+let buildOptions = {
+  external: [
+    '@orbit/core',
+    '@orbit/coordinator',
+    '@orbit/data',
+    '@orbit/immutable',
+    '@orbit/indexeddb',
+    '@orbit/indexeddb-bucket',
+    '@orbit/jsonapi',
+    '@orbit/local-storage',
+    '@orbit/local-storage-bucket',
+    '@orbit/record-cache',
+    '@orbit/serializers',
+    '@orbit/store',
+    '@orbit/utils',
+    'sinon'
+  ]
+};
+
+if (process.env.BROCCOLI_ENV === 'tests') {
+  buildOptions.vendorTrees = [
+    packageDist('@orbit/core'),
+    packageDist('@orbit/coordinator'),
+    packageDist('@orbit/data'),
+    packageDist('@orbit/record-cache'),
+    packageDist('@orbit/immutable'),
+    packageDist('@orbit/indexeddb'),
+    packageDist('@orbit/indexeddb-bucket'),
+    packageDist('@orbit/jsonapi'),
+    packageDist('@orbit/local-storage'),
+    packageDist('@orbit/local-storage-bucket'),
+    packageDist('@orbit/serializers'),
+    packageDist('@orbit/store'),
+    packageDist('@orbit/utils'),
+    funnel(path.join(require.resolve('rsvp'), '..'), { include: ['rsvp.js'] }),
+    funnel(path.join(require.resolve('sinon'), '../../pkg'), { include: ['sinon.js'] }),
+    funnel(path.join(require.resolve('whatwg-fetch'), '../'), { include: ['fetch.js'] })
+  ];
+}
+
+module.exports = build(buildOptions);

--- a/packages/@orbit/integration-tests/LICENSE
+++ b/packages/@orbit/integration-tests/LICENSE
@@ -1,0 +1,20 @@
+Copyright 2014-2019 Cerebris Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/@orbit/integration-tests/README.md
+++ b/packages/@orbit/integration-tests/README.md
@@ -1,0 +1,45 @@
+# @orbit/integration-tests
+
+This package is used to perform integration tests for core Orbit packages. It's
+useful for simulating complex interactions among sources and strategies.
+
+This is a private package with no publishable source code.
+
+## Contributing
+
+### Installation
+
+Install dependencies:
+
+```
+npm install
+```
+
+### Testing
+
+#### CI Testing
+
+Test in CI mode by running:
+
+```
+npm test
+```
+
+Or directly with testem (useful for configuring options):
+
+```
+testem ci
+```
+
+#### Browser Testing
+
+Test within a browser
+(at [http://localhost:4200/tests/](http://localhost:4200/tests/)) by running:
+
+```
+testem
+```
+
+## License
+
+Copyright 2014-2019 Cerebris Corporation. MIT License (see LICENSE for details).

--- a/packages/@orbit/integration-tests/package-lock.json
+++ b/packages/@orbit/integration-tests/package-lock.json
@@ -1,0 +1,4575 @@
+{
+	"name": "@orbit/integration-tests",
+	"version": "0.16.0-beta.2",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@babel/types": {
+			"version": "7.3.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz",
+			"integrity": "sha512-WEkp8MsLftM7O/ty580wAmZzN1nDmCACc5+jFzUt+GUFNNIi3LdRlueYz0YIlmJhlZx1QYDMZL5vdWCL0fNjFQ==",
+			"dev": true,
+			"requires": {
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.11",
+				"to-fast-properties": "^2.0.0"
+			},
+			"dependencies": {
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
+				}
+			}
+		},
+		"@glimmer/build": {
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/@glimmer/build/-/build-0.9.1.tgz",
+			"integrity": "sha512-0POQT9+xzCVSs1oGaEsgRMUeqEGk/Frg5OrIM3hVI3f5MUKMpNHOKGK7CKxTVzOTnc4QOR4W5mEiyrJ4FJT8HA==",
+			"dev": true,
+			"requires": {
+				"@types/qunit": "^2.5.2",
+				"amd-name-resolver": "1.2.0",
+				"babel-generator": "^6.26.1",
+				"babel-helpers": "^6.24.1",
+				"babel-plugin-check-es2015-constants": "^6.22.0",
+				"babel-plugin-debug-macros": "^0.1.11",
+				"babel-plugin-external-helpers": "^6.22.0",
+				"babel-plugin-feature-flags": "^0.3.1",
+				"babel-plugin-filter-imports": "~2.0.0",
+				"babel-plugin-strip-glimmer-utils": "^0.1.1",
+				"babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+				"babel-plugin-transform-es2015-block-scoping": "^6.26.0",
+				"babel-plugin-transform-es2015-classes": "^6.24.1",
+				"babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+				"babel-plugin-transform-es2015-destructuring": "^6.23.0",
+				"babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
+				"babel-plugin-transform-es2015-parameters": "^6.24.1",
+				"babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+				"babel-plugin-transform-es2015-spread": "^6.22.0",
+				"babel-plugin-transform-es2015-template-literals": "^6.22.0",
+				"babel-plugin-transform-proto-to-assign": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"broccoli": "^1.1.4",
+				"broccoli-babel-transpiler": "^6.5.0",
+				"broccoli-cli": "^1.0.0",
+				"broccoli-concat": "^3.5.1",
+				"broccoli-file-creator": "^2.1.1",
+				"broccoli-funnel": "^2.0.1",
+				"broccoli-merge-trees": "^2.0.1",
+				"broccoli-rollup": "^1.3.0",
+				"broccoli-string-replace": "^0.1.2",
+				"broccoli-typescript-compiler": "4.0.1",
+				"loader.js": "^4.7.0",
+				"qunit": "^2.6.1",
+				"resolve": "^1.8.1",
+				"stack-trace": "^0.0.10",
+				"testem": "^2.9.2",
+				"tslint": "^5.11.0",
+				"typescript": "~3.0.1"
+			}
+		},
+		"@orbit/coordinator": {
+			"version": "0.16.0-beta.1",
+			"resolved": "https://registry.npmjs.org/@orbit/coordinator/-/coordinator-0.16.0-beta.1.tgz",
+			"integrity": "sha512-EayPyFVZr3TiuRaWKPZoTumMkzDbaleZd97j+JV+WjDLLh0R6Z9k7QO/GETvRag6au9MtCDxPvRL4cqfIIC2hA==",
+			"requires": {
+				"@orbit/core": "^0.16.0-beta.1",
+				"@orbit/data": "^0.16.0-beta.1",
+				"@orbit/utils": "^0.16.0-beta.1"
+			}
+		},
+		"@orbit/core": {
+			"version": "0.16.0-beta.1",
+			"resolved": "https://registry.npmjs.org/@orbit/core/-/core-0.16.0-beta.1.tgz",
+			"integrity": "sha512-V3CCyl+o1UF/paSRy4+wqU2H55OuDsGpQSbkRVpHt2mlJiMASO6iYH/q1oKEi1jpATr+2ubN9dVzfLztY+i5Ng==",
+			"requires": {
+				"@orbit/utils": "^0.16.0-beta.1"
+			}
+		},
+		"@orbit/data": {
+			"version": "0.16.0-beta.1",
+			"resolved": "https://registry.npmjs.org/@orbit/data/-/data-0.16.0-beta.1.tgz",
+			"integrity": "sha512-cdt+3XN/YLN0GDK6WZeeCueqIiimnMPBBznw/EeW1eIMmHT3e9WP+JzuaOsm/j8IKUm2hYhLmonAl0/DV9fj/Q==",
+			"requires": {
+				"@orbit/core": "^0.16.0-beta.1",
+				"@orbit/utils": "^0.16.0-beta.1"
+			}
+		},
+		"@orbit/immutable": {
+			"version": "0.16.0-beta.1",
+			"resolved": "https://registry.npmjs.org/@orbit/immutable/-/immutable-0.16.0-beta.1.tgz",
+			"integrity": "sha512-lK/2BamKuvYac/zErBFDboTTdxfS6Sz4ajKyD3UCSuWFd1s89L3yv3QvjXLux+IHm5IaO3CiLuObEeVaWsvTaA=="
+		},
+		"@orbit/indexeddb": {
+			"version": "0.16.0-beta.2",
+			"resolved": "https://registry.npmjs.org/@orbit/indexeddb/-/indexeddb-0.16.0-beta.2.tgz",
+			"integrity": "sha512-EUxBjIjuyyiDNs9Uolxuta4jYRE11/2Tu1WxGSb5voej+mFhcM0UTH7QkRnyRDgTGbOBjMHzCU+zoQjBoe/iuQ==",
+			"requires": {
+				"@orbit/core": "^0.16.0-beta.1",
+				"@orbit/data": "^0.16.0-beta.1",
+				"@orbit/record-cache": "^0.16.0-beta.2",
+				"@orbit/utils": "^0.16.0-beta.1"
+			}
+		},
+		"@orbit/indexeddb-bucket": {
+			"version": "0.16.0-beta.1",
+			"resolved": "https://registry.npmjs.org/@orbit/indexeddb-bucket/-/indexeddb-bucket-0.16.0-beta.1.tgz",
+			"integrity": "sha512-yTdECxNljPKqPWkATJ/NjJSRA9Y36/HLXYXDTdUiYA462pxbWfbRKeTVilTqJ6Qr0dG4ljONlvhOoi220akshQ==",
+			"requires": {
+				"@orbit/core": "^0.16.0-beta.1",
+				"@orbit/utils": "^0.16.0-beta.1"
+			}
+		},
+		"@orbit/jsonapi": {
+			"version": "0.16.0-beta.1",
+			"resolved": "https://registry.npmjs.org/@orbit/jsonapi/-/jsonapi-0.16.0-beta.1.tgz",
+			"integrity": "sha512-zBTJDXOs+eOZlcKE/vjTObtseWBfzh4M2umHnI1SIOhzQqasvKEte4GHQDqkXHkswatxZdorWbBFWF5Fdk6mgg==",
+			"requires": {
+				"@orbit/core": "^0.16.0-beta.1",
+				"@orbit/data": "^0.16.0-beta.1",
+				"@orbit/serializers": "^0.16.0-beta.1",
+				"@orbit/utils": "^0.16.0-beta.1"
+			}
+		},
+		"@orbit/local-storage": {
+			"version": "0.16.0-beta.2",
+			"resolved": "https://registry.npmjs.org/@orbit/local-storage/-/local-storage-0.16.0-beta.2.tgz",
+			"integrity": "sha512-DW/7eW4zQVU+UdfXApDy2MM03GhhObuV7nK1wexYjuCN1INZENodloH6QpLbz1F6dkTEejVyVlC9zZ5NmeaAhA==",
+			"requires": {
+				"@orbit/core": "^0.16.0-beta.1",
+				"@orbit/data": "^0.16.0-beta.1",
+				"@orbit/record-cache": "^0.16.0-beta.2",
+				"@orbit/utils": "^0.16.0-beta.1"
+			}
+		},
+		"@orbit/local-storage-bucket": {
+			"version": "0.16.0-beta.1",
+			"resolved": "https://registry.npmjs.org/@orbit/local-storage-bucket/-/local-storage-bucket-0.16.0-beta.1.tgz",
+			"integrity": "sha512-+5mpbFZqW06yoAd9jukZThfDGQElb2w+3PgyXblsQgFYQ8uugb9Fvd9KP/9tid41VM2BDD2ErGXH1YzhUhRgXw==",
+			"requires": {
+				"@orbit/core": "^0.16.0-beta.1",
+				"@orbit/utils": "^0.16.0-beta.1"
+			}
+		},
+		"@orbit/record-cache": {
+			"version": "0.16.0-beta.2",
+			"resolved": "https://registry.npmjs.org/@orbit/record-cache/-/record-cache-0.16.0-beta.2.tgz",
+			"integrity": "sha512-dkEkXX2WiKTk1nq8RNtROWcEEs0TnS5uSvBQhODP6KqOS2w3w1PVRp80kb9yCxNVm9N8sQadCIvCjpEYiGNNRQ==",
+			"requires": {
+				"@orbit/core": "^0.16.0-beta.1",
+				"@orbit/data": "^0.16.0-beta.1",
+				"@orbit/utils": "^0.16.0-beta.1"
+			}
+		},
+		"@orbit/serializers": {
+			"version": "0.16.0-beta.1",
+			"resolved": "https://registry.npmjs.org/@orbit/serializers/-/serializers-0.16.0-beta.1.tgz",
+			"integrity": "sha512-S33BBowqN92TUIdlSJWOh3GW9Ve3KfA2jnzMwkyWHv1RHrinR8nb0+ZIN0D2iYgZ6oEkBVJb7iHVg9HIyqXASg=="
+		},
+		"@orbit/store": {
+			"version": "0.16.0-beta.2",
+			"resolved": "https://registry.npmjs.org/@orbit/store/-/store-0.16.0-beta.2.tgz",
+			"integrity": "sha512-/SRsxsXY6gAMJVsBixnFzPj82aHGzB+EDk4i3wgB8n+EV4BvcJ5Ddn+6sCFFEsjE192PS0QnmTZ4etWBLkbyEw==",
+			"requires": {
+				"@orbit/core": "^0.16.0-beta.1",
+				"@orbit/data": "^0.16.0-beta.1",
+				"@orbit/immutable": "^0.16.0-beta.1",
+				"@orbit/record-cache": "^0.16.0-beta.2",
+				"@orbit/utils": "^0.16.0-beta.1"
+			}
+		},
+		"@orbit/utils": {
+			"version": "0.16.0-beta.1",
+			"resolved": "https://registry.npmjs.org/@orbit/utils/-/utils-0.16.0-beta.1.tgz",
+			"integrity": "sha512-S8rp47/xQmBx+ub0Y1a7DQcKA+OQwXpv8vNAhMqw+Ew0sDUHYaeRibSsgCGDatC3UkP8ClUVFHgJifS19jxDPQ=="
+		},
+		"@sinonjs/commons": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+			"integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
+			"dev": true,
+			"requires": {
+				"type-detect": "4.0.8"
+			}
+		},
+		"@sinonjs/formatio": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+			"integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1",
+				"@sinonjs/samsam": "^3.1.0"
+			}
+		},
+		"@sinonjs/samsam": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.0.tgz",
+			"integrity": "sha512-beHeJM/RRAaLLsMJhsCvHK31rIqZuobfPLa/80yGH5hnD8PV1hyh9xJBJNFfNmO7yWqm+zomijHsXpI6iTQJfQ==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1.0.2",
+				"array-from": "^2.1.1",
+				"lodash": "^4.17.11"
+			}
+		},
+		"@sinonjs/text-encoding": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+			"integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+			"dev": true
+		},
+		"@types/qunit": {
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/@types/qunit/-/qunit-2.5.4.tgz",
+			"integrity": "sha512-VHi2lEd4/zp8OOouf43JXGJJ5ZxHvdLL1dU0Yakp6Iy73SjpuXl7yjwAwmh1qhTv8krDgHteSwaySr++uXX9YQ==",
+			"dev": true
+		},
+		"@types/sinon": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.0.3.tgz",
+			"integrity": "sha512-cjmJQLx2B5Hp9SzO7rdSivipo3kBqRqeYkTW17nLST1tn5YLWBjTdnzdmeTJXA1+KrrBLsEuvKQ0fUPGrfazQg==",
+			"dev": true
+		},
+		"accepts": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+			"dev": true,
+			"requires": {
+				"mime-types": "~2.1.18",
+				"negotiator": "0.6.1"
+			}
+		},
+		"after": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+			"integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
+			"dev": true
+		},
+		"amd-name-resolver": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/amd-name-resolver/-/amd-name-resolver-1.2.0.tgz",
+			"integrity": "sha512-hlSTWGS1t6/xq5YCed7YALg7tKZL3rkl7UwEZ/eCIkn8JxmM6fU6Qs/1hwtjQqfuYxlffuUcgYEm0f5xP4YKaA==",
+			"dev": true,
+			"requires": {
+				"ensure-posix-path": "^1.0.1"
+			}
+		},
+		"amdefine": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+			"dev": true
+		},
+		"ansi-regex": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
+		},
+		"ansi-styles": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+			"dev": true
+		},
+		"anymatch": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"dev": true,
+			"requires": {
+				"micromatch": "^2.1.5",
+				"normalize-path": "^2.0.0"
+			}
+		},
+		"aproba": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+			"dev": true
+		},
+		"are-we-there-yet": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+			"dev": true,
+			"requires": {
+				"delegates": "^1.0.0",
+				"readable-stream": "^2.0.6"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "2.3.6",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+					"dev": true,
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+					"dev": true,
+					"requires": {
+						"safe-buffer": "~5.1.0"
+					}
+				}
+			}
+		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"requires": {
+				"sprintf-js": "~1.0.2"
+			},
+			"dependencies": {
+				"sprintf-js": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+					"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+					"dev": true
+				}
+			}
+		},
+		"arr-diff": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+			"dev": true,
+			"requires": {
+				"arr-flatten": "^1.0.1"
+			}
+		},
+		"arr-flatten": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+			"dev": true
+		},
+		"array-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+			"dev": true
+		},
+		"array-flatten": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+			"dev": true
+		},
+		"array-from": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+			"integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+			"dev": true
+		},
+		"array-unique": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+			"dev": true
+		},
+		"arraybuffer.slice": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+			"integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
+			"dev": true
+		},
+		"async": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+			"integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.17.11"
+			}
+		},
+		"async-disk-cache": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-1.3.4.tgz",
+			"integrity": "sha512-qsIvGJ/XYZ5bSGf5vHt2aEQHZnyuehmk/+51rCJhpkZl4LtvOZ+STbhLbdFAJGYO+dLzUT5Bb4nLKqHBX83vhw==",
+			"dev": true,
+			"requires": {
+				"debug": "^2.1.3",
+				"heimdalljs": "^0.2.3",
+				"istextorbinary": "2.1.0",
+				"mkdirp": "^0.5.0",
+				"rimraf": "^2.5.3",
+				"rsvp": "^3.0.18",
+				"username-sync": "^1.0.2"
+			}
+		},
+		"async-limiter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+			"dev": true
+		},
+		"async-promise-queue": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/async-promise-queue/-/async-promise-queue-1.0.4.tgz",
+			"integrity": "sha512-GQ5X3DT+TefYuFPHdvIPXFTlKnh39U7dwtl+aUBGeKjMea9nBpv3c91DXgeyBQmY07vQ97f3Sr9XHqkamEameQ==",
+			"dev": true,
+			"requires": {
+				"async": "^2.4.1",
+				"debug": "^2.6.8"
+			}
+		},
+		"babel-code-frame": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+			"dev": true,
+			"requires": {
+				"chalk": "^1.1.3",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.2"
+			}
+		},
+		"babel-core": {
+			"version": "6.26.3",
+			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+			"dev": true,
+			"requires": {
+				"babel-code-frame": "^6.26.0",
+				"babel-generator": "^6.26.0",
+				"babel-helpers": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-register": "^6.26.0",
+				"babel-runtime": "^6.26.0",
+				"babel-template": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"convert-source-map": "^1.5.1",
+				"debug": "^2.6.9",
+				"json5": "^0.5.1",
+				"lodash": "^4.17.4",
+				"minimatch": "^3.0.4",
+				"path-is-absolute": "^1.0.1",
+				"private": "^0.1.8",
+				"slash": "^1.0.0",
+				"source-map": "^0.5.7"
+			}
+		},
+		"babel-generator": {
+			"version": "6.26.1",
+			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+			"dev": true,
+			"requires": {
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"detect-indent": "^4.0.0",
+				"jsesc": "^1.3.0",
+				"lodash": "^4.17.4",
+				"source-map": "^0.5.7",
+				"trim-right": "^1.0.1"
+			}
+		},
+		"babel-helper-call-delegate": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+			"dev": true,
+			"requires": {
+				"babel-helper-hoist-variables": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
+			}
+		},
+		"babel-helper-define-map": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+			"dev": true,
+			"requires": {
+				"babel-helper-function-name": "^6.24.1",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"lodash": "^4.17.4"
+			}
+		},
+		"babel-helper-function-name": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+			"dev": true,
+			"requires": {
+				"babel-helper-get-function-arity": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
+			}
+		},
+		"babel-helper-get-function-arity": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
+			}
+		},
+		"babel-helper-hoist-variables": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
+			}
+		},
+		"babel-helper-optimise-call-expression": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
+			}
+		},
+		"babel-helper-replace-supers": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+			"dev": true,
+			"requires": {
+				"babel-helper-optimise-call-expression": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
+			}
+		},
+		"babel-helpers": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
+			}
+		},
+		"babel-messages": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.22.0"
+			}
+		},
+		"babel-plugin-check-es2015-constants": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.22.0"
+			}
+		},
+		"babel-plugin-debug-macros": {
+			"version": "0.1.11",
+			"resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.11.tgz",
+			"integrity": "sha512-hZw5qNNGAR02Y+yBUrtsnJHh8OXavkayPRqKGAXnIm4t5rWVpj3ArwsC7TWdpZsBguQvHAeyTxZ7s23yY60HHg==",
+			"dev": true,
+			"requires": {
+				"semver": "^5.3.0"
+			}
+		},
+		"babel-plugin-external-helpers": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz",
+			"integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.22.0"
+			}
+		},
+		"babel-plugin-feature-flags": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-feature-flags/-/babel-plugin-feature-flags-0.3.1.tgz",
+			"integrity": "sha1-nIJ8+aTrmhn3JcyyOehcqwIDb8E=",
+			"dev": true
+		},
+		"babel-plugin-filter-imports": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/babel-plugin-filter-imports/-/babel-plugin-filter-imports-2.0.4.tgz",
+			"integrity": "sha512-Ra4VylqMFsmTJCUeLRJ/OP2ZqO0cCJQK2HKihNTnoKP4f8IhxHKL4EkbmfkwGjXCeDyXd0xQ6UTK8Nd+h9V/SQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.1.5",
+				"lodash": "^4.17.11"
+			}
+		},
+		"babel-plugin-strip-glimmer-utils": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-strip-glimmer-utils/-/babel-plugin-strip-glimmer-utils-0.1.1.tgz",
+			"integrity": "sha1-33Sko0nQuFIvQ0xFfLbO8gSDyeo=",
+			"dev": true
+		},
+		"babel-plugin-transform-es2015-arrow-functions": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.22.0"
+			}
+		},
+		"babel-plugin-transform-es2015-block-scoping": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.26.0",
+				"babel-template": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"lodash": "^4.17.4"
+			}
+		},
+		"babel-plugin-transform-es2015-classes": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+			"dev": true,
+			"requires": {
+				"babel-helper-define-map": "^6.24.1",
+				"babel-helper-function-name": "^6.24.1",
+				"babel-helper-optimise-call-expression": "^6.24.1",
+				"babel-helper-replace-supers": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
+			}
+		},
+		"babel-plugin-transform-es2015-computed-properties": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
+			}
+		},
+		"babel-plugin-transform-es2015-destructuring": {
+			"version": "6.23.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.22.0"
+			}
+		},
+		"babel-plugin-transform-es2015-modules-commonjs": {
+			"version": "6.26.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+			"integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+			"dev": true,
+			"requires": {
+				"babel-plugin-transform-strict-mode": "^6.24.1",
+				"babel-runtime": "^6.26.0",
+				"babel-template": "^6.26.0",
+				"babel-types": "^6.26.0"
+			}
+		},
+		"babel-plugin-transform-es2015-parameters": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+			"dev": true,
+			"requires": {
+				"babel-helper-call-delegate": "^6.24.1",
+				"babel-helper-get-function-arity": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
+			}
+		},
+		"babel-plugin-transform-es2015-shorthand-properties": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
+			}
+		},
+		"babel-plugin-transform-es2015-spread": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.22.0"
+			}
+		},
+		"babel-plugin-transform-es2015-template-literals": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.22.0"
+			}
+		},
+		"babel-plugin-transform-proto-to-assign": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-proto-to-assign/-/babel-plugin-transform-proto-to-assign-6.26.0.tgz",
+			"integrity": "sha1-xJPiSmJ0mkT37ellBsDLOhiR9ns=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.26.0",
+				"lodash": "^4.17.4"
+			}
+		},
+		"babel-plugin-transform-strict-mode": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
+			}
+		},
+		"babel-register": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+			"dev": true,
+			"requires": {
+				"babel-core": "^6.26.0",
+				"babel-runtime": "^6.26.0",
+				"core-js": "^2.5.0",
+				"home-or-tmp": "^2.0.0",
+				"lodash": "^4.17.4",
+				"mkdirp": "^0.5.1",
+				"source-map-support": "^0.4.15"
+			}
+		},
+		"babel-runtime": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+			"dev": true,
+			"requires": {
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.11.0"
+			}
+		},
+		"babel-template": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"lodash": "^4.17.4"
+			}
+		},
+		"babel-traverse": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+			"dev": true,
+			"requires": {
+				"babel-code-frame": "^6.26.0",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"debug": "^2.6.8",
+				"globals": "^9.18.0",
+				"invariant": "^2.2.2",
+				"lodash": "^4.17.4"
+			}
+		},
+		"babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
+			}
+		},
+		"babylon": {
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+			"dev": true
+		},
+		"backbone": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
+			"integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
+			"dev": true,
+			"requires": {
+				"underscore": ">=1.8.3"
+			}
+		},
+		"backo2": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+			"integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
+			"dev": true
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
+		},
+		"base64-arraybuffer": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+			"integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
+			"dev": true
+		},
+		"base64id": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
+			"integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
+			"dev": true
+		},
+		"better-assert": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+			"integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+			"dev": true,
+			"requires": {
+				"callsite": "1.0.0"
+			}
+		},
+		"binaryextensions": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.1.2.tgz",
+			"integrity": "sha512-xVNN69YGDghOqCCtA6FI7avYrr02mTJjOgB0/f1VPD3pJC8QEvjTKWc4epDx8AqxxA75NI0QpVM2gPJXUbE4Tg==",
+			"dev": true
+		},
+		"blank-object": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/blank-object/-/blank-object-1.0.2.tgz",
+			"integrity": "sha1-+ZB5P76ajI3QE/syGUIL7IHV9Lk=",
+			"dev": true
+		},
+		"blob": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
+			"integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==",
+			"dev": true
+		},
+		"bluebird": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+			"integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
+			"dev": true
+		},
+		"body-parser": {
+			"version": "1.18.3",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+			"integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+			"dev": true,
+			"requires": {
+				"bytes": "3.0.0",
+				"content-type": "~1.0.4",
+				"debug": "2.6.9",
+				"depd": "~1.1.2",
+				"http-errors": "~1.6.3",
+				"iconv-lite": "0.4.23",
+				"on-finished": "~2.3.0",
+				"qs": "6.5.2",
+				"raw-body": "2.3.3",
+				"type-is": "~1.6.16"
+			}
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"braces": {
+			"version": "1.8.5",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+			"dev": true,
+			"requires": {
+				"expand-range": "^1.8.1",
+				"preserve": "^0.2.0",
+				"repeat-element": "^1.1.2"
+			}
+		},
+		"broccoli": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/broccoli/-/broccoli-1.1.4.tgz",
+			"integrity": "sha1-sCOwKLhm9EftFDQQB5Ye/QP3JRw=",
+			"dev": true,
+			"requires": {
+				"broccoli-node-info": "1.1.0",
+				"broccoli-slow-trees": "2.0.0",
+				"broccoli-source": "^1.1.0",
+				"commander": "^2.5.0",
+				"connect": "^3.3.3",
+				"copy-dereference": "^1.0.0",
+				"findup-sync": "^1.0.0",
+				"handlebars": "^4.0.4",
+				"heimdalljs-logger": "^0.1.7",
+				"mime": "^1.2.11",
+				"rimraf": "^2.4.3",
+				"rsvp": "^3.5.0",
+				"sane": "^1.4.1",
+				"tmp": "0.0.31",
+				"underscore.string": "^3.2.2"
+			}
+		},
+		"broccoli-babel-transpiler": {
+			"version": "6.5.1",
+			"resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.5.1.tgz",
+			"integrity": "sha512-w6GcnkxvHcNCte5FcLGEG1hUdQvlfvSN/6PtGWU/otg69Ugk8rUk51h41R0Ugoc+TNxyeFG1opRt2RlA87XzNw==",
+			"dev": true,
+			"requires": {
+				"babel-core": "^6.26.0",
+				"broccoli-funnel": "^2.0.1",
+				"broccoli-merge-trees": "^2.0.0",
+				"broccoli-persistent-filter": "^1.4.3",
+				"clone": "^2.0.0",
+				"hash-for-dep": "^1.2.3",
+				"heimdalljs-logger": "^0.1.7",
+				"json-stable-stringify": "^1.0.0",
+				"rsvp": "^4.8.2",
+				"workerpool": "^2.3.0"
+			},
+			"dependencies": {
+				"rsvp": {
+					"version": "4.8.4",
+					"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz",
+					"integrity": "sha512-6FomvYPfs+Jy9TfXmBpBuMWNH94SgCsZmJKcanySzgNNP6LjWxBvyLTa9KaMfDDM5oxRfrKDB0r/qeRsLwnBfA==",
+					"dev": true
+				}
+			}
+		},
+		"broccoli-cli": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/broccoli-cli/-/broccoli-cli-1.0.0.tgz",
+			"integrity": "sha1-aURFIaXmMVaTAPvBluheGAl7IqQ=",
+			"dev": true,
+			"requires": {
+				"resolve": "~0.6.1"
+			},
+			"dependencies": {
+				"resolve": {
+					"version": "0.6.3",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
+					"integrity": "sha1-3ZV5gufnNt699TtYpN2RdUV13UY=",
+					"dev": true
+				}
+			}
+		},
+		"broccoli-concat": {
+			"version": "3.7.3",
+			"resolved": "https://registry.npmjs.org/broccoli-concat/-/broccoli-concat-3.7.3.tgz",
+			"integrity": "sha512-2Ma9h81EJ0PRb9n4sW0i8KZlcnpTQfKxcj87zvi5DFe1fd8CTDEdseHDotK2beuA2l+LbgVPfd8EHaBJKm/Y8g==",
+			"dev": true,
+			"requires": {
+				"broccoli-debug": "^0.6.5",
+				"broccoli-kitchen-sink-helpers": "^0.3.1",
+				"broccoli-plugin": "^1.3.0",
+				"ensure-posix-path": "^1.0.2",
+				"fast-sourcemap-concat": "^1.4.0",
+				"find-index": "^1.1.0",
+				"fs-extra": "^4.0.3",
+				"fs-tree-diff": "^0.5.7",
+				"lodash.merge": "^4.3.1",
+				"lodash.omit": "^4.1.0",
+				"lodash.uniq": "^4.2.0",
+				"walk-sync": "^0.3.2"
+			}
+		},
+		"broccoli-debug": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.5.tgz",
+			"integrity": "sha512-RIVjHvNar9EMCLDW/FggxFRXqpjhncM/3qq87bn/y+/zR9tqEkHvTqbyOc4QnB97NO2m6342w4wGkemkaeOuWg==",
+			"dev": true,
+			"requires": {
+				"broccoli-plugin": "^1.2.1",
+				"fs-tree-diff": "^0.5.2",
+				"heimdalljs": "^0.2.1",
+				"heimdalljs-logger": "^0.1.7",
+				"symlink-or-copy": "^1.1.8",
+				"tree-sync": "^1.2.2"
+			}
+		},
+		"broccoli-file-creator": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/broccoli-file-creator/-/broccoli-file-creator-2.1.1.tgz",
+			"integrity": "sha512-YpjOExWr92C5vhnK0kmD81kM7U09kdIRZk9w4ZDCDHuHXW+VE/x6AGEOQQW3loBQQ6Jk+k+TSm8dESy4uZsnjw==",
+			"dev": true,
+			"requires": {
+				"broccoli-plugin": "^1.1.0",
+				"mkdirp": "^0.5.1"
+			}
+		},
+		"broccoli-funnel": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+			"integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+			"dev": true,
+			"requires": {
+				"array-equal": "^1.0.0",
+				"blank-object": "^1.0.1",
+				"broccoli-plugin": "^1.3.0",
+				"debug": "^2.2.0",
+				"fast-ordered-set": "^1.0.0",
+				"fs-tree-diff": "^0.5.3",
+				"heimdalljs": "^0.2.0",
+				"minimatch": "^3.0.0",
+				"mkdirp": "^0.5.0",
+				"path-posix": "^1.0.0",
+				"rimraf": "^2.4.3",
+				"symlink-or-copy": "^1.0.0",
+				"walk-sync": "^0.3.1"
+			}
+		},
+		"broccoli-kitchen-sink-helpers": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.3.1.tgz",
+			"integrity": "sha1-d8fBgZS5ZkFj7E/O4nk0RJJuDAY=",
+			"dev": true,
+			"requires": {
+				"glob": "^5.0.10",
+				"mkdirp": "^0.5.1"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "5.0.15",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+					"dev": true,
+					"requires": {
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "2 || 3",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				}
+			}
+		},
+		"broccoli-merge-trees": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.1.tgz",
+			"integrity": "sha512-WjaexJ+I8BxP5V5RNn6um/qDRSmKoiBC/QkRi79FT9ClHfldxRyCDs9mcV7mmoaPlsshmmPaUz5jdtcKA6DClQ==",
+			"dev": true,
+			"requires": {
+				"broccoli-plugin": "^1.3.0",
+				"merge-trees": "^1.0.1"
+			}
+		},
+		"broccoli-node-info": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/broccoli-node-info/-/broccoli-node-info-1.1.0.tgz",
+			"integrity": "sha1-OqLjHgflvbUW3SUhT3xFuhxFlBI=",
+			"dev": true
+		},
+		"broccoli-persistent-filter": {
+			"version": "1.4.6",
+			"resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz",
+			"integrity": "sha512-0RejLwoC95kv4kta8KAa+FmECJCK78Qgm8SRDEK7YyU0N9Cx6KpY3UCDy9WELl3mCXLN8TokNxc7/hp3lL4lfw==",
+			"dev": true,
+			"requires": {
+				"async-disk-cache": "^1.2.1",
+				"async-promise-queue": "^1.0.3",
+				"broccoli-plugin": "^1.0.0",
+				"fs-tree-diff": "^0.5.2",
+				"hash-for-dep": "^1.0.2",
+				"heimdalljs": "^0.2.1",
+				"heimdalljs-logger": "^0.1.7",
+				"mkdirp": "^0.5.1",
+				"promise-map-series": "^0.2.1",
+				"rimraf": "^2.6.1",
+				"rsvp": "^3.0.18",
+				"symlink-or-copy": "^1.0.1",
+				"walk-sync": "^0.3.1"
+			}
+		},
+		"broccoli-plugin": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
+			"integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
+			"dev": true,
+			"requires": {
+				"promise-map-series": "^0.2.1",
+				"quick-temp": "^0.1.3",
+				"rimraf": "^2.3.4",
+				"symlink-or-copy": "^1.1.8"
+			}
+		},
+		"broccoli-rollup": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/broccoli-rollup/-/broccoli-rollup-1.3.0.tgz",
+			"integrity": "sha1-Q6CneYVVurVCFwCetHCk/1oFbfA=",
+			"dev": true,
+			"requires": {
+				"broccoli-plugin": "^1.2.1",
+				"es6-map": "^0.1.4",
+				"fs-extra": "^0.30.0",
+				"fs-tree-diff": "^0.5.2",
+				"heimdalljs": "^0.2.1",
+				"heimdalljs-logger": "^0.1.7",
+				"md5-hex": "^1.3.0",
+				"node-modules-path": "^1.0.1",
+				"rollup": "^0.41.4",
+				"symlink-or-copy": "^1.1.8",
+				"walk-sync": "^0.3.1"
+			},
+			"dependencies": {
+				"fs-extra": {
+					"version": "0.30.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+					"integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^2.1.0",
+						"klaw": "^1.0.0",
+						"path-is-absolute": "^1.0.0",
+						"rimraf": "^2.2.8"
+					}
+				},
+				"jsonfile": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+					"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.6"
+					}
+				}
+			}
+		},
+		"broccoli-slow-trees": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/broccoli-slow-trees/-/broccoli-slow-trees-2.0.0.tgz",
+			"integrity": "sha1-l0Gv6ZJ4et1krsf3yCEd/MBYJ40=",
+			"dev": true
+		},
+		"broccoli-source": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-1.1.0.tgz",
+			"integrity": "sha1-VPDoLItz9GWAy7xPV48LMvyo+Ak=",
+			"dev": true
+		},
+		"broccoli-string-replace": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/broccoli-string-replace/-/broccoli-string-replace-0.1.2.tgz",
+			"integrity": "sha1-HtkvhWgK+NUDAjkl51Tk4zZ2uR8=",
+			"dev": true,
+			"requires": {
+				"broccoli-persistent-filter": "^1.1.5",
+				"minimatch": "^3.0.3"
+			}
+		},
+		"broccoli-typescript-compiler": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/broccoli-typescript-compiler/-/broccoli-typescript-compiler-4.0.1.tgz",
+			"integrity": "sha512-3psnblHnaMTfh3sE9lkLTKs8XjK563vbKMh/1mslmabqt9wuAOfTMUNEMbmGCofVoMUd9C/ydrmN5eZ6mJUNpQ==",
+			"dev": true,
+			"requires": {
+				"broccoli-funnel": "^2.0.1",
+				"broccoli-merge-trees": "^3.0.0",
+				"broccoli-plugin": "^1.3.0",
+				"fs-tree-diff": "^0.5.7",
+				"heimdalljs": "0.3.3",
+				"md5-hex": "^2.0.0",
+				"typescript": "~3.0.1",
+				"walk-sync": "^0.3.2"
+			},
+			"dependencies": {
+				"broccoli-merge-trees": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
+					"integrity": "sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==",
+					"dev": true,
+					"requires": {
+						"broccoli-plugin": "^1.3.0",
+						"merge-trees": "^2.0.0"
+					}
+				},
+				"heimdalljs": {
+					"version": "0.3.3",
+					"resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.3.3.tgz",
+					"integrity": "sha1-6S0sb3f9RtW/ULYQ0orTF1UFTQs=",
+					"dev": true,
+					"requires": {
+						"rsvp": "~3.2.1"
+					}
+				},
+				"md5-hex": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
+					"integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
+					"dev": true,
+					"requires": {
+						"md5-o-matic": "^0.1.1"
+					}
+				},
+				"merge-trees": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-2.0.0.tgz",
+					"integrity": "sha512-5xBbmqYBalWqmhYm51XlohhkmVOua3VAUrrWh8t9iOkaLpS6ifqm/UVuUjQCeDVJ9Vx3g2l6ihfkbLSTeKsHbw==",
+					"dev": true,
+					"requires": {
+						"fs-updater": "^1.0.4",
+						"heimdalljs": "^0.2.5"
+					},
+					"dependencies": {
+						"heimdalljs": {
+							"version": "0.2.6",
+							"resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.6.tgz",
+							"integrity": "sha512-o9bd30+5vLBvBtzCPwwGqpry2+n0Hi6H1+qwt6y+0kwRHGGF8TFIhJPmnuM0xO97zaKrDZMwO/V56fAnn8m/tA==",
+							"dev": true,
+							"requires": {
+								"rsvp": "~3.2.1"
+							}
+						}
+					}
+				},
+				"rsvp": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+					"integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
+					"dev": true
+				}
+			}
+		},
+		"bser": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+			"dev": true,
+			"requires": {
+				"node-int64": "^0.4.0"
+			}
+		},
+		"builtin-modules": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+			"dev": true
+		},
+		"bytes": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+			"dev": true
+		},
+		"callsite": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+			"integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
+			"dev": true
+		},
+		"can-symlink": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/can-symlink/-/can-symlink-1.0.0.tgz",
+			"integrity": "sha1-l7YH2KhLtsbiKLkC2GTstZS50hk=",
+			"dev": true,
+			"requires": {
+				"tmp": "0.0.28"
+			},
+			"dependencies": {
+				"tmp": {
+					"version": "0.0.28",
+					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
+					"integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
+					"dev": true,
+					"requires": {
+						"os-tmpdir": "~1.0.1"
+					}
+				}
+			}
+		},
+		"chalk": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^2.2.1",
+				"escape-string-regexp": "^1.0.2",
+				"has-ansi": "^2.0.0",
+				"strip-ansi": "^3.0.0",
+				"supports-color": "^2.0.0"
+			}
+		},
+		"charm": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/charm/-/charm-1.0.2.tgz",
+			"integrity": "sha1-it02cVOm2aWBMxBSxAkJkdqZXjU=",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.1"
+			}
+		},
+		"clean-up-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/clean-up-path/-/clean-up-path-1.0.0.tgz",
+			"integrity": "sha512-PHGlEF0Z6976qQyN6gM7kKH6EH0RdfZcc8V+QhFe36eRxV0SMH5OUBZG7Bxa9YcreNzyNbK63cGiZxdSZgosRw==",
+			"dev": true
+		},
+		"clone": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+			"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+			"dev": true
+		},
+		"code-point-at": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
+		"commander": {
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+			"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+			"dev": true
+		},
+		"component-bind": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+			"integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
+			"dev": true
+		},
+		"component-emitter": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+			"dev": true
+		},
+		"component-inherit": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+			"integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
+			"dev": true
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"connect": {
+			"version": "3.6.6",
+			"resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
+			"integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
+			"dev": true,
+			"requires": {
+				"debug": "2.6.9",
+				"finalhandler": "1.1.0",
+				"parseurl": "~1.3.2",
+				"utils-merge": "1.0.1"
+			}
+		},
+		"console-control-strings": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+			"dev": true
+		},
+		"consolidate": {
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.15.1.tgz",
+			"integrity": "sha512-DW46nrsMJgy9kqAbPt5rKaCr7uFtpo4mSUvLHIUbJEjm0vo+aY5QLwBUq3FK4tRnJr/X0Psc0C4jf/h+HtXSMw==",
+			"dev": true,
+			"requires": {
+				"bluebird": "^3.1.1"
+			}
+		},
+		"content-disposition": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+			"integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+			"dev": true
+		},
+		"content-type": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+			"dev": true
+		},
+		"convert-source-map": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "~5.1.1"
+			}
+		},
+		"cookie": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+			"dev": true
+		},
+		"cookie-signature": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+			"integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+			"dev": true
+		},
+		"copy-dereference": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/copy-dereference/-/copy-dereference-1.0.0.tgz",
+			"integrity": "sha1-axMYZUIP2BtBO6mUtE02VTERUrY=",
+			"dev": true
+		},
+		"core-js": {
+			"version": "2.6.5",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+			"integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+			"dev": true
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+			"dev": true
+		},
+		"cross-spawn": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+			"dev": true,
+			"requires": {
+				"nice-try": "^1.0.4",
+				"path-key": "^2.0.1",
+				"semver": "^5.5.0",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
+			}
+		},
+		"d": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+			"dev": true,
+			"requires": {
+				"es5-ext": "^0.10.9"
+			}
+		},
+		"debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"delegates": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+			"dev": true
+		},
+		"depd": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+			"dev": true
+		},
+		"destroy": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+			"dev": true
+		},
+		"detect-file": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
+			"integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
+			"dev": true,
+			"requires": {
+				"fs-exists-sync": "^0.1.0"
+			}
+		},
+		"detect-indent": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+			"dev": true,
+			"requires": {
+				"repeating": "^2.0.0"
+			}
+		},
+		"diff": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+			"dev": true
+		},
+		"editions": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+			"integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
+			"dev": true
+		},
+		"ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+			"dev": true
+		},
+		"encodeurl": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+			"dev": true
+		},
+		"end-of-stream": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"dev": true,
+			"requires": {
+				"once": "^1.4.0"
+			}
+		},
+		"engine.io": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.3.2.tgz",
+			"integrity": "sha512-AsaA9KG7cWPXWHp5FvHdDWY3AMWeZ8x+2pUVLcn71qE5AtAzgGbxuclOytygskw8XGmiQafTmnI9Bix3uihu2w==",
+			"dev": true,
+			"requires": {
+				"accepts": "~1.3.4",
+				"base64id": "1.0.0",
+				"cookie": "0.3.1",
+				"debug": "~3.1.0",
+				"engine.io-parser": "~2.1.0",
+				"ws": "~6.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
+		},
+		"engine.io-client": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.3.2.tgz",
+			"integrity": "sha512-y0CPINnhMvPuwtqXfsGuWE8BB66+B6wTtCofQDRecMQPYX3MYUZXFNKDhdrSe3EVjgOu4V3rxdeqN/Tr91IgbQ==",
+			"dev": true,
+			"requires": {
+				"component-emitter": "1.2.1",
+				"component-inherit": "0.0.3",
+				"debug": "~3.1.0",
+				"engine.io-parser": "~2.1.1",
+				"has-cors": "1.1.0",
+				"indexof": "0.0.1",
+				"parseqs": "0.0.5",
+				"parseuri": "0.0.5",
+				"ws": "~6.1.0",
+				"xmlhttprequest-ssl": "~1.5.4",
+				"yeast": "0.1.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
+		},
+		"engine.io-parser": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.3.tgz",
+			"integrity": "sha512-6HXPre2O4Houl7c4g7Ic/XzPnHBvaEmN90vtRO9uLmwtRqQmTOw0QMevL1TOfL2Cpu1VzsaTmMotQgMdkzGkVA==",
+			"dev": true,
+			"requires": {
+				"after": "0.8.2",
+				"arraybuffer.slice": "~0.0.7",
+				"base64-arraybuffer": "0.1.5",
+				"blob": "0.0.5",
+				"has-binary2": "~1.0.2"
+			}
+		},
+		"ensure-posix-path": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.1.1.tgz",
+			"integrity": "sha512-VWU0/zXzVbeJNXvME/5EmLuEj2TauvoaTz6aFYK1Z92JCBlDlZ3Gu0tuGR42kpW1754ywTs+QB0g5TP0oj9Zaw==",
+			"dev": true
+		},
+		"es5-ext": {
+			"version": "0.10.49",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.49.tgz",
+			"integrity": "sha512-3NMEhi57E31qdzmYp2jwRArIUsj1HI/RxbQ4bgnSB+AIKIxsAmTiK83bYMifIcpWvEc3P1X30DhUKOqEtF/kvg==",
+			"dev": true,
+			"requires": {
+				"es6-iterator": "~2.0.3",
+				"es6-symbol": "~3.1.1",
+				"next-tick": "^1.0.0"
+			}
+		},
+		"es6-iterator": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+			"dev": true,
+			"requires": {
+				"d": "1",
+				"es5-ext": "^0.10.35",
+				"es6-symbol": "^3.1.1"
+			}
+		},
+		"es6-map": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+			"dev": true,
+			"requires": {
+				"d": "1",
+				"es5-ext": "~0.10.14",
+				"es6-iterator": "~2.0.1",
+				"es6-set": "~0.1.5",
+				"es6-symbol": "~3.1.1",
+				"event-emitter": "~0.3.5"
+			}
+		},
+		"es6-set": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+			"dev": true,
+			"requires": {
+				"d": "1",
+				"es5-ext": "~0.10.14",
+				"es6-iterator": "~2.0.1",
+				"es6-symbol": "3.1.1",
+				"event-emitter": "~0.3.5"
+			}
+		},
+		"es6-symbol": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+			"dev": true,
+			"requires": {
+				"d": "1",
+				"es5-ext": "~0.10.14"
+			}
+		},
+		"escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+			"dev": true
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
+		},
+		"esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true
+		},
+		"esutils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+			"dev": true
+		},
+		"etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+			"dev": true
+		},
+		"event-emitter": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+			"dev": true,
+			"requires": {
+				"d": "1",
+				"es5-ext": "~0.10.14"
+			}
+		},
+		"eventemitter3": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+			"integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
+			"dev": true
+		},
+		"events-to-array": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
+			"integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
+			"dev": true
+		},
+		"exec-sh": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
+			"integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
+			"dev": true,
+			"requires": {
+				"merge": "^1.2.0"
+			}
+		},
+		"execa": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+			"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+			"dev": true,
+			"requires": {
+				"cross-spawn": "^6.0.0",
+				"get-stream": "^4.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
+			}
+		},
+		"expand-brackets": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+			"dev": true,
+			"requires": {
+				"is-posix-bracket": "^0.1.0"
+			}
+		},
+		"expand-range": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+			"dev": true,
+			"requires": {
+				"fill-range": "^2.1.0"
+			}
+		},
+		"expand-tilde": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+			"integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+			"dev": true,
+			"requires": {
+				"os-homedir": "^1.0.1"
+			}
+		},
+		"express": {
+			"version": "4.16.4",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
+			"integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+			"dev": true,
+			"requires": {
+				"accepts": "~1.3.5",
+				"array-flatten": "1.1.1",
+				"body-parser": "1.18.3",
+				"content-disposition": "0.5.2",
+				"content-type": "~1.0.4",
+				"cookie": "0.3.1",
+				"cookie-signature": "1.0.6",
+				"debug": "2.6.9",
+				"depd": "~1.1.2",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"finalhandler": "1.1.1",
+				"fresh": "0.5.2",
+				"merge-descriptors": "1.0.1",
+				"methods": "~1.1.2",
+				"on-finished": "~2.3.0",
+				"parseurl": "~1.3.2",
+				"path-to-regexp": "0.1.7",
+				"proxy-addr": "~2.0.4",
+				"qs": "6.5.2",
+				"range-parser": "~1.2.0",
+				"safe-buffer": "5.1.2",
+				"send": "0.16.2",
+				"serve-static": "1.13.2",
+				"setprototypeof": "1.1.0",
+				"statuses": "~1.4.0",
+				"type-is": "~1.6.16",
+				"utils-merge": "1.0.1",
+				"vary": "~1.1.2"
+			},
+			"dependencies": {
+				"finalhandler": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+					"integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+					"dev": true,
+					"requires": {
+						"debug": "2.6.9",
+						"encodeurl": "~1.0.2",
+						"escape-html": "~1.0.3",
+						"on-finished": "~2.3.0",
+						"parseurl": "~1.3.2",
+						"statuses": "~1.4.0",
+						"unpipe": "~1.0.0"
+					}
+				},
+				"statuses": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+					"dev": true
+				}
+			}
+		},
+		"extglob": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+			"dev": true,
+			"requires": {
+				"is-extglob": "^1.0.0"
+			}
+		},
+		"fast-ordered-set": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/fast-ordered-set/-/fast-ordered-set-1.0.3.tgz",
+			"integrity": "sha1-P7s2Y097555PftvbSjV97iXRhOs=",
+			"dev": true,
+			"requires": {
+				"blank-object": "^1.0.1"
+			}
+		},
+		"fast-sourcemap-concat": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/fast-sourcemap-concat/-/fast-sourcemap-concat-1.4.0.tgz",
+			"integrity": "sha512-x90Wlx/2C83lfyg7h4oguTZN4MyaVfaiUSJQNpU+YEA0Odf9u659Opo44b0LfoVg9G/bOE++GdID/dkyja+XcA==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.0",
+				"fs-extra": "^5.0.0",
+				"heimdalljs-logger": "^0.1.9",
+				"memory-streams": "^0.1.3",
+				"mkdirp": "^0.5.0",
+				"source-map": "^0.4.2",
+				"source-map-url": "^0.3.0",
+				"sourcemap-validator": "^1.1.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"fs-extra": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+					"integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
+					}
+				},
+				"source-map": {
+					"version": "0.4.4",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+					"dev": true,
+					"requires": {
+						"amdefine": ">=0.0.4"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"fb-watchman": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+			"dev": true,
+			"requires": {
+				"bser": "^2.0.0"
+			}
+		},
+		"filename-regex": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+			"dev": true
+		},
+		"fill-range": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+			"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+			"dev": true,
+			"requires": {
+				"is-number": "^2.1.0",
+				"isobject": "^2.0.0",
+				"randomatic": "^3.0.0",
+				"repeat-element": "^1.1.2",
+				"repeat-string": "^1.5.2"
+			}
+		},
+		"finalhandler": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+			"integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+			"dev": true,
+			"requires": {
+				"debug": "2.6.9",
+				"encodeurl": "~1.0.1",
+				"escape-html": "~1.0.3",
+				"on-finished": "~2.3.0",
+				"parseurl": "~1.3.2",
+				"statuses": "~1.3.1",
+				"unpipe": "~1.0.0"
+			}
+		},
+		"find-index": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/find-index/-/find-index-1.1.1.tgz",
+			"integrity": "sha512-XYKutXMrIK99YMUPf91KX5QVJoG31/OsgftD6YoTPAObfQIxM4ziA9f0J1AsqKhJmo+IeaIPP0CFopTD4bdUBw==",
+			"dev": true
+		},
+		"findup-sync": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-1.0.0.tgz",
+			"integrity": "sha1-b35LV7buOkA3tEFOrt6j9Y9x4Ow=",
+			"dev": true,
+			"requires": {
+				"detect-file": "^0.1.0",
+				"is-glob": "^2.0.1",
+				"micromatch": "^2.3.7",
+				"resolve-dir": "^0.1.0"
+			}
+		},
+		"fireworm": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/fireworm/-/fireworm-0.7.1.tgz",
+			"integrity": "sha1-zPIPeUHxCIg/zduZOD2+bhhhx1g=",
+			"dev": true,
+			"requires": {
+				"async": "~0.2.9",
+				"is-type": "0.0.1",
+				"lodash.debounce": "^3.1.1",
+				"lodash.flatten": "^3.0.2",
+				"minimatch": "^3.0.2"
+			},
+			"dependencies": {
+				"async": {
+					"version": "0.2.10",
+					"resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+					"integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+					"dev": true
+				}
+			}
+		},
+		"follow-redirects": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
+			"integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
+			"dev": true,
+			"requires": {
+				"debug": "^3.2.6"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
+			}
+		},
+		"for-in": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+			"dev": true
+		},
+		"for-own": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
+			"requires": {
+				"for-in": "^1.0.1"
+			}
+		},
+		"forwarded": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+			"integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+			"dev": true
+		},
+		"fresh": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+			"dev": true
+		},
+		"fs-exists-sync": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+			"integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
+			"dev": true
+		},
+		"fs-extra": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+			"integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			}
+		},
+		"fs-tree-diff": {
+			"version": "0.5.9",
+			"resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
+			"integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
+			"dev": true,
+			"requires": {
+				"heimdalljs-logger": "^0.1.7",
+				"object-assign": "^4.1.0",
+				"path-posix": "^1.0.0",
+				"symlink-or-copy": "^1.1.8"
+			}
+		},
+		"fs-updater": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/fs-updater/-/fs-updater-1.0.4.tgz",
+			"integrity": "sha512-0pJX4mJF/qLsNEwTct8CdnnRdagfb+LmjRPJ8sO+nCnAZLW0cTmz4rTgU25n+RvTuWSITiLKrGVJceJPBIPlKg==",
+			"dev": true,
+			"requires": {
+				"can-symlink": "^1.0.0",
+				"clean-up-path": "^1.0.0",
+				"heimdalljs": "^0.2.5",
+				"heimdalljs-logger": "^0.1.9",
+				"rimraf": "^2.6.2"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"gauge": {
+			"version": "2.7.4",
+			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+			"dev": true,
+			"requires": {
+				"aproba": "^1.0.3",
+				"console-control-strings": "^1.0.0",
+				"has-unicode": "^2.0.0",
+				"object-assign": "^4.1.0",
+				"signal-exit": "^3.0.0",
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1",
+				"wide-align": "^1.1.0"
+			}
+		},
+		"get-stream": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+			"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+			"dev": true,
+			"requires": {
+				"pump": "^3.0.0"
+			}
+		},
+		"glob": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+			"dev": true,
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"glob-base": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+			"dev": true,
+			"requires": {
+				"glob-parent": "^2.0.0",
+				"is-glob": "^2.0.0"
+			}
+		},
+		"glob-parent": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+			"dev": true,
+			"requires": {
+				"is-glob": "^2.0.0"
+			}
+		},
+		"global-modules": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+			"integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+			"dev": true,
+			"requires": {
+				"global-prefix": "^0.1.4",
+				"is-windows": "^0.2.0"
+			}
+		},
+		"global-prefix": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+			"integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+			"dev": true,
+			"requires": {
+				"homedir-polyfill": "^1.0.0",
+				"ini": "^1.3.4",
+				"is-windows": "^0.2.0",
+				"which": "^1.2.12"
+			}
+		},
+		"globals": {
+			"version": "9.18.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+			"dev": true
+		},
+		"graceful-fs": {
+			"version": "4.1.15",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+			"dev": true
+		},
+		"growly": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+			"dev": true
+		},
+		"handlebars": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
+			"integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
+			"dev": true,
+			"requires": {
+				"async": "^2.5.0",
+				"optimist": "^0.6.1",
+				"source-map": "^0.6.1",
+				"uglify-js": "^3.1.4"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				}
+			}
+		},
+		"has-ansi": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^2.0.0"
+			}
+		},
+		"has-binary2": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
+			"integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
+			"dev": true,
+			"requires": {
+				"isarray": "2.0.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+					"dev": true
+				}
+			}
+		},
+		"has-cors": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+			"integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
+			"dev": true
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
+		},
+		"has-unicode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+			"dev": true
+		},
+		"hash-for-dep": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.5.0.tgz",
+			"integrity": "sha512-Jtp264IRh25UmNHBNjB9jgYQGOpUVFMzt8E2MS6dJyR5uAO14bq4B9q5znOStkKpOpcxNUrYtg3hgpOSjQSONw==",
+			"dev": true,
+			"requires": {
+				"broccoli-kitchen-sink-helpers": "^0.3.1",
+				"heimdalljs": "^0.2.3",
+				"heimdalljs-logger": "^0.1.7",
+				"path-root": "^0.1.1",
+				"resolve": "^1.10.0",
+				"resolve-package-path": "^1.0.11"
+			}
+		},
+		"heimdalljs": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.6.tgz",
+			"integrity": "sha512-o9bd30+5vLBvBtzCPwwGqpry2+n0Hi6H1+qwt6y+0kwRHGGF8TFIhJPmnuM0xO97zaKrDZMwO/V56fAnn8m/tA==",
+			"dev": true,
+			"requires": {
+				"rsvp": "~3.2.1"
+			},
+			"dependencies": {
+				"rsvp": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
+					"integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
+					"dev": true
+				}
+			}
+		},
+		"heimdalljs-logger": {
+			"version": "0.1.10",
+			"resolved": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.10.tgz",
+			"integrity": "sha512-pO++cJbhIufVI/fmB/u2Yty3KJD0TqNPecehFae0/eps0hkZ3b4Zc/PezUMOpYuHFQbA7FxHZxa305EhmjLj4g==",
+			"dev": true,
+			"requires": {
+				"debug": "^2.2.0",
+				"heimdalljs": "^0.2.6"
+			}
+		},
+		"home-or-tmp": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+			"dev": true,
+			"requires": {
+				"os-homedir": "^1.0.0",
+				"os-tmpdir": "^1.0.1"
+			}
+		},
+		"homedir-polyfill": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+			"integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+			"dev": true,
+			"requires": {
+				"parse-passwd": "^1.0.0"
+			}
+		},
+		"http-errors": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+			"dev": true,
+			"requires": {
+				"depd": "~1.1.2",
+				"inherits": "2.0.3",
+				"setprototypeof": "1.1.0",
+				"statuses": ">= 1.4.0 < 2"
+			},
+			"dependencies": {
+				"statuses": {
+					"version": "1.5.0",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+					"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+					"dev": true
+				}
+			}
+		},
+		"http-proxy": {
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
+			"integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+			"dev": true,
+			"requires": {
+				"eventemitter3": "^3.0.0",
+				"follow-redirects": "^1.0.0",
+				"requires-port": "^1.0.0"
+			}
+		},
+		"iconv-lite": {
+			"version": "0.4.23",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+			"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+			"dev": true,
+			"requires": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			}
+		},
+		"indexof": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+			"dev": true
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+			"dev": true
+		},
+		"ini": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+			"dev": true
+		},
+		"invariant": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.0.0"
+			}
+		},
+		"ipaddr.js": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
+			"integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
+			"dev": true
+		},
+		"is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
+		},
+		"is-dotfile": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+			"dev": true
+		},
+		"is-equal-shallow": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+			"dev": true,
+			"requires": {
+				"is-primitive": "^2.0.0"
+			}
+		},
+		"is-extendable": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+			"dev": true
+		},
+		"is-extglob": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+			"dev": true
+		},
+		"is-finite": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+			"dev": true,
+			"requires": {
+				"number-is-nan": "^1.0.0"
+			}
+		},
+		"is-fullwidth-code-point": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+			"dev": true,
+			"requires": {
+				"number-is-nan": "^1.0.0"
+			}
+		},
+		"is-glob": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+			"dev": true,
+			"requires": {
+				"is-extglob": "^1.0.0"
+			}
+		},
+		"is-number": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			}
+		},
+		"is-posix-bracket": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+			"dev": true
+		},
+		"is-primitive": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+			"dev": true
+		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
+		},
+		"is-type": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/is-type/-/is-type-0.0.1.tgz",
+			"integrity": "sha1-9lHYXDZdRJVdFKUdjXBh8/a0d5w=",
+			"dev": true,
+			"requires": {
+				"core-util-is": "~1.0.0"
+			}
+		},
+		"is-windows": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+			"integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+			"dev": true
+		},
+		"is-wsl": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+			"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+			"dev": true
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+			"dev": true
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
+		},
+		"isobject": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+			"dev": true,
+			"requires": {
+				"isarray": "1.0.0"
+			}
+		},
+		"istextorbinary": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.1.0.tgz",
+			"integrity": "sha1-2+0qb1G+L3R1to+JRlgRFBt1iHQ=",
+			"dev": true,
+			"requires": {
+				"binaryextensions": "1 || 2",
+				"editions": "^1.1.1",
+				"textextensions": "1 || 2"
+			}
+		},
+		"js-reporters": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/js-reporters/-/js-reporters-1.2.1.tgz",
+			"integrity": "sha1-+IxgjjJKM3OpW8xFrTBeXJecRZs=",
+			"dev": true
+		},
+		"js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
+		},
+		"js-yaml": {
+			"version": "3.12.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
+			"integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+			"dev": true,
+			"requires": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			}
+		},
+		"jsesc": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+			"integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+			"dev": true
+		},
+		"json-stable-stringify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+			"dev": true,
+			"requires": {
+				"jsonify": "~0.0.0"
+			}
+		},
+		"json5": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+			"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+			"dev": true
+		},
+		"jsonfile": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"jsonify": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+			"dev": true
+		},
+		"just-extend": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+			"integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+			"dev": true
+		},
+		"kind-of": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"dev": true,
+			"requires": {
+				"is-buffer": "^1.1.5"
+			}
+		},
+		"klaw": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+			"integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+			"dev": true,
+			"requires": {
+				"graceful-fs": "^4.1.9"
+			}
+		},
+		"loader.js": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/loader.js/-/loader.js-4.7.0.tgz",
+			"integrity": "sha512-9M2KvGT6duzGMgkOcTkWb+PR/Q2Oe54df/tLgHGVmFpAmtqJ553xJh6N63iFYI2yjo2PeJXbS5skHi/QpJq4vA==",
+			"dev": true
+		},
+		"lodash": {
+			"version": "4.17.11",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+			"dev": true
+		},
+		"lodash._basebind": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash._basebind/-/lodash._basebind-2.3.0.tgz",
+			"integrity": "sha1-K1vEUqDhBhQ7IYafIzvbWHQX0kg=",
+			"dev": true,
+			"requires": {
+				"lodash._basecreate": "~2.3.0",
+				"lodash._setbinddata": "~2.3.0",
+				"lodash.isobject": "~2.3.0"
+			}
+		},
+		"lodash._basecreate": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-2.3.0.tgz",
+			"integrity": "sha1-m4ioak3P97fzxh2Dovz8BnHsneA=",
+			"dev": true,
+			"requires": {
+				"lodash._renative": "~2.3.0",
+				"lodash.isobject": "~2.3.0",
+				"lodash.noop": "~2.3.0"
+			}
+		},
+		"lodash._basecreatecallback": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash._basecreatecallback/-/lodash._basecreatecallback-2.3.0.tgz",
+			"integrity": "sha1-N7KrF1kaM56YjbMln81GAZ16w2I=",
+			"dev": true,
+			"requires": {
+				"lodash._setbinddata": "~2.3.0",
+				"lodash.bind": "~2.3.0",
+				"lodash.identity": "~2.3.0",
+				"lodash.support": "~2.3.0"
+			}
+		},
+		"lodash._basecreatewrapper": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.3.0.tgz",
+			"integrity": "sha1-qgxhrZYETDkzN2ExSDqXWcNlEkc=",
+			"dev": true,
+			"requires": {
+				"lodash._basecreate": "~2.3.0",
+				"lodash._setbinddata": "~2.3.0",
+				"lodash._slice": "~2.3.0",
+				"lodash.isobject": "~2.3.0"
+			}
+		},
+		"lodash._baseflatten": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+			"integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
+			"dev": true,
+			"requires": {
+				"lodash.isarguments": "^3.0.0",
+				"lodash.isarray": "^3.0.0"
+			}
+		},
+		"lodash._createwrapper": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash._createwrapper/-/lodash._createwrapper-2.3.0.tgz",
+			"integrity": "sha1-0arhEC2t9EDo4G/BM6bt1/4UYHU=",
+			"dev": true,
+			"requires": {
+				"lodash._basebind": "~2.3.0",
+				"lodash._basecreatewrapper": "~2.3.0",
+				"lodash.isfunction": "~2.3.0"
+			}
+		},
+		"lodash._escapehtmlchar": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.3.0.tgz",
+			"integrity": "sha1-0D2mvYLu3zjcCltQPXQOzQ6JRZI=",
+			"dev": true,
+			"requires": {
+				"lodash._htmlescapes": "~2.3.0"
+			}
+		},
+		"lodash._escapestringchar": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.3.0.tgz",
+			"integrity": "sha1-zOc65g/G2lXSv4oGecI8orqxSfw=",
+			"dev": true
+		},
+		"lodash._getnative": {
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+			"dev": true
+		},
+		"lodash._htmlescapes": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.3.0.tgz",
+			"integrity": "sha1-HKmIY8rfH6HYLITzXzHkBVagTzo=",
+			"dev": true
+		},
+		"lodash._isiterateecall": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+			"integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+			"dev": true
+		},
+		"lodash._objecttypes": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.3.0.tgz",
+			"integrity": "sha1-aj6jmH3W7rgCGy1cnDA1Scwrrh4=",
+			"dev": true
+		},
+		"lodash._reinterpolate": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.3.0.tgz",
+			"integrity": "sha1-A+6dhcDlXL1ZDXFgiilb3aURKOw=",
+			"dev": true
+		},
+		"lodash._renative": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash._renative/-/lodash._renative-2.3.0.tgz",
+			"integrity": "sha1-d9jt1M7SbdWXH54Vpfdy5OMX+9M=",
+			"dev": true
+		},
+		"lodash._reunescapedhtml": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.3.0.tgz",
+			"integrity": "sha1-25ILVax/P/glk5rOubosIxcT0k0=",
+			"dev": true,
+			"requires": {
+				"lodash._htmlescapes": "~2.3.0",
+				"lodash.keys": "~2.3.0"
+			}
+		},
+		"lodash._setbinddata": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash._setbinddata/-/lodash._setbinddata-2.3.0.tgz",
+			"integrity": "sha1-5WEEkKzRMnfVmFjZW18nJ/FQjwQ=",
+			"dev": true,
+			"requires": {
+				"lodash._renative": "~2.3.0",
+				"lodash.noop": "~2.3.0"
+			}
+		},
+		"lodash._shimkeys": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.3.0.tgz",
+			"integrity": "sha1-YR+TFJ4+bHIQlrSHae8pU3rai6k=",
+			"dev": true,
+			"requires": {
+				"lodash._objecttypes": "~2.3.0"
+			}
+		},
+		"lodash._slice": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash._slice/-/lodash._slice-2.3.0.tgz",
+			"integrity": "sha1-FHGYEyhZly5GgMoppZkshVZpqlw=",
+			"dev": true
+		},
+		"lodash.assignin": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+			"integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI=",
+			"dev": true
+		},
+		"lodash.bind": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-2.3.0.tgz",
+			"integrity": "sha1-wqjhi2jl7MFS4rFoJmEW/qWwFsw=",
+			"dev": true,
+			"requires": {
+				"lodash._createwrapper": "~2.3.0",
+				"lodash._renative": "~2.3.0",
+				"lodash._slice": "~2.3.0"
+			}
+		},
+		"lodash.castarray": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+			"integrity": "sha1-wCUTUV4wna3dTCTGDP3c9ZdtkRU=",
+			"dev": true
+		},
+		"lodash.clonedeep": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+			"dev": true
+		},
+		"lodash.debounce": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.1.tgz",
+			"integrity": "sha1-gSIRw3ipTMKdWqTjNGzwv846ffU=",
+			"dev": true,
+			"requires": {
+				"lodash._getnative": "^3.0.0"
+			}
+		},
+		"lodash.defaults": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.3.0.tgz",
+			"integrity": "sha1-qDKwAfE487uXIcKBmip8xa4h7SU=",
+			"dev": true,
+			"requires": {
+				"lodash._objecttypes": "~2.3.0",
+				"lodash.keys": "~2.3.0"
+			}
+		},
+		"lodash.escape": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.3.0.tgz",
+			"integrity": "sha1-hEw4xY+EThNi6+lnJhWbYs9fKlg=",
+			"dev": true,
+			"requires": {
+				"lodash._escapehtmlchar": "~2.3.0",
+				"lodash._reunescapedhtml": "~2.3.0",
+				"lodash.keys": "~2.3.0"
+			}
+		},
+		"lodash.find": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
+			"integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=",
+			"dev": true
+		},
+		"lodash.flatten": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-3.0.2.tgz",
+			"integrity": "sha1-3hz1d1j49EeTGdNcPpzGDEUBk4w=",
+			"dev": true,
+			"requires": {
+				"lodash._baseflatten": "^3.0.0",
+				"lodash._isiterateecall": "^3.0.0"
+			}
+		},
+		"lodash.foreach": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-2.3.0.tgz",
+			"integrity": "sha1-CDQEyR6EbudyRf3512UZxosq8Wg=",
+			"dev": true,
+			"requires": {
+				"lodash._basecreatecallback": "~2.3.0",
+				"lodash.forown": "~2.3.0"
+			}
+		},
+		"lodash.forown": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.forown/-/lodash.forown-2.3.0.tgz",
+			"integrity": "sha1-JPtKr4ANRfwtxgv+w84EyDajrX8=",
+			"dev": true,
+			"requires": {
+				"lodash._basecreatecallback": "~2.3.0",
+				"lodash._objecttypes": "~2.3.0",
+				"lodash.keys": "~2.3.0"
+			}
+		},
+		"lodash.identity": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.identity/-/lodash.identity-2.3.0.tgz",
+			"integrity": "sha1-awGiEMlIU1XCqRO0i2cRIZoXPe0=",
+			"dev": true
+		},
+		"lodash.isarguments": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+			"dev": true
+		},
+		"lodash.isarray": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+			"dev": true
+		},
+		"lodash.isfunction": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-2.3.0.tgz",
+			"integrity": "sha1-aylz5HpkfPEucNZ2rqE2Q3BuUmc=",
+			"dev": true
+		},
+		"lodash.isobject": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.3.0.tgz",
+			"integrity": "sha1-LhbT/Fg9qYMZaJU/LY5tc0NPZ5k=",
+			"dev": true,
+			"requires": {
+				"lodash._objecttypes": "~2.3.0"
+			}
+		},
+		"lodash.keys": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.3.0.tgz",
+			"integrity": "sha1-s1D0+Syqn0WkouzwGEVM8vKK4lM=",
+			"dev": true,
+			"requires": {
+				"lodash._renative": "~2.3.0",
+				"lodash._shimkeys": "~2.3.0",
+				"lodash.isobject": "~2.3.0"
+			}
+		},
+		"lodash.merge": {
+			"version": "4.6.1",
+			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+			"integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
+			"dev": true
+		},
+		"lodash.noop": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.noop/-/lodash.noop-2.3.0.tgz",
+			"integrity": "sha1-MFnWKNUbv5N80qC2/Dp/ISpmnCw=",
+			"dev": true
+		},
+		"lodash.omit": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+			"integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
+			"dev": true
+		},
+		"lodash.support": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.support/-/lodash.support-2.3.0.tgz",
+			"integrity": "sha1-fq8DivTw1qq3drRKptz8gDNMm/0=",
+			"dev": true,
+			"requires": {
+				"lodash._renative": "~2.3.0"
+			}
+		},
+		"lodash.template": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.3.0.tgz",
+			"integrity": "sha1-Tj4pxDO0z+pnXsg15vEjkcYf0is=",
+			"dev": true,
+			"requires": {
+				"lodash._escapestringchar": "~2.3.0",
+				"lodash._reinterpolate": "~2.3.0",
+				"lodash.defaults": "~2.3.0",
+				"lodash.escape": "~2.3.0",
+				"lodash.keys": "~2.3.0",
+				"lodash.templatesettings": "~2.3.0",
+				"lodash.values": "~2.3.0"
+			}
+		},
+		"lodash.templatesettings": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.3.0.tgz",
+			"integrity": "sha1-MD0TLDQnEAQNWhjvqi1XL9A/jNw=",
+			"dev": true,
+			"requires": {
+				"lodash._reinterpolate": "~2.3.0",
+				"lodash.escape": "~2.3.0"
+			}
+		},
+		"lodash.uniq": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+			"dev": true
+		},
+		"lodash.uniqby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+			"integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
+			"dev": true
+		},
+		"lodash.values": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.3.0.tgz",
+			"integrity": "sha1-ypb75gogsLDsK6K6X8anZb0Uo7o=",
+			"dev": true,
+			"requires": {
+				"lodash.keys": "~2.3.0"
+			}
+		},
+		"lolex": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/lolex/-/lolex-3.1.0.tgz",
+			"integrity": "sha512-zFo5MgCJ0rZ7gQg69S4pqBsLURbFw11X68C18OcJjJQbqaXm2NoTrGl1IMM3TIz0/BnN1tIs2tzmmqvCsOMMjw==",
+			"dev": true
+		},
+		"loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dev": true,
+			"requires": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			}
+		},
+		"makeerror": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+			"dev": true,
+			"requires": {
+				"tmpl": "1.0.x"
+			}
+		},
+		"matcher-collection": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
+			"integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
+			"dev": true,
+			"requires": {
+				"minimatch": "^3.0.2"
+			}
+		},
+		"math-random": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+			"integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
+			"dev": true
+		},
+		"md5-hex": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+			"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+			"dev": true,
+			"requires": {
+				"md5-o-matic": "^0.1.1"
+			}
+		},
+		"md5-o-matic": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+			"integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
+			"dev": true
+		},
+		"media-typer": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+			"dev": true
+		},
+		"memory-streams": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/memory-streams/-/memory-streams-0.1.3.tgz",
+			"integrity": "sha512-qVQ/CjkMyMInPaaRMrwWNDvf6boRZXaT/DbQeMYcCWuXPEBf1v8qChOc9OlEVQp2uOvRXa1Qu30fLmKhY6NipA==",
+			"dev": true,
+			"requires": {
+				"readable-stream": "~1.0.2"
+			}
+		},
+		"merge": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+			"integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
+			"dev": true
+		},
+		"merge-descriptors": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+			"integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+			"dev": true
+		},
+		"merge-trees": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-1.0.1.tgz",
+			"integrity": "sha1-zL5nRWl4f53vF/1G5lJfVwC70j4=",
+			"dev": true,
+			"requires": {
+				"can-symlink": "^1.0.0",
+				"fs-tree-diff": "^0.5.4",
+				"heimdalljs": "^0.2.1",
+				"heimdalljs-logger": "^0.1.7",
+				"rimraf": "^2.4.3",
+				"symlink-or-copy": "^1.0.0"
+			}
+		},
+		"methods": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+			"dev": true
+		},
+		"micromatch": {
+			"version": "2.3.11",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"dev": true,
+			"requires": {
+				"arr-diff": "^2.0.0",
+				"array-unique": "^0.2.1",
+				"braces": "^1.8.2",
+				"expand-brackets": "^0.1.4",
+				"extglob": "^0.3.1",
+				"filename-regex": "^2.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.1",
+				"kind-of": "^3.0.2",
+				"normalize-path": "^2.0.1",
+				"object.omit": "^2.0.0",
+				"parse-glob": "^3.0.4",
+				"regex-cache": "^0.4.2"
+			}
+		},
+		"mime": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+			"dev": true
+		},
+		"mime-db": {
+			"version": "1.38.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+			"integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
+			"dev": true
+		},
+		"mime-types": {
+			"version": "2.1.22",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+			"integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+			"dev": true,
+			"requires": {
+				"mime-db": "~1.38.0"
+			}
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"minimist": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+			"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+			"dev": true
+		},
+		"minipass": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+			"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.1.2",
+				"yallist": "^3.0.0"
+			}
+		},
+		"mkdirp": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"dev": true,
+			"requires": {
+				"minimist": "0.0.8"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+					"dev": true
+				}
+			}
+		},
+		"mktemp": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.4.0.tgz",
+			"integrity": "sha1-bQUVYRyKjITkhKogABKbmOmB/ws=",
+			"dev": true
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
+		},
+		"mustache": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/mustache/-/mustache-3.0.1.tgz",
+			"integrity": "sha512-jFI/4UVRsRYdUbuDTKT7KzfOp7FiD5WzYmmwNwXyUVypC0xjoTL78Fqc0jHUPIvvGD+6DQSPHIt1NE7D1ArsqA==",
+			"dev": true
+		},
+		"negotiator": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+			"dev": true
+		},
+		"next-tick": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+			"dev": true
+		},
+		"nice-try": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"dev": true
+		},
+		"nise": {
+			"version": "1.4.10",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-1.4.10.tgz",
+			"integrity": "sha512-sa0RRbj53dovjc7wombHmVli9ZihXbXCQ2uH3TNm03DyvOSIQbxg+pbqDKrk2oxMK1rtLGVlKxcB9rrc6X5YjA==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/formatio": "^3.1.0",
+				"@sinonjs/text-encoding": "^0.7.1",
+				"just-extend": "^4.0.2",
+				"lolex": "^2.3.2",
+				"path-to-regexp": "^1.7.0"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				},
+				"lolex": {
+					"version": "2.7.5",
+					"resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+					"integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+					"dev": true
+				},
+				"path-to-regexp": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+					"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+					"dev": true,
+					"requires": {
+						"isarray": "0.0.1"
+					}
+				}
+			}
+		},
+		"node-int64": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+			"dev": true
+		},
+		"node-modules-path": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/node-modules-path/-/node-modules-path-1.0.2.tgz",
+			"integrity": "sha512-6Gbjq+d7uhkO7epaKi5DNgUJn7H0gEyA4Jg0Mo1uQOi3Rk50G83LtmhhFyw0LxnAFhtlspkiiw52ISP13qzcBg==",
+			"dev": true
+		},
+		"node-notifier": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
+			"integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
+			"dev": true,
+			"requires": {
+				"growly": "^1.3.0",
+				"is-wsl": "^1.1.0",
+				"semver": "^5.5.0",
+				"shellwords": "^0.1.1",
+				"which": "^1.3.0"
+			}
+		},
+		"node-watch": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.6.0.tgz",
+			"integrity": "sha512-XAgTL05z75ptd7JSVejH1a2Dm1zmXYhuDr9l230Qk6Z7/7GPcnAs/UyJJ4ggsXSvWil8iOzwQLW0zuGUvHpG8g==",
+			"dev": true
+		},
+		"normalize-path": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+			"dev": true,
+			"requires": {
+				"remove-trailing-separator": "^1.0.1"
+			}
+		},
+		"npm-run-path": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"dev": true,
+			"requires": {
+				"path-key": "^2.0.0"
+			}
+		},
+		"npmlog": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+			"dev": true,
+			"requires": {
+				"are-we-there-yet": "~1.1.2",
+				"console-control-strings": "~1.1.0",
+				"gauge": "~2.7.3",
+				"set-blocking": "~2.0.0"
+			}
+		},
+		"number-is-nan": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
+		},
+		"object-component": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+			"integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
+			"dev": true
+		},
+		"object.omit": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+			"dev": true,
+			"requires": {
+				"for-own": "^0.1.4",
+				"is-extendable": "^0.1.1"
+			}
+		},
+		"on-finished": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+			"dev": true,
+			"requires": {
+				"ee-first": "1.1.1"
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"optimist": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+			"dev": true,
+			"requires": {
+				"minimist": "~0.0.1",
+				"wordwrap": "~0.0.2"
+			}
+		},
+		"os-homedir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+			"dev": true
+		},
+		"os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
+		},
+		"p-finally": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+			"dev": true
+		},
+		"parse-glob": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+			"dev": true,
+			"requires": {
+				"glob-base": "^0.3.0",
+				"is-dotfile": "^1.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.0"
+			}
+		},
+		"parse-passwd": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+			"dev": true
+		},
+		"parseqs": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+			"integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+			"dev": true,
+			"requires": {
+				"better-assert": "~1.0.0"
+			}
+		},
+		"parseuri": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+			"integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+			"dev": true,
+			"requires": {
+				"better-assert": "~1.0.0"
+			}
+		},
+		"parseurl": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+			"dev": true
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
+		},
+		"path-key": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+			"dev": true
+		},
+		"path-parse": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
+		},
+		"path-posix": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz",
+			"integrity": "sha1-BrJhE/Vr6rBCVFojv6iAA8ysJg8=",
+			"dev": true
+		},
+		"path-root": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+			"integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+			"dev": true,
+			"requires": {
+				"path-root-regex": "^0.1.0"
+			}
+		},
+		"path-root-regex": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+			"integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
+			"dev": true
+		},
+		"path-to-regexp": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+			"integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+			"dev": true
+		},
+		"preserve": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+			"dev": true
+		},
+		"printf": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/printf/-/printf-0.5.1.tgz",
+			"integrity": "sha512-UaE/jO0hNsrvPGQEb4LyNzcrJv9Z00tsreBduOSxMtrebvoUhxiEJ4YCHX8YHf6akwfKsC2Gyv5zv47UXhMiLg==",
+			"dev": true
+		},
+		"private": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+			"dev": true
+		},
+		"process-nextick-args": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+			"dev": true
+		},
+		"promise-map-series": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.2.3.tgz",
+			"integrity": "sha1-wtN3r8kyU/a9A9u3d1XriKsgqEc=",
+			"dev": true,
+			"requires": {
+				"rsvp": "^3.0.14"
+			}
+		},
+		"proxy-addr": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
+			"integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
+			"dev": true,
+			"requires": {
+				"forwarded": "~0.1.2",
+				"ipaddr.js": "1.8.0"
+			}
+		},
+		"pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"dev": true,
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"qs": {
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"dev": true
+		},
+		"quick-temp": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/quick-temp/-/quick-temp-0.1.8.tgz",
+			"integrity": "sha1-urAqJCq4+w3XWKPJd2sy+aXZRAg=",
+			"dev": true,
+			"requires": {
+				"mktemp": "~0.4.0",
+				"rimraf": "^2.5.4",
+				"underscore.string": "~3.3.4"
+			}
+		},
+		"qunit": {
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/qunit/-/qunit-2.9.2.tgz",
+			"integrity": "sha512-wTOYHnioWHcx5wa85Wl15IE7D6zTZe2CQlsodS14yj7s2FZ3MviRnQluspBZsueIDEO7doiuzKlv05yfky1R7w==",
+			"dev": true,
+			"requires": {
+				"commander": "2.12.2",
+				"js-reporters": "1.2.1",
+				"minimatch": "3.0.4",
+				"node-watch": "0.6.0",
+				"resolve": "1.9.0"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.12.2",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+					"integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+					"dev": true
+				},
+				"resolve": {
+					"version": "1.9.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.9.0.tgz",
+					"integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
+					"dev": true,
+					"requires": {
+						"path-parse": "^1.0.6"
+					}
+				}
+			}
+		},
+		"randomatic": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+			"integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+			"dev": true,
+			"requires": {
+				"is-number": "^4.0.0",
+				"kind-of": "^6.0.0",
+				"math-random": "^1.0.1"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+					"dev": true
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				}
+			}
+		},
+		"range-parser": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+			"dev": true
+		},
+		"raw-body": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+			"integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+			"dev": true,
+			"requires": {
+				"bytes": "3.0.0",
+				"http-errors": "1.6.3",
+				"iconv-lite": "0.4.23",
+				"unpipe": "1.0.0"
+			}
+		},
+		"readable-stream": {
+			"version": "1.0.34",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+			"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+			"dev": true,
+			"requires": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.1",
+				"isarray": "0.0.1",
+				"string_decoder": "~0.10.x"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				}
+			}
+		},
+		"regenerator-runtime": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+			"dev": true
+		},
+		"regex-cache": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+			"dev": true,
+			"requires": {
+				"is-equal-shallow": "^0.1.3"
+			}
+		},
+		"remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+			"dev": true
+		},
+		"repeat-element": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+			"dev": true
+		},
+		"repeat-string": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+			"dev": true
+		},
+		"repeating": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+			"dev": true,
+			"requires": {
+				"is-finite": "^1.0.0"
+			}
+		},
+		"requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+			"dev": true
+		},
+		"resolve": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+			"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+			"dev": true,
+			"requires": {
+				"path-parse": "^1.0.6"
+			}
+		},
+		"resolve-dir": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+			"integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+			"dev": true,
+			"requires": {
+				"expand-tilde": "^1.2.2",
+				"global-modules": "^0.2.3"
+			}
+		},
+		"resolve-package-path": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-1.2.4.tgz",
+			"integrity": "sha512-AOIfR/AauBM1w1Oq9swqGxUjL4PW7bMztN7UCQ4KWg9AR2t03bGb9faegZbE0meAOHlntAni/4kXkcsQ7dWLPQ==",
+			"dev": true,
+			"requires": {
+				"path-root": "^0.1.1",
+				"resolve": "^1.10.0"
+			}
+		},
+		"rimraf": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3"
+			}
+		},
+		"rollup": {
+			"version": "0.41.6",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-0.41.6.tgz",
+			"integrity": "sha1-4NBUl4d6OYwQTYFtJzOnGKepTio=",
+			"dev": true,
+			"requires": {
+				"source-map-support": "^0.4.0"
+			}
+		},
+		"rsvp": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+			"integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+			"dev": true
+		},
+		"safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
+		},
+		"safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
+		},
+		"sane": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/sane/-/sane-1.7.0.tgz",
+			"integrity": "sha1-s1ebzLRclM8gNVzIESSZDf00bjA=",
+			"dev": true,
+			"requires": {
+				"anymatch": "^1.3.0",
+				"exec-sh": "^0.2.0",
+				"fb-watchman": "^2.0.0",
+				"minimatch": "^3.0.2",
+				"minimist": "^1.1.1",
+				"walker": "~1.0.5",
+				"watch": "~0.10.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				}
+			}
+		},
+		"semver": {
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+			"integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+			"dev": true
+		},
+		"send": {
+			"version": "0.16.2",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+			"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+			"dev": true,
+			"requires": {
+				"debug": "2.6.9",
+				"depd": "~1.1.2",
+				"destroy": "~1.0.4",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"fresh": "0.5.2",
+				"http-errors": "~1.6.2",
+				"mime": "1.4.1",
+				"ms": "2.0.0",
+				"on-finished": "~2.3.0",
+				"range-parser": "~1.2.0",
+				"statuses": "~1.4.0"
+			},
+			"dependencies": {
+				"mime": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+					"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+					"dev": true
+				},
+				"statuses": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+					"dev": true
+				}
+			}
+		},
+		"serve-static": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+			"dev": true,
+			"requires": {
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"parseurl": "~1.3.2",
+				"send": "0.16.2"
+			}
+		},
+		"set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"dev": true
+		},
+		"setprototypeof": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+			"dev": true
+		},
+		"shebang-command": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"dev": true,
+			"requires": {
+				"shebang-regex": "^1.0.0"
+			}
+		},
+		"shebang-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"dev": true
+		},
+		"shellwords": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+			"dev": true
+		},
+		"signal-exit": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+			"dev": true
+		},
+		"sinon": {
+			"version": "7.2.7",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-7.2.7.tgz",
+			"integrity": "sha512-rlrre9F80pIQr3M36gOdoCEWzFAMDgHYD8+tocqOw+Zw9OZ8F84a80Ds69eZfcjnzDqqG88ulFld0oin/6rG/g==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1.3.1",
+				"@sinonjs/formatio": "^3.2.1",
+				"@sinonjs/samsam": "^3.2.0",
+				"diff": "^3.5.0",
+				"lolex": "^3.1.0",
+				"nise": "^1.4.10",
+				"supports-color": "^5.5.0"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"slash": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+			"dev": true
+		},
+		"socket.io": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.2.0.tgz",
+			"integrity": "sha512-wxXrIuZ8AILcn+f1B4ez4hJTPG24iNgxBBDaJfT6MsyOhVYiTXWexGoPkd87ktJG8kQEcL/NBvRi64+9k4Kc0w==",
+			"dev": true,
+			"requires": {
+				"debug": "~4.1.0",
+				"engine.io": "~3.3.1",
+				"has-binary2": "~1.0.2",
+				"socket.io-adapter": "~1.1.0",
+				"socket.io-client": "2.2.0",
+				"socket.io-parser": "~3.3.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
+			}
+		},
+		"socket.io-adapter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
+			"integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs=",
+			"dev": true
+		},
+		"socket.io-client": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.2.0.tgz",
+			"integrity": "sha512-56ZrkTDbdTLmBIyfFYesgOxsjcLnwAKoN4CiPyTVkMQj3zTUh0QAx3GbvIvLpFEOvQWu92yyWICxB0u7wkVbYA==",
+			"dev": true,
+			"requires": {
+				"backo2": "1.0.2",
+				"base64-arraybuffer": "0.1.5",
+				"component-bind": "1.0.0",
+				"component-emitter": "1.2.1",
+				"debug": "~3.1.0",
+				"engine.io-client": "~3.3.1",
+				"has-binary2": "~1.0.2",
+				"has-cors": "1.1.0",
+				"indexof": "0.0.1",
+				"object-component": "0.0.3",
+				"parseqs": "0.0.5",
+				"parseuri": "0.0.5",
+				"socket.io-parser": "~3.3.0",
+				"to-array": "0.1.4"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				}
+			}
+		},
+		"socket.io-parser": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
+			"integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
+			"dev": true,
+			"requires": {
+				"component-emitter": "1.2.1",
+				"debug": "~3.1.0",
+				"isarray": "2.0.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"isarray": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+					"dev": true
+				}
+			}
+		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true
+		},
+		"source-map-support": {
+			"version": "0.4.18",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+			"dev": true,
+			"requires": {
+				"source-map": "^0.5.6"
+			}
+		},
+		"source-map-url": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
+			"integrity": "sha1-fsrxO1e80J2opAxdJp2zN5nUqvk=",
+			"dev": true
+		},
+		"sourcemap-validator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/sourcemap-validator/-/sourcemap-validator-1.1.0.tgz",
+			"integrity": "sha512-Hmdu39KL+EoAAZ69OTk7RXXJdPRRizJvOZOWhCW9jLGfEQflCNPTlSoCXFPdKWFwwf0uzLcGR/fc7EP/PT8vRQ==",
+			"dev": true,
+			"requires": {
+				"jsesc": "~0.3.x",
+				"lodash.foreach": "~2.3.x",
+				"lodash.template": "~2.3.x",
+				"source-map": "~0.1.x"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "0.3.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.3.0.tgz",
+					"integrity": "sha1-G/XuY7RTn+LibQwemcJAuXpFeXI=",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.1.43",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+					"integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+					"dev": true,
+					"requires": {
+						"amdefine": ">=0.0.4"
+					}
+				}
+			}
+		},
+		"spawn-args": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/spawn-args/-/spawn-args-0.2.0.tgz",
+			"integrity": "sha1-+30L0dcP1DFr2ePew4nmX51jYbs=",
+			"dev": true
+		},
+		"sprintf-js": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+			"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+			"dev": true
+		},
+		"stack-trace": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+			"dev": true
+		},
+		"statuses": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+			"integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+			"dev": true
+		},
+		"string-width": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+			"dev": true,
+			"requires": {
+				"code-point-at": "^1.0.0",
+				"is-fullwidth-code-point": "^1.0.0",
+				"strip-ansi": "^3.0.0"
+			}
+		},
+		"string_decoder": {
+			"version": "0.10.31",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+			"dev": true
+		},
+		"strip-ansi": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^2.0.0"
+			}
+		},
+		"strip-eof": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+			"dev": true
+		},
+		"styled_string": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/styled_string/-/styled_string-0.0.1.tgz",
+			"integrity": "sha1-0ieCvYEpVFm8Tx3xjEutjpTdEko=",
+			"dev": true
+		},
+		"supports-color": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+			"dev": true
+		},
+		"symlink-or-copy": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/symlink-or-copy/-/symlink-or-copy-1.2.0.tgz",
+			"integrity": "sha512-W31+GLiBmU/ZR02Ii0mVZICuNEN9daZ63xZMPDsYgPgNjMtg+atqLEGI7PPI936jYSQZxoLb/63xos8Adrx4Eg==",
+			"dev": true
+		},
+		"tap-parser": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-7.0.0.tgz",
+			"integrity": "sha512-05G8/LrzqOOFvZhhAk32wsGiPZ1lfUrl+iV7+OkKgfofZxiceZWMHkKmow71YsyVQ8IvGBP2EjcIjE5gL4l5lA==",
+			"dev": true,
+			"requires": {
+				"events-to-array": "^1.0.1",
+				"js-yaml": "^3.2.7",
+				"minipass": "^2.2.0"
+			}
+		},
+		"testem": {
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/testem/-/testem-2.14.0.tgz",
+			"integrity": "sha512-tldpNPCzXfibmxOoTMGOfr8ztUiHf9292zSXCu7SitBx9dCK83k7vEoa77qJBS9t3RGCQCRF+GNMUuiFw//Mbw==",
+			"dev": true,
+			"requires": {
+				"backbone": "^1.1.2",
+				"bluebird": "^3.4.6",
+				"charm": "^1.0.0",
+				"commander": "^2.6.0",
+				"consolidate": "^0.15.1",
+				"execa": "^1.0.0",
+				"express": "^4.10.7",
+				"fireworm": "^0.7.0",
+				"glob": "^7.0.4",
+				"http-proxy": "^1.13.1",
+				"js-yaml": "^3.2.5",
+				"lodash.assignin": "^4.1.0",
+				"lodash.castarray": "^4.4.0",
+				"lodash.clonedeep": "^4.4.1",
+				"lodash.find": "^4.5.1",
+				"lodash.uniqby": "^4.7.0",
+				"mkdirp": "^0.5.1",
+				"mustache": "^3.0.0",
+				"node-notifier": "^5.0.1",
+				"npmlog": "^4.0.0",
+				"printf": "^0.5.1",
+				"rimraf": "^2.4.4",
+				"socket.io": "^2.1.0",
+				"spawn-args": "^0.2.0",
+				"styled_string": "0.0.1",
+				"tap-parser": "^7.0.0",
+				"tmp": "0.0.33",
+				"xmldom": "^0.1.19"
+			},
+			"dependencies": {
+				"tmp": {
+					"version": "0.0.33",
+					"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+					"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+					"dev": true,
+					"requires": {
+						"os-tmpdir": "~1.0.2"
+					}
+				}
+			}
+		},
+		"textextensions": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.4.0.tgz",
+			"integrity": "sha512-qftQXnX1DzpSV8EddtHIT0eDDEiBF8ywhFYR2lI9xrGtxqKN+CvLXhACeCIGbCpQfxxERbrkZEFb8cZcDKbVZA==",
+			"dev": true
+		},
+		"tmp": {
+			"version": "0.0.31",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
+			"integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
+			"dev": true,
+			"requires": {
+				"os-tmpdir": "~1.0.1"
+			}
+		},
+		"tmpl": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+			"integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+			"dev": true
+		},
+		"to-array": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+			"integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
+			"dev": true
+		},
+		"to-fast-properties": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+			"dev": true
+		},
+		"tree-sync": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/tree-sync/-/tree-sync-1.4.0.tgz",
+			"integrity": "sha512-YvYllqh3qrR5TAYZZTXdspnIhlKAYezPYw11ntmweoceu4VK+keN356phHRIIo1d+RDmLpHZrUlmxga2gc9kSQ==",
+			"dev": true,
+			"requires": {
+				"debug": "^2.2.0",
+				"fs-tree-diff": "^0.5.6",
+				"mkdirp": "^0.5.1",
+				"quick-temp": "^0.1.5",
+				"walk-sync": "^0.3.3"
+			}
+		},
+		"trim-right": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
+		},
+		"tslib": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+			"dev": true
+		},
+		"tslint": {
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.14.0.tgz",
+			"integrity": "sha512-IUla/ieHVnB8Le7LdQFRGlVJid2T/gaJe5VkjzRVSRR6pA2ODYrnfR1hmxi+5+au9l50jBwpbBL34txgv4NnTQ==",
+			"dev": true,
+			"requires": {
+				"babel-code-frame": "^6.22.0",
+				"builtin-modules": "^1.1.1",
+				"chalk": "^2.3.0",
+				"commander": "^2.12.1",
+				"diff": "^3.2.0",
+				"glob": "^7.1.1",
+				"js-yaml": "^3.7.0",
+				"minimatch": "^3.0.4",
+				"mkdirp": "^0.5.1",
+				"resolve": "^1.3.2",
+				"semver": "^5.3.0",
+				"tslib": "^1.8.0",
+				"tsutils": "^2.29.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"tsutils": {
+			"version": "2.29.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+			"dev": true,
+			"requires": {
+				"tslib": "^1.8.1"
+			}
+		},
+		"type-detect": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true
+		},
+		"type-is": {
+			"version": "1.6.16",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+			"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+			"dev": true,
+			"requires": {
+				"media-typer": "0.3.0",
+				"mime-types": "~2.1.18"
+			}
+		},
+		"typescript": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
+			"integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==",
+			"dev": true
+		},
+		"uglify-js": {
+			"version": "3.4.9",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
+			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"commander": "~2.17.1",
+				"source-map": "~0.6.1"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.17.1",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+					"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+					"dev": true,
+					"optional": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
+		"underscore": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+			"integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
+			"dev": true
+		},
+		"underscore.string": {
+			"version": "3.3.5",
+			"resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
+			"integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
+			"dev": true,
+			"requires": {
+				"sprintf-js": "^1.0.3",
+				"util-deprecate": "^1.0.2"
+			}
+		},
+		"universalify": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true
+		},
+		"unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+			"dev": true
+		},
+		"username-sync": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/username-sync/-/username-sync-1.0.2.tgz",
+			"integrity": "sha512-ayNkOJdoNSGNDBE46Nkc+l6IXmeugbzahZLSMkwvgRWv5y5ZqNY2IrzcgmkR4z32sj1W3tM3TuTUMqkqBzO+RA==",
+			"dev": true
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
+		},
+		"utils-merge": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+			"dev": true
+		},
+		"vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+			"dev": true
+		},
+		"walk-sync": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
+			"integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
+			"dev": true,
+			"requires": {
+				"ensure-posix-path": "^1.0.0",
+				"matcher-collection": "^1.0.0"
+			}
+		},
+		"walker": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+			"dev": true,
+			"requires": {
+				"makeerror": "1.0.x"
+			}
+		},
+		"watch": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz",
+			"integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw=",
+			"dev": true
+		},
+		"whatwg-fetch": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+			"integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
+			"dev": true
+		},
+		"which": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
+			"requires": {
+				"isexe": "^2.0.0"
+			}
+		},
+		"wide-align": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+			"dev": true,
+			"requires": {
+				"string-width": "^1.0.2 || 2"
+			}
+		},
+		"wordwrap": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+			"dev": true
+		},
+		"workerpool": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-2.3.3.tgz",
+			"integrity": "sha512-L1ovlYHp6UObYqElXXpbd214GgbEKDED0d3sj7pRdFXjNkb2+un/AUcCkceHizO0IVI6SOGGncrcjozruCkRgA==",
+			"dev": true,
+			"requires": {
+				"object-assign": "4.1.1"
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		},
+		"ws": {
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
+			"integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
+			"dev": true,
+			"requires": {
+				"async-limiter": "~1.0.0"
+			}
+		},
+		"xmldom": {
+			"version": "0.1.27",
+			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+			"integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
+			"dev": true
+		},
+		"xmlhttprequest-ssl": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+			"integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+			"dev": true
+		},
+		"yallist": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+			"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+			"dev": true
+		},
+		"yeast": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+			"integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
+			"dev": true
+		}
+	}
+}

--- a/packages/@orbit/integration-tests/package.json
+++ b/packages/@orbit/integration-tests/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@orbit/integration-tests",
+  "private": true,
+  "version": "0.16.0-beta.2",
+  "description": "Integration tests for core Orbit packages.",
+  "contributors": [
+    "Dan Gebhardt <dan@cerebris.com>"
+  ],
+  "keywords": [
+    "orbit",
+    "orbit.js"
+  ],
+  "repository": "https://github.com/orbitjs/orbit",
+  "license": "MIT",
+  "scripts": {
+    "build:tests": "rm -rf tests && BROCCOLI_ENV=tests broccoli build tests",
+    "prepare": "npm run build:tests",
+    "release": "",
+    "test": "testem ci"
+  },
+  "dependencies": {
+    "@orbit/coordinator": "^0.16.0-beta.1",
+    "@orbit/core": "^0.16.0-beta.1",
+    "@orbit/data": "^0.16.0-beta.1",
+    "@orbit/immutable": "^0.16.0-beta.1",
+    "@orbit/indexeddb": "^0.16.0-beta.2",
+    "@orbit/indexeddb-bucket": "^0.16.0-beta.1",
+    "@orbit/jsonapi": "^0.16.0-beta.1",
+    "@orbit/local-storage": "^0.16.0-beta.2",
+    "@orbit/local-storage-bucket": "^0.16.0-beta.1",
+    "@orbit/record-cache": "^0.16.0-beta.2",
+    "@orbit/serializers": "^0.16.0-beta.1",
+    "@orbit/store": "^0.16.0-beta.2",
+    "@orbit/utils": "^0.16.0-beta.1"
+  },
+  "devDependencies": {
+    "@glimmer/build": "^0.9.0",
+    "@types/sinon": "7.0.3",
+    "merge": ">=1.2.1",
+    "randomatic": ">=3.0.0",
+    "sinon": "^7.2.2",
+    "whatwg-fetch": "^2.0.3"
+  }
+}

--- a/packages/@orbit/integration-tests/test/.eslintrc.js
+++ b/packages/@orbit/integration-tests/test/.eslintrc.js
@@ -1,0 +1,15 @@
+module.exports = {
+  globals: {
+    module: true,
+    test: true,
+    ok: true,
+    strictEqual: true,
+    equal: true,
+    throws: true,
+    notEqual: true,
+    deepEqual: true,
+    expect: true,
+    QUnit: true,
+    notStrictEqual: true
+  }
+}

--- a/packages/@orbit/integration-tests/test/store-jsonapi-clientid-pessimistic-test.ts
+++ b/packages/@orbit/integration-tests/test/store-jsonapi-clientid-pessimistic-test.ts
@@ -1,0 +1,122 @@
+import {
+  Record,
+  Schema
+} from '@orbit/data';
+import JSONAPISource from '@orbit/jsonapi';
+import Store from '@orbit/store';
+import Coordinator, { RequestStrategy, SyncStrategy } from '@orbit/coordinator';
+import { jsonapiResponse } from './support/jsonapi';
+import { SinonStatic, SinonStub} from 'sinon';
+
+declare const sinon: SinonStatic;
+const { module, test } = QUnit;
+
+module('Store + JSONAPISource + client-generated IDs + pessimistic coordination', function(hooks) {
+  let fetchStub: SinonStub;
+  let schema: Schema;
+  let remote: JSONAPISource;
+  let store: Store;
+  let coordinator: Coordinator;
+
+  hooks.beforeEach(() => {
+    fetchStub = sinon.stub(self, 'fetch');
+
+    schema = new Schema({
+      models: {
+        planet: {
+          keys: {
+            remoteId: {}
+          },
+          attributes: {
+            name: { type: 'string' },
+            classification: { type: 'string' },
+            lengthOfDay: { type: 'number' }
+          },
+          relationships: {
+            moons: { type: 'hasMany', model: 'moon', inverse: 'planet' },
+            solarSystem: { type: 'hasOne', model: 'solarSystem', inverse: 'planets' }
+          }
+        },
+        moon: {
+          attributes: {
+            name: { type: 'string' }
+          },
+          relationships: {
+            planet: { type: 'hasOne', model: 'planet', inverse: 'moons' }
+          }
+        },
+        solarSystem: {
+          attributes: {
+            name: { type: 'string' }
+          },
+          relationships: {
+            planets: { type: 'hasMany', model: 'planet', inverse: 'solarSystem' }
+          }
+        }
+      }
+    });
+
+    store = new Store({ schema });
+
+    remote = new JSONAPISource({ schema, name: 'remote' });
+
+    coordinator = new Coordinator({
+      sources: [store, remote]
+    });
+
+    // Query the remote server whenever the store is queried
+    coordinator.addStrategy(new RequestStrategy({
+      source: 'store',
+      on: 'beforeQuery',
+      target: 'remote',
+      action: 'pull',
+      blocking: true
+    }));
+
+    // Update the remote server whenever the store is updated
+    coordinator.addStrategy(new RequestStrategy({
+      source: 'store',
+      on: 'beforeUpdate',
+      target: 'remote',
+      action: 'push',
+      blocking: true
+    }));
+
+    // Sync all changes received from the remote server to the store
+    coordinator.addStrategy(new SyncStrategy({
+      source: 'remote',
+      target: 'store',
+      blocking: true
+    }));
+  });
+
+  hooks.afterEach(() => {
+    schema = remote = store = coordinator = null;
+
+    fetchStub.restore();
+  });
+
+  test('Adding a record to the store immediately pushes the update to the remote', async function(assert) {
+    assert.expect(1);
+
+    await coordinator.activate();
+
+    let planet: Record = { type: 'planet', id: schema.generateId(), attributes: { name: 'Jupiter', classification: 'gas giant' } };
+
+    fetchStub
+      .withArgs('/planets')
+      .returns(jsonapiResponse(201, {
+        data: { id: planet.id, type: 'planets', attributes: { name: 'Jupiter', classification: 'gas giant' } }
+      }));
+
+    await store.update(t => t.addRecord(planet));
+
+    let result = store.cache.query(q => q.findRecord(planet));
+
+    assert.deepEqual(result, {
+      type: 'planet',
+      id: planet.id,
+      attributes: { name: 'Jupiter', classification: 'gas giant' }
+    });
+  });
+});

--- a/packages/@orbit/integration-tests/test/store-jsonapi-remoteid-optimistic-test.ts
+++ b/packages/@orbit/integration-tests/test/store-jsonapi-remoteid-optimistic-test.ts
@@ -1,0 +1,147 @@
+import {
+  KeyMap,
+  Record,
+  Schema
+} from '@orbit/data';
+import JSONAPISource from '@orbit/jsonapi';
+import Store from '@orbit/store';
+import Coordinator, { RequestStrategy, SyncStrategy } from '@orbit/coordinator';
+import { jsonapiResponse } from './support/jsonapi';
+import { SinonStatic, SinonStub} from 'sinon';
+
+declare const sinon: SinonStatic;
+const { module, test } = QUnit;
+
+module('Store + JSONAPISource + remote IDs + optimistic coordination', function(hooks) {
+  let fetchStub: SinonStub;
+  let keyMap: KeyMap;
+  let schema: Schema;
+  let remote: JSONAPISource;
+  let store: Store;
+  let coordinator: Coordinator;
+
+  hooks.beforeEach(() => {
+    fetchStub = sinon.stub(self, 'fetch');
+
+    schema = new Schema({
+      models: {
+        planet: {
+          keys: {
+            remoteId: {}
+          },
+          attributes: {
+            name: { type: 'string' },
+            classification: { type: 'string' },
+            lengthOfDay: { type: 'number' }
+          },
+          relationships: {
+            moons: { type: 'hasMany', model: 'moon', inverse: 'planet' },
+            solarSystem: { type: 'hasOne', model: 'solarSystem', inverse: 'planets' }
+          }
+        },
+        moon: {
+          keys: {
+            remoteId: {}
+          },
+          attributes: {
+            name: { type: 'string' }
+          },
+          relationships: {
+            planet: { type: 'hasOne', model: 'planet', inverse: 'moons' }
+          }
+        },
+        solarSystem: {
+          keys: {
+            remoteId: {}
+          },
+          attributes: {
+            name: { type: 'string' }
+          },
+          relationships: {
+            planets: { type: 'hasMany', model: 'planet', inverse: 'solarSystem' }
+          }
+        }
+      }
+    });
+
+    keyMap = new KeyMap();
+
+    store = new Store({ schema, keyMap });
+
+    remote = new JSONAPISource({ schema, keyMap, name: 'remote' });
+    remote.serializer.resourceKey = function() { return 'remoteId'; };
+
+    coordinator = new Coordinator({
+      sources: [store, remote]
+    });
+
+    // Query the remote server whenever the store is queried
+    coordinator.addStrategy(new RequestStrategy({
+      source: 'store',
+      on: 'beforeQuery',
+      target: 'remote',
+      action: 'pull',
+      blocking: false
+    }));
+
+    // Update the remote server whenever the store is updated
+    coordinator.addStrategy(new RequestStrategy({
+      source: 'store',
+      on: 'beforeUpdate',
+      target: 'remote',
+      action: 'push',
+      blocking: false
+    }));
+
+    // Sync all changes received from the remote server to the store
+    coordinator.addStrategy(new SyncStrategy({
+      source: 'remote',
+      target: 'store',
+      blocking: true
+    }));
+  });
+
+  hooks.afterEach(() => {
+    keyMap = schema = remote = store = coordinator = null;
+
+    fetchStub.restore();
+  });
+
+  test('Adding a record to the store queues an update request which will be pushed to the remote', async function(assert) {
+    assert.expect(2);
+
+    await coordinator.activate();
+
+    fetchStub
+      .withArgs('/planets')
+      .returns(jsonapiResponse(201, {
+        data: { id: '12345', type: 'planets', attributes: { name: 'Jupiter', classification: 'gas giant' } }
+      }));
+
+    let planet: Record = { type: 'planet', id: schema.generateId(), attributes: { name: 'Jupiter', classification: 'gas giant' } };
+    await store.update(t => t.addRecord(planet));
+
+    assert.deepEqual(
+      store.cache.query(q => q.findRecord(planet)),
+      {
+        type: 'planet',
+        id: planet.id,
+        attributes: { name: 'Jupiter', classification: 'gas giant' }
+      },
+      'keys have not been syncd up yet - remote source still needs to process request'
+    );
+
+    await remote.requestQueue.process();
+
+    assert.deepEqual(
+      store.cache.query(q => q.findRecord(planet)),
+      {
+        type: 'planet',
+        id: planet.id,
+        keys: { remoteId: '12345' },
+        attributes: { name: 'Jupiter', classification: 'gas giant' }
+      },
+      'keys are syncd up after remote source finishes processing requests'
+    );
+  });
+});

--- a/packages/@orbit/integration-tests/test/store-jsonapi-remoteid-pessimistic-test.ts
+++ b/packages/@orbit/integration-tests/test/store-jsonapi-remoteid-pessimistic-test.ts
@@ -1,0 +1,136 @@
+import {
+  KeyMap,
+  Record,
+  Schema
+} from '@orbit/data';
+import JSONAPISource from '@orbit/jsonapi';
+import Store from '@orbit/store';
+import Coordinator, { RequestStrategy, SyncStrategy } from '@orbit/coordinator';
+import { jsonapiResponse } from './support/jsonapi';
+import { SinonStatic, SinonStub} from 'sinon';
+
+declare const sinon: SinonStatic;
+const { module, test } = QUnit;
+
+module('Store + JSONAPISource + remote IDs + pessimistic coordination', function(hooks) {
+  let fetchStub: SinonStub;
+  let keyMap: KeyMap;
+  let schema: Schema;
+  let remote: JSONAPISource;
+  let store: Store;
+  let coordinator: Coordinator;
+
+  hooks.beforeEach(() => {
+    fetchStub = sinon.stub(self, 'fetch');
+
+    schema = new Schema({
+      models: {
+        planet: {
+          keys: {
+            remoteId: {}
+          },
+          attributes: {
+            name: { type: 'string' },
+            classification: { type: 'string' },
+            lengthOfDay: { type: 'number' }
+          },
+          relationships: {
+            moons: { type: 'hasMany', model: 'moon', inverse: 'planet' },
+            solarSystem: { type: 'hasOne', model: 'solarSystem', inverse: 'planets' }
+          }
+        },
+        moon: {
+          keys: {
+            remoteId: {}
+          },
+          attributes: {
+            name: { type: 'string' }
+          },
+          relationships: {
+            planet: { type: 'hasOne', model: 'planet', inverse: 'moons' }
+          }
+        },
+        solarSystem: {
+          keys: {
+            remoteId: {}
+          },
+          attributes: {
+            name: { type: 'string' }
+          },
+          relationships: {
+            planets: { type: 'hasMany', model: 'planet', inverse: 'solarSystem' }
+          }
+        }
+      }
+    });
+
+    keyMap = new KeyMap();
+
+    store = new Store({ schema, keyMap });
+
+    remote = new JSONAPISource({ schema, keyMap, name: 'remote' });
+    remote.serializer.resourceKey = function() { return 'remoteId'; };
+
+    coordinator = new Coordinator({
+      sources: [store, remote]
+    });
+
+    // Query the remote server whenever the store is queried
+    coordinator.addStrategy(new RequestStrategy({
+      source: 'store',
+      on: 'beforeQuery',
+      target: 'remote',
+      action: 'pull',
+      blocking: true
+    }));
+
+    // Update the remote server whenever the store is updated
+    coordinator.addStrategy(new RequestStrategy({
+      source: 'store',
+      on: 'beforeUpdate',
+      target: 'remote',
+      action: 'push',
+      blocking: true
+    }));
+
+    // Sync all changes received from the remote server to the store
+    coordinator.addStrategy(new SyncStrategy({
+      source: 'remote',
+      target: 'store',
+      blocking: true
+    }));
+  });
+
+  hooks.afterEach(() => {
+    keyMap = schema = remote = store = coordinator = null;
+
+    fetchStub.restore();
+  });
+
+  test('Adding a record to the store immediately pushes the update to the remote', async function(assert) {
+    assert.expect(3);
+
+    await coordinator.activate();
+
+    fetchStub
+      .withArgs('/planets')
+      .returns(jsonapiResponse(201, {
+        data: { id: '12345', type: 'planets', attributes: { name: 'Jupiter', classification: 'gas giant' } }
+      }));
+
+    let planet: Record = { type: 'planet', id: schema.generateId(), attributes: { name: 'Jupiter', classification: 'gas giant' } };
+    await store.update(t => t.addRecord(planet));
+
+    let result = store.cache.query(q => q.findRecord(planet));
+
+    assert.deepEqual(result, {
+      type: 'planet',
+      id: planet.id,
+      keys: { remoteId: '12345' },
+      attributes: { name: 'Jupiter', classification: 'gas giant' }
+    });
+
+    assert.equal(keyMap.idToKey('planet', 'remoteId', planet.id), '12345', 'id mapped to key');
+    assert.equal(keyMap.keyToId('planet', 'remoteId', '12345'), planet.id, 'key mapped to id');
+  });
+});

--- a/packages/@orbit/integration-tests/test/support/jsonapi.ts
+++ b/packages/@orbit/integration-tests/test/support/jsonapi.ts
@@ -1,0 +1,47 @@
+import Orbit from '@orbit/core';
+
+export function jsonapiResponse(_options: any, body?: any, timeout?: number): Promise<Response> {
+  let options: any;
+  let response: Response;
+
+  if (typeof _options === 'number') {
+    options = { status: _options };
+  } else {
+    options = _options || {};
+  }
+  options.statusText = options.statusText || statusText(options.status);
+  options.headers = options.headers || {};
+
+  if (body) {
+    options.headers['Content-Type'] = 'application/vnd.api+json';
+    response = new Orbit.globals.Response(JSON.stringify(body), options);
+  } else {
+    response = new Orbit.globals.Response(options);
+  }
+
+  // console.log('jsonapiResponse', body, options, response.headers.get('Content-Type'));
+
+  if (timeout) {
+    return new Promise((resolve: (response: Response) => void) => {
+        let timer = Orbit.globals.setTimeout(() => {
+          Orbit.globals.clearTimeout(timer);
+          resolve(response);
+        }, timeout);
+      });
+  } else {
+    return Promise.resolve(response);
+  }
+}
+
+function statusText(code: number): string {
+  switch (code) {
+    case 200:
+      return 'OK';
+    case 201:
+      return 'Created';
+    case 204:
+      return 'No Content';
+    case 422:
+      return 'Unprocessable Entity';
+  }
+}

--- a/packages/@orbit/integration-tests/testem.json
+++ b/packages/@orbit/integration-tests/testem.json
@@ -1,0 +1,17 @@
+{
+  "framework": "qunit",
+  "test_page": "tests/index.html",
+  "on_start": "npm run build:tests",
+  "on_change": "npm run build:tests",
+  "src_files": ["test/**/*"],
+  "launch_in_ci": ["Chrome"],
+  "browser_args": {
+    "mode": "ci",
+    "Chrome": [
+      "--headless",
+      "--disable-gpu",
+      "--remote-debugging-port=9222",
+      "--no-sandbox"
+    ]
+  }
+}

--- a/packages/@orbit/integration-tests/tsconfig.tests.json
+++ b/packages/@orbit/integration-tests/tsconfig.tests.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "es2015",
+    "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "inlineSources": true,
+    "inlineSourceMap": true,
+    "declaration": false,
+    "newLine": "LF",
+    "types": ["qunit"],
+    "noImplicitAny": true
+  },
+  "include": [
+    "test/**/*.ts"
+  ]
+}


### PR DESCRIPTION
This is a private package used for testing interactions among the core orbit packages.

It initially contains several variants on coordinating mutations between a store and a remote JSONAPISource. This suite should expand quite a bit over time.