### PR TITLE
[FAILING] Add tests for testing inverse relationships population on addRecord

### DIFF
--- a/packages/@orbit/record-cache/test/async-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/async-record-cache-test.ts
@@ -158,6 +158,38 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
+
+  test('#patch updates inverse hasOne relationship when a record is added', async function(assert) {
+    const cache = new Cache({ schema, keyMap });
+
+    const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' }, relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } } };
+    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' }};
+
+    await cache.patch(t => [
+      t.addRecord(jupiter),
+      t.addRecord(io)
+    ]);
+
+    assert.deepEqual((await cache.getRecordAsync({ type: 'planet', id: 'p1' })).relationships.moons.data, [{ type: 'moon', id: 'm1' }], 'Jupiter has been assigned to Io');
+    assert.deepEqual((await cache.getRecordAsync({ type: 'moon', id: 'm1' })).relationships.planet.data, { type: 'planet', id: 'p1' }, 'Io has been assigned to Jupiter');
+  });
+
+
+  test('#patch updates inverse hasMany relationship when a record is added', async function(assert) {
+    const cache = new Cache({ schema, keyMap });
+
+    const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' } };
+    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
+
+    await cache.patch(t => [
+      t.addRecord(jupiter),
+      t.addRecord(io)
+    ]);
+
+    assert.deepEqual((await cache.getRecordAsync({ type: 'planet', id: 'p1' })).relationships.moons.data, [{ type: 'moon', id: 'm1' }], 'Jupiter has been assigned to Io');
+    assert.deepEqual((await cache.getRecordAsync({ type: 'moon', id: 'm1' })).relationships.planet.data, { type: 'planet', id: 'p1' }, 'Io has been assigned to Jupiter');
+  });
+
   test('#patch tracks refs and clears them from hasOne relationships when a referenced record is removed', async function(assert) {
     const cache = new Cache({ schema, keyMap });
 

--- a/packages/@orbit/record-cache/test/async-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/async-record-cache-test.ts
@@ -163,7 +163,7 @@ module('AsyncRecordCache', function(hooks) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' }, relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } } };
-    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' }};
+    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: null } }};
 
     await cache.patch(t => [
       t.addRecord(jupiter),
@@ -178,7 +178,7 @@ module('AsyncRecordCache', function(hooks) {
   test('#patch updates inverse hasMany relationship when a record is added', async function(assert) {
     const cache = new Cache({ schema, keyMap });
 
-    const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' } };
+    const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' }, relationships: { moons: { data: [] } } };
     const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
 
     await cache.patch(t => [

--- a/packages/@orbit/record-cache/test/sync-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/sync-record-cache-test.ts
@@ -169,7 +169,7 @@ module('SyncRecordCache', function(hooks) {
       t.addRecord(io)
     ]);
 
-    assert.deepEqual(cache.getRecordSync({ type: 'planet', id: 'p1' }).relationships.moons.data , [{ type: 'moon', id: 'm1' }], 'Jupiter has been assigned to Io');
+    assert.deepEqual(cache.getRecordSync({ type: 'planet', id: 'p1' }).relationships.moons.data, [{ type: 'moon', id: 'm1' }], 'Jupiter has been assigned to Io');
     assert.deepEqual(cache.getRecordSync({ type: 'moon', id: 'm1' }).relationships.planet.data, { type: 'planet', id: 'p1' }, 'Io has been assigned to Jupiter');
   });
 
@@ -185,7 +185,7 @@ module('SyncRecordCache', function(hooks) {
       t.addRecord(io)
     ]);
 
-    assert.deepEqual(cache.getRecordSync({ type: 'planet', id: 'p1' }).relationships.moons.data , [{ type: 'moon', id: 'm1' }], 'Jupiter has been assigned to Io');
+    assert.deepEqual(cache.getRecordSync({ type: 'planet', id: 'p1' }).relationships.moons.data, [{ type: 'moon', id: 'm1' }], 'Jupiter has been assigned to Io');
     assert.deepEqual(cache.getRecordSync({ type: 'moon', id: 'm1' }).relationships.planet.data, { type: 'planet', id: 'p1' }, 'Io has been assigned to Jupiter');
   });
 

--- a/packages/@orbit/record-cache/test/sync-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/sync-record-cache-test.ts
@@ -162,7 +162,7 @@ module('SyncRecordCache', function(hooks) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' }, relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } } };
-    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' }};
+    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: null } }};
 
     cache.patch(t => [
       t.addRecord(jupiter),
@@ -177,12 +177,12 @@ module('SyncRecordCache', function(hooks) {
   test('#patch updates inverse hasMany relationship when a record is added', function(assert) {
     const cache = new Cache({ schema, keyMap });
 
-    const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' } };
     const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
+    const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' }, relationships: { moons: { data: [] } } };
 
     cache.patch(t => [
-      t.addRecord(jupiter),
-      t.addRecord(io)
+      t.addRecord(io),
+      t.addRecord(jupiter)
     ]);
 
     assert.deepEqual(cache.getRecordSync({ type: 'planet', id: 'p1' }).relationships.moons.data, [{ type: 'moon', id: 'm1' }], 'Jupiter has been assigned to Io');

--- a/packages/@orbit/record-cache/test/sync-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/sync-record-cache-test.ts
@@ -158,6 +158,37 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
+  test('#patch updates inverse hasOne relationship when a record is added', function(assert) {
+    const cache = new Cache({ schema, keyMap });
+
+    const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' }, relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } } };
+    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' }};
+
+    cache.patch(t => [
+      t.addRecord(jupiter),
+      t.addRecord(io)
+    ]);
+
+    assert.deepEqual(cache.getRecordSync({ type: 'planet', id: 'p1' }).relationships.moons.data , [{ type: 'moon', id: 'm1' }], 'Jupiter has been assigned to Io');
+    assert.deepEqual(cache.getRecordSync({ type: 'moon', id: 'm1' }).relationships.planet.data, { type: 'planet', id: 'p1' }, 'Io has been assigned to Jupiter');
+  });
+
+
+  test('#patch updates inverse hasMany relationship when a record is added', function(assert) {
+    const cache = new Cache({ schema, keyMap });
+
+    const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' } };
+    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
+
+    cache.patch(t => [
+      t.addRecord(jupiter),
+      t.addRecord(io)
+    ]);
+
+    assert.deepEqual(cache.getRecordSync({ type: 'planet', id: 'p1' }).relationships.moons.data , [{ type: 'moon', id: 'm1' }], 'Jupiter has been assigned to Io');
+    assert.deepEqual(cache.getRecordSync({ type: 'moon', id: 'm1' }).relationships.planet.data, { type: 'planet', id: 'p1' }, 'Io has been assigned to Jupiter');
+  });
+
   test('#patch tracks refs and clears them from hasOne relationships when a referenced record is removed', function(assert) {
     const cache = new Cache({ schema, keyMap });
 


### PR DESCRIPTION
Test fails = #patch updates inverse hasOne relationship when a record is added

Test Passes - #patch updates inverse hasMany relationship when a record is added

Adding a failing test for #617 