### PR TITLE
Extract appendQueryParams in its own method

### DIFF
--- a/packages/@orbit/jsonapi/src/jsonapi-source.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-source.ts
@@ -182,12 +182,7 @@ export default class JSONAPISource extends Source implements Pullable, Pushable,
 
   fetch(url: string, customSettings?: FetchSettings): Promise<any> {
     let settings = this.initFetchSettings(customSettings);
-
-    let fullUrl = url;
-    if (settings.params) {
-      fullUrl = appendQueryParams(fullUrl, settings.params);
-      delete settings.params;
-    }
+    let fullUrl = this.appendQueryParams(url, settings);
 
     let fetchFn = (Orbit as any).fetch || Orbit.globals.fetch;
 
@@ -243,6 +238,15 @@ export default class JSONAPISource extends Source implements Pullable, Pushable,
     }
 
     return settings;
+  }
+
+  protected appendQueryParams(url: string, settings: FetchSettings): string {
+    let fullUrl = url;
+    if (settings.params) {
+      fullUrl = appendQueryParams(fullUrl, settings.params);
+      delete settings.params;
+    }
+    return fullUrl;
   }
 
   protected async handleFetchResponse(response: Response): Promise<any> {


### PR DESCRIPTION
This makes overriding `fetch` method on the source easier. For example I want to replace timeout behaviour with cancelable `fetch` so just replacing `fetch` implementation is not enough. But if I replace `fetch` method on the source I have no way to serialise query params with the internal orbit implementation.
