### PR TITLE
Fix updating an empty record with an empty relationship

### DIFF
--- a/packages/@orbit/record-cache/src/operators/async-inverse-patch-operators.ts
+++ b/packages/@orbit/record-cache/src/operators/async-inverse-patch-operators.ts
@@ -71,7 +71,7 @@ export const AsyncInversePatchOperators: Dict<AsyncInversePatchOperator> = {
           let data = deepGet(replacement, ['relationships', field, 'data']);
 
           let relationshipMatch;
-          if (isArray(data)) {
+          if (isArray(data) && isArray(currentData)) {
             relationshipMatch = equalRecordIdentitySets(currentData, data);
           } else {
             relationshipMatch = equalRecordIdentities(currentData, data);

--- a/packages/@orbit/record-cache/src/operators/async-inverse-patch-operators.ts
+++ b/packages/@orbit/record-cache/src/operators/async-inverse-patch-operators.ts
@@ -67,19 +67,32 @@ export const AsyncInversePatchOperators: Dict<AsyncInversePatchOperator> = {
 
       if (replacement.relationships) {
         Object.keys(replacement.relationships).forEach(field => {
-          let currentData = deepGet(current, ['relationships', field, 'data']);
           let data = deepGet(replacement, ['relationships', field, 'data']);
+          if (data !== undefined) {
+            let currentData = deepGet(current, ['relationships', field, 'data']);
+            let relationshipChanged;
 
-          let relationshipMatch;
-          if (isArray(data) && isArray(currentData)) {
-            relationshipMatch = equalRecordIdentitySets(currentData, data);
-          } else {
-            relationshipMatch = equalRecordIdentities(currentData, data);
-          }
+            if (isArray(data)) {
+              if (currentData) {
+                relationshipChanged = !equalRecordIdentitySets(currentData, data);
+              } else {
+                relationshipChanged = true;
+                currentData = [];
+              }
 
-          if (!relationshipMatch) {
-            changed = true;
-            deepSet(result, ['relationships', field, 'data'], currentData === undefined ? null : currentData);
+            } else {
+              if (currentData) {
+                relationshipChanged = !equalRecordIdentities(currentData, data);
+              } else {
+                relationshipChanged = true;
+                currentData = null;
+              }
+            }
+
+            if (relationshipChanged) {
+              changed = true;
+              deepSet(result, ['relationships', field, 'data'], currentData);
+            }
           }
         });
       }

--- a/packages/@orbit/record-cache/src/operators/sync-inverse-patch-operators.ts
+++ b/packages/@orbit/record-cache/src/operators/sync-inverse-patch-operators.ts
@@ -71,7 +71,7 @@ export const SyncInversePatchOperators: Dict<SyncInversePatchOperator> = {
           let data = deepGet(replacement, ['relationships', field, 'data']);
 
           let relationshipMatch;
-          if (isArray(data)) {
+          if (isArray(data) && isArray(currentData)) {
             relationshipMatch = equalRecordIdentitySets(currentData, data);
           } else {
             relationshipMatch = equalRecordIdentities(currentData, data);

--- a/packages/@orbit/record-cache/src/operators/sync-inverse-patch-operators.ts
+++ b/packages/@orbit/record-cache/src/operators/sync-inverse-patch-operators.ts
@@ -67,19 +67,32 @@ export const SyncInversePatchOperators: Dict<SyncInversePatchOperator> = {
 
       if (replacement.relationships) {
         Object.keys(replacement.relationships).forEach(field => {
-          let currentData = deepGet(current, ['relationships', field, 'data']);
           let data = deepGet(replacement, ['relationships', field, 'data']);
+          if (data !== undefined) {
+            let currentData = deepGet(current, ['relationships', field, 'data']);
+            let relationshipChanged;
 
-          let relationshipMatch;
-          if (isArray(data) && isArray(currentData)) {
-            relationshipMatch = equalRecordIdentitySets(currentData, data);
-          } else {
-            relationshipMatch = equalRecordIdentities(currentData, data);
-          }
+            if (isArray(data)) {
+              if (currentData) {
+                relationshipChanged = !equalRecordIdentitySets(currentData, data);
+              } else {
+                relationshipChanged = true;
+                currentData = [];
+              }
 
-          if (!relationshipMatch) {
-            changed = true;
-            deepSet(result, ['relationships', field, 'data'], currentData === undefined ? null : currentData);
+            } else {
+              if (currentData) {
+                relationshipChanged = !equalRecordIdentities(currentData, data);
+              } else {
+                relationshipChanged = true;
+                currentData = null;
+              }
+            }
+
+            if (relationshipChanged) {
+              changed = true;
+              deepSet(result, ['relationships', field, 'data'], currentData);
+            }
           }
         });
       }

--- a/packages/@orbit/record-cache/test/async-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/async-record-cache-test.ts
@@ -800,6 +800,28 @@ module('AsyncRecordCache', function(hooks) {
 
   });
 
+  test('#patch can update existing record with empty relationship', async function(assert) {
+    const cache = new Cache({ schema, keyMap });
+
+    await cache.patch(t => [
+      t.addRecord({
+        id: '1',
+        type: 'planet'
+      }),
+      t.updateRecord({
+        id: '1',
+        type: 'planet',
+        relationships: {
+          moons: { data: [] }
+        }
+      })
+    ]);
+
+    const planet = await cache.getRecordAsync({ type: 'planet', id: '1' });
+    assert.ok(planet, 'planet exists');
+    assert.deepEqual(planet.relationships.moons.data, [], 'planet has empty moons relationship');
+  });
+
   test('#query can retrieve an individual record', async function(assert) {
     const cache = new Cache({ schema, keyMap });
 

--- a/packages/@orbit/record-cache/test/sync-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/sync-record-cache-test.ts
@@ -798,6 +798,28 @@ module('SyncRecordCache', function(hooks) {
 
   });
 
+  test('#patch can update existing record with empty relationship', function(assert) {
+    const cache = new Cache({ schema, keyMap });
+
+    cache.patch(t => [
+      t.addRecord({
+        id: '1',
+        type: 'planet'
+      }),
+      t.updateRecord({
+        id: '1',
+        type: 'planet',
+        relationships: {
+          moons: { data: [] }
+        }
+      })
+    ]);
+
+    const planet = cache.getRecordSync({ type: 'planet', id: '1' });
+    assert.ok(planet, 'planet exists');
+    assert.deepEqual(planet.relationships.moons.data, [], 'planet has empty moons relationship');
+  });
+
   test('#query can retrieve an individual record', function(assert) {
     const cache = new Cache({ schema, keyMap });
 


### PR DESCRIPTION
Fixes #624

Given my superficial knowledge here, please double check twice that this is the right place and way to fix it! :)

It does however fix the added test, which was failing before, and it also fixes the actual error I saw in our app (when using the patched `record-cache` as a linked package).