### PR TITLE
Polymorphic relationships

### DIFF
--- a/packages/@orbit/data/src/exception.ts
+++ b/packages/@orbit/data/src/exception.ts
@@ -102,6 +102,24 @@ export class ModelNotFound extends SchemaError {
 }
 
 /**
+ * A relationship definition could not be found in the model definition
+ */
+export class RelationshipNotFound extends SchemaError {
+  constructor(relationshipType: string, recordType: string) {
+    super(`Relationship definition for ${relationshipType} not found for model definition ${recordType}`)
+  }
+}
+
+/**
+ * A related record of the incorrect type was attempted to be added to a relationship of a model definition
+ */
+export class IncorrectRelatedRecordType extends SchemaError {
+  constructor(relatedRecordType: string, relationship: string, recordType: string) {
+    super(`Relationship definition ${relationship} for model definition ${recordType} does not accept record of type ${relatedRecordType}`);
+  }
+}
+
+/**
  * An error occurred related to a particular record.
  */
 export abstract class RecordException extends Exception {

--- a/packages/@orbit/data/src/schema.ts
+++ b/packages/@orbit/data/src/schema.ts
@@ -13,7 +13,7 @@ export interface AttributeDefinition {
 
 export interface RelationshipDefinition {
   type: 'hasMany' | 'hasOne';
-  model?: string;
+  model?: string | string[];
   inverse?: string;
   dependent?: 'remove';
 }

--- a/packages/@orbit/record-cache/src/operation-processors/sync-schema-validation-processor.ts
+++ b/packages/@orbit/record-cache/src/operation-processors/sync-schema-validation-processor.ts
@@ -99,6 +99,10 @@ export default class SyncSchemaValidationProcessor extends SyncOperationProcesso
     this._validateRecordIdentity(record);
   }
 
+  protected _validateRecordIdentity(record: RecordIdentity) {
+    this._getModelSchema(record.type);
+  }
+
   protected _validateRelationship(record: Record, relationship: string, relatedRecord: RecordIdentity) {
     const modelSchema = this._getModelSchema(record.type);
     const relationshipDef = modelSchema.relationships && modelSchema.relationships[relationship];
@@ -109,18 +113,15 @@ export default class SyncSchemaValidationProcessor extends SyncOperationProcesso
       if (!relationshipDef.model.includes(relatedRecord.type)) {
         throw new IncorrectRelatedRecordType(relatedRecord.type, relationship, record.type);
       }
-    } else {
+    } else if (typeof relationshipDef.model === 'string') {
       if (relationshipDef.model !== relatedRecord.type) {
         throw new IncorrectRelatedRecordType(relatedRecord.type, relationship, record.type);
       }
     }
   } 
 
-  protected _getModelSchema(type: string) {
+  private _getModelSchema(type: string) {
     return this.accessor.schema.getModel(type);
   }
 
-  protected _validateRecordIdentity(record: RecordIdentity) {
-    this._getModelSchema(record.type);
-  }
 }

--- a/packages/@orbit/record-cache/test/operation-processors/schema-validation-processor-test.ts
+++ b/packages/@orbit/record-cache/test/operation-processors/schema-validation-processor-test.ts
@@ -2,7 +2,9 @@ import {
   KeyMap,
   Schema,
   SchemaSettings,
-  ModelNotFound
+  ModelNotFound,
+  RelationshipNotFound,
+  IncorrectRelatedRecordType
 } from '@orbit/data';
 import Cache from '../support/example-sync-record-cache';
 import { SyncSchemaValidationProcessor } from '../../src/index';
@@ -22,6 +24,30 @@ module('SchemaValidationProcessor', function(hooks) {
         relationships: {
           parent: { type: 'hasOne', model: 'node', inverse: 'children' },
           children: { type: 'hasMany', model: 'node', inverse: 'parent' }
+        }
+      },
+      person: {
+        attributes: {
+          name: { type: 'string' }
+        },
+        relationships: {
+          pets: { type: 'hasMany', model: ['cat', 'dog'], inverse: 'owner' }
+        }
+      },
+      cat: {
+        attributes: {
+          name: { type: 'string' }
+        },
+        relationships: {
+          owner: { type: 'hasOne', model: 'person', inverse: 'pets' }
+        }
+      },
+      dog: {
+        attributes: {
+          name: { type: 'string' }
+        },
+        relationships: {
+          owner: { type: 'hasOne', model: 'person', inverse: 'pets' }
         }
       }
     }
@@ -84,6 +110,18 @@ module('SchemaValidationProcessor', function(hooks) {
     }, unknownError);
   });
 
+  test('addToRelatedRecords with an unknown relationship type', assert => {
+    assert.throws(() => {
+      cache.patch(t => t.addToRelatedRecords({ type: 'person', id: '1'}, 'animals', { type: 'dog', id: '1' }));
+    }, new RelationshipNotFound('animals', 'person'));
+  });
+
+  test('addToRelatedRecords with a related record with an invalid type for a polymorphic relationship', assert => {
+    assert.throws(() => {
+      cache.patch(t => t.addToRelatedRecords({ type: 'person', id: '1'}, 'pets', { type: 'person', id: '2' }));
+    }, new IncorrectRelatedRecordType('person', 'pets', 'person'));
+  });
+
   test('removeFromRelatedRecords with an unknown model type', assert => {
     assert.throws(() => {
       cache.patch(t => t.removeFromRelatedRecords(unknown, 'children', node));
@@ -108,6 +146,18 @@ module('SchemaValidationProcessor', function(hooks) {
     }, unknownError);
   });
 
+  test('replaceRelatedRecords with an unknown relationship type', assert => {
+    assert.throws(() => {
+      cache.patch(t => t.replaceRelatedRecords({ type: 'person', id: '1'}, 'animals', [{ type: 'dog', id: '1' }]));
+    }, new RelationshipNotFound('animals', 'person'));
+  });
+  
+  test('replaceRelatedRecords with a related record with an invalid type for a polymorphic relationship', assert => {
+    assert.throws(() => {
+      cache.patch(t => t.replaceRelatedRecords({ type: 'person', id: '1'}, 'pets', [{ type: 'person', id: '2' }]));
+    }, new IncorrectRelatedRecordType('person', 'pets', 'person'));
+  });
+
   test('replaceRelatedRecord with an unknown model type', assert => {
     assert.throws(() => {
       cache.patch(t => t.replaceRelatedRecord(unknown, 'parent', node));
@@ -123,5 +173,17 @@ module('SchemaValidationProcessor', function(hooks) {
   test('replaceRelatedRecord with a null related model', assert => {
     cache.patch(t => t.replaceRelatedRecord(node, 'parent', null));
     assert.ok(true, 'no error is thrown');
+  });
+
+  test('replaceRelatedRecord with an unknown relationship type', assert => {
+    assert.throws(() => {
+      cache.patch(t => t.replaceRelatedRecord({ type: 'dog', id: '1'}, 'human', { type: 'person', id: '1' }));
+    }, new RelationshipNotFound('human', 'dog'));
+  });
+
+  test('replaceRelatedRecord with an invalid type', assert => {
+    assert.throws(() => {
+      cache.patch(t => t.replaceRelatedRecord({ type: 'dog', id: '1'}, 'owner', { type: 'dog', id: '2' }));
+    }, new RelationshipNotFound('dog', 'owner', 'dog'));
   });
 });

--- a/packages/@orbit/record-cache/test/operation-processors/schema-validation-processor-test.ts
+++ b/packages/@orbit/record-cache/test/operation-processors/schema-validation-processor-test.ts
@@ -31,6 +31,7 @@ module('SchemaValidationProcessor', function(hooks) {
           name: { type: 'string' }
         },
         relationships: {
+          favoritePet: { type: 'hasOne', model: ['cat', 'dog'] },
           pets: { type: 'hasMany', model: ['cat', 'dog'], inverse: 'owner' }
         }
       },
@@ -110,10 +111,16 @@ module('SchemaValidationProcessor', function(hooks) {
     }, unknownError);
   });
 
-  test('addToRelatedRecords with an unknown relationship type', assert => {
+  test('addToRelatedRecords with a relationship not defined in the schema', assert => {
     assert.throws(() => {
-      cache.patch(t => t.addToRelatedRecords({ type: 'person', id: '1'}, 'animals', { type: 'dog', id: '1' }));
-    }, new RelationshipNotFound('animals', 'person'));
+      cache.patch(t => t.addToRelatedRecords({ type: 'node', id: '1'}, 'sibling', { type: 'node', id: '2' }));
+    }, new RelationshipNotFound('sibling', 'node'));
+  });
+
+  test('addToRelatedRecord with a related record with an invalid type for a non-polymorphic relationship', assert => {
+    assert.throws(() => {
+      cache.patch(t => t.addToRelatedRecords({ type: 'node', id: '1'}, 'children', { type: 'person', id: '1' }));
+    }, new IncorrectRelatedRecordType('person', 'children', 'node'));
   });
 
   test('addToRelatedRecords with a related record with an invalid type for a polymorphic relationship', assert => {
@@ -146,10 +153,16 @@ module('SchemaValidationProcessor', function(hooks) {
     }, unknownError);
   });
 
-  test('replaceRelatedRecords with an unknown relationship type', assert => {
+  test('replaceRelatedRecords with a relationship not defined in the schema', assert => {
     assert.throws(() => {
-      cache.patch(t => t.replaceRelatedRecords({ type: 'person', id: '1'}, 'animals', [{ type: 'dog', id: '1' }]));
-    }, new RelationshipNotFound('animals', 'person'));
+      cache.patch(t => t.replaceRelatedRecords({ type: 'node', id: '1'}, 'siblings', [{ type: 'node', id: '2' }]));
+    }, new RelationshipNotFound('siblings', 'node'));
+  });
+
+  test('replaceRelatedRecords with a related record with an invalid type for a non-polymorphic relationship', assert => {
+    assert.throws(() => {
+      cache.patch(t => t.replaceRelatedRecords({ type: 'node', id: '1'}, 'children', [{ type: 'person', id: '1' }]));
+    }, new IncorrectRelatedRecordType('person', 'children', 'node'));
   });
   
   test('replaceRelatedRecords with a related record with an invalid type for a polymorphic relationship', assert => {
@@ -175,15 +188,21 @@ module('SchemaValidationProcessor', function(hooks) {
     assert.ok(true, 'no error is thrown');
   });
 
-  test('replaceRelatedRecord with an unknown relationship type', assert => {
+  test('replaceRelatedRecord with a relationship not defined in the schema', assert => {
     assert.throws(() => {
-      cache.patch(t => t.replaceRelatedRecord({ type: 'dog', id: '1'}, 'human', { type: 'person', id: '1' }));
-    }, new RelationshipNotFound('human', 'dog'));
+      cache.patch(t => t.replaceRelatedRecord({ type: 'node', id: '1'}, 'mother', { type: 'node', id: '1' }));
+    }, new RelationshipNotFound('mother', 'node'));
   });
 
-  test('replaceRelatedRecord with an invalid type', assert => {
+  test('replaceRelatedRecord with a related record with an invalid type for a non-polymorphic relationship', assert => {
     assert.throws(() => {
-      cache.patch(t => t.replaceRelatedRecord({ type: 'dog', id: '1'}, 'owner', { type: 'dog', id: '2' }));
-    }, new RelationshipNotFound('dog', 'owner', 'dog'));
+      cache.patch(t => t.replaceRelatedRecord({ type: 'node', id: '1'}, 'parent', { type: 'person', id: '1' }));
+    }, new IncorrectRelatedRecordType('person', 'parent', 'node'));
+  });
+
+  test('replaceRelatedRecord with a related record with an invalid type for a polymorphic relationship', assert => {
+    assert.throws(() => {
+      cache.patch(t => t.replaceRelatedRecord({ type: 'person', id: '1'}, 'favoritePet', { type: 'person', id: '2' }));
+    }, new IncorrectRelatedRecordType('person', 'favoritePet', 'person'));
   });
 });

--- a/packages/@orbit/store/test/cache-test.ts
+++ b/packages/@orbit/store/test/cache-test.ts
@@ -213,8 +213,8 @@ module('Cache', function(hooks) {
     const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' }};
 
     cache.patch(t => [
-      t.addRecord(jupiter),
-      t.addRecord(io)
+      t.updateRecord(jupiter),
+      t.updateRecord(io)
     ]);
 
     assert.deepEqual(cache.getRecordSync({ type: 'planet', id: 'p1' }).relationships.moons.data, [{ type: 'moon', id: 'm1' }], 'Jupiter has been assigned to Io');
@@ -228,8 +228,8 @@ module('Cache', function(hooks) {
     const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' } };
 
     cache.patch(t => [
-      t.addRecord(io),
-      t.addRecord(jupiter)
+      t.updateRecord(io),
+      t.updateRecord(jupiter)
     ]);
 
     assert.deepEqual(cache.getRecordSync({ type: 'planet', id: 'p1' }).relationships.moons.data, [{ type: 'moon', id: 'm1' }], 'Jupiter has been assigned to Io');
@@ -243,8 +243,8 @@ module('Cache', function(hooks) {
     const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' }, relationships: { moons: { data: [] }}};
 
     cache.patch(t => [
-      t.addRecord(io),
-      t.addRecord(jupiter)
+      t.updateRecord(io),
+      t.updateRecord(jupiter)
     ]);
 
     assert.deepEqual(cache.getRecordSync({ type: 'planet', id: 'p1' }).relationships.moons.data, [], 'Jupiter has been assigned to Io');
@@ -258,8 +258,8 @@ module('Cache', function(hooks) {
     const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: null } } };
 
     cache.patch(t => [
-      t.addRecord(jupiter),
-      t.addRecord(io)
+      t.updateRecord(jupiter),
+      t.updateRecord(io)
     ]);
 
     assert.deepEqual(cache.getRecordSync({ type: 'planet', id: 'p1' }).relationships.moons.data, [], 'Jupiter has been assigned to Io');

--- a/packages/@orbit/store/test/cache-test.ts
+++ b/packages/@orbit/store/test/cache-test.ts
@@ -206,66 +206,6 @@ module('Cache', function(hooks) {
     );
   });
 
-  test('#patch updates inverse hasOne relationship when a record with relationships unspecified is added', function(assert) {
-    const cache = new Cache({ schema, keyMap });
-
-    const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' }, relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } } };
-    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' }};
-
-    cache.patch(t => [
-      t.addRecord(jupiter),
-      t.addRecord(io)
-    ]);
-
-    assert.deepEqual(cache.getRecordSync({ type: 'planet', id: 'p1' }).relationships.moons.data, [{ type: 'moon', id: 'm1' }], 'Jupiter has been assigned to Io');
-    assert.deepEqual(cache.getRecordSync({ type: 'moon', id: 'm1' }).relationships.planet.data, { type: 'planet', id: 'p1' }, 'Io has been assigned to Jupiter');
-  });
-
-  test('#patch updates inverse hasMany relationship when a record with relationships unspecified is added', function(assert) {
-    const cache = new Cache({ schema, keyMap });
-
-    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
-    const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' } };
-
-    cache.patch(t => [
-      t.addRecord(io),
-      t.addRecord(jupiter)
-    ]);
-
-    assert.deepEqual(cache.getRecordSync({ type: 'planet', id: 'p1' }).relationships.moons.data, [{ type: 'moon', id: 'm1' }], 'Jupiter has been assigned to Io');
-    assert.deepEqual(cache.getRecordSync({ type: 'moon', id: 'm1' }).relationships.planet.data, { type: 'planet', id: 'p1' }, 'Io has been assigned to Jupiter');
-  });
-
-  test('#patch updates inverse hasOne relationship when a record with an empty relationship is added', function(assert) {
-    const cache = new Cache({ schema, keyMap });
-
-    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: { type: 'planet', id: 'p1'} } } };
-    const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' }, relationships: { moons: { data: [] }}};
-
-    cache.patch(t => [
-      t.addRecord(io),
-      t.addRecord(jupiter)
-    ]);
-
-    assert.deepEqual(cache.getRecordSync({ type: 'planet', id: 'p1' }).relationships.moons.data, [], 'Jupiter has been assigned to Io');
-    assert.deepEqual(cache.getRecordSync({ type: 'moon', id: 'm1' }).relationships.planet.data, null, 'Io has been assigned to Jupiter');
-  });
-
-  test('#patch updates inverse hasMany relationship when a record with an empty relationship is added', function(assert) {
-    const cache = new Cache({ schema, keyMap });
-
-    const jupiter: Record = { type: 'planet', id: 'p1', attributes: { name: 'Jupiter' }, relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } } };
-    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' }, relationships: { planet: { data: null } } };
-
-    cache.patch(t => [
-      t.addRecord(jupiter),
-      t.addRecord(io)
-    ]);
-
-    assert.deepEqual(cache.getRecordSync({ type: 'planet', id: 'p1' }).relationships.moons.data, [], 'Jupiter has been assigned to Io');
-    assert.deepEqual(cache.getRecordSync({ type: 'moon', id: 'm1' }).relationships.planet.data, null, 'Io has been assigned to Jupiter');
-  });
-
   test('#patch tracks refs and clears them from hasOne relationships when a referenced record is removed', function(assert) {
     let cache = new Cache({ schema, keyMap });
 


### PR DESCRIPTION
Aims to get the ball rolling on #475.

Allows the model property in the relationship definition to be a string or an array of strings

Add relationship validation to the `schema-validation-processor`.
This validations ensure that a relationships being added/replaced must be specified in the schema model definition.
It also ensures that relationship being added/replaced must adhere to the types specified in the `model` property on the relationship definition.