### PR TITLE
Polymorphic Relationships

### DIFF
--- a/packages/@orbit/data/src/exception.ts
+++ b/packages/@orbit/data/src/exception.ts
@@ -102,6 +102,24 @@ export class ModelNotFound extends SchemaError {
 }
 
 /**
+ * A relationship definition could not be found in the model definition
+ */
+export class RelationshipNotFound extends SchemaError {
+  constructor(relationshipType: string, recordType: string) {
+    super(`Relationship definition for ${relationshipType} not found for model definition ${recordType}`)
+  }
+}
+
+/**
+ * A related record of the incorrect type was attempted to be added to a relationship of a model definition
+ */
+export class IncorrectRelatedRecordType extends SchemaError {
+  constructor(relatedRecordType: string, relationship: string, recordType: string) {
+    super(`Relationship definition ${relationship} for model definition ${recordType} does not accept record of type ${relatedRecordType}`);
+  }
+}
+
+/**
  * An error occurred related to a particular record.
  */
 export abstract class RecordException extends Exception {

--- a/packages/@orbit/data/src/schema.ts
+++ b/packages/@orbit/data/src/schema.ts
@@ -13,7 +13,7 @@ export interface AttributeDefinition {
 
 export interface RelationshipDefinition {
   type: 'hasMany' | 'hasOne';
-  model?: string;
+  model?: string | string[];
   inverse?: string;
   dependent?: 'remove';
 }

--- a/packages/@orbit/record-cache/src/operation-processors/sync-schema-validation-processor.ts
+++ b/packages/@orbit/record-cache/src/operation-processors/sync-schema-validation-processor.ts
@@ -2,6 +2,8 @@ import {
   Record,
   RecordIdentity,
   RecordOperation,
+  RelationshipNotFound,
+  IncorrectRelatedRecordType
 } from '@orbit/data';
 import { SyncOperationProcessor } from '../sync-operation-processor';
 
@@ -67,6 +69,7 @@ export default class SyncSchemaValidationProcessor extends SyncOperationProcesso
   protected _relatedRecordAdded(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity) {
     this._validateRecordIdentity(record);
     this._validateRecordIdentity(relatedRecord);
+    this._validateRelationship(record, relationship, relatedRecord);
   }
 
   protected _relatedRecordRemoved(record: RecordIdentity, relationship: string, relatedRecord: RecordIdentity) {
@@ -77,8 +80,9 @@ export default class SyncSchemaValidationProcessor extends SyncOperationProcesso
   protected _relatedRecordsReplaced(record: RecordIdentity, relationship: string, relatedRecords: RecordIdentity[]) {
     this._validateRecordIdentity(record);
 
-    relatedRecords.forEach(record => {
-      this._validateRecordIdentity(record);
+    relatedRecords.forEach(relatedRecord => {
+      this._validateRecordIdentity(relatedRecord);
+      this._validateRelationship(record, relationship, relatedRecord);
     });
   }
 
@@ -87,6 +91,7 @@ export default class SyncSchemaValidationProcessor extends SyncOperationProcesso
 
     if (relatedRecord) {
       this._validateRecordIdentity(relatedRecord);
+      this._validateRelationship(record, relationship, relatedRecord);
     }
   }
 
@@ -95,6 +100,28 @@ export default class SyncSchemaValidationProcessor extends SyncOperationProcesso
   }
 
   protected _validateRecordIdentity(record: RecordIdentity) {
-    this.accessor.schema.getModel(record.type);
+    this._getModelSchema(record.type);
   }
+
+  protected _validateRelationship(record: Record, relationship: string, relatedRecord: RecordIdentity) {
+    const modelSchema = this._getModelSchema(record.type);
+    const relationshipDef = modelSchema.relationships && modelSchema.relationships[relationship];
+    if (relationshipDef === undefined) {
+      throw new RelationshipNotFound(relationship, record.type);
+    }
+    if (Array.isArray(relationshipDef.model)) {
+      if (!relationshipDef.model.includes(relatedRecord.type)) {
+        throw new IncorrectRelatedRecordType(relatedRecord.type, relationship, record.type);
+      }
+    } else if (typeof relationshipDef.model === 'string') {
+      if (relationshipDef.model !== relatedRecord.type) {
+        throw new IncorrectRelatedRecordType(relatedRecord.type, relationship, record.type);
+      }
+    }
+  } 
+
+  private _getModelSchema(type: string) {
+    return this.accessor.schema.getModel(type);
+  }
+
 }


### PR DESCRIPTION
Retry of #626 with branches properly rebased.

Aims to get the ball rolling on #475 .

Allows the model property in the relationship definition to be a string or an array of strings

Add relationship validation to the schema-validation-processor.
This validations ensure that a relationships being added/replaced must be specified in the schema model definition.
It also ensures that relationship being added/replaced must adhere to the types specified in the model property on the relationship definition.