### PR TITLE
Introduce JSONAPIRequestProcessor

### DIFF
--- a/packages/@orbit/integration-tests/test/store-jsonapi-remoteid-optimistic-test.ts
+++ b/packages/@orbit/integration-tests/test/store-jsonapi-remoteid-optimistic-test.ts
@@ -69,7 +69,7 @@ module('Store + JSONAPISource + remote IDs + optimistic coordination', function(
     store = new Store({ schema, keyMap });
 
     remote = new JSONAPISource({ schema, keyMap, name: 'remote' });
-    remote.serializer.resourceKey = function() { return 'remoteId'; };
+    remote.requestProcessor.serializer.resourceKey = function() { return 'remoteId'; };
 
     coordinator = new Coordinator({
       sources: [store, remote]

--- a/packages/@orbit/integration-tests/test/store-jsonapi-remoteid-pessimistic-test.ts
+++ b/packages/@orbit/integration-tests/test/store-jsonapi-remoteid-pessimistic-test.ts
@@ -69,7 +69,7 @@ module('Store + JSONAPISource + remote IDs + pessimistic coordination', function
     store = new Store({ schema, keyMap });
 
     remote = new JSONAPISource({ schema, keyMap, name: 'remote' });
-    remote.serializer.resourceKey = function() { return 'remoteId'; };
+    remote.requestProcessor.serializer.resourceKey = function() { return 'remoteId'; };
 
     coordinator = new Coordinator({
       sources: [store, remote]

--- a/packages/@orbit/jsonapi/src/index.ts
+++ b/packages/@orbit/jsonapi/src/index.ts
@@ -1,4 +1,5 @@
 export { default } from './jsonapi-source';
 export * from './jsonapi-serializer';
+export { default as JSONAPIRequestProcessor } from './jsonapi-request-processor';
 export * from './record-document';
 export * from './resource-document';

--- a/packages/@orbit/jsonapi/src/index.ts
+++ b/packages/@orbit/jsonapi/src/index.ts
@@ -1,5 +1,6 @@
 export { default } from './jsonapi-source';
 export * from './jsonapi-serializer';
 export { default as JSONAPIRequestProcessor } from './jsonapi-request-processor';
+export { default as JSONAPIURLBuilder } from './jsonapi-url-builder';
 export * from './record-document';
 export * from './resource-document';

--- a/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
@@ -10,8 +10,10 @@ import Orbit, {
   Transform,
 } from '@orbit/data';
 import { InvalidServerResponse } from './lib/exceptions';
+import { TransformRecordRequest } from './lib/transform-requests';
 import { deepGet, deepMerge, toArray } from '@orbit/utils';
 import { RecordDocument } from './record-document';
+import { ResourceDocument } from './resource-document';
 import {
   RequestOptions,
   buildFetchSettings
@@ -52,9 +54,7 @@ export interface JSONAPIRequestProcessorSettings {
 
 export default class JSONAPIRequestProcessor {
   sourceName: string;
-  SerializerClass?: (new (settings: JSONAPISerializerSettings) => JSONAPISerializer);
   serializer: JSONAPISerializer;
-  URLBuilderClass?: (new (settings: JSONAPIURLBuilderSettings) => JSONAPIURLBuilder);
   urlBuilder: JSONAPIURLBuilder;
   allowedContentTypes: string[];
   defaultFetchSettings: FetchSettings;
@@ -173,6 +173,8 @@ export default class JSONAPIRequestProcessor {
   customRequestOptions(queryOrTransform: Query | Transform): RequestOptions {
     return deepGet(queryOrTransform, ['options', 'sources', this.sourceName]);
   }
+
+  preprocessResponseDocument(document: ResourceDocument, queryOrTransformRecordRequest:Query|TransformRecordRequest) {}
 
   protected responseHasContent(response: Response): boolean {
     if (response.status === 204) {

--- a/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
@@ -1,0 +1,313 @@
+import Orbit, {
+  AttributeFilterSpecifier,
+  AttributeSortSpecifier,
+  ClientError,
+  FilterSpecifier,
+  NetworkError,
+  Operation,
+  PageSpecifier,
+  Query,
+  QueryExpressionParseError,
+  Record,
+  RelatedRecordFilterSpecifier,
+  RelatedRecordsFilterSpecifier,
+  ServerError,
+  SortSpecifier,
+  Transform,
+  TransformNotAllowed,
+} from '@orbit/data';
+import JSONAPISource from './jsonapi-source';
+import { InvalidServerResponse } from './lib/exceptions';
+import { appendQueryParams } from './lib/query-params';
+import { clone, deepMerge, toArray } from '@orbit/utils';
+import { QueryOperator, QueryOperators } from "./lib/query-operators";
+import { RecordDocument } from './record-document';
+import { TransformRequestProcessors, TransformRecordRequest, getTransformRequests } from  './lib/transform-requests';
+import {
+  Filter,
+  RequestOptions,
+  buildFetchSettings,
+  customRequestOptions
+} from './lib/request-settings';
+const { assert, deprecate } = Orbit;
+
+export interface FetchSettings {
+  headers?: object;
+  method?: string;
+  json?: object;
+  body?: string;
+  params?: any;
+  timeout?: number;
+  credentials?: string;
+  cache?: string;
+  redirect?: string;
+  referrer?: string;
+  referrerPolicy?: string;
+  integrity?: string;
+}
+
+export interface JSONAPIRequestProcessorSettings {
+  namespace?: string;
+  host?: string;
+  defaultFetchHeaders?: object;
+  defaultFetchTimeout?: number;
+  defaultFetchSettings?: FetchSettings;
+  allowedContentTypes?: string[];
+  maxRequestsPerTransform?: number;
+}
+
+export default class JSONAPIRequestProcessor {
+  source: JSONAPISource;
+  allowedContentTypes: string[];
+  defaultFetchSettings: FetchSettings;
+  maxRequestsPerTransform: number;
+
+  constructor(source: JSONAPISource, settings: JSONAPIRequestProcessorSettings = {}) {
+    this.source = source;
+    this.allowedContentTypes = settings.allowedContentTypes || ['application/vnd.api+json', 'application/json'];
+    this.maxRequestsPerTransform = settings.maxRequestsPerTransform;
+    this.initDefaultFetchSettings(settings);
+  }
+
+  fetch(url: string, customSettings?: FetchSettings): Promise<any> {
+    let settings = this.initFetchSettings(customSettings);
+    let fullUrl = this.appendQueryParams(url, settings);
+
+    let fetchFn = (Orbit as any).fetch || Orbit.globals.fetch;
+
+    // console.log('fetch', fullUrl, settings, 'polyfill', fetchFn.polyfill);
+
+    if (settings.timeout) {
+      let timeout = settings.timeout;
+      delete settings.timeout;
+
+      return new Promise((resolve, reject) => {
+        let timedOut: boolean;
+
+        let timer = Orbit.globals.setTimeout(() => {
+          timedOut = true;
+          reject(new NetworkError(`No fetch response within ${timeout}ms.`));
+        }, timeout);
+
+        fetchFn(fullUrl, settings)
+          .catch((e: Error) => {
+            Orbit.globals.clearTimeout(timer);
+
+            if (!timedOut) {
+              return this.handleFetchError(e);
+            }
+          })
+          .then((response: any) => {
+            Orbit.globals.clearTimeout(timer);
+
+            if (!timedOut) {
+              return this.handleFetchResponse(response);
+            }
+          })
+          .then(resolve, reject);
+      });
+    } else {
+      return fetchFn(fullUrl, settings)
+        .catch((e: Error) => this.handleFetchError(e))
+        .then((response: any) => this.handleFetchResponse(response));
+    }
+  }
+
+  initFetchSettings(customSettings: FetchSettings = {}): FetchSettings {
+    let settings: FetchSettings = deepMerge({}, this.defaultFetchSettings, customSettings);
+
+    if (settings.json) {
+      assert('`json` and `body` can\'t both be set for fetch requests.', !settings.body);
+      settings.body = JSON.stringify(settings.json);
+      delete settings.json;
+    }
+
+    if (settings.headers && !settings.body) {
+      delete (settings.headers as any)['Content-Type'];
+    }
+
+    return settings;
+  }
+
+  responseHasContent(response: Response): boolean {
+    if (response.status === 204) {
+      return false;
+    }
+
+    let contentType = response.headers.get('Content-Type');
+    if (contentType) {
+      for (let allowedContentType of this.allowedContentTypes) {
+        if (contentType.indexOf(allowedContentType) > -1) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  getTransformRequests(transform: Transform): TransformRecordRequest[] {
+    const transformRequests = getTransformRequests(this.source, transform);
+    if (this.maxRequestsPerTransform && transformRequests.length > this.maxRequestsPerTransform) {
+      throw new TransformNotAllowed(
+        `This transform requires ${transformRequests.length} requests, which exceeds the specified limit of ${this.maxRequestsPerTransform} requests per transform.`,
+        transform);
+    }
+    return transformRequests;
+  }
+
+  getQueryOperator(query: Query): QueryOperator {
+    const operator: QueryOperator = QueryOperators[query.expression.op];
+    if (!operator) {
+      throw new Error('JSONAPIRequestProcessor does not support the `${query.expression.op}` operator for queries.');
+    }
+    return operator;
+  }
+
+  getTransformRequestProcessor(request:TransformRecordRequest):TransformRequestProcessor {
+    return TransformRequestProcessors[request.op];
+  }
+
+  operationsFromDeserializedDocument(deserialized: RecordDocument): Operation[] {
+    const records: Record[] = [];
+    Array.prototype.push.apply(records, toArray(deserialized.data));
+
+    if (deserialized.included) {
+      Array.prototype.push.apply(records, deserialized.included);
+    }
+
+    return records.map(record => {
+      return {
+        op: 'updateRecord',
+        record
+      };
+    });
+  }
+
+  buildFilterParam(filterSpecifiers: FilterSpecifier[]): Filter[] {
+    const filters: Filter[] = [];
+
+    filterSpecifiers.forEach(filterSpecifier => {
+      if (filterSpecifier.kind === 'attribute' && filterSpecifier.op === 'equal') {
+        const attributeFilter = filterSpecifier as AttributeFilterSpecifier;
+
+        // Note: We don't know the `type` of the attribute here, so passing `null`
+        const resourceAttribute = this.source.serializer.resourceAttribute(null, attributeFilter.attribute);
+        filters.push({ [resourceAttribute]: attributeFilter.value });
+      } else if (filterSpecifier.kind === 'relatedRecord') {
+        const relatedRecordFilter = filterSpecifier as RelatedRecordFilterSpecifier;
+        if (Array.isArray(relatedRecordFilter.record)) {
+          filters.push({ [relatedRecordFilter.relation]: relatedRecordFilter.record.map(e => e.id).join(',') });
+        } else {
+          filters.push({ [relatedRecordFilter.relation]: relatedRecordFilter.record.id });
+        }
+      } else if (filterSpecifier.kind === 'relatedRecords') {
+        if (filterSpecifier.op !== 'equal') {
+          throw new Error(`Operation "${filterSpecifier.op}" is not supported in JSONAPI for relatedRecords filtering`);
+        }
+        const relatedRecordsFilter = filterSpecifier as RelatedRecordsFilterSpecifier;
+        filters.push({ [relatedRecordsFilter.relation]: relatedRecordsFilter.records.map(e => e.id).join(',') });
+      } else {
+        throw new QueryExpressionParseError(`Filter operation ${filterSpecifier.op} not recognized for JSONAPISource.`, filterSpecifier);
+      }
+    });
+
+    return filters;
+  }
+
+  buildSortParam(sortSpecifiers: SortSpecifier[]): string {
+    return sortSpecifiers.map(sortSpecifier => {
+      if (sortSpecifier.kind === 'attribute') {
+        const attributeSort = sortSpecifier as AttributeSortSpecifier;
+
+        // Note: We don't know the `type` of the attribute here, so passing `null`
+        const resourceAttribute = this.source.serializer.resourceAttribute(null, attributeSort.attribute);
+        return (sortSpecifier.order === 'descending' ? '-' : '') + resourceAttribute;
+      }
+      throw new QueryExpressionParseError(`Sort specifier ${sortSpecifier.kind} not recognized for JSONAPISource.`, sortSpecifier);
+    }).join(',');
+  }
+
+  buildPageParam(pageSpecifier: PageSpecifier): object {
+    let pageParam = clone(pageSpecifier);
+    delete pageParam.kind;
+    return pageParam;
+  }
+
+  buildFetchSettings(options: RequestOptions = {}, customSettings?: FetchSettings): FetchSettings {
+    return buildFetchSettings(options, customSettings);
+  }
+
+  customRequestOptions(queryOrTransform: Query | Transform): RequestOptions {
+    return customRequestOptions(this.source, queryOrTransform);
+  }
+
+  protected appendQueryParams(url: string, settings: FetchSettings): string {
+    let fullUrl = url;
+    if (settings.params) {
+      fullUrl = appendQueryParams(fullUrl, settings.params);
+      delete settings.params;
+    }
+    return fullUrl;
+  }
+
+  protected initDefaultFetchSettings(settings: JSONAPIRequestProcessorSettings): void {
+    this.defaultFetchSettings = {
+      headers: {
+        Accept: 'application/vnd.api+json',
+        'Content-Type': 'application/vnd.api+json'
+      },
+      timeout: 5000
+    };
+
+    if (settings.defaultFetchHeaders || settings.defaultFetchTimeout) {
+      deprecate('Pass `defaultFetchSettings` with `headers` instead of `defaultFetchHeaders` to initialize source', settings.defaultFetchHeaders === undefined);
+      deprecate('Pass `defaultFetchSettings` with `timeout` instead of `defaultFetchTimeout` to initialize source', settings.defaultFetchTimeout === undefined);
+
+      deepMerge(this.defaultFetchSettings, {
+        headers: settings.defaultFetchHeaders,
+        timeout: settings.defaultFetchTimeout
+      });
+    }
+
+    if (settings.defaultFetchSettings) {
+      deepMerge(this.defaultFetchSettings, settings.defaultFetchSettings);
+    }
+  }
+
+  protected async handleFetchResponse(response: Response): Promise<any> {
+    if (response.status === 201) {
+      if (this.responseHasContent(response)) {
+        return response.json();
+      } else {
+        throw new InvalidServerResponse(`Server responses with a ${response.status} status should return content with one of the following content types: ${this.allowedContentTypes.join(', ')}.`);
+      }
+    } else if (response.status >= 200 && response.status < 300) {
+      if (this.responseHasContent(response)) {
+        return response.json();
+      }
+    } else {
+      if (this.responseHasContent(response)) {
+        return response.json()
+          .then((data: any) => this.handleFetchResponseError(response, data));
+      } else {
+        return this.handleFetchResponseError(response);
+      }
+    }
+  }
+
+  protected async handleFetchResponseError(response: Response, data?: any): Promise<any> {
+    let error: any;
+    if (response.status >= 400 && response.status < 500) {
+      error = new ClientError(response.statusText);
+    } else {
+      error = new ServerError(response.statusText);
+    }
+    error.response = response;
+    error.data = data;
+    throw error;
+  }
+
+  protected async handleFetchError(e: any): Promise<any> {
+    throw new NetworkError(e);
+  }
+}

--- a/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
@@ -163,7 +163,7 @@ export default class JSONAPIRequestProcessor {
   }
 
   getTransformRequests(transform: Transform): TransformRecordRequest[] {
-    const transformRequests = getTransformRequests(this.source, transform);
+    const transformRequests = getTransformRequests(this, transform);
     if (this.maxRequestsPerTransform && transformRequests.length > this.maxRequestsPerTransform) {
       throw new TransformNotAllowed(
         `This transform requires ${transformRequests.length} requests, which exceeds the specified limit of ${this.maxRequestsPerTransform} requests per transform.`,

--- a/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
@@ -21,7 +21,7 @@ import Orbit, {
 import JSONAPISource from './jsonapi-source';
 import { InvalidServerResponse } from './lib/exceptions';
 import { appendQueryParams } from './lib/query-params';
-import { clone, deepMerge, toArray } from '@orbit/utils';
+import { clone, deepGet, deepMerge, toArray } from '@orbit/utils';
 import { QueryOperator, QueryOperators } from "./lib/query-operators";
 import { RecordDocument } from './record-document';
 import {
@@ -33,8 +33,7 @@ import {
 import {
   Filter,
   RequestOptions,
-  buildFetchSettings,
-  customRequestOptions
+  buildFetchSettings
 } from './lib/request-settings';
 const { assert, deprecate } = Orbit;
 
@@ -56,6 +55,7 @@ export interface FetchSettings {
 import { JSONAPISerializer, JSONAPISerializerSettings } from './jsonapi-serializer';
 
 export interface JSONAPIRequestProcessorSettings {
+  sourceName: string;
   SerializerClass?: (new (settings: JSONAPISerializerSettings) => JSONAPISerializer);
   namespace?: string;
   host?: string;
@@ -70,6 +70,7 @@ export interface JSONAPIRequestProcessorSettings {
 
 export default class JSONAPIRequestProcessor {
   source: JSONAPISource;
+  sourceName: string;
   SerializerClass?: (new (settings: JSONAPISerializerSettings) => JSONAPISerializer);
   serializer: JSONAPISerializer;
   allowedContentTypes: string[];
@@ -82,6 +83,7 @@ export default class JSONAPIRequestProcessor {
 
   constructor(source: JSONAPISource, settings: JSONAPIRequestProcessorSettings) {
     this.source = source;
+    this.sourceName = settings.sourceName;
     this.allowedContentTypes = settings.allowedContentTypes || ['application/vnd.api+json', 'application/json'];
     this.maxRequestsPerTransform = settings.maxRequestsPerTransform;
     this.host = settings.host;
@@ -308,7 +310,7 @@ export default class JSONAPIRequestProcessor {
   }
 
   customRequestOptions(queryOrTransform: Query | Transform): RequestOptions {
-    return customRequestOptions(this.source, queryOrTransform);
+    return deepGet(queryOrTransform, ['options', 'sources', this.sourceName]);
   }
 
   protected appendQueryParams(url: string, settings: FetchSettings): string {

--- a/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
@@ -8,15 +8,10 @@ import Orbit, {
   Schema,
   ServerError,
   Transform,
-  TransformNotAllowed,
 } from '@orbit/data';
 import { InvalidServerResponse } from './lib/exceptions';
 import { deepGet, deepMerge, toArray } from '@orbit/utils';
 import { RecordDocument } from './record-document';
-import {
-  TransformRecordRequest,
-  getTransformRequests
-} from  './lib/transform-requests';
 import {
   RequestOptions,
   buildFetchSettings
@@ -51,7 +46,6 @@ export interface JSONAPIRequestProcessorSettings {
   defaultFetchTimeout?: number;
   defaultFetchSettings?: FetchSettings;
   allowedContentTypes?: string[];
-  maxRequestsPerTransform?: number;
   schema: Schema;
   keyMap: KeyMap;
 }
@@ -64,7 +58,6 @@ export default class JSONAPIRequestProcessor {
   urlBuilder: JSONAPIURLBuilder;
   allowedContentTypes: string[];
   defaultFetchSettings: FetchSettings;
-  maxRequestsPerTransform: number;
   host: string;
   namespace: string;
   schema: Schema;
@@ -73,7 +66,6 @@ export default class JSONAPIRequestProcessor {
   constructor(settings: JSONAPIRequestProcessorSettings) {
     this.sourceName = settings.sourceName;
     this.allowedContentTypes = settings.allowedContentTypes || ['application/vnd.api+json', 'application/json'];
-    this.maxRequestsPerTransform = settings.maxRequestsPerTransform;
     this.host = settings.host;
     this.namespace = settings.namespace;
     this.schema = settings.schema;
@@ -156,16 +148,6 @@ export default class JSONAPIRequestProcessor {
     }
 
     return settings;
-  }
-
-  getTransformRequests(transform: Transform): TransformRecordRequest[] {
-    const transformRequests = getTransformRequests(this, transform);
-    if (this.maxRequestsPerTransform && transformRequests.length > this.maxRequestsPerTransform) {
-      throw new TransformNotAllowed(
-        `This transform requires ${transformRequests.length} requests, which exceeds the specified limit of ${this.maxRequestsPerTransform} requests per transform.`,
-        transform);
-    }
-    return transformRequests;
   }
 
   operationsFromDeserializedDocument(deserialized: RecordDocument): Operation[] {

--- a/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
@@ -18,7 +18,6 @@ import Orbit, {
   Transform,
   TransformNotAllowed,
 } from '@orbit/data';
-import JSONAPISource from './jsonapi-source';
 import { InvalidServerResponse } from './lib/exceptions';
 import { appendQueryParams } from './lib/query-params';
 import { clone, deepGet, deepMerge, toArray } from '@orbit/utils';
@@ -69,7 +68,6 @@ export interface JSONAPIRequestProcessorSettings {
 }
 
 export default class JSONAPIRequestProcessor {
-  source: JSONAPISource;
   sourceName: string;
   SerializerClass?: (new (settings: JSONAPISerializerSettings) => JSONAPISerializer);
   serializer: JSONAPISerializer;
@@ -81,8 +79,7 @@ export default class JSONAPIRequestProcessor {
   schema: Schema;
   keyMap: KeyMap;
 
-  constructor(source: JSONAPISource, settings: JSONAPIRequestProcessorSettings) {
-    this.source = source;
+  constructor(settings: JSONAPIRequestProcessorSettings) {
     this.sourceName = settings.sourceName;
     this.allowedContentTypes = settings.allowedContentTypes || ['application/vnd.api+json', 'application/json'];
     this.maxRequestsPerTransform = settings.maxRequestsPerTransform;
@@ -332,8 +329,8 @@ export default class JSONAPIRequestProcessor {
     };
 
     if (settings.defaultFetchHeaders || settings.defaultFetchTimeout) {
-      deprecate('Pass `defaultFetchSettings` with `headers` instead of `defaultFetchHeaders` to initialize source', settings.defaultFetchHeaders === undefined);
-      deprecate('Pass `defaultFetchSettings` with `timeout` instead of `defaultFetchTimeout` to initialize source', settings.defaultFetchTimeout === undefined);
+      deprecate('Pass `defaultFetchSettings` with `headers` instead of `defaultFetchHeaders` to initialize requestProcessor', settings.defaultFetchHeaders === undefined);
+      deprecate('Pass `defaultFetchSettings` with `timeout` instead of `defaultFetchTimeout` to initialize requestProcessor', settings.defaultFetchTimeout === undefined);
 
       deepMerge(this.defaultFetchSettings, {
         headers: settings.defaultFetchHeaders,

--- a/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
@@ -21,11 +21,8 @@ import Orbit, {
 import { InvalidServerResponse } from './lib/exceptions';
 import { appendQueryParams } from './lib/query-params';
 import { clone, deepGet, deepMerge, toArray } from '@orbit/utils';
-import { QueryOperator, QueryOperators } from "./lib/query-operators";
 import { RecordDocument } from './record-document';
 import {
-  TransformRequestProcessor,
-  TransformRequestProcessors,
   TransformRecordRequest,
   getTransformRequests
 } from  './lib/transform-requests';
@@ -179,18 +176,6 @@ export default class JSONAPIRequestProcessor {
         transform);
     }
     return transformRequests;
-  }
-
-  getQueryOperator(query: Query): QueryOperator {
-    const operator: QueryOperator = QueryOperators[query.expression.op];
-    if (!operator) {
-      throw new Error('JSONAPIRequestProcessor does not support the `${query.expression.op}` operator for queries.');
-    }
-    return operator;
-  }
-
-  getTransformRequestProcessor(request:TransformRecordRequest):TransformRequestProcessor {
-    return TransformRequestProcessors[request.op];
   }
 
   resourceNamespace(type?: string): string {

--- a/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
@@ -58,16 +58,12 @@ export default class JSONAPIRequestProcessor {
   urlBuilder: JSONAPIURLBuilder;
   allowedContentTypes: string[];
   defaultFetchSettings: FetchSettings;
-  host: string;
-  namespace: string;
   schema: Schema;
   keyMap: KeyMap;
 
   constructor(settings: JSONAPIRequestProcessorSettings) {
     this.sourceName = settings.sourceName;
     this.allowedContentTypes = settings.allowedContentTypes || ['application/vnd.api+json', 'application/json'];
-    this.host = settings.host;
-    this.namespace = settings.namespace;
     this.schema = settings.schema;
     this.keyMap = settings.keyMap;
     let SerializerClass = settings.SerializerClass || JSONAPISerializer;

--- a/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
@@ -24,7 +24,12 @@ import { appendQueryParams } from './lib/query-params';
 import { clone, deepMerge, toArray } from '@orbit/utils';
 import { QueryOperator, QueryOperators } from "./lib/query-operators";
 import { RecordDocument } from './record-document';
-import { TransformRequestProcessors, TransformRecordRequest, getTransformRequests } from  './lib/transform-requests';
+import {
+  TransformRequestProcessor,
+  TransformRequestProcessors,
+  TransformRecordRequest,
+  getTransformRequests
+} from  './lib/transform-requests';
 import {
   Filter,
   RequestOptions,

--- a/packages/@orbit/jsonapi/src/jsonapi-source.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-source.ts
@@ -30,7 +30,7 @@ export interface JSONAPISourceSettings extends SourceSettings {
   defaultFetchSettings?: FetchSettings;
   allowedContentTypes?: string[];
   SerializerClass?: (new (settings: JSONAPISerializerSettings) => JSONAPISerializer);
-  RequestProcessorClass?: (new (source: JSONAPISource, settings: JSONAPIRequestProcessorSettings) => JSONAPIRequestProcessor);
+  RequestProcessorClass?: (new (settings: JSONAPIRequestProcessorSettings) => JSONAPIRequestProcessor);
   schema?: Schema,
   keyMap?: KeyMap
 }
@@ -78,7 +78,7 @@ export default class JSONAPISource extends Source implements Pullable, Pushable,
     this.host = settings.host;
 
     const RequestProcessorClass = settings.RequestProcessorClass || JSONAPIRequestProcessor;
-    this.requestProcessor = new RequestProcessorClass(this, {
+    this.requestProcessor = new RequestProcessorClass({
       sourceName: this.name,
       SerializerClass: settings.SerializerClass || JSONAPISerializer,
       allowedContentTypes: settings.allowedContentTypes,

--- a/packages/@orbit/jsonapi/src/jsonapi-source.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-source.ts
@@ -154,6 +154,7 @@ export default class JSONAPISource extends Source implements Pullable, Pushable,
    *        resourceURL
    *        resourcePath
    *        resourceRelationshipURL
+   *        responseHasContent
    *        relatedResourceURL
    *        resourceNamespace
    *        resourceHost
@@ -162,11 +163,6 @@ export default class JSONAPISource extends Source implements Pullable, Pushable,
   fetch(url: string, customSettings?: FetchSettings): Promise<any> {
     deprecate('JSONAPISource: fetch has moved to the requestProcessor', true);
     return this.requestProcessor.fetch(url, customSettings);
-  }
-
-  responseHasContent(response: Response): boolean {
-    deprecate('JSONAPISource: responseHasContent has moved to the requestProcessor', true);
-    return this.requestProcessor.responseHasContent(response);
   }
 
   initFetchSettings(customSettings: FetchSettings = {}): FetchSettings {

--- a/packages/@orbit/jsonapi/src/jsonapi-source.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-source.ts
@@ -16,6 +16,7 @@ import JSONAPIRequestProcessor, {
   FetchSettings
 } from './jsonapi-request-processor';
 import { JSONAPISerializer, JSONAPISerializerSettings } from './jsonapi-serializer';
+import JSONAPIURLBuilder, { JSONAPIURLBuilderSettings } from './jsonapi-url-builder';
 import { QueryOperator, QueryOperators } from "./lib/query-operators";
 import {
   TransformRequestProcessor,
@@ -36,6 +37,7 @@ export interface JSONAPISourceSettings extends SourceSettings {
   allowedContentTypes?: string[];
   SerializerClass?: (new (settings: JSONAPISerializerSettings) => JSONAPISerializer);
   RequestProcessorClass?: (new (settings: JSONAPIRequestProcessorSettings) => JSONAPIRequestProcessor);
+  URLBuilderClass?: (new (settings: JSONAPIURLBuilderSettings) => JSONAPIURLBuilder);
   schema?: Schema,
   keyMap?: KeyMap
 }
@@ -60,7 +62,6 @@ export interface JSONAPISourceSettings extends SourceSettings {
 export default class JSONAPISource extends Source implements Pullable, Pushable, Queryable {
   namespace: string;
   host: string;
-  serializer: JSONAPISerializer;
   requestProcessor: JSONAPIRequestProcessor;
 
   // Pullable interface stubs
@@ -86,6 +87,7 @@ export default class JSONAPISource extends Source implements Pullable, Pushable,
     this.requestProcessor = new RequestProcessorClass({
       sourceName: this.name,
       SerializerClass: settings.SerializerClass || JSONAPISerializer,
+      URLBuilderClass: settings.URLBuilderClass || JSONAPIURLBuilder,
       allowedContentTypes: settings.allowedContentTypes,
       defaultFetchSettings: settings.defaultFetchSettings,
       maxRequestsPerTransform: settings.maxRequestsPerTransform,

--- a/packages/@orbit/jsonapi/src/jsonapi-source.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-source.ts
@@ -79,6 +79,7 @@ export default class JSONAPISource extends Source implements Pullable, Pushable,
 
     const RequestProcessorClass = settings.RequestProcessorClass || JSONAPIRequestProcessor;
     this.requestProcessor = new RequestProcessorClass(this, {
+      sourceName: this.name,
       SerializerClass: settings.SerializerClass || JSONAPISerializer,
       allowedContentTypes: settings.allowedContentTypes,
       defaultFetchSettings: settings.defaultFetchSettings,

--- a/packages/@orbit/jsonapi/src/jsonapi-source.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-source.ts
@@ -77,14 +77,9 @@ export default class JSONAPISource extends Source implements Pullable, Pushable,
     this.namespace = settings.namespace;
     this.host = settings.host;
 
-    const SerializerClass = settings.SerializerClass || JSONAPISerializer;
-    this.serializer = new SerializerClass({
-      schema: settings.schema,
-      keyMap: settings.keyMap
-    });
-
     const RequestProcessorClass = settings.RequestProcessorClass || JSONAPIRequestProcessor;
     this.requestProcessor = new RequestProcessorClass(this, {
+      SerializerClass: settings.SerializerClass || JSONAPISerializer,
       allowedContentTypes: settings.allowedContentTypes,
       defaultFetchSettings: settings.defaultFetchSettings,
       maxRequestsPerTransform: settings.maxRequestsPerTransform,

--- a/packages/@orbit/jsonapi/src/jsonapi-source.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-source.ts
@@ -96,13 +96,14 @@ export default class JSONAPISource extends Source implements Pullable, Pushable,
   /////////////////////////////////////////////////////////////////////////////
 
   async _push(transform: Transform): Promise<Transform[]> {
-    const requests = this.requestProcessor.getTransformRequests(transform);
+    let { requestProcessor } = this;
+    const requests = requestProcessor.getTransformRequests(transform);
     const transforms: Transform[] = [];
 
     for (let request of requests) {
-      let processor = this.requestProcessor.getTransformRequestProcessor(request);
+      let processor = requestProcessor.getTransformRequestProcessor(request);
 
-      let additionalTransforms: Transform[] = await processor(this, request);
+      let additionalTransforms: Transform[] = await processor(requestProcessor, request);
       if (additionalTransforms) {
         Array.prototype.push.apply(transforms, additionalTransforms);
       }
@@ -117,8 +118,9 @@ export default class JSONAPISource extends Source implements Pullable, Pushable,
   /////////////////////////////////////////////////////////////////////////////
 
   async _pull(query: Query): Promise<Transform[]> {
-    const operator: QueryOperator = this.requestProcessor.getQueryOperator(query);
-    const response = await operator(this, query);
+    let { requestProcessor } = this;
+    const operator: QueryOperator = requestProcessor.getQueryOperator(query);
+    const response = await operator(requestProcessor, query);
     return response.transforms;
   }
 
@@ -127,8 +129,9 @@ export default class JSONAPISource extends Source implements Pullable, Pushable,
   /////////////////////////////////////////////////////////////////////////////
 
   async _query(query: Query): Promise<Record|Record[]> {
-    const operator: QueryOperator = this.requestProcessor.getQueryOperator(query);
-    const response = await operator(this, query);
+    let { requestProcessor } = this;
+    const operator: QueryOperator = requestProcessor.getQueryOperator(query);
+    const response = await operator(requestProcessor, query);
     await this._transformed(response.transforms);
     return response.primaryData;
   }

--- a/packages/@orbit/jsonapi/src/jsonapi-url-builder.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-url-builder.ts
@@ -1,0 +1,137 @@
+import {
+  AttributeFilterSpecifier,
+  AttributeSortSpecifier,
+  FilterSpecifier,
+  KeyMap,
+  PageSpecifier,
+  QueryExpressionParseError,
+  RelatedRecordFilterSpecifier,
+  RelatedRecordsFilterSpecifier,
+  SortSpecifier,
+} from '@orbit/data';
+import { clone } from '@orbit/utils';
+import { JSONAPISerializer } from './jsonapi-serializer';
+import { Filter } from './lib/request-settings';
+import { appendQueryParams } from './lib/query-params';
+
+export interface JSONAPIURLBuilderSettings {
+  host?: string;
+  namespace?: string;
+  serializer: JSONAPISerializer;
+  keyMap: KeyMap;
+}
+
+export default class JSONAPIURLBuilder {
+  host: string;
+  namespace: string;
+  serializer: JSONAPISerializer;
+  keyMap: KeyMap;
+
+  constructor(settings:JSONAPIURLBuilderSettings) {
+    this.host = settings.host;
+    this.namespace = settings.namespace;
+    this.serializer = settings.serializer;
+    this.keyMap = settings.keyMap;
+  }
+
+  resourceNamespace(type?: string): string {
+    return this.namespace;
+  }
+
+  resourceHost(type?: string): string {
+    return this.host;
+  }
+
+  resourceURL(type: string, id?: string): string {
+    let host = this.resourceHost(type);
+    let namespace = this.resourceNamespace(type);
+    let url: string[] = [];
+
+    if (host) { url.push(host); }
+    if (namespace) { url.push(namespace); }
+    url.push(this.resourcePath(type, id));
+
+    if (!host) { url.unshift(''); }
+
+    return url.join('/');
+  }
+
+  resourcePath(type: string, id?: string): string {
+    let path = [this.serializer.resourceType(type)];
+    if (id) {
+      let resourceId = this.serializer.resourceId(type, id);
+      if (resourceId) {
+        path.push(resourceId);
+      }
+    }
+    return path.join('/');
+  }
+
+  resourceRelationshipURL(type: string, id: string, relationship: string): string {
+    return this.resourceURL(type, id) +
+           '/relationships/' + this.serializer.resourceRelationship(type, relationship);
+  }
+
+  relatedResourceURL(type: string, id: string, relationship: string): string {
+    return this.resourceURL(type, id) +
+           '/' + this.serializer.resourceRelationship(type, relationship);
+  }
+
+  buildFilterParam(filterSpecifiers: FilterSpecifier[]): Filter[] {
+    const filters: Filter[] = [];
+
+    filterSpecifiers.forEach(filterSpecifier => {
+      if (filterSpecifier.kind === 'attribute' && filterSpecifier.op === 'equal') {
+        const attributeFilter = filterSpecifier as AttributeFilterSpecifier;
+
+        // Note: We don't know the `type` of the attribute here, so passing `null`
+        const resourceAttribute = this.serializer.resourceAttribute(null, attributeFilter.attribute);
+        filters.push({ [resourceAttribute]: attributeFilter.value });
+      } else if (filterSpecifier.kind === 'relatedRecord') {
+        const relatedRecordFilter = filterSpecifier as RelatedRecordFilterSpecifier;
+        if (Array.isArray(relatedRecordFilter.record)) {
+          filters.push({ [relatedRecordFilter.relation]: relatedRecordFilter.record.map(e => e.id).join(',') });
+        } else {
+          filters.push({ [relatedRecordFilter.relation]: relatedRecordFilter.record.id });
+        }
+      } else if (filterSpecifier.kind === 'relatedRecords') {
+        if (filterSpecifier.op !== 'equal') {
+          throw new Error(`Operation "${filterSpecifier.op}" is not supported in JSONAPI for relatedRecords filtering`);
+        }
+        const relatedRecordsFilter = filterSpecifier as RelatedRecordsFilterSpecifier;
+        filters.push({ [relatedRecordsFilter.relation]: relatedRecordsFilter.records.map(e => e.id).join(',') });
+      } else {
+        throw new QueryExpressionParseError(`Filter operation ${filterSpecifier.op} not recognized for JSONAPISource.`, filterSpecifier);
+      }
+    });
+
+    return filters;
+  }
+
+  buildSortParam(sortSpecifiers: SortSpecifier[]): string {
+    return sortSpecifiers.map(sortSpecifier => {
+      if (sortSpecifier.kind === 'attribute') {
+        const attributeSort = sortSpecifier as AttributeSortSpecifier;
+
+        // Note: We don't know the `type` of the attribute here, so passing `null`
+        const resourceAttribute = this.serializer.resourceAttribute(null, attributeSort.attribute);
+        return (sortSpecifier.order === 'descending' ? '-' : '') + resourceAttribute;
+      }
+      throw new QueryExpressionParseError(`Sort specifier ${sortSpecifier.kind} not recognized for JSONAPISource.`, sortSpecifier);
+    }).join(',');
+  }
+
+  buildPageParam(pageSpecifier: PageSpecifier): object {
+    let pageParam = clone(pageSpecifier);
+    delete pageParam.kind;
+    return pageParam;
+  }
+
+  appendQueryParams(url: string, params: any): string {
+    let fullUrl = url;
+    if (params) {
+      fullUrl = appendQueryParams(fullUrl, params);
+    }
+    return fullUrl;
+  }
+}

--- a/packages/@orbit/jsonapi/src/lib/query-operators.ts
+++ b/packages/@orbit/jsonapi/src/lib/query-operators.ts
@@ -30,7 +30,7 @@ export const QueryOperators: Dict<QueryOperator> = {
     const requestOptions = requestProcessor.customRequestOptions(query);
     const settings = requestProcessor.buildFetchSettings(requestOptions);
 
-    const document = await requestProcessor.fetch(requestProcessor.resourceURL(record.type, record.id), settings);
+    const document = await requestProcessor.fetch(requestProcessor.urlBuilder.resourceURL(record.type, record.id), settings);
 
     const deserialized = requestProcessor.serializer.deserialize(document);
     const operations = requestProcessor.operationsFromDeserializedDocument(deserialized);
@@ -44,19 +44,19 @@ export const QueryOperators: Dict<QueryOperator> = {
   async findRecords(requestProcessor: JSONAPIRequestProcessor, query: Query): Promise<QueryOperatorResponse> {
     const expression = query.expression as FindRecords;
     const { type } = expression;
-
+    let { urlBuilder } = requestProcessor;
     let requestOptions: RequestOptions = {};
 
     if (expression.filter) {
-      requestOptions.filter = requestProcessor.buildFilterParam(expression.filter);
+      requestOptions.filter = urlBuilder.buildFilterParam(expression.filter);
     }
 
     if (expression.sort) {
-      requestOptions.sort = requestProcessor.buildSortParam(expression.sort);
+      requestOptions.sort = urlBuilder.buildSortParam(expression.sort);
     }
 
     if (expression.page) {
-      requestOptions.page = requestProcessor.buildPageParam(expression.page);
+      requestOptions.page = urlBuilder.buildPageParam(expression.page);
     }
 
     let customOptions = requestProcessor.customRequestOptions(query);
@@ -66,7 +66,7 @@ export const QueryOperators: Dict<QueryOperator> = {
 
     const settings = requestProcessor.buildFetchSettings(requestOptions);
 
-    const document = await requestProcessor.fetch(requestProcessor.resourceURL(type), settings);
+    const document = await requestProcessor.fetch(requestProcessor.urlBuilder.resourceURL(type), settings);
 
     const deserialized = requestProcessor.serializer.deserialize(document);
     const operations = requestProcessor.operationsFromDeserializedDocument(deserialized);
@@ -83,7 +83,7 @@ export const QueryOperators: Dict<QueryOperator> = {
     const requestOptions = requestProcessor.customRequestOptions(query);
     const settings = requestProcessor.buildFetchSettings(requestOptions);
 
-    const document = await requestProcessor.fetch(requestProcessor.relatedResourceURL(record.type, record.id, relationship), settings);
+    const document = await requestProcessor.fetch(requestProcessor.urlBuilder.relatedResourceURL(record.type, record.id, relationship), settings);
 
     const deserialized = requestProcessor.serializer.deserialize(document);
     const relatedRecord = deserialized.data;
@@ -107,7 +107,7 @@ export const QueryOperators: Dict<QueryOperator> = {
     let requestOptions = requestProcessor.customRequestOptions(query);
     const settings = requestProcessor.buildFetchSettings(requestOptions);
 
-    const document = await requestProcessor.fetch(requestProcessor.relatedResourceURL(record.type, record.id, relationship), settings);
+    const document = await requestProcessor.fetch(requestProcessor.urlBuilder.relatedResourceURL(record.type, record.id, relationship), settings);
 
     const deserialized = requestProcessor.serializer.deserialize(document);
     const relatedRecords = deserialized.data;

--- a/packages/@orbit/jsonapi/src/lib/query-operators.ts
+++ b/packages/@orbit/jsonapi/src/lib/query-operators.ts
@@ -11,7 +11,7 @@ import {
   Record,
   Transform,
 } from '@orbit/data';
-import JSONAPISource from '../jsonapi-source';
+import JSONAPIRequestProcessor from '../jsonapi-request-processor';
 import { RequestOptions } from './request-settings';
 
 export interface QueryOperatorResponse {
@@ -20,14 +20,13 @@ export interface QueryOperatorResponse {
 }
 
 export interface QueryOperator {
-  (source: JSONAPISource, query: Query): Promise<QueryOperatorResponse>;
+  (requestProcessor: JSONAPIRequestProcessor, query: Query): Promise<QueryOperatorResponse>;
 }
 
 export const QueryOperators: Dict<QueryOperator> = {
-  async findRecord(source: JSONAPISource, query: Query): Promise<QueryOperatorResponse> {
+  async findRecord(requestProcessor: JSONAPIRequestProcessor, query: Query): Promise<QueryOperatorResponse> {
     const expression = query.expression as FindRecord;
     const { record } = expression;
-    const { requestProcessor } = source;
     const requestOptions = requestProcessor.customRequestOptions(query);
     const settings = requestProcessor.buildFetchSettings(requestOptions);
 
@@ -42,10 +41,9 @@ export const QueryOperators: Dict<QueryOperator> = {
     return { transforms, primaryData };
   },
 
-  async findRecords(source: JSONAPISource, query: Query): Promise<QueryOperatorResponse> {
+  async findRecords(requestProcessor: JSONAPIRequestProcessor, query: Query): Promise<QueryOperatorResponse> {
     const expression = query.expression as FindRecords;
     const { type } = expression;
-    const { requestProcessor } = source;
 
     let requestOptions: RequestOptions = {};
 
@@ -79,9 +77,8 @@ export const QueryOperators: Dict<QueryOperator> = {
     return { transforms, primaryData };
   },
 
-  async findRelatedRecord(source: JSONAPISource, query: Query): Promise<QueryOperatorResponse> {
+  async findRelatedRecord(requestProcessor: JSONAPIRequestProcessor, query: Query): Promise<QueryOperatorResponse> {
     const expression = query.expression as FindRelatedRecord;
-    const { requestProcessor } = source;
     const { record, relationship } = expression;
     const requestOptions = requestProcessor.customRequestOptions(query);
     const settings = requestProcessor.buildFetchSettings(requestOptions);
@@ -104,9 +101,8 @@ export const QueryOperators: Dict<QueryOperator> = {
     return { transforms, primaryData };
   },
 
-  async findRelatedRecords(source: JSONAPISource, query: Query): Promise<QueryOperatorResponse> {
+  async findRelatedRecords(requestProcessor: JSONAPIRequestProcessor, query: Query): Promise<QueryOperatorResponse> {
     const expression = query.expression as FindRelatedRecords;
-    const { requestProcessor } = source;
     const { record, relationship } = expression;
     let requestOptions = requestProcessor.customRequestOptions(query);
     const settings = requestProcessor.buildFetchSettings(requestOptions);

--- a/packages/@orbit/jsonapi/src/lib/query-operators.ts
+++ b/packages/@orbit/jsonapi/src/lib/query-operators.ts
@@ -27,13 +27,13 @@ export const QueryOperators: Dict<QueryOperator> = {
   async findRecord(source: JSONAPISource, query: Query): Promise<QueryOperatorResponse> {
     const expression = query.expression as FindRecord;
     const { record } = expression;
-    const { serializer, requestProcessor } = source;
+    const { requestProcessor } = source;
     const requestOptions = requestProcessor.customRequestOptions(query);
     const settings = requestProcessor.buildFetchSettings(requestOptions);
 
     const document = await requestProcessor.fetch(requestProcessor.resourceURL(record.type, record.id), settings);
 
-    const deserialized = serializer.deserialize(document);
+    const deserialized = requestProcessor.serializer.deserialize(document);
     const operations = requestProcessor.operationsFromDeserializedDocument(deserialized);
 
     const transforms = [buildTransform(operations)];
@@ -45,7 +45,7 @@ export const QueryOperators: Dict<QueryOperator> = {
   async findRecords(source: JSONAPISource, query: Query): Promise<QueryOperatorResponse> {
     const expression = query.expression as FindRecords;
     const { type } = expression;
-    const { serializer, requestProcessor } = source;
+    const { requestProcessor } = source;
 
     let requestOptions: RequestOptions = {};
 
@@ -70,7 +70,7 @@ export const QueryOperators: Dict<QueryOperator> = {
 
     const document = await requestProcessor.fetch(requestProcessor.resourceURL(type), settings);
 
-    const deserialized = serializer.deserialize(document);
+    const deserialized = requestProcessor.serializer.deserialize(document);
     const operations = requestProcessor.operationsFromDeserializedDocument(deserialized);
 
     const transforms = [buildTransform(operations)];
@@ -81,14 +81,14 @@ export const QueryOperators: Dict<QueryOperator> = {
 
   async findRelatedRecord(source: JSONAPISource, query: Query): Promise<QueryOperatorResponse> {
     const expression = query.expression as FindRelatedRecord;
-    const { serializer, requestProcessor } = source;
+    const { requestProcessor } = source;
     const { record, relationship } = expression;
     const requestOptions = requestProcessor.customRequestOptions(query);
     const settings = requestProcessor.buildFetchSettings(requestOptions);
 
     const document = await requestProcessor.fetch(requestProcessor.relatedResourceURL(record.type, record.id, relationship), settings);
 
-    const deserialized = serializer.deserialize(document);
+    const deserialized = requestProcessor.serializer.deserialize(document);
     const relatedRecord = deserialized.data;
     const operations = requestProcessor.operationsFromDeserializedDocument(deserialized);
     operations.push({
@@ -106,14 +106,14 @@ export const QueryOperators: Dict<QueryOperator> = {
 
   async findRelatedRecords(source: JSONAPISource, query: Query): Promise<QueryOperatorResponse> {
     const expression = query.expression as FindRelatedRecords;
-    const { serializer, requestProcessor } = source;
+    const { requestProcessor } = source;
     const { record, relationship } = expression;
     let requestOptions = requestProcessor.customRequestOptions(query);
     const settings = requestProcessor.buildFetchSettings(requestOptions);
 
     const document = await requestProcessor.fetch(requestProcessor.relatedResourceURL(record.type, record.id, relationship), settings);
 
-    const deserialized = serializer.deserialize(document);
+    const deserialized = requestProcessor.serializer.deserialize(document);
     const relatedRecords = deserialized.data;
 
     const operations = requestProcessor.operationsFromDeserializedDocument(deserialized);

--- a/packages/@orbit/jsonapi/src/lib/query-operators.ts
+++ b/packages/@orbit/jsonapi/src/lib/query-operators.ts
@@ -12,7 +12,7 @@ import {
   Transform,
 } from '@orbit/data';
 import JSONAPIRequestProcessor from '../jsonapi-request-processor';
-import { RequestOptions } from './request-settings';
+import { RequestOptions, mergeRequestOptions } from './request-settings';
 
 export interface QueryOperatorResponse {
   transforms: Transform[];
@@ -45,23 +45,24 @@ export const QueryOperators: Dict<QueryOperator> = {
     const expression = query.expression as FindRecords;
     const { type } = expression;
     let { urlBuilder } = requestProcessor;
-    let requestOptions: RequestOptions = {};
+    let standardRequestOptions: RequestOptions = {};
 
     if (expression.filter) {
-      requestOptions.filter = urlBuilder.buildFilterParam(expression.filter);
+      standardRequestOptions.filter = await urlBuilder.buildFilterParam(expression.filter);
     }
 
     if (expression.sort) {
-      requestOptions.sort = urlBuilder.buildSortParam(expression.sort);
+      standardRequestOptions.sort = await urlBuilder.buildSortParam(expression.sort);
     }
 
     if (expression.page) {
-      requestOptions.page = urlBuilder.buildPageParam(expression.page);
+      standardRequestOptions.page = await urlBuilder.buildPageParam(expression.page);
     }
 
     let customOptions = requestProcessor.customRequestOptions(query);
+    let requestOptions = standardRequestOptions;
     if (customOptions) {
-      merge(requestOptions, customOptions);
+      requestOptions = mergeRequestOptions(standardRequestOptions, customOptions);
     }
 
     const settings = requestProcessor.buildFetchSettings(requestOptions);

--- a/packages/@orbit/jsonapi/src/lib/query-operators.ts
+++ b/packages/@orbit/jsonapi/src/lib/query-operators.ts
@@ -31,7 +31,7 @@ export const QueryOperators: Dict<QueryOperator> = {
     const settings = requestProcessor.buildFetchSettings(requestOptions);
 
     const document = await requestProcessor.fetch(requestProcessor.urlBuilder.resourceURL(record.type, record.id), settings);
-
+    requestProcessor.preprocessResponseDocument(document, query);
     const deserialized = requestProcessor.serializer.deserialize(document);
     const operations = requestProcessor.operationsFromDeserializedDocument(deserialized);
 
@@ -67,7 +67,7 @@ export const QueryOperators: Dict<QueryOperator> = {
     const settings = requestProcessor.buildFetchSettings(requestOptions);
 
     const document = await requestProcessor.fetch(requestProcessor.urlBuilder.resourceURL(type), settings);
-
+    requestProcessor.preprocessResponseDocument(document, query);
     const deserialized = requestProcessor.serializer.deserialize(document);
     const operations = requestProcessor.operationsFromDeserializedDocument(deserialized);
 
@@ -84,6 +84,7 @@ export const QueryOperators: Dict<QueryOperator> = {
     const settings = requestProcessor.buildFetchSettings(requestOptions);
 
     const document = await requestProcessor.fetch(requestProcessor.urlBuilder.relatedResourceURL(record.type, record.id, relationship), settings);
+    requestProcessor.preprocessResponseDocument(document, query);
 
     const deserialized = requestProcessor.serializer.deserialize(document);
     const relatedRecord = deserialized.data;
@@ -108,7 +109,7 @@ export const QueryOperators: Dict<QueryOperator> = {
     const settings = requestProcessor.buildFetchSettings(requestOptions);
 
     const document = await requestProcessor.fetch(requestProcessor.urlBuilder.relatedResourceURL(record.type, record.id, relationship), settings);
-
+    requestProcessor.preprocessResponseDocument(document, query);
     const deserialized = requestProcessor.serializer.deserialize(document);
     const relatedRecords = deserialized.data;
 

--- a/packages/@orbit/jsonapi/src/lib/query-operators.ts
+++ b/packages/@orbit/jsonapi/src/lib/query-operators.ts
@@ -31,7 +31,7 @@ export const QueryOperators: Dict<QueryOperator> = {
     const requestOptions = requestProcessor.customRequestOptions(query);
     const settings = requestProcessor.buildFetchSettings(requestOptions);
 
-    const document = await requestProcessor.fetch(source.resourceURL(record.type, record.id), settings);
+    const document = await requestProcessor.fetch(requestProcessor.resourceURL(record.type, record.id), settings);
 
     const deserialized = serializer.deserialize(document);
     const operations = requestProcessor.operationsFromDeserializedDocument(deserialized);
@@ -68,7 +68,7 @@ export const QueryOperators: Dict<QueryOperator> = {
 
     const settings = requestProcessor.buildFetchSettings(requestOptions);
 
-    const document = await requestProcessor.fetch(source.resourceURL(type), settings);
+    const document = await requestProcessor.fetch(requestProcessor.resourceURL(type), settings);
 
     const deserialized = serializer.deserialize(document);
     const operations = requestProcessor.operationsFromDeserializedDocument(deserialized);
@@ -86,7 +86,7 @@ export const QueryOperators: Dict<QueryOperator> = {
     const requestOptions = requestProcessor.customRequestOptions(query);
     const settings = requestProcessor.buildFetchSettings(requestOptions);
 
-    const document = await requestProcessor.fetch(source.relatedResourceURL(record.type, record.id, relationship), settings);
+    const document = await requestProcessor.fetch(requestProcessor.relatedResourceURL(record.type, record.id, relationship), settings);
 
     const deserialized = serializer.deserialize(document);
     const relatedRecord = deserialized.data;
@@ -111,7 +111,7 @@ export const QueryOperators: Dict<QueryOperator> = {
     let requestOptions = requestProcessor.customRequestOptions(query);
     const settings = requestProcessor.buildFetchSettings(requestOptions);
 
-    const document = await requestProcessor.fetch(source.relatedResourceURL(record.type, record.id, relationship), settings);
+    const document = await requestProcessor.fetch(requestProcessor.relatedResourceURL(record.type, record.id, relationship), settings);
 
     const deserialized = serializer.deserialize(document);
     const relatedRecords = deserialized.data;

--- a/packages/@orbit/jsonapi/src/lib/request-settings.ts
+++ b/packages/@orbit/jsonapi/src/lib/request-settings.ts
@@ -57,18 +57,18 @@ export function mergeRequestOptions(options: RequestOptions, customOptions: Requ
 
 function mergeIncludePaths(paths:string[], customPaths:string[]) {
   let result = clone(paths);
-  customPaths.forEach((customPath) => {
+  for (let customPath of customPaths) {
     if (!paths.includes(customPath)) {
         result.push(customPath);
     }
-  });
+  }
   return result;
 }
 
 function mergeFilters(filters: Filter[], customFilters: Filter[]) {
   let result: Filter[] = clone(filters);
   let filterKeys:string[] = filters.map((f) => filterKey(f));
-  customFilters.forEach((customFilter) => {
+  for (let customFilter of customFilters) {
     let customerFilterKey = filterKey(customFilter);
     if (filterKeys.includes(customerFilterKey)) {
       let filterToOverride = result.find(f => filterKey(f) === customerFilterKey);
@@ -76,7 +76,7 @@ function mergeFilters(filters: Filter[], customFilters: Filter[]) {
     } else {
       result.push(customFilter);
     }
-  });
+  }
   return result;
 }
 

--- a/packages/@orbit/jsonapi/src/lib/request-settings.ts
+++ b/packages/@orbit/jsonapi/src/lib/request-settings.ts
@@ -1,6 +1,6 @@
-import { clone, deepGet, deepMerge, deepSet, isArray } from '@orbit/utils';
+import { clone, deepMerge, deepSet, merge, isArray } from '@orbit/utils';
 import { FetchSettings } from '../jsonapi-request-processor';
-import Orbit, { Source, Query, Transform } from '@orbit/data';
+import Orbit from '@orbit/data';
 
 const { deprecate } = Orbit;
 
@@ -41,4 +41,53 @@ export function buildFetchSettings(options: RequestOptions = {}, customSettings?
   }
 
   return settings;
+}
+
+export function mergeRequestOptions(options: RequestOptions, customOptions: RequestOptions) {
+  let result: RequestOptions = {}
+  merge(result, options, customOptions);
+  if (options.include && customOptions.include) {
+    result.include = mergeIncludePaths(options.include, customOptions.include);
+  }
+  if (options.filter && customOptions.filter) {
+    result.filter = mergeFilters(options.filter, customOptions.filter);
+  }
+  return result;
+}
+
+function mergeIncludePaths(paths:string[], customPaths:string[]) {
+  let result = clone(paths);
+  customPaths.forEach((customPath) => {
+    if (!paths.includes(customPath)) {
+        result.push(customPath);
+    }
+  });
+  return result;
+}
+
+function mergeFilters(filters: Filter[], customFilters: Filter[]) {
+  let result: Filter[] = clone(filters);
+  let filterKeys:string[] = filters.map((f) => filterKey(f));
+  customFilters.forEach((customFilter) => {
+    let customerFilterKey = filterKey(customFilter);
+    if (filterKeys.includes(customerFilterKey)) {
+      let filterToOverride = result.find(f => filterKey(f) === customerFilterKey);
+      setFilterValue(filterToOverride, filterValue(customFilter));
+    } else {
+      result.push(customFilter);
+    }
+  });
+  return result;
+}
+
+function filterKey(filter: Filter) : string {
+  return Object.keys(filter)[0];
+}
+
+function filterValue(filter: Filter) : string {
+  return Object.values(filter)[0];
+}
+
+function setFilterValue(filter: Filter, value: any) {
+  filter[filterKey(filter)] = value;
 }

--- a/packages/@orbit/jsonapi/src/lib/request-settings.ts
+++ b/packages/@orbit/jsonapi/src/lib/request-settings.ts
@@ -16,10 +16,6 @@ export interface RequestOptions {
   settings?: FetchSettings;
 }
 
-export function customRequestOptions(source: Source, queryOrTransform: Query | Transform): RequestOptions {
-  return deepGet(queryOrTransform, ['options', 'sources', source.name]);
-}
-
 export function buildFetchSettings(options: RequestOptions = {}, customSettings?: FetchSettings): FetchSettings {
   let settings = options.settings ? clone(options.settings) : {};
 

--- a/packages/@orbit/jsonapi/src/lib/request-settings.ts
+++ b/packages/@orbit/jsonapi/src/lib/request-settings.ts
@@ -1,5 +1,5 @@
 import { clone, deepGet, deepMerge, deepSet, isArray } from '@orbit/utils';
-import { FetchSettings } from '../jsonapi-source';
+import { FetchSettings } from '../jsonapi-request-processor';
 import Orbit, { Source, Query, Transform } from '@orbit/data';
 
 const { deprecate } = Orbit;

--- a/packages/@orbit/jsonapi/src/lib/transform-requests.ts
+++ b/packages/@orbit/jsonapi/src/lib/transform-requests.ts
@@ -77,7 +77,9 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     const settings = requestProcessor.buildFetchSettings(request.options, { method: 'POST', json: requestDoc });
 
     let raw: ResourceDocument = await requestProcessor.fetch(requestProcessor.urlBuilder.resourceURL(record.type), settings);
-    return handleChanges(record, requestProcessor.serializer.deserialize(raw, { primaryRecord: record }));
+    requestProcessor.preprocessResponseDocument(raw, request);
+    let deserialized = requestProcessor.serializer.deserialize(raw, { primaryRecord: record });
+    return handleChanges(record, deserialized);
   },
 
   async removeRecord(requestProcessor: JSONAPIRequestProcessor, request: RemoveRecordRequest): Promise<Transform[]> {
@@ -96,7 +98,9 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
 
     let raw: ResourceDocument = await requestProcessor.fetch(requestProcessor.urlBuilder.resourceURL(type, id), settings)
     if (raw) {
-      return handleChanges(record, requestProcessor.serializer.deserialize(raw, { primaryRecord: record }));
+      requestProcessor.preprocessResponseDocument(raw, request);
+      let deserialized = requestProcessor.serializer.deserialize(raw, { primaryRecord: record })
+      return handleChanges(record, deserialized);
     } else {
       return [];
     }

--- a/packages/@orbit/jsonapi/src/lib/transform-requests.ts
+++ b/packages/@orbit/jsonapi/src/lib/transform-requests.ts
@@ -18,6 +18,7 @@ import Orbit, {
 } from '@orbit/data';
 import { clone, deepSet, Dict } from '@orbit/utils';
 import JSONAPISource from '../jsonapi-source';
+import JSONAPIRequestProcessor from '../jsonapi-request-processor';
 import { ResourceDocument } from '../resource-document';
 import { RecordDocument } from '../record-document';
 import { RequestOptions } from './request-settings';
@@ -158,7 +159,7 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
   }
 };
 
-export function getTransformRequests(source: JSONAPISource, transform: Transform): TransformRecordRequest[] {
+export function getTransformRequests(requestProcessor: JSONAPIRequestProcessor, transform: Transform): TransformRecordRequest[] {
   const requests: TransformRecordRequest[] = [];
   let prevRequest: TransformRecordRequest;
 
@@ -198,7 +199,7 @@ export function getTransformRequests(source: JSONAPISource, transform: Transform
     }
 
     if (request) {
-      let options = source.requestProcessor.customRequestOptions(transform);
+      let options = requestProcessor.customRequestOptions(transform);
       if (options) {
         request.options = options;
       }

--- a/packages/@orbit/jsonapi/src/lib/transform-requests.ts
+++ b/packages/@orbit/jsonapi/src/lib/transform-requests.ts
@@ -73,13 +73,13 @@ export interface TransformRequestProcessor {
 
 export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
   async addRecord(source: JSONAPISource, request: AddRecordRequest): Promise<Transform[]> {
-    const { serializer, requestProcessor } = source;
+    const { requestProcessor } = source;
     const record = request.record;
-    const requestDoc: ResourceDocument = serializer.serialize({ data: record });
+    const requestDoc: ResourceDocument = requestProcessor.serializer.serialize({ data: record });
     const settings = requestProcessor.buildFetchSettings(request.options, { method: 'POST', json: requestDoc });
 
     let raw: ResourceDocument = await requestProcessor.fetch(requestProcessor.resourceURL(record.type), settings);
-    return handleChanges(record, serializer.deserialize(raw, { primaryRecord: record }));
+    return handleChanges(record, requestProcessor.serializer.deserialize(raw, { primaryRecord: record }));
   },
 
   async removeRecord(source: JSONAPISource, request: RemoveRecordRequest): Promise<Transform[]> {
@@ -92,15 +92,15 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
   },
 
   async updateRecord(source: JSONAPISource, request: UpdateRecordRequest): Promise<Transform[]> {
-    const { serializer, requestProcessor } = source;
+    const { requestProcessor } = source;
     const record = request.record;
     const { type, id } = record;
-    const requestDoc: ResourceDocument = serializer.serialize({ data: record });
+    const requestDoc: ResourceDocument = requestProcessor.serializer.serialize({ data: record });
     const settings = requestProcessor.buildFetchSettings(request.options, { method: 'PATCH', json: requestDoc });
 
     let raw: ResourceDocument = await requestProcessor.fetch(requestProcessor.resourceURL(type, id), settings)
     if (raw) {
-      return handleChanges(record, serializer.deserialize(raw, { primaryRecord: record }));
+      return handleChanges(record, requestProcessor.serializer.deserialize(raw, { primaryRecord: record }));
     } else {
       return [];
     }
@@ -111,7 +111,7 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     const { relationship } = request;
     const { requestProcessor } = source;
     const json = {
-      data: request.relatedRecords.map(r => source.serializer.resourceIdentity(r))
+      data: request.relatedRecords.map(r => requestProcessor.serializer.resourceIdentity(r))
     };
     const settings = requestProcessor.buildFetchSettings(request.options, { method: 'POST', json });
 
@@ -122,9 +122,9 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
   async removeFromRelatedRecords(source: JSONAPISource, request: RemoveFromRelatedRecordsRequest): Promise<Transform[]> {
     const { type, id } = request.record;
     const { relationship } = request;
-    const { serializer, requestProcessor } = source;
+    const { requestProcessor } = source;
     const json = {
-      data: request.relatedRecords.map(r => serializer.resourceIdentity(r))
+      data: request.relatedRecords.map(r => requestProcessor.serializer.resourceIdentity(r))
     };
     const settings = requestProcessor.buildFetchSettings(request.options, { method: 'DELETE', json });
 
@@ -135,9 +135,9 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
   async replaceRelatedRecord(source: JSONAPISource, request: ReplaceRelatedRecordRequest): Promise<Transform[]> {
     const { type, id } = request.record;
     const { relationship, relatedRecord } = request;
-    const { serializer, requestProcessor } = source;
+    const { requestProcessor } = source;
     const json = {
-      data: relatedRecord ? serializer.resourceIdentity(relatedRecord) : null
+      data: relatedRecord ? requestProcessor.serializer.resourceIdentity(relatedRecord) : null
     };
     const settings = requestProcessor.buildFetchSettings(request.options, { method: 'PATCH', json });
 
@@ -148,9 +148,9 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
   async replaceRelatedRecords(source: JSONAPISource, request: ReplaceRelatedRecordsRequest): Promise<Transform[]> {
     const { type, id } = request.record;
     const { relationship, relatedRecords } = request;
-    const { serializer, requestProcessor } = source;
+    const { requestProcessor } = source;
     const json = {
-      data: relatedRecords.map(r => serializer.resourceIdentity(r))
+      data: relatedRecords.map(r => requestProcessor.serializer.resourceIdentity(r))
     };
     const settings = requestProcessor.buildFetchSettings(request.options, { method: 'PATCH', json });
 

--- a/packages/@orbit/jsonapi/src/lib/transform-requests.ts
+++ b/packages/@orbit/jsonapi/src/lib/transform-requests.ts
@@ -77,7 +77,7 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     const requestDoc: ResourceDocument = serializer.serialize({ data: record });
     const settings = requestProcessor.buildFetchSettings(request.options, { method: 'POST', json: requestDoc });
 
-    let raw: ResourceDocument = await requestProcessor.fetch(source.resourceURL(record.type), settings);
+    let raw: ResourceDocument = await requestProcessor.fetch(requestProcessor.resourceURL(record.type), settings);
     return handleChanges(record, serializer.deserialize(raw, { primaryRecord: record }));
   },
 
@@ -86,7 +86,7 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     const { requestProcessor } = source;
     const settings = requestProcessor.buildFetchSettings(request.options, { method: 'DELETE' });
 
-    await requestProcessor.fetch(source.resourceURL(type, id), settings);
+    await requestProcessor.fetch(requestProcessor.resourceURL(type, id), settings);
     return [];
   },
 
@@ -97,7 +97,7 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     const requestDoc: ResourceDocument = serializer.serialize({ data: record });
     const settings = requestProcessor.buildFetchSettings(request.options, { method: 'PATCH', json: requestDoc });
 
-    let raw: ResourceDocument = await requestProcessor.fetch(source.resourceURL(type, id), settings)
+    let raw: ResourceDocument = await requestProcessor.fetch(requestProcessor.resourceURL(type, id), settings)
     if (raw) {
       return handleChanges(record, serializer.deserialize(raw, { primaryRecord: record }));
     } else {
@@ -114,7 +114,7 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     };
     const settings = requestProcessor.buildFetchSettings(request.options, { method: 'POST', json });
 
-    await requestProcessor.fetch(source.resourceRelationshipURL(type, id, relationship), settings);
+    await requestProcessor.fetch(requestProcessor.resourceRelationshipURL(type, id, relationship), settings);
     return [];
   },
 
@@ -127,7 +127,7 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     };
     const settings = requestProcessor.buildFetchSettings(request.options, { method: 'DELETE', json });
 
-    await requestProcessor.fetch(source.resourceRelationshipURL(type, id, relationship), settings);
+    await requestProcessor.fetch(requestProcessor.resourceRelationshipURL(type, id, relationship), settings);
     return [];
   },
 
@@ -140,7 +140,7 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     };
     const settings = requestProcessor.buildFetchSettings(request.options, { method: 'PATCH', json });
 
-    await requestProcessor.fetch(source.resourceRelationshipURL(type, id, relationship), settings)
+    await requestProcessor.fetch(requestProcessor.resourceRelationshipURL(type, id, relationship), settings)
     return [];
   },
 
@@ -153,7 +153,7 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     };
     const settings = requestProcessor.buildFetchSettings(request.options, { method: 'PATCH', json });
 
-    await requestProcessor.fetch(source.resourceRelationshipURL(type, id, relationship), settings);
+    await requestProcessor.fetch(requestProcessor.resourceRelationshipURL(type, id, relationship), settings);
     return [];
   }
 };

--- a/packages/@orbit/jsonapi/src/lib/transform-requests.ts
+++ b/packages/@orbit/jsonapi/src/lib/transform-requests.ts
@@ -20,7 +20,7 @@ import { clone, deepSet, Dict } from '@orbit/utils';
 import JSONAPISource from '../jsonapi-source';
 import { ResourceDocument } from '../resource-document';
 import { RecordDocument } from '../record-document';
-import { buildFetchSettings, customRequestOptions, RequestOptions } from './request-settings';
+import { RequestOptions } from './request-settings';
 
 export interface TransformRecordRequest {
   op: string;
@@ -72,31 +72,32 @@ export interface TransformRequestProcessor {
 
 export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
   async addRecord(source: JSONAPISource, request: AddRecordRequest): Promise<Transform[]> {
-    const { serializer } = source;
+    const { serializer, requestProcessor } = source;
     const record = request.record;
     const requestDoc: ResourceDocument = serializer.serialize({ data: record });
-    const settings = buildFetchSettings(request.options, { method: 'POST', json: requestDoc });
+    const settings = requestProcessor.buildFetchSettings(request.options, { method: 'POST', json: requestDoc });
 
-    let raw: ResourceDocument = await source.fetch(source.resourceURL(record.type), settings);
+    let raw: ResourceDocument = await requestProcessor.fetch(source.resourceURL(record.type), settings);
     return handleChanges(record, serializer.deserialize(raw, { primaryRecord: record }));
   },
 
   async removeRecord(source: JSONAPISource, request: RemoveRecordRequest): Promise<Transform[]> {
     const { type, id } = request.record;
-    const settings = buildFetchSettings(request.options, { method: 'DELETE' });
+    const { requestProcessor } = source;
+    const settings = requestProcessor.buildFetchSettings(request.options, { method: 'DELETE' });
 
-    await source.fetch(source.resourceURL(type, id), settings);
+    await requestProcessor.fetch(source.resourceURL(type, id), settings);
     return [];
   },
 
   async updateRecord(source: JSONAPISource, request: UpdateRecordRequest): Promise<Transform[]> {
-    const { serializer } = source;
+    const { serializer, requestProcessor } = source;
     const record = request.record;
     const { type, id } = record;
     const requestDoc: ResourceDocument = serializer.serialize({ data: record });
-    const settings = buildFetchSettings(request.options, { method: 'PATCH', json: requestDoc });
+    const settings = requestProcessor.buildFetchSettings(request.options, { method: 'PATCH', json: requestDoc });
 
-    let raw: ResourceDocument = await source.fetch(source.resourceURL(type, id), settings)
+    let raw: ResourceDocument = await requestProcessor.fetch(source.resourceURL(type, id), settings)
     if (raw) {
       return handleChanges(record, serializer.deserialize(raw, { primaryRecord: record }));
     } else {
@@ -107,48 +108,52 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
   async addToRelatedRecords(source: JSONAPISource, request: AddToRelatedRecordsRequest): Promise<Transform[]> {
     const { type, id } = request.record;
     const { relationship } = request;
+    const { requestProcessor } = source;
     const json = {
       data: request.relatedRecords.map(r => source.serializer.resourceIdentity(r))
     };
-    const settings = buildFetchSettings(request.options, { method: 'POST', json });
+    const settings = requestProcessor.buildFetchSettings(request.options, { method: 'POST', json });
 
-    await source.fetch(source.resourceRelationshipURL(type, id, relationship), settings);
+    await requestProcessor.fetch(source.resourceRelationshipURL(type, id, relationship), settings);
     return [];
   },
 
   async removeFromRelatedRecords(source: JSONAPISource, request: RemoveFromRelatedRecordsRequest): Promise<Transform[]> {
     const { type, id } = request.record;
     const { relationship } = request;
+    const { serializer, requestProcessor } = source;
     const json = {
-      data: request.relatedRecords.map(r => source.serializer.resourceIdentity(r))
+      data: request.relatedRecords.map(r => serializer.resourceIdentity(r))
     };
-    const settings = buildFetchSettings(request.options, { method: 'DELETE', json });
+    const settings = requestProcessor.buildFetchSettings(request.options, { method: 'DELETE', json });
 
-    await source.fetch(source.resourceRelationshipURL(type, id, relationship), settings);
+    await requestProcessor.fetch(source.resourceRelationshipURL(type, id, relationship), settings);
     return [];
   },
 
   async replaceRelatedRecord(source: JSONAPISource, request: ReplaceRelatedRecordRequest): Promise<Transform[]> {
     const { type, id } = request.record;
     const { relationship, relatedRecord } = request;
+    const { serializer, requestProcessor } = source;
     const json = {
-      data: relatedRecord ? source.serializer.resourceIdentity(relatedRecord) : null
+      data: relatedRecord ? serializer.resourceIdentity(relatedRecord) : null
     };
-    const settings = buildFetchSettings(request.options, { method: 'PATCH', json });
+    const settings = requestProcessor.buildFetchSettings(request.options, { method: 'PATCH', json });
 
-    await source.fetch(source.resourceRelationshipURL(type, id, relationship), settings)
+    await requestProcessor.fetch(source.resourceRelationshipURL(type, id, relationship), settings)
     return [];
   },
 
   async replaceRelatedRecords(source: JSONAPISource, request: ReplaceRelatedRecordsRequest): Promise<Transform[]> {
     const { type, id } = request.record;
     const { relationship, relatedRecords } = request;
+    const { serializer, requestProcessor } = source;
     const json = {
-      data: relatedRecords.map(r => source.serializer.resourceIdentity(r))
+      data: relatedRecords.map(r => serializer.resourceIdentity(r))
     };
-    const settings = buildFetchSettings(request.options, { method: 'PATCH', json });
+    const settings = requestProcessor.buildFetchSettings(request.options, { method: 'PATCH', json });
 
-    await source.fetch(source.resourceRelationshipURL(type, id, relationship), settings);
+    await requestProcessor.fetch(source.resourceRelationshipURL(type, id, relationship), settings);
     return [];
   }
 };
@@ -193,7 +198,7 @@ export function getTransformRequests(source: JSONAPISource, transform: Transform
     }
 
     if (request) {
-      let options = customRequestOptions(source, transform);
+      let options = source.requestProcessor.customRequestOptions(transform);
       if (options) {
         request.options = options;
       }

--- a/packages/@orbit/jsonapi/src/lib/transform-requests.ts
+++ b/packages/@orbit/jsonapi/src/lib/transform-requests.ts
@@ -76,7 +76,7 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     const requestDoc: ResourceDocument = requestProcessor.serializer.serialize({ data: record });
     const settings = requestProcessor.buildFetchSettings(request.options, { method: 'POST', json: requestDoc });
 
-    let raw: ResourceDocument = await requestProcessor.fetch(requestProcessor.resourceURL(record.type), settings);
+    let raw: ResourceDocument = await requestProcessor.fetch(requestProcessor.urlBuilder.resourceURL(record.type), settings);
     return handleChanges(record, requestProcessor.serializer.deserialize(raw, { primaryRecord: record }));
   },
 
@@ -84,7 +84,7 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     const { type, id } = request.record;
     const settings = requestProcessor.buildFetchSettings(request.options, { method: 'DELETE' });
 
-    await requestProcessor.fetch(requestProcessor.resourceURL(type, id), settings);
+    await requestProcessor.fetch(requestProcessor.urlBuilder.resourceURL(type, id), settings);
     return [];
   },
 
@@ -94,7 +94,7 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     const requestDoc: ResourceDocument = requestProcessor.serializer.serialize({ data: record });
     const settings = requestProcessor.buildFetchSettings(request.options, { method: 'PATCH', json: requestDoc });
 
-    let raw: ResourceDocument = await requestProcessor.fetch(requestProcessor.resourceURL(type, id), settings)
+    let raw: ResourceDocument = await requestProcessor.fetch(requestProcessor.urlBuilder.resourceURL(type, id), settings)
     if (raw) {
       return handleChanges(record, requestProcessor.serializer.deserialize(raw, { primaryRecord: record }));
     } else {
@@ -110,7 +110,7 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     };
     const settings = requestProcessor.buildFetchSettings(request.options, { method: 'POST', json });
 
-    await requestProcessor.fetch(requestProcessor.resourceRelationshipURL(type, id, relationship), settings);
+    await requestProcessor.fetch(requestProcessor.urlBuilder.resourceRelationshipURL(type, id, relationship), settings);
     return [];
   },
 
@@ -122,7 +122,7 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     };
     const settings = requestProcessor.buildFetchSettings(request.options, { method: 'DELETE', json });
 
-    await requestProcessor.fetch(requestProcessor.resourceRelationshipURL(type, id, relationship), settings);
+    await requestProcessor.fetch(requestProcessor.urlBuilder.resourceRelationshipURL(type, id, relationship), settings);
     return [];
   },
 
@@ -134,7 +134,7 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     };
     const settings = requestProcessor.buildFetchSettings(request.options, { method: 'PATCH', json });
 
-    await requestProcessor.fetch(requestProcessor.resourceRelationshipURL(type, id, relationship), settings)
+    await requestProcessor.fetch(requestProcessor.urlBuilder.resourceRelationshipURL(type, id, relationship), settings)
     return [];
   },
 
@@ -146,7 +146,7 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     };
     const settings = requestProcessor.buildFetchSettings(request.options, { method: 'PATCH', json });
 
-    await requestProcessor.fetch(requestProcessor.resourceRelationshipURL(type, id, relationship), settings);
+    await requestProcessor.fetch(requestProcessor.urlBuilder.resourceRelationshipURL(type, id, relationship), settings);
     return [];
   }
 };

--- a/packages/@orbit/jsonapi/src/lib/transform-requests.ts
+++ b/packages/@orbit/jsonapi/src/lib/transform-requests.ts
@@ -17,7 +17,6 @@ import Orbit, {
   buildTransform
 } from '@orbit/data';
 import { clone, deepSet, Dict } from '@orbit/utils';
-import JSONAPISource from '../jsonapi-source';
 import JSONAPIRequestProcessor from '../jsonapi-request-processor';
 import { ResourceDocument } from '../resource-document';
 import { RecordDocument } from '../record-document';
@@ -68,12 +67,11 @@ export interface ReplaceRelatedRecordsRequest extends TransformRecordRelationshi
 }
 
 export interface TransformRequestProcessor {
-  (source: JSONAPISource, request: TransformRecordRequest): Promise<Transform[]>;
+  (requestProcessor: JSONAPIRequestProcessor, request: TransformRecordRequest): Promise<Transform[]>;
 }
 
 export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
-  async addRecord(source: JSONAPISource, request: AddRecordRequest): Promise<Transform[]> {
-    const { requestProcessor } = source;
+  async addRecord(requestProcessor: JSONAPIRequestProcessor, request: AddRecordRequest): Promise<Transform[]> {
     const record = request.record;
     const requestDoc: ResourceDocument = requestProcessor.serializer.serialize({ data: record });
     const settings = requestProcessor.buildFetchSettings(request.options, { method: 'POST', json: requestDoc });
@@ -82,17 +80,15 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     return handleChanges(record, requestProcessor.serializer.deserialize(raw, { primaryRecord: record }));
   },
 
-  async removeRecord(source: JSONAPISource, request: RemoveRecordRequest): Promise<Transform[]> {
+  async removeRecord(requestProcessor: JSONAPIRequestProcessor, request: RemoveRecordRequest): Promise<Transform[]> {
     const { type, id } = request.record;
-    const { requestProcessor } = source;
     const settings = requestProcessor.buildFetchSettings(request.options, { method: 'DELETE' });
 
     await requestProcessor.fetch(requestProcessor.resourceURL(type, id), settings);
     return [];
   },
 
-  async updateRecord(source: JSONAPISource, request: UpdateRecordRequest): Promise<Transform[]> {
-    const { requestProcessor } = source;
+  async updateRecord(requestProcessor: JSONAPIRequestProcessor, request: UpdateRecordRequest): Promise<Transform[]> {
     const record = request.record;
     const { type, id } = record;
     const requestDoc: ResourceDocument = requestProcessor.serializer.serialize({ data: record });
@@ -106,10 +102,9 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     }
   },
 
-  async addToRelatedRecords(source: JSONAPISource, request: AddToRelatedRecordsRequest): Promise<Transform[]> {
+  async addToRelatedRecords(requestProcessor: JSONAPIRequestProcessor, request: AddToRelatedRecordsRequest): Promise<Transform[]> {
     const { type, id } = request.record;
     const { relationship } = request;
-    const { requestProcessor } = source;
     const json = {
       data: request.relatedRecords.map(r => requestProcessor.serializer.resourceIdentity(r))
     };
@@ -119,10 +114,9 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     return [];
   },
 
-  async removeFromRelatedRecords(source: JSONAPISource, request: RemoveFromRelatedRecordsRequest): Promise<Transform[]> {
+  async removeFromRelatedRecords(requestProcessor: JSONAPIRequestProcessor, request: RemoveFromRelatedRecordsRequest): Promise<Transform[]> {
     const { type, id } = request.record;
     const { relationship } = request;
-    const { requestProcessor } = source;
     const json = {
       data: request.relatedRecords.map(r => requestProcessor.serializer.resourceIdentity(r))
     };
@@ -132,10 +126,9 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     return [];
   },
 
-  async replaceRelatedRecord(source: JSONAPISource, request: ReplaceRelatedRecordRequest): Promise<Transform[]> {
+  async replaceRelatedRecord(requestProcessor: JSONAPIRequestProcessor, request: ReplaceRelatedRecordRequest): Promise<Transform[]> {
     const { type, id } = request.record;
     const { relationship, relatedRecord } = request;
-    const { requestProcessor } = source;
     const json = {
       data: relatedRecord ? requestProcessor.serializer.resourceIdentity(relatedRecord) : null
     };
@@ -145,10 +138,9 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     return [];
   },
 
-  async replaceRelatedRecords(source: JSONAPISource, request: ReplaceRelatedRecordsRequest): Promise<Transform[]> {
+  async replaceRelatedRecords(requestProcessor: JSONAPIRequestProcessor, request: ReplaceRelatedRecordsRequest): Promise<Transform[]> {
     const { type, id } = request.record;
     const { relationship, relatedRecords } = request;
-    const { requestProcessor } = source;
     const json = {
       data: relatedRecords.map(r => requestProcessor.serializer.resourceIdentity(r))
     };

--- a/packages/@orbit/jsonapi/test/jsonapi-request-processor-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-request-processor-test.ts
@@ -12,7 +12,7 @@ module('JSONAPIRequestProcessor', function(hooks) {
   let processor: JSONAPIRequestProcessor;
 
   hooks.beforeEach(() => {
-    let schema = new Schema({
+    schema = new Schema({
       models: {
         planet: {
           keys: {
@@ -54,8 +54,7 @@ module('JSONAPIRequestProcessor', function(hooks) {
     });
 
     keyMap = new KeyMap();
-    let source = new JSONAPISource({ schema, keyMap, RequestProcessorClass: JSONAPIRequestProcessor });
-    processor = source.requestProcessor;
+    processor = new JSONAPIRequestProcessor({ schema, keyMap, sourceName: 'foo' });
     processor.serializer.resourceKey = function() { return 'remoteId'; };
   });
 

--- a/packages/@orbit/jsonapi/test/jsonapi-request-processor-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-request-processor-test.ts
@@ -1,0 +1,147 @@
+const { module, test } = QUnit;
+import Orbit, {
+  KeyMap,
+  Schema
+} from '@orbit/data';
+import JSONAPISource from '../src/index';
+import { JSONAPIRequestProcessor } from '../src/index';
+
+module('JSONAPIRequestProcessor', function(hooks) {
+  let processor;
+
+  hooks.beforeEach(() => {
+    let schema = new Schema({
+      models: {
+        planet: {
+          keys: {
+            remoteId: {}
+          },
+          attributes: {
+            name: { type: 'string' },
+            classification: { type: 'string' },
+            lengthOfDay: { type: 'number' }
+          },
+          relationships: {
+            moons: { type: 'hasMany', model: 'moon', inverse: 'planet' },
+            solarSystem: { type: 'hasOne', model: 'solarSystem', inverse: 'planets' }
+          }
+        },
+        moon: {
+          keys: {
+            remoteId: {}
+          },
+          attributes: {
+            name: { type: 'string' }
+          },
+          relationships: {
+            planet: { type: 'hasOne', model: 'planet', inverse: 'moons' }
+          }
+        },
+        solarSystem: {
+          keys: {
+            remoteId: {}
+          },
+          attributes: {
+            name: { type: 'string' }
+          },
+          relationships: {
+            planets: { type: 'hasMany', model: 'planet', inverse: 'solarSystem' }
+          }
+        }
+      }
+    });
+
+    let keyMap = new KeyMap();
+    let source = new JSONAPISource({ schema, keyMap });
+    processor = new JSONAPIRequestProcessor(source, {});
+  });
+
+  test('it exists', function(assert) {
+    assert.ok(processor);
+  });
+
+  test('processor has default settings', function(assert) {
+    assert.deepEqual(processor.allowedContentTypes, ['application/vnd.api+json', 'application/json'], 'allowedContentTypes are set to default');
+  });
+
+  test('#initFetchSettings will override defaults with custom settings provided', function(assert) {
+    assert.deepEqual(
+      processor.initFetchSettings({
+        headers: {
+          Accept: 'application/json'
+        },
+        method: 'POST',
+        body: '{"data": {}}',
+        timeout: 10000
+      }),
+      {
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/vnd.api+json'
+        },
+        method: 'POST',
+        body: '{"data": {}}',
+        timeout: 10000
+      });
+  });
+
+  test('#initFetchSettings will convert json to a stringified body', function(assert) {
+    assert.deepEqual(
+      processor.initFetchSettings({
+        headers: {
+          Accept: 'application/json'
+        },
+        method: 'POST',
+        json: { data: { a: 123 } },
+        timeout: 10000
+      }),
+      {
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/vnd.api+json'
+        },
+        method: 'POST',
+        body: '{"data":{"a":123}}',
+        timeout: 10000
+      });
+  });
+
+  test('#initFetchSettings will not include a `Content-Type` header with no body', function(assert) {
+    assert.deepEqual(
+      processor.initFetchSettings({
+        method: 'GET'
+      }),
+      {
+        headers: {
+          Accept: 'application/vnd.api+json'
+        },
+        method: 'GET',
+        timeout: 5000
+      });
+  });
+
+
+  test('#responseHasContent - returns true if one of the `allowedContentTypes` appears anywhere in `Content-Type` header', function(assert) {
+    let response = new Orbit.globals.Response('{ data: null }', { headers: { 'Content-Type': 'application/vnd.api+json' } });
+    assert.equal(processor.responseHasContent(response), true, 'Accepts content that is _only_ the JSONAPI media type.');
+
+    response = new Orbit.globals.Response('{ data: null }', { headers: { 'Content-Type': 'multipart,application/vnd.api+json; charset=utf-8' } });
+    assert.equal(processor.responseHasContent(response), true, 'Position of JSONAPI media type is not important.');
+
+    response = new Orbit.globals.Response('{ data: null }', { headers: { 'Content-Type': 'application/json' } });
+    assert.equal(processor.responseHasContent(response), true, 'Source will attempt to parse plain json.');
+
+    response = new Orbit.globals.Response('{ data: null }', { headers: { 'Content-Type': 'application/xml' } });
+    assert.equal(processor.responseHasContent(response), false, 'XML is not acceptable.');
+
+    processor.allowedContentTypes = ['application/custom'];
+    response = new Orbit.globals.Response('{ data: null }', { headers: { 'Content-Type': 'application/custom' } });
+    assert.equal(processor.responseHasContent(response), true, 'Source will accept custom content type if specifically allowed.');
+  });
+
+  test('#responseHasContent - returns false if response has status code 204', function(assert) {
+    let response = new Orbit.globals.Response(null, { status: 204, headers: { 'Content-Type': 'application/vnd.api+json' } });
+
+    assert.equal(processor.responseHasContent(response), false, 'A 204 - No Content response has no content.');
+  });
+});

--- a/packages/@orbit/jsonapi/test/jsonapi-request-processor-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-request-processor-test.ts
@@ -55,8 +55,8 @@ module('JSONAPIRequestProcessor', function(hooks) {
 
     keyMap = new KeyMap();
     let source = new JSONAPISource({ schema, keyMap, RequestProcessorClass: JSONAPIRequestProcessor });
-    source.serializer.resourceKey = function() { return 'remoteId'; };
     processor = source.requestProcessor;
+    processor.serializer.resourceKey = function() { return 'remoteId'; };
   });
 
   hooks.afterEach(() => {

--- a/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
@@ -182,62 +182,6 @@ module('JSONAPISource', function() {
         });
     });
 
-    test('#initFetchSettings will override defaults with custom settings provided', function(assert) {
-      assert.deepEqual(
-        source.initFetchSettings({
-          headers: {
-            Accept: 'application/json'
-          },
-          method: 'POST',
-          body: '{"data": {}}',
-          timeout: 10000
-        }),
-        {
-          headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/vnd.api+json'
-          },
-          method: 'POST',
-          body: '{"data": {}}',
-          timeout: 10000
-        });
-    });
-
-    test('#initFetchSettings will convert json to a stringified body', function(assert) {
-      assert.deepEqual(
-        source.initFetchSettings({
-          headers: {
-            Accept: 'application/json'
-          },
-          method: 'POST',
-          json: { data: { a: 123 } },
-          timeout: 10000
-        }),
-        {
-          headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/vnd.api+json'
-          },
-          method: 'POST',
-          body: '{"data":{"a":123}}',
-          timeout: 10000
-        });
-    });
-
-    test('#initFetchSettings will not include a `Content-Type` header with no body', function(assert) {
-      assert.deepEqual(
-        source.initFetchSettings({
-          method: 'GET'
-        }),
-        {
-          headers: {
-            Accept: 'application/vnd.api+json'
-          },
-          method: 'GET',
-          timeout: 5000
-        });
-    });
-
     test('#responseHasContent - returns true if one of the `allowedContentTypes` appears anywhere in `Content-Type` header', function(assert) {
       let response = new Orbit.globals.Response('{ data: null }', { headers: { 'Content-Type': 'application/vnd.api+json' } });
       assert.equal(source.responseHasContent(response), true, 'Accepts content that is _only_ the JSONAPI media type.');

--- a/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
@@ -121,8 +121,8 @@ module('JSONAPISource', function() {
 
       const headers = source.defaultFetchSettings.headers as any;
       assert.equal(headers['User-Agent'], 'CERN-LineMode/2.15 libwww/2.17b3', 'Headers should be defined');
-      assert.equal(source.requestProcessor.resourceNamespace(), source.namespace, 'Default namespace should be used by default');
-      assert.equal(source.requestProcessor.resourceHost(), source.host, 'Default host should be used by default');
+      assert.equal(source.requestProcessor.urlBuilder.resourceNamespace(), 'api', 'Default namespace should be used by default');
+      assert.equal(source.requestProcessor.urlBuilder.resourceHost(), '127.0.0.1:8888', 'Default host should be used by default');
     });
 
     test('#defaultFetchSettings - include JSONAPI Accept and Content-Type headers and a 5000ms timeout by default', function(assert) {

--- a/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
@@ -102,7 +102,7 @@ module('JSONAPISource', function() {
       assert.deepEqual(source.allowedContentTypes, ['application/vnd.api+json', 'application/json'], 'allowedContentTypes are set to default');
     });
 
-    test('source saves options', function(assert) {
+     test('source saves options', function(assert) {
       assert.expect(7);
 
       let schema = new Schema({} as SchemaSettings);
@@ -117,38 +117,13 @@ module('JSONAPISource', function() {
       });
       assert.equal(source.name, 'custom', 'name is custom');
       assert.deepEqual(source.allowedContentTypes, ['application/custom'], 'allowedContentTypes are custom');
-      assert.equal(source.namespace, 'api', 'Namespace should be defined');
-      assert.equal(source.host, '127.0.0.1:8888', 'Host should be defined');
+      assert.equal(source.requestProcessor.namespace, 'api', 'Namespace should be defined');
+      assert.equal(source.requestProcessor.host, '127.0.0.1:8888', 'Host should be defined');
 
       const headers = source.defaultFetchSettings.headers as any;
       assert.equal(headers['User-Agent'], 'CERN-LineMode/2.15 libwww/2.17b3', 'Headers should be defined');
-      assert.equal(source.resourceNamespace(), source.namespace, 'Default namespace should be used by default');
-      assert.equal(source.resourceHost(), source.host, 'Default host should be used by default');
-    });
-
-    test('#resourcePath - returns resource\'s path without its host and namespace', function(assert) {
-      assert.expect(1);
-      source.host = 'http://127.0.0.1:8888';
-      source.namespace = 'api';
-      keyMap.pushRecord({ type: 'planet', id: '1', keys: { remoteId: 'a' }, attributes: { name: 'Jupiter' } });
-
-      assert.equal(source.resourcePath('planet', '1'), 'planets/a', 'resourcePath returns the path to the resource relative to the host and namespace');
-    });
-
-    test('#resourceURL - respects options to construct URLs', function(assert) {
-      assert.expect(1);
-      source.host = 'http://127.0.0.1:8888';
-      source.namespace = 'api';
-      keyMap.pushRecord({ type: 'planet', id: '1', keys: { remoteId: 'a' }, attributes: { name: 'Jupiter' } });
-
-      assert.equal(source.resourceURL('planet', '1'), 'http://127.0.0.1:8888/api/planets/a', 'resourceURL method should use the options to construct URLs');
-    });
-
-    test('#resourceRelationshipURL - constructs relationship URLs based upon base resourceURL', function(assert) {
-      assert.expect(1);
-      keyMap.pushRecord({ type: 'planet', id: '1', keys: { remoteId: 'a' }, attributes: { name: 'Jupiter' } });
-
-      assert.equal(source.resourceRelationshipURL('planet', '1', 'moons'), '/planets/a/relationships/moons', 'resourceRelationshipURL appends /relationships/[relationship] to resourceURL');
+      assert.equal(source.requestProcessor.resourceNamespace(), source.namespace, 'Default namespace should be used by default');
+      assert.equal(source.requestProcessor.resourceHost(), source.host, 'Default host should be used by default');
     });
 
     test('#defaultFetchSettings - include JSONAPI Accept and Content-Type headers and a 5000ms timeout by default', function(assert) {

--- a/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
@@ -103,7 +103,7 @@ module('JSONAPISource', function() {
     });
 
      test('source saves options', function(assert) {
-      assert.expect(7);
+      assert.expect(5);
 
       let schema = new Schema({} as SchemaSettings);
       source = new JSONAPISource({
@@ -117,8 +117,6 @@ module('JSONAPISource', function() {
       });
       assert.equal(source.name, 'custom', 'name is custom');
       assert.deepEqual(source.allowedContentTypes, ['application/custom'], 'allowedContentTypes are custom');
-      assert.equal(source.requestProcessor.namespace, 'api', 'Namespace should be defined');
-      assert.equal(source.requestProcessor.host, '127.0.0.1:8888', 'Host should be defined');
 
       const headers = source.defaultFetchSettings.headers as any;
       assert.equal(headers['User-Agent'], 'CERN-LineMode/2.15 libwww/2.17b3', 'Headers should be defined');

--- a/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
@@ -76,12 +76,11 @@ module('JSONAPISource', function() {
       keyMap = new KeyMap();
       source = new JSONAPISource({ schema, keyMap });
 
-      source.serializer.resourceKey = function() { return 'remoteId'; };
+      source.requestProcessor.serializer.resourceKey = function() { return 'remoteId'; };
     });
 
     hooks.afterEach(() => {
       keyMap = schema = source = null;
-
       fetchStub.restore();
     });
 
@@ -157,36 +156,12 @@ module('JSONAPISource', function() {
         });
     });
 
-    test('#responseHasContent - returns true if one of the `allowedContentTypes` appears anywhere in `Content-Type` header', function(assert) {
-      let response = new Orbit.globals.Response('{ data: null }', { headers: { 'Content-Type': 'application/vnd.api+json' } });
-      assert.equal(source.responseHasContent(response), true, 'Accepts content that is _only_ the JSONAPI media type.');
-
-      response = new Orbit.globals.Response('{ data: null }', { headers: { 'Content-Type': 'multipart,application/vnd.api+json; charset=utf-8' } });
-      assert.equal(source.responseHasContent(response), true, 'Position of JSONAPI media type is not important.');
-
-      response = new Orbit.globals.Response('{ data: null }', { headers: { 'Content-Type': 'application/json' } });
-      assert.equal(source.responseHasContent(response), true, 'Source will attempt to parse plain json.');
-
-      response = new Orbit.globals.Response('{ data: null }', { headers: { 'Content-Type': 'application/xml' } });
-      assert.equal(source.responseHasContent(response), false, 'XML is not acceptable.');
-
-      source.allowedContentTypes = ['application/custom'];
-      response = new Orbit.globals.Response('{ data: null }', { headers: { 'Content-Type': 'application/custom' } });
-      assert.equal(source.responseHasContent(response), true, 'Source will accept custom content type if specifically allowed.');
-    });
-
-    test('#responseHasContent - returns false if response has status code 204', function(assert) {
-      let response = new Orbit.globals.Response(null, { status: 204, headers: { 'Content-Type': 'application/vnd.api+json' } });
-
-      assert.equal(source.responseHasContent(response), false, 'A 204 - No Content response has no content.');
-    });
-
     test('#push - can add records', async function(assert) {
       assert.expect(7);
 
       let transformCount = 0;
 
-      let planet: Record = source.serializer.deserializeResource({ type: 'planet', attributes: { name: 'Jupiter', classification: 'gas giant' } });
+      let planet: Record = source.requestProcessor.serializer.deserializeResource({ type: 'planet', attributes: { name: 'Jupiter', classification: 'gas giant' } });
 
       let addPlanetOp = {
         op: 'addRecord',
@@ -259,7 +234,7 @@ module('JSONAPISource', function() {
 
       let transformCount = 0;
 
-      let planet: Record = source.serializer.deserializeResource({ type: 'planet', attributes: { name: 'Jupiter', classification: 'gas giant' } });
+      let planet: Record = source.requestProcessor.serializer.deserializeResource({ type: 'planet', attributes: { name: 'Jupiter', classification: 'gas giant' } });
 
       let addPlanetOp = {
         op: 'addRecord',
@@ -367,7 +342,7 @@ module('JSONAPISource', function() {
 
       let transformCount = 0;
 
-      let planet = source.serializer.deserializeResource({
+      let planet = source.requestProcessor.serializer.deserializeResource({
         type: 'planet',
         id: '12345',
         attributes: {
@@ -438,7 +413,7 @@ module('JSONAPISource', function() {
     test('#push - can replace a single attribute', async function(assert) {
       assert.expect(5);
 
-      let planet = source.serializer.deserializeResource({
+      let planet = source.requestProcessor.serializer.deserializeResource({
         type: 'planet',
         id: '12345',
         attributes: {
@@ -476,7 +451,7 @@ module('JSONAPISource', function() {
     test('#push - can accept remote changes', async function(assert) {
       assert.expect(2);
 
-      let planet = source.serializer.deserializeResource({
+      let planet = source.requestProcessor.serializer.deserializeResource({
         type: 'planet',
         id: '12345',
         attributes: {
@@ -507,7 +482,7 @@ module('JSONAPISource', function() {
     test('#push - can delete records', async function(assert) {
       assert.expect(4);
 
-      let planet = source.serializer.deserializeResource({
+      let planet = source.requestProcessor.serializer.deserializeResource({
         type: 'planet',
         id: '12345'
       });
@@ -527,12 +502,12 @@ module('JSONAPISource', function() {
     test('#push - can add a hasMany relationship with POST', async function(assert) {
       assert.expect(5);
 
-      let planet = source.serializer.deserializeResource({
+      let planet = source.requestProcessor.serializer.deserializeResource({
         type: 'planet',
         id: '12345'
       });
 
-      let moon = source.serializer.deserializeResource({
+      let moon = source.requestProcessor.serializer.deserializeResource({
         type: 'moon',
         id: '987'
       });
@@ -557,12 +532,12 @@ module('JSONAPISource', function() {
     test('#push - can remove a relationship with DELETE', async function(assert) {
       assert.expect(4);
 
-      let planet = source.serializer.deserializeResource({
+      let planet = source.requestProcessor.serializer.deserializeResource({
         type: 'planet',
         id: '12345'
       });
 
-      let moon = source.serializer.deserializeResource({
+      let moon = source.requestProcessor.serializer.deserializeResource({
         type: 'moon',
         id: '987'
       });
@@ -586,12 +561,12 @@ module('JSONAPISource', function() {
     test('#push - can update a hasOne relationship with PATCH', async function(assert) {
       assert.expect(5);
 
-      let planet = source.serializer.deserializeResource({
+      let planet = source.requestProcessor.serializer.deserializeResource({
         type: 'planet',
         id: '12345'
       });
 
-      let moon = source.serializer.deserializeResource({
+      let moon = source.requestProcessor.serializer.deserializeResource({
         type: 'moon',
         id: '987'
       });
@@ -623,7 +598,7 @@ module('JSONAPISource', function() {
         attributes: { name: 'Jupiter', classification: 'gas giant' }
       };
 
-      let moon = source.serializer.deserializeResource({
+      let moon = source.requestProcessor.serializer.deserializeResource({
         type: 'moon',
         id: '987'
       });
@@ -658,7 +633,7 @@ module('JSONAPISource', function() {
     test('#push - can clear a hasOne relationship with PATCH', async function(assert) {
       assert.expect(5);
 
-      let moon = source.serializer.deserializeResource({
+      let moon = source.requestProcessor.serializer.deserializeResource({
         type: 'moon',
         id: '987'
       });
@@ -684,12 +659,12 @@ module('JSONAPISource', function() {
     test('#push - can replace a hasMany relationship with PATCH', async function(assert) {
       assert.expect(5);
 
-      let planet = source.serializer.deserializeResource({
+      let planet = source.requestProcessor.serializer.deserializeResource({
         type: 'planet',
         id: '12345'
       });
 
-      let moon = source.serializer.deserializeResource({
+      let moon = source.requestProcessor.serializer.deserializeResource({
         type: 'moon',
         id: '987'
       });
@@ -715,8 +690,8 @@ module('JSONAPISource', function() {
     test('#push - a single transform can result in multiple requests', async function(assert) {
       assert.expect(6);
 
-      let planet1 = source.serializer.deserializeResource({ type: 'planet', id: '1' });
-      let planet2 = source.serializer.deserializeResource({ type: 'planet', id: '2' });
+      let planet1 = source.requestProcessor.serializer.deserializeResource({ type: 'planet', id: '1' });
+      let planet2 = source.requestProcessor.serializer.deserializeResource({ type: 'planet', id: '2' });
 
       fetchStub
         .withArgs('/planets/1')
@@ -745,8 +720,8 @@ module('JSONAPISource', function() {
     test('#push - source can limit the number of allowed requests per transform with `maxRequestsPerTransform`', async function(assert) {
       assert.expect(1);
 
-      let planet1 = source.serializer.deserializeResource({ type: 'planet', id: '1' });
-      let planet2 = source.serializer.deserializeResource({ type: 'planet', id: '2' });
+      let planet1 = source.requestProcessor.serializer.deserializeResource({ type: 'planet', id: '1' });
+      let planet2 = source.requestProcessor.serializer.deserializeResource({ type: 'planet', id: '2' });
 
       source.maxRequestsPerTransform = 1;
 
@@ -763,7 +738,7 @@ module('JSONAPISource', function() {
     test('#push - request can timeout', async function(assert) {
       assert.expect(2);
 
-      let planet = source.serializer.deserializeResource({
+      let planet = source.requestProcessor.serializer.deserializeResource({
         type: 'planet',
         id: '12345',
         attributes: {
@@ -791,7 +766,7 @@ module('JSONAPISource', function() {
     test('#push - allowed timeout can be specified per-request', async function(assert) {
       assert.expect(2);
 
-      let planet = source.serializer.deserializeResource({
+      let planet = source.requestProcessor.serializer.deserializeResource({
         type: 'planet',
         id: '12345',
         attributes: {
@@ -826,7 +801,7 @@ module('JSONAPISource', function() {
     test('#push - fetch can reject with a NetworkError', async function(assert) {
       assert.expect(2);
 
-      let planet = source.serializer.deserializeResource({
+      let planet = source.requestProcessor.serializer.deserializeResource({
         type: 'planet',
         id: '12345',
         attributes: {
@@ -851,7 +826,7 @@ module('JSONAPISource', function() {
     test('#push - response can trigger a ClientError', async function(assert) {
       assert.expect(3);
 
-      let planet = source.serializer.deserializeResource({
+      let planet = source.requestProcessor.serializer.deserializeResource({
         type: 'planet',
         id: '12345',
         attributes: {
@@ -884,7 +859,7 @@ module('JSONAPISource', function() {
 
       const data: Resource = { type: 'planets', id: '12345', attributes: { name: 'Jupiter', classification: 'gas giant' } };
 
-      const planet = source.serializer.deserializeResource({
+      const planet = source.requestProcessor.serializer.deserializeResource({
         type: 'planet',
         id: '12345'
       });
@@ -913,7 +888,7 @@ module('JSONAPISource', function() {
         relationships: { moons: { data: [] } }
       };
 
-      const planet = source.serializer.deserializeResource({
+      const planet = source.requestProcessor.serializer.deserializeResource({
         type: 'planet',
         id: '12345'
       });
@@ -944,7 +919,7 @@ module('JSONAPISource', function() {
         relationships: { moons: { data: [] } }
       };
 
-      const planet = source.serializer.deserializeResource({
+      const planet = source.requestProcessor.serializer.deserializeResource({
         type: 'planet',
         id: '12345'
       });
@@ -976,7 +951,7 @@ module('JSONAPISource', function() {
     test('#pull - fetch can reject with a NetworkError', async function(assert) {
       assert.expect(2);
 
-      const planet = source.serializer.deserializeResource({
+      const planet = source.requestProcessor.serializer.deserializeResource({
         type: 'planet',
         id: '12345'
       });
@@ -1004,7 +979,7 @@ module('JSONAPISource', function() {
         relationships: { moons: { data: [] } }
       };
 
-      const planet = source.serializer.deserializeResource({
+      const planet = source.requestProcessor.serializer.deserializeResource({
         type: 'planet',
         id: '12345'
       });
@@ -1348,7 +1323,7 @@ module('JSONAPISource', function() {
     test('#pull - relatedRecord', async function(assert) {
       assert.expect(12);
 
-      const planetRecord: Record = source.serializer.deserialize({
+      const planetRecord: Record = source.requestProcessor.serializer.deserialize({
         data: {
           type: 'planets',
           id: 'jupiter'
@@ -1396,7 +1371,7 @@ module('JSONAPISource', function() {
     test('#pull - relatedRecords', async function(assert) {
       assert.expect(8);
 
-      let planetRecord: Record = source.serializer.deserialize({
+      let planetRecord: Record = source.requestProcessor.serializer.deserialize({
         data: {
           type: 'planets',
           id: 'jupiter'
@@ -1435,7 +1410,7 @@ module('JSONAPISource', function() {
     test('#pull - relatedRecords with include', async function(assert) {
       assert.expect(2);
 
-      const planetRecord = source.serializer.deserialize({
+      const planetRecord = source.requestProcessor.serializer.deserialize({
         data: {
           type: 'planets',
           id: 'jupiter'
@@ -1465,7 +1440,7 @@ module('JSONAPISource', function() {
 
       const data: Resource = { type: 'planets', id: '12345', attributes: { name: 'Jupiter', classification: 'gas giant' } };
 
-      const planet = source.serializer.deserializeResource({
+      const planet = source.requestProcessor.serializer.deserializeResource({
         type: 'planet',
         id: '12345'
       });
@@ -1493,7 +1468,7 @@ module('JSONAPISource', function() {
         relationships: { moons: { data: [] } }
       };
 
-      const planet = source.serializer.deserializeResource({
+      const planet = source.requestProcessor.serializer.deserializeResource({
         type: 'planet',
         id: '12345'
       });
@@ -1524,7 +1499,7 @@ module('JSONAPISource', function() {
         relationships: { moons: { data: [] } }
       };
 
-      const planet = source.serializer.deserializeResource({
+      const planet = source.requestProcessor.serializer.deserializeResource({
         type: 'planet',
         id: '12345'
       });
@@ -1555,7 +1530,7 @@ module('JSONAPISource', function() {
     test('#query - fetch can reject with a NetworkError', async function(assert) {
       assert.expect(2);
 
-      const planet = source.serializer.deserializeResource({
+      const planet = source.requestProcessor.serializer.deserializeResource({
         type: 'planet',
         id: '12345'
       });
@@ -1583,7 +1558,7 @@ module('JSONAPISource', function() {
         relationships: { moons: { data: [] } }
       };
 
-      const planet = source.serializer.deserializeResource({
+      const planet = source.requestProcessor.serializer.deserializeResource({
         type: 'planet',
         id: '12345'
       });
@@ -1925,7 +1900,7 @@ module('JSONAPISource', function() {
     test('#query - relatedRecords', async function(assert) {
       assert.expect(5);
 
-      let planetRecord: Record = source.serializer.deserialize({
+      let planetRecord: Record = source.requestProcessor.serializer.deserialize({
         data: {
           type: 'planets',
           id: 'jupiter'
@@ -1957,7 +1932,7 @@ module('JSONAPISource', function() {
     test('#query - relatedRecords with include', async function(assert) {
       assert.expect(2);
 
-      const planetRecord = source.serializer.deserialize({
+      const planetRecord = source.requestProcessor.serializer.deserialize({
         data: {
           type: 'planets',
           id: 'jupiter'

--- a/packages/@orbit/jsonapi/test/jsonapi-url-builder-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-url-builder-test.ts
@@ -1,0 +1,89 @@
+const { module, test } = QUnit;
+import { KeyMap, Schema } from '@orbit/data';
+import { JSONAPIURLBuilder } from '../src/index';
+import { JSONAPISerializer } from '../src/index';
+
+module('JSONAPIRequestProcessor', function(hooks) {
+  let keyMap: KeyMap;
+  let urlBuilder: JSONAPIURLBuilder;
+
+  hooks.beforeEach(() => {
+    keyMap = new KeyMap();
+    let schema = new Schema({
+      models: {
+        planet: {
+          keys: {
+            remoteId: {}
+          },
+          attributes: {
+            name: { type: 'string' },
+            classification: { type: 'string' },
+            lengthOfDay: { type: 'number' }
+          },
+          relationships: {
+            moons: { type: 'hasMany', model: 'moon', inverse: 'planet' },
+            solarSystem: { type: 'hasOne', model: 'solarSystem', inverse: 'planets' }
+          }
+        },
+        moon: {
+          keys: {
+            remoteId: {}
+          },
+          attributes: {
+            name: { type: 'string' }
+          },
+          relationships: {
+            planet: { type: 'hasOne', model: 'planet', inverse: 'moons' }
+          }
+        },
+        solarSystem: {
+          keys: {
+            remoteId: {}
+          },
+          attributes: {
+            name: { type: 'string' }
+          },
+          relationships: {
+            planets: { type: 'hasMany', model: 'planet', inverse: 'solarSystem' }
+          }
+        }
+      }
+    });
+    let serializer = new JSONAPISerializer({ schema, keyMap });
+    urlBuilder = new JSONAPIURLBuilder({ serializer, keyMap });
+    urlBuilder.serializer.resourceKey = function() { return 'remoteId'; };
+  });
+
+  hooks.afterEach(() => {
+    keyMap = urlBuilder = null;
+  });
+
+  test('it exists', function(assert) {
+    assert.ok(urlBuilder);
+  });
+
+  test('#resourceURL - respects options to construct URLs', function(assert) {
+    assert.expect(1);
+    urlBuilder.host = 'http://127.0.0.1:8888';
+    urlBuilder.namespace = 'api';
+    keyMap.pushRecord({ type: 'planet', id: '1', keys: { remoteId: 'a' }, attributes: { name: 'Jupiter' } });
+
+    assert.equal(urlBuilder.resourceURL('planet', '1'), 'http://127.0.0.1:8888/api/planets/a', 'resourceURL method should use the options to construct URLs');
+  });
+
+  test('#resourcePath - returns resource\'s path without its host and namespace', function(assert) {
+    assert.expect(1);
+    urlBuilder.host = 'http://127.0.0.1:8888';
+    urlBuilder.namespace = 'api';
+    keyMap.pushRecord({ type: 'planet', id: '1', keys: { remoteId: 'a' }, attributes: { name: 'Jupiter' } });
+
+    assert.equal(urlBuilder.resourcePath('planet', '1'), 'planets/a', 'resourcePath returns the path to the resource relative to the host and namespace');
+  });
+
+  test('#resourceRelationshipURL - constructs relationship URLs based upon base resourceURL', function(assert) {
+    assert.expect(1);
+    keyMap.pushRecord({ type: 'planet', id: '1', keys: { remoteId: 'a' }, attributes: { name: 'Jupiter' } });
+
+    assert.equal(urlBuilder.resourceRelationshipURL('planet', '1', 'moons'), '/planets/a/relationships/moons', 'resourceRelationshipURL appends /relationships/[relationship] to resourceURL');
+  });
+});

--- a/packages/@orbit/jsonapi/test/lib/request-settings-test.ts
+++ b/packages/@orbit/jsonapi/test/lib/request-settings-test.ts
@@ -1,0 +1,76 @@
+import { mergeRequestOptions } from '../../src/lib/request-settings';
+
+const { module, test } = QUnit;
+
+module('RequestSettings', function() {
+  module('mergeRequestOptions', function() {
+    const OPTIONS = {
+      filter: [{ 'foo': 'bar' }],
+      include: ['baz.bay']
+    };
+
+    test('merge empty options', function(assert) {
+      assert.deepEqual(mergeRequestOptions(OPTIONS, {}), OPTIONS);
+    });
+
+    test('add sort', function(assert) {
+      assert.deepEqual(
+        mergeRequestOptions(OPTIONS, { sort: ['qay'] }),
+        {
+          filter: [{ 'foo': 'bar' }],
+          include: ['baz.bay'],
+          sort: ['qay']
+        }
+      )
+    });
+
+    test('merge includes', function(assert) {
+      assert.deepEqual(
+        mergeRequestOptions(OPTIONS, { include: ['baz.bay', 'snoop.dog'] }),
+        {
+          filter: [{ 'foo': 'bar' }],
+          include: ['baz.bay', 'snoop.dog']
+        }
+      )
+    });
+
+    test('merge filters', function(assert) {
+      assert.deepEqual(
+        mergeRequestOptions(OPTIONS, { filter: [{ 'intelligence': 'low' }] }),
+        {
+          filter: [{ 'foo': 'bar' }, { 'intelligence': 'low' }],
+          include: ['baz.bay']
+        }
+      )
+    });
+
+    test('override filter', function(assert) {
+      assert.deepEqual(
+        mergeRequestOptions(OPTIONS, { filter: [{ 'foo': 'zaz' }] }),
+        {
+          filter: [{ 'foo': 'zaz' }],
+          include: ['baz.bay']
+        }
+      )
+    });
+
+    test('add page', function(assert) {
+      assert.deepEqual(
+        mergeRequestOptions(OPTIONS, { page: {
+          kind: 'offsetLimit',
+          offset: 5,
+          limit: 100
+        }}),
+        {
+          filter: [{ 'foo': 'bar' }],
+          include: ['baz.bay'],
+          page: {
+            kind: 'offsetLimit',
+            offset: 5,
+            limit: 100
+          }
+        }
+      )
+    });
+  });
+});

--- a/packages/@orbit/jsonapi/test/lib/transform-requests-test.ts
+++ b/packages/@orbit/jsonapi/test/lib/transform-requests-test.ts
@@ -5,21 +5,19 @@ import {
   buildTransform
 } from '@orbit/data';
 import { getTransformRequests } from '../../src/lib/transform-requests';
-import JSONAPISource from '../../src/jsonapi-source';
 import JSONAPIRequestProcessor from '../../src/jsonapi-request-processor';
 
 const { module, test } = QUnit;
 
-module('TransformRequests', function(hooks) {
+module('TransformRequests', function(/* hooks */) {
   module('getTransformRequests', function(hooks) {
     let keyMap: KeyMap;
     let schema: Schema;
-    let source: JSONAPISource;
     let requestProcessor: JSONAPIRequestProcessor;
     let tb: TransformBuilder;
 
     hooks.beforeEach(() => {
-      let schema = new Schema({
+      schema = new Schema({
         models: {
           planet: {
             keys: {
@@ -61,14 +59,13 @@ module('TransformRequests', function(hooks) {
       });
 
       keyMap = new KeyMap();
-      source = new JSONAPISource({ schema });
-      requestProcessor = new JSONAPIRequestProcessor(source, { keyMap, schema, sourceName: source.name });
+      requestProcessor = new JSONAPIRequestProcessor({ keyMap, schema, sourceName: 'foo' });
 
       tb = new TransformBuilder();
     });
 
     hooks.afterEach(() => {
-      schema = source = requestProcessor = null;
+      schema = requestProcessor = null;
     });
 
     test('addRecord', function(assert) {

--- a/packages/@orbit/jsonapi/test/lib/transform-requests-test.ts
+++ b/packages/@orbit/jsonapi/test/lib/transform-requests-test.ts
@@ -62,7 +62,7 @@ module('TransformRequests', function(hooks) {
 
       keyMap = new KeyMap();
       source = new JSONAPISource({ schema });
-      requestProcessor = new JSONAPIRequestProcessor(source, { keyMap, schema });
+      requestProcessor = new JSONAPIRequestProcessor(source, { keyMap, schema, sourceName: source.name });
 
       tb = new TransformBuilder();
     });

--- a/packages/@orbit/jsonapi/test/support/jsonapi.ts
+++ b/packages/@orbit/jsonapi/test/support/jsonapi.ts
@@ -13,7 +13,7 @@ export function jsonapiResponse(_options: any, body?: any, timeout?: number): Pr
   options.headers = options.headers || {};
 
   if (body) {
-    options.headers['Content-Type'] = 'application/vnd.api+json';
+    options.headers['Content-Type'] = options.headers['Content-Type'] || 'application/vnd.api+json';
     response = new Orbit.globals.Response(JSON.stringify(body), options);
   } else {
     response = new Orbit.globals.Response(options);


### PR DESCRIPTION
Implementation of #628.

TODO List:

- [x] Move URL generation methods from JSONAPISource to JSONAPIRequestProcessor 
- [x] Should JSONAPIRequestProcessor be broken down 
- [x] JSONAPIRequestProcessor method visibility
- [x] JSONAPIRequestProcessor-specific tests
- [x] Consider direction of dependency between JSONAPiSource <-> JSONAPIRequestProcessor
- [ ] Document breaking changes
- [ ] Add deprecations
- [ ] Consider naming
