### PR TITLE
Update language level of module target to es2017

### DIFF
--- a/packages/@orbit/coordinator/package.json
+++ b/packages/@orbit/coordinator/package.json
@@ -14,7 +14,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es5/index.js",
+  "module": "dist/modules/es2017/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/core/package.json
+++ b/packages/@orbit/core/package.json
@@ -14,7 +14,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es5/index.js",
+  "module": "dist/modules/es2017/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/data/package.json
+++ b/packages/@orbit/data/package.json
@@ -14,7 +14,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es5/index.js",
+  "module": "dist/modules/es2017/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/identity-map/package.json
+++ b/packages/@orbit/identity-map/package.json
@@ -15,7 +15,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es5/index.js",
+  "module": "dist/modules/es2017/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/immutable/package.json
+++ b/packages/@orbit/immutable/package.json
@@ -13,7 +13,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es5/index.js",
+  "module": "dist/modules/es2017/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/indexeddb-bucket/package.json
+++ b/packages/@orbit/indexeddb-bucket/package.json
@@ -13,7 +13,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es5/index.js",
+  "module": "dist/modules/es2017/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/indexeddb/package.json
+++ b/packages/@orbit/indexeddb/package.json
@@ -13,7 +13,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es5/index.js",
+  "module": "dist/modules/es2017/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/jsonapi/package.json
+++ b/packages/@orbit/jsonapi/package.json
@@ -16,7 +16,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es5/index.js",
+  "module": "dist/modules/es2017/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/local-storage-bucket/package.json
+++ b/packages/@orbit/local-storage-bucket/package.json
@@ -13,7 +13,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es5/index.js",
+  "module": "dist/modules/es2017/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/local-storage/package.json
+++ b/packages/@orbit/local-storage/package.json
@@ -13,7 +13,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es5/index.js",
+  "module": "dist/modules/es2017/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/memory/package.json
+++ b/packages/@orbit/memory/package.json
@@ -14,7 +14,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es5/index.js",
+  "module": "dist/modules/es2017/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/record-cache/package.json
+++ b/packages/@orbit/record-cache/package.json
@@ -14,7 +14,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es5/index.js",
+  "module": "dist/modules/es2017/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/serializers/package.json
+++ b/packages/@orbit/serializers/package.json
@@ -14,7 +14,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es5/index.js",
+  "module": "dist/modules/es2017/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/store/package.json
+++ b/packages/@orbit/store/package.json
@@ -14,7 +14,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es5/index.js",
+  "module": "dist/modules/es2017/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/utils/package.json
+++ b/packages/@orbit/utils/package.json
@@ -14,7 +14,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es5/index.js",
+  "module": "dist/modules/es2017/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",


### PR DESCRIPTION
The `module` field for all Orbit packages has been pointing to the ES5 transpiled build.

Instead of deoptimizing build size and language features, Orbit will now point to the latest ES builds (currently the ES2017 target of the TS compiler).

If you wish to continue to use the ES5 builds, please adjust your app's build processes to ensure that you grab the right distribution from `dist`.