### PR TITLE
Revert "Update language level of module target to es2017"

### DIFF
--- a/packages/@orbit/coordinator/package.json
+++ b/packages/@orbit/coordinator/package.json
@@ -14,7 +14,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es2017/index.js",
+  "module": "dist/modules/es5/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/core/package.json
+++ b/packages/@orbit/core/package.json
@@ -14,7 +14,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es2017/index.js",
+  "module": "dist/modules/es5/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/data/package.json
+++ b/packages/@orbit/data/package.json
@@ -14,7 +14,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es2017/index.js",
+  "module": "dist/modules/es5/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/identity-map/package.json
+++ b/packages/@orbit/identity-map/package.json
@@ -15,7 +15,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es2017/index.js",
+  "module": "dist/modules/es5/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/immutable/package.json
+++ b/packages/@orbit/immutable/package.json
@@ -13,7 +13,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es2017/index.js",
+  "module": "dist/modules/es5/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/indexeddb-bucket/package.json
+++ b/packages/@orbit/indexeddb-bucket/package.json
@@ -13,7 +13,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es2017/index.js",
+  "module": "dist/modules/es5/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/indexeddb/package.json
+++ b/packages/@orbit/indexeddb/package.json
@@ -13,7 +13,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es2017/index.js",
+  "module": "dist/modules/es5/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/jsonapi/package.json
+++ b/packages/@orbit/jsonapi/package.json
@@ -16,7 +16,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es2017/index.js",
+  "module": "dist/modules/es5/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/local-storage-bucket/package.json
+++ b/packages/@orbit/local-storage-bucket/package.json
@@ -13,7 +13,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es2017/index.js",
+  "module": "dist/modules/es5/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/local-storage/package.json
+++ b/packages/@orbit/local-storage/package.json
@@ -13,7 +13,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es2017/index.js",
+  "module": "dist/modules/es5/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/memory/package.json
+++ b/packages/@orbit/memory/package.json
@@ -14,7 +14,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es2017/index.js",
+  "module": "dist/modules/es5/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/record-cache/package.json
+++ b/packages/@orbit/record-cache/package.json
@@ -14,7 +14,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es2017/index.js",
+  "module": "dist/modules/es5/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/serializers/package.json
+++ b/packages/@orbit/serializers/package.json
@@ -14,7 +14,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es2017/index.js",
+  "module": "dist/modules/es5/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/store/package.json
+++ b/packages/@orbit/store/package.json
@@ -14,7 +14,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es2017/index.js",
+  "module": "dist/modules/es5/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",

--- a/packages/@orbit/utils/package.json
+++ b/packages/@orbit/utils/package.json
@@ -14,7 +14,7 @@
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/es5/index.js",
-  "module": "dist/modules/es2017/index.js",
+  "module": "dist/modules/es5/index.js",
   "types": "dist/types/index.d.ts",
   "scripts": {
     "build": "rm -rf dist && BROCCOLI_ENV=dist broccoli build dist",


### PR DESCRIPTION
The v0.16-beta.6 release came with an unacceptable number of breakages due to changing the default `module` target from es5 to es2017.

I'm going to revert this change and wait until at least v0.17 to change the target.