### PR TITLE
JSONAPIRequestProcessor#handleFetchResponseError must return a rejected promise instead of throwing

### DIFF
--- a/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
@@ -246,6 +246,6 @@ export default class JSONAPIRequestProcessor {
   }
 
   protected async handleFetchError(e: any): Promise<any> {
-    throw new NetworkError(e);
+    return Promise.reject(new NetworkError(e));
   }
 }

--- a/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
@@ -242,7 +242,7 @@ export default class JSONAPIRequestProcessor {
     }
     error.response = response;
     error.data = data;
-    throw error;
+    return Promise.reject(error);
   }
 
   protected async handleFetchError(e: any): Promise<any> {

--- a/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
@@ -225,8 +225,8 @@ export default class JSONAPIRequestProcessor {
       }
     } else {
       if (this.responseHasContent(response)) {
-        return response.json()
-          .then((data: any) => this.handleFetchResponseError(response, data));
+        let data = await response.json();
+        return this.handleFetchResponseError(response, data)
       } else {
         return this.handleFetchResponseError(response);
       }


### PR DESCRIPTION
This maintains backwards-compatibility and allows the `catch(e, transform)` method of the
strategies to invoked on failures. This is how it worked in 0.15: https://github.com/orbitjs/orbit/blob/release-0-15/packages/%40orbit/jsonapi/src/jsonapi-source.ts#L268

Closes #651