### PR TITLE
Fix generation of empty responses on tests

### DIFF
--- a/packages/@orbit/integration-tests/test/support/jsonapi.ts
+++ b/packages/@orbit/integration-tests/test/support/jsonapi.ts
@@ -16,7 +16,7 @@ export function jsonapiResponse(_options: any, body?: any, timeout?: number): Pr
     options.headers['Content-Type'] = 'application/vnd.api+json';
     response = new Orbit.globals.Response(JSON.stringify(body), options);
   } else {
-    response = new Orbit.globals.Response(options);
+    response = new Orbit.globals.Response(null, options);
   }
 
   // console.log('jsonapiResponse', body, options, response.headers.get('Content-Type'));

--- a/packages/@orbit/jsonapi/test/support/jsonapi.ts
+++ b/packages/@orbit/jsonapi/test/support/jsonapi.ts
@@ -16,7 +16,7 @@ export function jsonapiResponse(_options: any, body?: any, timeout?: number): Pr
     options.headers['Content-Type'] = options.headers['Content-Type'] || 'application/vnd.api+json';
     response = new Orbit.globals.Response(JSON.stringify(body), options);
   } else {
-    response = new Orbit.globals.Response(options);
+    response = new Orbit.globals.Response(null, options);
   }
 
   // console.log('jsonapiResponse', body, options, response.headers.get('Content-Type'));


### PR DESCRIPTION
The right syntax to generate a Response without a body is `new Response(null, initOpts)`.
Before this changes, all those invocations were generating 200 OK responses:

```
jsonapiResponse(404)
jsonapiResponse({status: 404});
jsonapiResponse({status: 404}, null);
jsonapiResponse({status: 404, headers: { 'Content-Type': 'application/vnd.api+json' }, null);
```

If fact this `jsonapiResponse({ status: 204 })` was generating a 200 OK response too.