### PR TITLE
Throw when invalid filter expression.

### DIFF
--- a/packages/@orbit/data/src/query-term.ts
+++ b/packages/@orbit/data/src/query-term.ts
@@ -202,7 +202,7 @@ function filterParamToSpecifier(param: FilterQBParam): FilterSpecifier {
         records: (param as RelatedRecordsFilterQBParam).records
       } as RelatedRecordsFilterSpecifier;
     }
-  } else {
+  } else if (param.hasOwnProperty('attribute')) {
     return {
       kind: 'attribute',
       op,

--- a/packages/@orbit/data/test/query-builder-test.ts
+++ b/packages/@orbit/data/test/query-builder-test.ts
@@ -100,6 +100,37 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
+  test('findRecords + filter (invalid filter expression)', function(assert) {
+    assert.throws(() => {
+      oqb
+        .findRecords('planet')
+        // @ts-ignore: testing a common mistake for a new Orbiteer not using TypeScript
+        .filter({ name: 'Pluto' })
+        .toQueryExpression();
+    }, new Error('Unrecognized filter param.'));
+  });
+
+  test('findRecords + attribute filter', function(assert) {
+    assert.deepEqual(
+      oqb
+        .findRecords('planet')
+        .filter({ attribute: 'name', value: 'Pluto' })
+        .toQueryExpression(),
+      {
+        op: 'findRecords',
+        type: 'planet',
+        filter: [
+          {
+            op: 'equal',
+            kind: 'attribute',
+            attribute: 'name',
+            value: 'Pluto'
+          }
+        ]
+      } as FindRecords
+    );
+  });
+
   test('findRecords + hasOne filter', function(assert) {
     assert.deepEqual(
       oqb


### PR DESCRIPTION
Previously, the QueryBuilder assumed that a filter specifier without a `kind` was an attribute filter. This was true even if no attribute property was present, which could never work. This silently failed to filter anything. Furthermore, an end-developer used to other filter APIs might attempt to pass something like `{ firstName: 'Luke' }` to filter, which would fall into this silent failure path.

This commit ensures that an attribute is specified before assuming the filter is an attribute filter. In the example above, that means the well-meaning and otherwise intelligent and good-looking end developer will receive a helpful error instead of, say, shipping a non-functional filter to production.

@mattmcmanus / @lukemelia