### PR TITLE
Use native isArray

### DIFF
--- a/packages/@orbit/data/src/source-interfaces/syncable.ts
+++ b/packages/@orbit/data/src/source-interfaces/syncable.ts
@@ -1,4 +1,3 @@
-import { isArray } from '@orbit/utils';
 import Orbit, { fulfillInSeries, settleInSeries } from '@orbit/core';
 import { Source, SourceClass } from '../source';
 import { Transform } from '../transform';
@@ -56,7 +55,7 @@ export default function syncable(Klass: SourceClass): void {
   proto.sync = function(
     transformOrTransforms: Transform | Transform[]
   ): Promise<void> {
-    if (isArray(transformOrTransforms)) {
+    if (Array.isArray(transformOrTransforms)) {
       const transforms = transformOrTransforms as Transform[];
 
       return transforms.reduce((chain, transform) => {

--- a/packages/@orbit/data/src/transform.ts
+++ b/packages/@orbit/data/src/transform.ts
@@ -1,7 +1,7 @@
 /* eslint-disable valid-jsdoc */
 import Orbit from './main';
 import { Operation } from './operation';
-import { isObject, isArray } from '@orbit/utils';
+import { isObject } from '@orbit/utils';
 import TransformBuilder from './transform-builder';
 
 export type TransformBuilderFunc = (
@@ -58,7 +58,7 @@ export function buildTransform(
       operations = transform.operations;
       options = transformOptions || transform.options;
     } else {
-      if (isArray(transformOrOperations)) {
+      if (Array.isArray(transformOrOperations)) {
         operations = transformOrOperations as Operation[];
       } else {
         operations = [transformOrOperations as Operation];

--- a/packages/@orbit/jsonapi/src/jsonapi-serializer.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-serializer.ts
@@ -1,4 +1,4 @@
-import { isArray, dasherize, camelize, deepSet, Dict } from '@orbit/utils';
+import { dasherize, camelize, deepSet, Dict } from '@orbit/utils';
 import Orbit, {
   Schema,
   KeyMap,
@@ -152,7 +152,7 @@ export class JSONAPISerializer
     let data = document.data;
 
     return {
-      data: isArray(data)
+      data: Array.isArray(data)
         ? this.serializeRecords(data as Record[])
         : this.serializeRecord(data as Record)
     };
@@ -409,7 +409,7 @@ export class JSONAPISerializer
 
     let data;
 
-    if (isArray(value)) {
+    if (Array.isArray(value)) {
       data = (value as RecordIdentity[]).map(id => this.resourceIdentity(id));
     } else if (value !== null) {
       data = this.resourceIdentity(value as RecordIdentity);
@@ -432,7 +432,7 @@ export class JSONAPISerializer
     let result: RecordDocument;
     let data;
 
-    if (isArray(document.data)) {
+    if (Array.isArray(document.data)) {
       let primaryRecords = options && options.primaryRecords;
       if (primaryRecords) {
         data = (document.data as Resource[]).map((entry, i) => {
@@ -721,7 +721,7 @@ export class JSONAPISerializer
 
       if (resourceData === null) {
         data = null;
-      } else if (isArray(resourceData)) {
+      } else if (Array.isArray(resourceData)) {
         data = (resourceData as ResourceIdentity[]).map(resourceIdentity =>
           this.recordIdentity(resourceIdentity)
         );

--- a/packages/@orbit/jsonapi/src/lib/request-settings.ts
+++ b/packages/@orbit/jsonapi/src/lib/request-settings.ts
@@ -1,4 +1,4 @@
-import { clone, deepMerge, deepSet, merge, isArray } from '@orbit/utils';
+import { clone, deepMerge, deepSet, merge } from '@orbit/utils';
 import { FetchSettings } from '../jsonapi-request-processor';
 import Orbit from '@orbit/data';
 
@@ -29,7 +29,7 @@ export function buildFetchSettings(
   ['filter', 'include', 'page', 'sort'].forEach(param => {
     let value = (options as any)[param];
     if (value) {
-      if (param === 'include' && isArray(value)) {
+      if (param === 'include' && Array.isArray(value)) {
         value = value.join(',');
       }
 

--- a/packages/@orbit/record-cache/src/async-record-cache.ts
+++ b/packages/@orbit/record-cache/src/async-record-cache.ts
@@ -1,5 +1,5 @@
 import Orbit, { evented, Evented, Listener } from '@orbit/core';
-import { isArray, deepGet, Dict } from '@orbit/utils';
+import { deepGet, Dict } from '@orbit/utils';
 import {
   KeyMap,
   Record,
@@ -222,7 +222,7 @@ export abstract class AsyncRecordCache implements Evented, AsyncRecordAccessor {
       data: []
     };
 
-    if (isArray(operationOrOperations)) {
+    if (Array.isArray(operationOrOperations)) {
       await this._applyPatchOperations(
         operationOrOperations as RecordOperation[],
         result,

--- a/packages/@orbit/record-cache/src/operators/async-inverse-patch-operators.ts
+++ b/packages/@orbit/record-cache/src/operators/async-inverse-patch-operators.ts
@@ -1,4 +1,4 @@
-import { Dict, deepGet, deepSet, eq, isArray } from '@orbit/utils';
+import { Dict, deepGet, deepSet, eq } from '@orbit/utils';
 import {
   Record,
   RecordOperation,
@@ -90,7 +90,7 @@ export const AsyncInversePatchOperators: Dict<AsyncInversePatchOperator> = {
             ]);
             let relationshipChanged;
 
-            if (isArray(data)) {
+            if (Array.isArray(data)) {
               if (currentData) {
                 relationshipChanged = !equalRecordIdentitySets(
                   currentData,

--- a/packages/@orbit/record-cache/src/operators/sync-inverse-patch-operators.ts
+++ b/packages/@orbit/record-cache/src/operators/sync-inverse-patch-operators.ts
@@ -1,4 +1,4 @@
-import { Dict, deepGet, deepSet, eq, isArray } from '@orbit/utils';
+import { Dict, deepGet, deepSet, eq } from '@orbit/utils';
 import {
   Record,
   RecordOperation,
@@ -87,7 +87,7 @@ export const SyncInversePatchOperators: Dict<SyncInversePatchOperator> = {
             ]);
             let relationshipChanged;
 
-            if (isArray(data)) {
+            if (Array.isArray(data)) {
               if (currentData) {
                 relationshipChanged = !equalRecordIdentitySets(
                   currentData,

--- a/packages/@orbit/record-cache/src/sync-record-cache.ts
+++ b/packages/@orbit/record-cache/src/sync-record-cache.ts
@@ -1,5 +1,5 @@
 import Orbit, { evented, Evented, Listener } from '@orbit/core';
-import { isArray, deepGet, Dict } from '@orbit/utils';
+import { deepGet, Dict } from '@orbit/utils';
 import {
   KeyMap,
   Record,
@@ -218,7 +218,7 @@ export abstract class SyncRecordCache implements Evented, SyncRecordAccessor {
       data: []
     };
 
-    if (isArray(operationOrOperations)) {
+    if (Array.isArray(operationOrOperations)) {
       this._applyPatchOperations(
         operationOrOperations as RecordOperation[],
         result,

--- a/packages/@orbit/utils/src/objects.ts
+++ b/packages/@orbit/utils/src/objects.ts
@@ -102,7 +102,10 @@ export function extend(destination: any, ...sources: any[]): any {
  * @returns {boolean}
  */
 export function isArray(obj: any): boolean {
-  return Object.prototype.toString.call(obj) === '[object Array]';
+  console.warn(
+    '`isArray` from `@orbit/utils` is deprecated and will be removed in the next release. Please use `Array.isArray`.'
+  );
+  return Array.isArray(obj);
 }
 
 /**
@@ -116,7 +119,7 @@ export function toArray(obj: any): any[] {
   if (isNone(obj)) {
     return [];
   } else {
-    return isArray(obj) ? obj : [obj];
+    return Array.isArray(obj) ? obj : [obj];
   }
 }
 
@@ -184,7 +187,12 @@ export function deepMerge(object: any, ...sources: any[]): any {
       if (source.hasOwnProperty(field)) {
         let a = object[field];
         let b = source[field];
-        if (isObject(a) && isObject(b) && !isArray(a) && !isArray(b)) {
+        if (
+          isObject(a) &&
+          isObject(b) &&
+          !Array.isArray(a) &&
+          !Array.isArray(b)
+        ) {
           deepMerge(a, b);
         } else if (b !== undefined) {
           object[field] = clone(b);


### PR DESCRIPTION
`Array.isArray` is a type guard in TS as opposed to the custom one. I think it is a good enough reason to switch.