### PR TITLE
Remove queues processing from deactivate

### DIFF
--- a/packages/@orbit/data/src/source.ts
+++ b/packages/@orbit/data/src/source.ts
@@ -179,8 +179,6 @@ export abstract class Source implements Evented, Performer {
   async deactivate(): Promise<void> {
     if (this._activated) {
       await this._activated;
-      await this.requestQueue.process();
-      await this.syncQueue.process();
     }
 
     this._activated = undefined;


### PR DESCRIPTION
It have been a mistake to include queue processing in deactivate. The queues might be configured with autoProcess: false or they may be paused with an error.