### PR TITLE
[@orbit/memory] Support hints for `update`

### DIFF
--- a/packages/@orbit/memory/src/memory-source.ts
+++ b/packages/@orbit/memory/src/memory-source.ts
@@ -82,7 +82,9 @@ export default class MemorySource extends Source
     this.transformLog.on('truncate', this._logTruncated.bind(this));
     this.transformLog.on('rollback', this._logRolledback.bind(this));
 
-    let cacheSettings: MemoryCacheSettings = settings.cacheSettings || {};
+    let cacheSettings: MemoryCacheSettings = settings.cacheSettings || {
+      schema
+    };
     cacheSettings.schema = schema;
     cacheSettings.keyMap = keyMap;
     cacheSettings.queryBuilder =
@@ -160,8 +162,10 @@ export default class MemorySource extends Source
    * @returns The forked source.
    */
   fork(settings: MemorySourceSettings = {}): MemorySource {
-    settings.schema = this._schema;
-    settings.cacheSettings = settings.cacheSettings || {};
+    const schema = this._schema;
+
+    settings.schema = schema;
+    settings.cacheSettings = settings.cacheSettings || { schema };
     settings.keyMap = this._keyMap;
     settings.queryBuilder = this.queryBuilder;
     settings.transformBuilder = this.transformBuilder;

--- a/packages/@orbit/memory/src/memory-source.ts
+++ b/packages/@orbit/memory/src/memory-source.ts
@@ -15,7 +15,8 @@ import Orbit, {
   Transform,
   TransformOrOperations,
   coalesceRecordOperations,
-  buildTransform
+  buildTransform,
+  RecordIdentity
 } from '@orbit/data';
 import { Dict } from '@orbit/utils';
 import MemoryCache, { MemoryCacheSettings } from './memory-cache';
@@ -128,9 +129,14 @@ export default class MemorySource extends Source
   // Updatable interface implementation
   /////////////////////////////////////////////////////////////////////////////
 
-  async _update(transform: Transform): Promise<any> {
+  async _update(transform: Transform, hints?: any): Promise<any> {
     let results = this._applyTransform(transform);
-    return results.length === 1 ? results[0] : results;
+
+    if (hints && hints.data) {
+      return this._retrieveFromCache(hints.data);
+    } else {
+      return results.length === 1 ? results[0] : results;
+    }
   }
 
   /////////////////////////////////////////////////////////////////////////////
@@ -139,13 +145,10 @@ export default class MemorySource extends Source
 
   async _query(query: Query, hints?: any): Promise<any> {
     if (hints && hints.data) {
-      if (Array.isArray(hints.data)) {
-        return this._cache.query(q => q.findRecords(hints.data));
-      } else if (hints.data) {
-        return this._cache.query(q => q.findRecord(hints.data));
-      }
+      return this._retrieveFromCache(hints.data);
+    } else {
+      return this._cache.query(query);
     }
-    return this._cache.query(query);
   }
 
   /////////////////////////////////////////////////////////////////////////////
@@ -292,6 +295,14 @@ export default class MemorySource extends Source
   /////////////////////////////////////////////////////////////////////////////
   // Protected methods
   /////////////////////////////////////////////////////////////////////////////
+
+  protected _retrieveFromCache(idOrIds: RecordIdentity | RecordIdentity[]) {
+    if (Array.isArray(idOrIds)) {
+      return this._cache.getRecordsSync(idOrIds);
+    } else {
+      return this._cache.getRecordSync(idOrIds);
+    }
+  }
 
   protected _applyTransform(transform: Transform): PatchResultData[] {
     const result = this.cache.patch(transform.operations as RecordOperation[]);

--- a/packages/@orbit/memory/test/memory-source-test.ts
+++ b/packages/@orbit/memory/test/memory-source-test.ts
@@ -71,6 +71,7 @@ module('MemorySource', function(hooks) {
       schema,
       keyMap,
       cacheSettings: {
+        schema,
         processors: [
           SyncCacheIntegrityProcessor,
           SyncSchemaConsistencyProcessor

--- a/packages/@orbit/memory/test/memory-source-test.ts
+++ b/packages/@orbit/memory/test/memory-source-test.ts
@@ -7,7 +7,8 @@ import {
   SchemaSettings,
   Source,
   buildTransform,
-  RecordOperation
+  RecordOperation,
+  Transform
 } from '@orbit/data';
 import { clone } from '@orbit/utils';
 import {
@@ -162,6 +163,92 @@ module('MemorySource', function(hooks) {
       records,
       [jupiter, earth],
       'results array should be returned'
+    );
+  });
+
+  test('#update - accepts hints that can return a single record', async function(assert) {
+    assert.expect(2);
+
+    let jupiter = {
+      id: 'jupiter',
+      type: 'planet',
+      attributes: { name: 'Jupiter' }
+    };
+
+    let earth = {
+      id: 'earth',
+      type: 'planet',
+      attributes: { name: 'Earth' }
+    };
+
+    source.cache.patch(t => t.addRecord(earth));
+
+    source.on('beforeUpdate', (transform: Transform, hints: any) => {
+      if (transform.options.customizeResults) {
+        hints.data = earth;
+      }
+    });
+
+    let planet = await source.update(t => t.addRecord(jupiter), {
+      customizeResults: true
+    });
+
+    assert.equal(
+      source.cache.getRecordsSync('planet').length,
+      2,
+      'cache should contain two planets'
+    );
+
+    assert.deepEqual(planet, earth, 'added planet matches hinted record');
+  });
+
+  test('#update - accepts hints that can return a collection of records', async function(assert) {
+    assert.expect(2);
+
+    let jupiter = {
+      id: 'jupiter',
+      type: 'planet',
+      attributes: { name: 'Jupiter' }
+    };
+
+    let earth = {
+      id: 'earth',
+      type: 'planet',
+      attributes: { name: 'Earth' }
+    };
+
+    let uranus = {
+      id: 'uranus',
+      type: 'planet',
+      attributes: { name: 'Uranus' }
+    };
+
+    source.on('beforeUpdate', (transform: Transform, hints: any) => {
+      if (transform.options.customizeResults) {
+        hints.data = [
+          { type: 'planet', id: 'uranus' },
+          { type: 'planet', id: 'jupiter' }
+        ];
+      }
+    });
+
+    let planets = await source.update(
+      t => [t.addRecord(jupiter), t.addRecord(earth), t.addRecord(uranus)],
+      {
+        customizeResults: true
+      }
+    );
+
+    assert.equal(
+      source.cache.getRecordsSync('planet').length,
+      3,
+      'cache should contain three planets'
+    );
+
+    assert.deepEqual(
+      planets,
+      [uranus, jupiter],
+      'planets match hinted records'
     );
   });
 


### PR DESCRIPTION
Hints can be applied by a `beforeUpdate` listener to inform the results returned from calling `update` on a `MemorySource`.

The implementation aligns with the application of hints to `query`.