### PR TITLE
Standardize update responses

### DIFF
--- a/packages/@orbit/data/src/source-interfaces/pullable.ts
+++ b/packages/@orbit/data/src/source-interfaces/pullable.ts
@@ -88,7 +88,6 @@ export default function pullable(Klass: SourceClass): void {
 
       await fulfillInSeries(this, 'beforePull', query, hints);
       let result = await this._pull(query, hints);
-      await this._transformed(result);
       await settleInSeries(this, 'pull', query, result);
       return result;
     } catch (error) {

--- a/packages/@orbit/data/src/source-interfaces/pushable.ts
+++ b/packages/@orbit/data/src/source-interfaces/pushable.ts
@@ -89,7 +89,7 @@ export default function pushable(Klass: SourceClass): void {
     );
 
     if (this.transformLog.contains(transform.id)) {
-      return Promise.resolve([]);
+      return [];
     }
 
     return this._enqueueRequest('push', transform);
@@ -102,16 +102,10 @@ export default function pushable(Klass: SourceClass): void {
 
     try {
       const hints: any = {};
-
       await fulfillInSeries(this, 'beforePush', transform, hints);
-      if (this.transformLog.contains(transform.id)) {
-        return [];
-      } else {
-        let result = await this._push(transform, hints);
-        await this._transformed(result);
-        await settleInSeries(this, 'push', transform, result);
-        return result;
-      }
+      let result = await this._push(transform, hints);
+      await settleInSeries(this, 'push', transform, result);
+      return result;
     } catch (error) {
       await settleInSeries(this, 'pushFail', transform, error);
       throw error;

--- a/packages/@orbit/data/src/source-interfaces/syncable.ts
+++ b/packages/@orbit/data/src/source-interfaces/syncable.ts
@@ -80,13 +80,8 @@ export default function syncable(Klass: SourceClass): void {
 
     try {
       await fulfillInSeries(this, 'beforeSync', transform);
-      if (this.transformLog.contains(transform.id)) {
-        return;
-      } else {
-        await this._sync(transform);
-        await this._transformed([transform]);
-        await settleInSeries(this, 'sync', transform);
-      }
+      await this._sync(transform);
+      await settleInSeries(this, 'sync', transform);
     } catch (error) {
       await settleInSeries(this, 'syncFail', transform, error);
       throw error;

--- a/packages/@orbit/data/src/source-interfaces/updatable.ts
+++ b/packages/@orbit/data/src/source-interfaces/updatable.ts
@@ -97,14 +97,9 @@ export default function updatable(Klass: SourceClass): void {
     try {
       const hints: any = {};
       await fulfillInSeries(this, 'beforeUpdate', transform, hints);
-      if (this.transformLog.contains(transform.id)) {
-        return;
-      } else {
-        let result = await this._update(transform, hints);
-        await this._transformed([transform]);
-        await settleInSeries(this, 'update', transform, result);
-        return result;
-      }
+      let result = await this._update(transform, hints);
+      await settleInSeries(this, 'update', transform, result);
+      return result;
     } catch (error) {
       await settleInSeries(this, 'updateFail', transform, error);
       throw error;

--- a/packages/@orbit/data/test/source-interfaces/pullable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/pullable-test.ts
@@ -73,10 +73,11 @@ module('@pullable', function(hooks) {
       buildTransform({ op: 'replaceRecordAttribute' })
     ];
 
-    source._pull = function(query) {
+    source._pull = async function(query) {
       assert.equal(++order, 1, 'action performed after willPull');
       assert.strictEqual(query.expression, qe, 'query object matches');
-      return Promise.resolve(resultingTransforms);
+      await this._transformed(resultingTransforms);
+      return resultingTransforms;
     };
 
     let transformCount = 0;
@@ -134,6 +135,7 @@ module('@pullable', function(hooks) {
     source._pull = async function(query) {
       assert.equal(++order, 4, 'action performed after willPull');
       assert.strictEqual(query.expression, qe, 'query object matches');
+      await this._transformed(resultingTransforms);
       return resultingTransforms;
     };
 
@@ -268,6 +270,7 @@ module('@pullable', function(hooks) {
       assert.equal(++order, 4, 'action performed after willPull');
       assert.strictEqual(query.expression, qe, 'query object matches');
       assert.strictEqual(hints, h, '_pull is passed same hints instance');
+      await this._transformed(resultingTransforms);
       return hints.data;
     };
 

--- a/packages/@orbit/data/test/source-interfaces/syncable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/syncable-test.ts
@@ -100,14 +100,14 @@ module('@syncable', function(hooks) {
       assert.strictEqual(transform, addRecordTransform, 'transform matches');
     });
 
-    source._sync = function(transform) {
+    source._sync = async function(transform) {
       assert.equal(++order, 2, 'action performed after beforeSync');
       assert.strictEqual(
         transform,
         addRecordTransform,
         'transform object matches'
       );
-      return Promise.resolve();
+      await this._transformed([transform]);
     };
 
     source.on('transform', transform => {
@@ -173,8 +173,8 @@ module('@syncable', function(hooks) {
     }
   });
 
-  test('#sync should not call `_sync` if the transform has been applied as a result of `beforeSync` resolution', async function(assert) {
-    assert.expect(2);
+  test('#sync should still call `_sync` if the transform has been applied as a result of `beforeSync` resolution', async function(assert) {
+    assert.expect(5);
 
     let order = 0;
 
@@ -194,11 +194,15 @@ module('@syncable', function(hooks) {
     });
 
     source._sync = async function(transform: Transform) {
-      assert.ok(false, '_sync should not be reached');
+      assert.ok(true, '_sync should still be reached');
+      assert.ok(
+        this.transformLog.contains(transform.id),
+        'transform is already contained in the log'
+      );
     };
 
     source.on('sync', () => {
-      assert.ok(false, 'sync should not be reached');
+      assert.ok(true, 'sync should still be reached');
     });
 
     await source.sync(addRecordTransform);

--- a/packages/@orbit/indexeddb/src/source.ts
+++ b/packages/@orbit/indexeddb/src/source.ts
@@ -104,7 +104,10 @@ export default class IndexedDBSource extends Source
   /////////////////////////////////////////////////////////////////////////////
 
   async _sync(transform: Transform): Promise<void> {
-    await this._cache.patch(transform.operations as RecordOperation[]);
+    if (!this.transformLog.contains(transform.id)) {
+      await this._cache.patch(transform.operations as RecordOperation[]);
+      await this._transformed([transform]);
+    }
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/packages/@orbit/indexeddb/src/source.ts
+++ b/packages/@orbit/indexeddb/src/source.ts
@@ -115,8 +115,17 @@ export default class IndexedDBSource extends Source
   /////////////////////////////////////////////////////////////////////////////
 
   async _push(transform: Transform): Promise<Transform[]> {
-    await this._cache.patch(transform.operations as RecordOperation[]);
-    return [transform];
+    let results: Transform[];
+
+    if (!this.transformLog.contains(transform.id)) {
+      await this._cache.patch(transform.operations as RecordOperation[]);
+      results = [transform];
+      await this._transformed(results);
+    } else {
+      results = [];
+    }
+
+    return results;
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/packages/@orbit/indexeddb/src/source.ts
+++ b/packages/@orbit/indexeddb/src/source.ts
@@ -147,6 +147,10 @@ export default class IndexedDBSource extends Source
       operations = [];
     }
 
-    return [buildTransform(operations)];
+    const transforms = [buildTransform(operations)];
+
+    await this._transformed(transforms);
+
+    return transforms;
   }
 }

--- a/packages/@orbit/indexeddb/test/source-test.ts
+++ b/packages/@orbit/indexeddb/test/source-test.ts
@@ -1,5 +1,11 @@
 import { getRecordFromIndexedDB } from './support/indexeddb';
-import { Record, Schema, KeyMap, AddRecordOperation } from '@orbit/data';
+import {
+  buildTransform,
+  Record,
+  Schema,
+  KeyMap,
+  AddRecordOperation
+} from '@orbit/data';
 import IndexedDBSource from '../src/source';
 
 const { module, test, skip } = QUnit;
@@ -157,6 +163,42 @@ module('IndexedDBSource', function(hooks) {
       await getRecordFromIndexedDB(source.cache, planet),
       planet,
       'indexeddb still contains record'
+    );
+  });
+
+  test('#sync - addRecord', async function(assert) {
+    assert.expect(3);
+
+    let planet: Record = {
+      type: 'planet',
+      id: 'jupiter',
+      keys: {
+        remoteId: 'j'
+      },
+      attributes: {
+        name: 'Jupiter',
+        classification: 'gas giant'
+      }
+    };
+
+    const t = buildTransform({
+      op: 'addRecord',
+      record: planet
+    } as AddRecordOperation);
+    await source.sync(t);
+
+    assert.ok(source.transformLog.contains(t.id), 'log contains transform');
+
+    assert.deepEqual(
+      await getRecordFromIndexedDB(source.cache, planet),
+      planet,
+      'indexeddb contains record'
+    );
+
+    assert.equal(
+      keyMap.keyToId('planet', 'remoteId', 'j'),
+      'jupiter',
+      'key has been mapped'
     );
   });
 

--- a/packages/@orbit/indexeddb/test/source-test.ts
+++ b/packages/@orbit/indexeddb/test/source-test.ts
@@ -1034,7 +1034,7 @@ module('IndexedDBSource', function(hooks) {
   });
 
   test('#pull - records of one type', async function(assert) {
-    assert.expect(3);
+    assert.expect(4);
 
     let earth: Record = {
       type: 'planet',
@@ -1071,6 +1071,10 @@ module('IndexedDBSource', function(hooks) {
     let transforms = await source.pull(q => q.findRecords('planet'));
 
     assert.equal(transforms.length, 1, 'one transform returned');
+    assert.ok(
+      source.transformLog.contains(transforms[0].id),
+      'log contains transform'
+    );
     assert.deepEqual(
       transforms[0].operations.map(o => o.op),
       ['updateRecord', 'updateRecord'],
@@ -1084,7 +1088,7 @@ module('IndexedDBSource', function(hooks) {
   });
 
   test('#pull - specific records', async function(assert) {
-    assert.expect(3);
+    assert.expect(4);
 
     let earth: Record = {
       type: 'planet',
@@ -1123,6 +1127,10 @@ module('IndexedDBSource', function(hooks) {
     );
 
     assert.equal(transforms.length, 1, 'one transform returned');
+    assert.ok(
+      source.transformLog.contains(transforms[0].id),
+      'log contains transform'
+    );
     assert.deepEqual(
       transforms[0].operations.map(o => o.op),
       ['updateRecord', 'updateRecord'],
@@ -1136,7 +1144,7 @@ module('IndexedDBSource', function(hooks) {
   });
 
   test('#pull - a specific record', async function(assert) {
-    assert.expect(3);
+    assert.expect(4);
 
     let earth: Record = {
       type: 'planet',
@@ -1179,12 +1187,15 @@ module('IndexedDBSource', function(hooks) {
     let transforms = await source.pull(q => q.findRecord(jupiter));
 
     assert.equal(transforms.length, 1, 'one transform returned');
+    assert.ok(
+      source.transformLog.contains(transforms[0].id),
+      'log contains transform'
+    );
     assert.deepEqual(
       transforms[0].operations.map(o => o.op),
       ['updateRecord'],
       'operations match expectations'
     );
-
     assert.equal(
       keyMap.keyToId('planet', 'remoteId', 'p2'),
       'jupiter',

--- a/packages/@orbit/jsonapi/src/jsonapi-source.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-source.ts
@@ -225,7 +225,7 @@ export default class JSONAPISource extends Source
       transforms.unshift(transform);
       await this._transformed(transforms);
 
-      return records.length === 1 ? records[0] : records;
+      return transform.operations.length === 1 ? records[0] : records;
     }
   }
 

--- a/packages/@orbit/jsonapi/src/jsonapi-source.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-source.ts
@@ -149,23 +149,28 @@ export default class JSONAPISource extends Source
   /////////////////////////////////////////////////////////////////////////////
 
   async _push(transform: Transform): Promise<Transform[]> {
-    const { requestProcessor } = this;
-    const requests = this.getTransformRequests(transform);
     const transforms: Transform[] = [];
 
-    for (let request of requests) {
-      let processor = this.getTransformRequestProcessor(request);
+    if (!this.transformLog.contains(transform.id)) {
+      const { requestProcessor } = this;
+      const requests = this.getTransformRequests(transform);
 
-      let { transforms: additionalTransforms } = await processor(
-        requestProcessor,
-        request
-      );
-      if (additionalTransforms.length) {
-        Array.prototype.push.apply(transforms, additionalTransforms);
+      for (let request of requests) {
+        let processor = this.getTransformRequestProcessor(request);
+
+        let { transforms: additionalTransforms } = await processor(
+          requestProcessor,
+          request
+        );
+        if (additionalTransforms.length) {
+          Array.prototype.push.apply(transforms, additionalTransforms);
+        }
       }
+
+      transforms.unshift(transform);
+      await this._transformed(transforms);
     }
 
-    transforms.unshift(transform);
     return transforms;
   }
 

--- a/packages/@orbit/jsonapi/src/jsonapi-source.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-source.ts
@@ -177,6 +177,7 @@ export default class JSONAPISource extends Source
     const { requestProcessor } = this;
     const operator: QueryOperator = this.getQueryOperator(query);
     const response = await operator(requestProcessor, query);
+    await this._transformed(response.transforms);
     return response.transforms;
   }
 

--- a/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
@@ -1941,7 +1941,7 @@ module('JSONAPISource', function() {
     });
 
     test('#pull - record', async function(assert) {
-      assert.expect(5);
+      assert.expect(6);
 
       const data: Resource = {
         type: 'planets',
@@ -1963,6 +1963,10 @@ module('JSONAPISource', function() {
       );
 
       assert.equal(transforms.length, 1, 'one transform returned');
+      assert.ok(
+        source.transformLog.contains(transforms[0].id),
+        'log contains transform'
+      );
       assert.deepEqual(transforms[0].operations.map(o => o.op), [
         'updateRecord'
       ]);
@@ -2113,7 +2117,7 @@ module('JSONAPISource', function() {
     });
 
     test('#pull - records', async function(assert) {
-      assert.expect(5);
+      assert.expect(6);
 
       const data: Resource[] = [
         {
@@ -2135,6 +2139,10 @@ module('JSONAPISource', function() {
       let transforms = await source.pull(q => q.findRecords('planet'));
 
       assert.equal(transforms.length, 1, 'one transform returned');
+      assert.ok(
+        source.transformLog.contains(transforms[0].id),
+        'log contains transform'
+      );
       assert.deepEqual(transforms[0].operations.map(o => o.op), [
         'updateRecord',
         'updateRecord',
@@ -2197,7 +2205,7 @@ module('JSONAPISource', function() {
     });
 
     test('#pull - records with attribute filters', async function(assert) {
-      assert.expect(5);
+      assert.expect(6);
 
       const data: Resource[] = [
         {
@@ -2227,6 +2235,10 @@ module('JSONAPISource', function() {
       );
 
       assert.equal(transforms.length, 1, 'one transform returned');
+      assert.ok(
+        source.transformLog.contains(transforms[0].id),
+        'log contains transform'
+      );
       assert.deepEqual(transforms[0].operations.map(o => o.op), [
         'updateRecord'
       ]);
@@ -2246,7 +2258,7 @@ module('JSONAPISource', function() {
     });
 
     test('#pull - records with relatedRecord filter (single value)', async function(assert) {
-      assert.expect(5);
+      assert.expect(6);
 
       const data: Resource[] = [
         {
@@ -2271,6 +2283,10 @@ module('JSONAPISource', function() {
       );
 
       assert.equal(transforms.length, 1, 'one transform returned');
+      assert.ok(
+        source.transformLog.contains(transforms[0].id),
+        'log contains transform'
+      );
       assert.deepEqual(transforms[0].operations.map(o => o.op), [
         'updateRecord'
       ]);
@@ -2290,7 +2306,7 @@ module('JSONAPISource', function() {
     });
 
     test('#pull - records with relatedRecord filter (multiple values)', async function(assert) {
-      assert.expect(5);
+      assert.expect(6);
 
       const data: Resource[] = [
         {
@@ -2338,6 +2354,10 @@ module('JSONAPISource', function() {
       );
 
       assert.equal(transforms.length, 1, 'one transform returned');
+      assert.ok(
+        source.transformLog.contains(transforms[0].id),
+        'log contains transform'
+      );
       assert.deepEqual(transforms[0].operations.map(o => o.op), [
         'updateRecord',
         'updateRecord',
@@ -2359,7 +2379,7 @@ module('JSONAPISource', function() {
     });
 
     test('#pull - records with relatedRecords filter', async function(assert) {
-      assert.expect(5);
+      assert.expect(6);
 
       const data: Resource[] = [
         {
@@ -2397,6 +2417,10 @@ module('JSONAPISource', function() {
       );
 
       assert.equal(transforms.length, 1, 'one transform returned');
+      assert.ok(
+        source.transformLog.contains(transforms[0].id),
+        'log contains transform'
+      );
       assert.deepEqual(transforms[0].operations.map(o => o.op), [
         'updateRecord'
       ]);
@@ -2416,7 +2440,7 @@ module('JSONAPISource', function() {
     });
 
     test('#pull - records with sort by an attribute in ascending order', async function(assert) {
-      assert.expect(5);
+      assert.expect(6);
 
       const data: Resource[] = [
         {
@@ -2442,6 +2466,10 @@ module('JSONAPISource', function() {
       );
 
       assert.equal(transforms.length, 1, 'one transform returned');
+      assert.ok(
+        source.transformLog.contains(transforms[0].id),
+        'log contains transform'
+      );
       assert.deepEqual(transforms[0].operations.map(o => o.op), [
         'updateRecord',
         'updateRecord',
@@ -2463,7 +2491,7 @@ module('JSONAPISource', function() {
     });
 
     test('#pull - records with sort by an attribute in descending order', async function(assert) {
-      assert.expect(5);
+      assert.expect(6);
 
       const data: Resource[] = [
         {
@@ -2489,6 +2517,10 @@ module('JSONAPISource', function() {
       );
 
       assert.equal(transforms.length, 1, 'one transform returned');
+      assert.ok(
+        source.transformLog.contains(transforms[0].id),
+        'log contains transform'
+      );
       assert.deepEqual(transforms[0].operations.map(o => o.op), [
         'updateRecord',
         'updateRecord',
@@ -2510,7 +2542,7 @@ module('JSONAPISource', function() {
     });
 
     test('#pull - records with sort by multiple fields', async function(assert) {
-      assert.expect(5);
+      assert.expect(6);
 
       const data: Resource[] = [
         {
@@ -2548,6 +2580,10 @@ module('JSONAPISource', function() {
       );
 
       assert.equal(transforms.length, 1, 'one transform returned');
+      assert.ok(
+        source.transformLog.contains(transforms[0].id),
+        'log contains transform'
+      );
       assert.deepEqual(transforms[0].operations.map(o => o.op), [
         'updateRecord',
         'updateRecord',
@@ -2569,7 +2605,7 @@ module('JSONAPISource', function() {
     });
 
     test('#pull - records with pagination', async function(assert) {
-      assert.expect(5);
+      assert.expect(6);
 
       const data: Resource[] = [
         {
@@ -2599,6 +2635,10 @@ module('JSONAPISource', function() {
       );
 
       assert.equal(transforms.length, 1, 'one transform returned');
+      assert.ok(
+        source.transformLog.contains(transforms[0].id),
+        'log contains transform'
+      );
       assert.deepEqual(transforms[0].operations.map(o => o.op), [
         'updateRecord',
         'updateRecord',
@@ -2620,7 +2660,7 @@ module('JSONAPISource', function() {
     });
 
     test('#pull - related records with attribute filter', async function(assert) {
-      assert.expect(5);
+      assert.expect(6);
 
       const solarSystem = source.requestProcessor.serializer.deserializeResource(
         {
@@ -2663,6 +2703,10 @@ module('JSONAPISource', function() {
       );
 
       assert.equal(transforms.length, 1, 'one transform returned');
+      assert.ok(
+        source.transformLog.contains(transforms[0].id),
+        'log contains transform'
+      );
       assert.deepEqual(transforms[0].operations.map(o => o.op), [
         'updateRecord',
         'addToRelatedRecords'
@@ -2681,7 +2725,7 @@ module('JSONAPISource', function() {
     });
 
     test('#pull - related records with attribute filters', async function(assert) {
-      assert.expect(5);
+      assert.expect(6);
 
       const solarSystem = source.requestProcessor.serializer.deserializeResource(
         {
@@ -2718,6 +2762,10 @@ module('JSONAPISource', function() {
       );
 
       assert.equal(transforms.length, 1, 'one transform returned');
+      assert.ok(
+        source.transformLog.contains(transforms[0].id),
+        'log contains transform'
+      );
       assert.deepEqual(transforms[0].operations.map(o => o.op), [
         'updateRecord',
         'addToRelatedRecords'
@@ -2736,7 +2784,7 @@ module('JSONAPISource', function() {
     });
 
     test('#pull - records with relatedRecord filter (single value)', async function(assert) {
-      assert.expect(5);
+      assert.expect(6);
 
       const solarSystem = source.requestProcessor.serializer.deserializeResource(
         {
@@ -2772,6 +2820,10 @@ module('JSONAPISource', function() {
       );
 
       assert.equal(transforms.length, 1, 'one transform returned');
+      assert.ok(
+        source.transformLog.contains(transforms[0].id),
+        'log contains transform'
+      );
       assert.deepEqual(transforms[0].operations.map(o => o.op), [
         'updateRecord',
         'addToRelatedRecords'
@@ -2790,7 +2842,7 @@ module('JSONAPISource', function() {
     });
 
     test('#pull - records with relatedRecord filter (multiple values)', async function(assert) {
-      assert.expect(5);
+      assert.expect(6);
 
       const solarSystem = source.requestProcessor.serializer.deserializeResource(
         {
@@ -2845,6 +2897,10 @@ module('JSONAPISource', function() {
       );
 
       assert.equal(transforms.length, 1, 'one transform returned');
+      assert.ok(
+        source.transformLog.contains(transforms[0].id),
+        'log contains transform'
+      );
       assert.deepEqual(transforms[0].operations.map(o => o.op), [
         'updateRecord',
         'updateRecord',
@@ -2873,7 +2929,7 @@ module('JSONAPISource', function() {
     });
 
     test('#pull - records with relatedRecords filter', async function(assert) {
-      assert.expect(5);
+      assert.expect(6);
 
       const solarSystem = source.requestProcessor.serializer.deserializeResource(
         {
@@ -2918,6 +2974,10 @@ module('JSONAPISource', function() {
       );
 
       assert.equal(transforms.length, 1, 'one transform returned');
+      assert.ok(
+        source.transformLog.contains(transforms[0].id),
+        'log contains transform'
+      );
       assert.deepEqual(transforms[0].operations.map(o => o.op), [
         'updateRecord',
         'addToRelatedRecords'
@@ -2936,7 +2996,7 @@ module('JSONAPISource', function() {
     });
 
     test('#pull - records with sort by an attribute in ascending order', async function(assert) {
-      assert.expect(5);
+      assert.expect(6);
 
       const solarSystem = source.requestProcessor.serializer.deserializeResource(
         {
@@ -2969,6 +3029,10 @@ module('JSONAPISource', function() {
       );
 
       assert.equal(transforms.length, 1, 'one transform returned');
+      assert.ok(
+        source.transformLog.contains(transforms[0].id),
+        'log contains transform'
+      );
       assert.deepEqual(transforms[0].operations.map(o => o.op), [
         'updateRecord',
         'updateRecord',
@@ -2997,7 +3061,7 @@ module('JSONAPISource', function() {
     });
 
     test('#pull - records with sort by an attribute in descending order', async function(assert) {
-      assert.expect(5);
+      assert.expect(6);
 
       const solarSystem = source.requestProcessor.serializer.deserializeResource(
         {
@@ -3030,6 +3094,10 @@ module('JSONAPISource', function() {
       );
 
       assert.equal(transforms.length, 1, 'one transform returned');
+      assert.ok(
+        source.transformLog.contains(transforms[0].id),
+        'log contains transform'
+      );
       assert.deepEqual(transforms[0].operations.map(o => o.op), [
         'updateRecord',
         'updateRecord',
@@ -3058,7 +3126,7 @@ module('JSONAPISource', function() {
     });
 
     test('#pull - records with sort by multiple fields', async function(assert) {
-      assert.expect(5);
+      assert.expect(6);
 
       const solarSystem = source.requestProcessor.serializer.deserializeResource(
         {
@@ -3107,6 +3175,10 @@ module('JSONAPISource', function() {
       );
 
       assert.equal(transforms.length, 1, 'one transform returned');
+      assert.ok(
+        source.transformLog.contains(transforms[0].id),
+        'log contains transform'
+      );
       assert.deepEqual(transforms[0].operations.map(o => o.op), [
         'updateRecord',
         'updateRecord',
@@ -3135,7 +3207,7 @@ module('JSONAPISource', function() {
     });
 
     test('#pull - records with pagination', async function(assert) {
-      assert.expect(5);
+      assert.expect(6);
 
       const solarSystem = source.requestProcessor.serializer.deserializeResource(
         {
@@ -3174,6 +3246,10 @@ module('JSONAPISource', function() {
       );
 
       assert.equal(transforms.length, 1, 'one transform returned');
+      assert.ok(
+        source.transformLog.contains(transforms[0].id),
+        'log contains transform'
+      );
       assert.deepEqual(transforms[0].operations.map(o => o.op), [
         'updateRecord',
         'updateRecord',
@@ -3254,7 +3330,7 @@ module('JSONAPISource', function() {
     });
 
     test('#pull - relatedRecord', async function(assert) {
-      assert.expect(12);
+      assert.expect(13);
 
       const planetRecord: Record = source.requestProcessor.serializer.deserialize(
         {
@@ -3282,6 +3358,10 @@ module('JSONAPISource', function() {
       );
 
       assert.equal(transforms.length, 1, 'one transform returned');
+      assert.ok(
+        source.transformLog.contains(transforms[0].id),
+        'log contains transform'
+      );
       const operations = transforms[0].operations as RecordOperation[];
 
       const planetId = keyMap.keyToId('planet', 'remoteId', 'jupiter');
@@ -3313,7 +3393,7 @@ module('JSONAPISource', function() {
     });
 
     test('#pull - relatedRecords', async function(assert) {
-      assert.expect(8);
+      assert.expect(9);
 
       let planetRecord: Record = source.requestProcessor.serializer.deserialize(
         {
@@ -3343,6 +3423,10 @@ module('JSONAPISource', function() {
       );
 
       assert.equal(transforms.length, 1, 'one transform returned');
+      assert.ok(
+        source.transformLog.contains(transforms[0].id),
+        'log contains transform'
+      );
       assert.deepEqual(transforms[0].operations.map(o => o.op), [
         'updateRecord',
         'replaceRelatedRecords'

--- a/packages/@orbit/local-storage/src/source.ts
+++ b/packages/@orbit/local-storage/src/source.ts
@@ -120,8 +120,17 @@ export default class LocalStorageSource extends Source
   /////////////////////////////////////////////////////////////////////////////
 
   async _push(transform: Transform): Promise<Transform[]> {
-    this._cache.patch(transform.operations as RecordOperation[]);
-    return [transform];
+    let results: Transform[];
+
+    if (!this.transformLog.contains(transform.id)) {
+      this._cache.patch(transform.operations as RecordOperation[]);
+      results = [transform];
+      await this._transformed(results);
+    } else {
+      results = [];
+    }
+
+    return results;
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/packages/@orbit/local-storage/src/source.ts
+++ b/packages/@orbit/local-storage/src/source.ts
@@ -109,7 +109,10 @@ export default class LocalStorageSource extends Source
   /////////////////////////////////////////////////////////////////////////////
 
   async _sync(transform: Transform): Promise<void> {
-    this._cache.patch(transform.operations as RecordOperation[]);
+    if (!this.transformLog.contains(transform.id)) {
+      this._cache.patch(transform.operations as RecordOperation[]);
+      await this._transformed([transform]);
+    }
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/packages/@orbit/local-storage/src/source.ts
+++ b/packages/@orbit/local-storage/src/source.ts
@@ -151,6 +151,10 @@ export default class LocalStorageSource extends Source
       operations = [];
     }
 
-    return [buildTransform(operations)];
+    const transforms = [buildTransform(operations)];
+
+    await this._transformed(transforms);
+
+    return transforms;
   }
 }

--- a/packages/@orbit/local-storage/test/source-test.ts
+++ b/packages/@orbit/local-storage/test/source-test.ts
@@ -854,8 +854,8 @@ module('LocalStorageSource', function(hooks) {
     assert.equal(Orbit.globals.localStorage.getItem('orbit-bucket/foo'), '{}');
   });
 
-  test('#pull - all records', function(assert) {
-    assert.expect(5);
+  test('#pull - all records', async function(assert) {
+    assert.expect(6);
 
     let earth = {
       type: 'planet',
@@ -892,49 +892,48 @@ module('LocalStorageSource', function(hooks) {
       }
     };
 
-    return source
-      .reset()
-      .then(() =>
-        source.push(t => [
-          t.addRecord(earth),
-          t.addRecord(jupiter),
-          t.addRecord(io)
-        ])
-      )
-      .then(() => {
-        // reset keyMap to verify that pulling records also adds keys
-        keyMap.reset();
-      })
-      .then(() => source.pull(q => q.findRecords()))
-      .then(transforms => {
-        assert.equal(transforms.length, 1, 'one transform returned');
-        assert.deepEqual(
-          transforms[0].operations.map(o => o.op),
-          ['updateRecord', 'updateRecord', 'updateRecord'],
-          'operations match expectations'
-        );
-      })
-      .then(() => {
-        assert.equal(
-          keyMap.keyToId('planet', 'remoteId', 'p1'),
-          'earth',
-          'key has been mapped'
-        );
-        assert.equal(
-          keyMap.keyToId('planet', 'remoteId', 'p2'),
-          'jupiter',
-          'key has been mapped'
-        );
-        assert.equal(
-          keyMap.keyToId('moon', 'remoteId', 'm1'),
-          'io',
-          'key has been mapped'
-        );
-      });
+    await source.reset();
+
+    await source.push(t => [
+      t.addRecord(earth),
+      t.addRecord(jupiter),
+      t.addRecord(io)
+    ]);
+
+    // reset keyMap to verify that pulling records also adds keys
+    keyMap.reset();
+
+    let transforms = await source.pull(q => q.findRecords());
+
+    assert.equal(transforms.length, 1, 'one transform returned');
+    assert.ok(
+      source.transformLog.contains(transforms[0].id),
+      'log contains transform'
+    );
+    assert.deepEqual(
+      transforms[0].operations.map(o => o.op),
+      ['updateRecord', 'updateRecord', 'updateRecord'],
+      'operations match expectations'
+    );
+    assert.equal(
+      keyMap.keyToId('planet', 'remoteId', 'p1'),
+      'earth',
+      'key has been mapped'
+    );
+    assert.equal(
+      keyMap.keyToId('planet', 'remoteId', 'p2'),
+      'jupiter',
+      'key has been mapped'
+    );
+    assert.equal(
+      keyMap.keyToId('moon', 'remoteId', 'm1'),
+      'io',
+      'key has been mapped'
+    );
   });
 
-  test('#pull - records of one type', function(assert) {
-    assert.expect(2);
+  test('#pull - records of one type', async function(assert) {
+    assert.expect(4);
 
     let earth = {
       type: 'planet',
@@ -962,28 +961,34 @@ module('LocalStorageSource', function(hooks) {
       }
     };
 
-    return source
-      .reset()
-      .then(() =>
-        source.push(t => [
-          t.addRecord(earth),
-          t.addRecord(jupiter),
-          t.addRecord(io)
-        ])
-      )
-      .then(() => source.pull(q => q.findRecords('planet')))
-      .then(transforms => {
-        assert.equal(transforms.length, 1, 'one transform returned');
-        assert.deepEqual(
-          transforms[0].operations.map(o => o.op),
-          ['updateRecord', 'updateRecord'],
-          'operations match expectations'
-        );
-      });
+    await source.reset();
+
+    await source.push(t => [
+      t.addRecord(earth),
+      t.addRecord(jupiter),
+      t.addRecord(io)
+    ]);
+
+    let transforms = await source.pull(q => q.findRecords('planet'));
+
+    assert.equal(transforms.length, 1, 'one transform returned');
+    assert.ok(
+      source.transformLog.contains(transforms[0].id),
+      'log contains transform'
+    );
+    assert.ok(
+      source.transformLog.contains(transforms[0].id),
+      'log contains transform'
+    );
+    assert.deepEqual(
+      transforms[0].operations.map(o => o.op),
+      ['updateRecord', 'updateRecord'],
+      'operations match expectations'
+    );
   });
 
   test('#pull - specific records', async function(assert) {
-    assert.expect(3);
+    assert.expect(4);
 
     let earth: Record = {
       type: 'planet',
@@ -1022,6 +1027,10 @@ module('LocalStorageSource', function(hooks) {
     );
 
     assert.equal(transforms.length, 1, 'one transform returned');
+    assert.ok(
+      source.transformLog.contains(transforms[0].id),
+      'log contains transform'
+    );
     assert.deepEqual(
       transforms[0].operations.map(o => o.op),
       ['updateRecord', 'updateRecord'],
@@ -1034,8 +1043,8 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#pull - a specific record', function(assert) {
-    assert.expect(3);
+  test('#pull - a specific record', async function(assert) {
+    assert.expect(4);
 
     let earth = {
       type: 'planet',
@@ -1066,51 +1075,50 @@ module('LocalStorageSource', function(hooks) {
       }
     };
 
-    return source
-      .reset()
-      .then(() =>
-        source.push(t => [
-          t.addRecord(earth),
-          t.addRecord(jupiter),
-          t.addRecord(io)
-        ])
-      )
-      .then(() => {
-        // reset keyMap to verify that pulling records also adds keys
-        keyMap.reset();
-      })
-      .then(() => source.pull(q => q.findRecord(jupiter)))
-      .then(transforms => {
-        assert.equal(transforms.length, 1, 'one transform returned');
-        assert.deepEqual(
-          transforms[0].operations.map(o => o.op),
-          ['updateRecord'],
-          'operations match expectations'
-        );
-      })
-      .then(() => {
-        assert.equal(
-          keyMap.keyToId('planet', 'remoteId', 'p2'),
-          'jupiter',
-          'key has been mapped'
-        );
-      });
+    await source.reset();
+
+    await source.push(t => [
+      t.addRecord(earth),
+      t.addRecord(jupiter),
+      t.addRecord(io)
+    ]);
+
+    // reset keyMap to verify that pulling records also adds keys
+    keyMap.reset();
+
+    let transforms = await source.pull(q => q.findRecord(jupiter));
+
+    assert.equal(transforms.length, 1, 'one transform returned');
+    assert.ok(
+      source.transformLog.contains(transforms[0].id),
+      'log contains transform'
+    );
+    assert.deepEqual(
+      transforms[0].operations.map(o => o.op),
+      ['updateRecord'],
+      'operations match expectations'
+    );
+    assert.equal(
+      keyMap.keyToId('planet', 'remoteId', 'p2'),
+      'jupiter',
+      'key has been mapped'
+    );
   });
 
-  test('#pull - ignores local-storage-bucket entries', function(assert) {
-    assert.expect(2);
+  test('#pull - ignores local-storage-bucket entries', async function(assert) {
+    assert.expect(3);
 
-    return source
-      .reset()
-      .then(() => Orbit.globals.localStorage.setItem('orbit-bucket/foo', '{}'))
-      .then(() => source.pull(q => q.findRecords()))
-      .then(transforms => {
-        assert.equal(transforms.length, 1, 'one transform returned');
-        assert.equal(
-          transforms[0].operations.length,
-          0,
-          'no operations returned'
-        );
-      });
+    await source.reset();
+
+    await Orbit.globals.localStorage.setItem('orbit-bucket/foo', '{}');
+
+    let transforms = await source.pull(q => q.findRecords());
+
+    assert.equal(transforms.length, 1, 'one transform returned');
+    assert.ok(
+      source.transformLog.contains(transforms[0].id),
+      'log contains transform'
+    );
+    assert.equal(transforms[0].operations.length, 0, 'no operations returned');
   });
 });

--- a/packages/@orbit/local-storage/test/source-test.ts
+++ b/packages/@orbit/local-storage/test/source-test.ts
@@ -3,6 +3,7 @@ import {
   isLocalStorageEmpty
 } from './support/local-storage';
 import {
+  buildTransform,
   AddRecordOperation,
   Record,
   Schema,
@@ -102,6 +103,41 @@ module('LocalStorageSource', function(hooks) {
       getRecordFromLocalStorage(source, planet),
       planet,
       'local storage still contains record'
+    );
+  });
+
+  test('#sync - addRecord', async function(assert) {
+    assert.expect(3);
+
+    let planet = {
+      type: 'planet',
+      id: 'jupiter',
+      keys: {
+        remoteId: 'j'
+      },
+      attributes: {
+        name: 'Jupiter',
+        classification: 'gas giant'
+      }
+    };
+
+    const t = buildTransform({
+      op: 'addRecord',
+      record: planet
+    } as AddRecordOperation);
+    await source.sync(t);
+
+    assert.ok(source.transformLog.contains(t.id), 'log contains transform');
+
+    assert.deepEqual(
+      getRecordFromLocalStorage(source, planet),
+      planet,
+      'local storage contains record'
+    );
+    assert.equal(
+      keyMap.keyToId('planet', 'remoteId', 'j'),
+      'jupiter',
+      'key has been mapped'
     );
   });
 

--- a/packages/@orbit/memory/src/memory-source.ts
+++ b/packages/@orbit/memory/src/memory-source.ts
@@ -122,7 +122,10 @@ export default class MemorySource extends Source
   /////////////////////////////////////////////////////////////////////////////
 
   async _sync(transform: Transform): Promise<void> {
-    this._applyTransform(transform);
+    if (!this.transformLog.contains(transform.id)) {
+      this._applyTransform(transform);
+      await this._transformed([transform]);
+    }
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/packages/@orbit/memory/src/memory-source.ts
+++ b/packages/@orbit/memory/src/memory-source.ts
@@ -133,7 +133,7 @@ export default class MemorySource extends Source
   /////////////////////////////////////////////////////////////////////////////
 
   async _update(transform: Transform, hints?: any): Promise<any> {
-    let results: any[];
+    let results: PatchResultData[];
 
     if (!this.transformLog.contains(transform.id)) {
       results = this._applyTransform(transform);
@@ -141,9 +141,19 @@ export default class MemorySource extends Source
     }
 
     if (hints && hints.data) {
-      return this._retrieveFromCache(hints.data);
-    } else if (results !== undefined) {
-      return results.length === 1 ? results[0] : results;
+      if (transform.operations.length > 1 && Array.isArray(hints.data)) {
+        return hints.data.map((idOrIds: RecordIdentity | RecordIdentity[]) =>
+          this._retrieveFromCache(idOrIds)
+        );
+      } else {
+        return this._retrieveFromCache(hints.data);
+      }
+    } else if (results) {
+      if (transform.operations.length === 1 && Array.isArray(results)) {
+        return results[0];
+      } else {
+        return results;
+      }
     }
   }
 

--- a/packages/@orbit/memory/src/memory-source.ts
+++ b/packages/@orbit/memory/src/memory-source.ts
@@ -130,11 +130,16 @@ export default class MemorySource extends Source
   /////////////////////////////////////////////////////////////////////////////
 
   async _update(transform: Transform, hints?: any): Promise<any> {
-    let results = this._applyTransform(transform);
+    let results: any[];
+
+    if (!this.transformLog.contains(transform.id)) {
+      results = this._applyTransform(transform);
+      await this._transformed([transform]);
+    }
 
     if (hints && hints.data) {
       return this._retrieveFromCache(hints.data);
-    } else {
+    } else if (results !== undefined) {
       return results.length === 1 ? results[0] : results;
     }
   }

--- a/packages/@orbit/memory/test/memory-source-test.ts
+++ b/packages/@orbit/memory/test/memory-source-test.ts
@@ -384,6 +384,25 @@ module('MemorySource', function(hooks) {
     }
   });
 
+  test('#sync - appends transform to log', async function(assert) {
+    const recordA = {
+      id: 'jupiter',
+      type: 'planet',
+      attributes: { name: 'Jupiter' }
+    };
+
+    const addRecordATransform = buildTransform(
+      source.transformBuilder.addRecord(recordA)
+    );
+
+    await source.sync(addRecordATransform);
+
+    assert.ok(
+      source.transformLog.contains(addRecordATransform.id),
+      'log contains transform'
+    );
+  });
+
   test('#getTransform - returns a particular transform given an id', async function(assert) {
     const recordA = {
       id: 'jupiter',

--- a/packages/@orbit/memory/test/memory-source-test.ts
+++ b/packages/@orbit/memory/test/memory-source-test.ts
@@ -252,6 +252,56 @@ module('MemorySource', function(hooks) {
     );
   });
 
+  test('#update - accepts hints that can return an array of varied results', async function(assert) {
+    assert.expect(2);
+
+    let jupiter = {
+      id: 'jupiter',
+      type: 'planet',
+      attributes: { name: 'Jupiter' }
+    };
+
+    let earth = {
+      id: 'earth',
+      type: 'planet',
+      attributes: { name: 'Earth' }
+    };
+
+    let uranus = {
+      id: 'uranus',
+      type: 'planet',
+      attributes: { name: 'Uranus' }
+    };
+
+    source.on('beforeUpdate', (transform: Transform, hints: any) => {
+      if (transform.options.customizeResults) {
+        hints.data = [
+          [{ type: 'planet', id: 'uranus' }, { type: 'planet', id: 'earth' }],
+          { type: 'planet', id: 'jupiter' }
+        ];
+      }
+    });
+
+    let planets = await source.update(
+      t => [t.addRecord(jupiter), t.addRecord(earth), t.addRecord(uranus)],
+      {
+        customizeResults: true
+      }
+    );
+
+    assert.equal(
+      source.cache.getRecordsSync('planet').length,
+      3,
+      'cache should contain three planets'
+    );
+
+    assert.deepEqual(
+      planets,
+      [[uranus, earth], jupiter],
+      'planets match hinted records'
+    );
+  });
+
   test("#query - queries the source's cache", async function(assert) {
     assert.expect(2);
 


### PR DESCRIPTION
This PR is based upon #678, and represents a very minor behavioral tweak to ensure that `Updatable` interfaces and hints will work even with custom-defined operations.

This PR clarifies that a singular result should be returned when `update` is called with a `Transform` that contains only one operation. Otherwise, an array of results should be returned.

For standard operations, this should not be a breaking change. However, if you've been defining your own custom operations that returned arrays together with hints in v0.16 beta, you'll want to test this change thoroughly.
