### PR TITLE
[DEPRECATION] Deprecate `_transformed` in favor of `transformed`

### DIFF
--- a/packages/@orbit/coordinator/test/strategies/log-truncation-strategy-test.ts
+++ b/packages/@orbit/coordinator/test/strategies/log-truncation-strategy-test.ts
@@ -165,9 +165,9 @@ module('LogTruncationStrategy', function(hooks) {
     });
 
     await coordinator.activate();
-    await s1._transformed([tA, tB]);
-    await s2._transformed([tA, tB]);
-    await s3._transformed([tA, tB]);
+    await s1.transformed([tA, tB]);
+    await s2.transformed([tA, tB]);
+    await s3.transformed([tA, tB]);
     await s1.syncQueue.clear();
     await s2.syncQueue.clear();
     await s3.syncQueue.clear();
@@ -187,9 +187,9 @@ module('LogTruncationStrategy', function(hooks) {
     });
 
     await coordinator.activate();
-    await s1._transformed([tA, tB, tC, tD]);
-    await s2._transformed([tA, tB, tC]);
-    await s3._transformed([tA, tB, tC]);
+    await s1.transformed([tA, tB, tC, tD]);
+    await s2.transformed([tA, tB, tC]);
+    await s3.transformed([tA, tB, tC]);
 
     await s1.syncQueue.clear();
     await s2.syncQueue.clear();

--- a/packages/@orbit/coordinator/test/strategies/sync-strategy-test.ts
+++ b/packages/@orbit/coordinator/test/strategies/sync-strategy-test.ts
@@ -126,7 +126,7 @@ module('SyncStrategy', function(hooks) {
     };
 
     await coordinator.activate();
-    await s1._transformed([tA]);
+    await s1.transformed([tA]);
   });
 
   test('can apply a `filter` function', async function(assert) {
@@ -156,7 +156,7 @@ module('SyncStrategy', function(hooks) {
     };
 
     await coordinator.activate();
-    await s1._transformed([tA, tB]);
+    await s1.transformed([tA, tB]);
   });
 
   test('can catch errors with a `catch` function', async function(assert) {
@@ -193,7 +193,7 @@ module('SyncStrategy', function(hooks) {
     };
 
     await coordinator.activate();
-    await s1._transformed([tA]);
+    await s1.transformed([tA]);
 
     assert.ok(true, 'transform event settled');
   });
@@ -233,7 +233,7 @@ module('SyncStrategy', function(hooks) {
     };
 
     await coordinator.activate();
-    await s1._transformed([tA]);
+    await s1.transformed([tA]);
 
     assert.ok(
       true,

--- a/packages/@orbit/data/src/source.ts
+++ b/packages/@orbit/data/src/source.ts
@@ -16,7 +16,7 @@ import QueryBuilder from './query-builder';
 import { Transform } from './transform';
 import TransformBuilder from './transform-builder';
 
-const { assert } = Orbit;
+const { assert, deprecate } = Orbit;
 
 export interface SourceSettings {
   name?: string;
@@ -193,6 +193,16 @@ export abstract class Source implements Evented, Performer {
   /////////////////////////////////////////////////////////////////////////////
 
   /**
+   * @deprecated
+   */
+  protected async _transformed(transforms: Transform[]): Promise<Transform[]> {
+    deprecate(
+      'The `_transformed` method on `Source` is deprecated in favor of `transformed`.'
+    );
+    return this.transformed(transforms);
+  }
+
+  /**
    * Notifies listeners that this source has been transformed by emitting the
    * `transform` event.
    *
@@ -200,7 +210,7 @@ export abstract class Source implements Evented, Performer {
    *
    * Also, adds an entry to the Source's `transformLog` for each transform.
    */
-  protected async _transformed(transforms: Transform[]): Promise<Transform[]> {
+  protected async transformed(transforms: Transform[]): Promise<Transform[]> {
     await this.activated;
     return transforms
       .reduce((chain, transform) => {

--- a/packages/@orbit/data/test/source-interfaces/pullable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/pullable-test.ts
@@ -76,7 +76,7 @@ module('@pullable', function(hooks) {
     source._pull = async function(query) {
       assert.equal(++order, 1, 'action performed after willPull');
       assert.strictEqual(query.expression, qe, 'query object matches');
-      await this._transformed(resultingTransforms);
+      await this.transformed(resultingTransforms);
       return resultingTransforms;
     };
 
@@ -135,7 +135,7 @@ module('@pullable', function(hooks) {
     source._pull = async function(query) {
       assert.equal(++order, 4, 'action performed after willPull');
       assert.strictEqual(query.expression, qe, 'query object matches');
-      await this._transformed(resultingTransforms);
+      await this.transformed(resultingTransforms);
       return resultingTransforms;
     };
 
@@ -270,7 +270,7 @@ module('@pullable', function(hooks) {
       assert.equal(++order, 4, 'action performed after willPull');
       assert.strictEqual(query.expression, qe, 'query object matches');
       assert.strictEqual(hints, h, '_pull is passed same hints instance');
-      await this._transformed(resultingTransforms);
+      await this.transformed(resultingTransforms);
       return hints.data;
     };
 

--- a/packages/@orbit/data/test/source-interfaces/pushable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/pushable-test.ts
@@ -85,7 +85,7 @@ module('@pushable', function(hooks) {
         addRecordTransform,
         'transform object matches'
       );
-      await this._transformed(resultingTransforms);
+      await this.transformed(resultingTransforms);
       return resultingTransforms;
     };
 

--- a/packages/@orbit/data/test/source-interfaces/syncable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/syncable-test.ts
@@ -107,7 +107,7 @@ module('@syncable', function(hooks) {
         addRecordTransform,
         'transform object matches'
       );
-      await this._transformed([transform]);
+      await this.transformed([transform]);
     };
 
     source.on('transform', transform => {

--- a/packages/@orbit/data/test/source-interfaces/updatable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/updatable-test.ts
@@ -80,7 +80,7 @@ module('@updatable', function(hooks) {
         addRecordTransform,
         'transform object matches'
       );
-      await this._transformed([transform]);
+      await this.transformed([transform]);
       return ':)';
     };
 
@@ -133,7 +133,7 @@ module('@updatable', function(hooks) {
         addRecordTransform,
         'transform object matches'
       );
-      await this._transformed([transform]);
+      await this.transformed([transform]);
       return ['a', 'b', 'c'];
     };
 

--- a/packages/@orbit/data/test/source-test.ts
+++ b/packages/@orbit/data/test/source-test.ts
@@ -209,7 +209,7 @@ module('Source', function(hooks) {
     );
   });
 
-  test('#_transformed should trigger `transform` event BEFORE resolving', async function(assert) {
+  test('#transformed should trigger `transform` event BEFORE resolving', async function(assert) {
     assert.expect(3);
 
     source = new MySource();
@@ -229,9 +229,9 @@ module('Source', function(hooks) {
       );
     });
 
-    await source._transformed([appliedTransform]);
+    await source.transformed([appliedTransform]);
 
-    assert.equal(++order, 2, '_transformed promise resolved last');
+    assert.equal(++order, 2, 'transformed promise resolved last');
   });
 
   test('#transformLog contains transforms applied', async function(assert) {
@@ -242,7 +242,7 @@ module('Source', function(hooks) {
 
     assert.ok(!source.transformLog.contains(appliedTransform.id));
 
-    await source._transformed([appliedTransform]);
+    await source.transformed([appliedTransform]);
 
     assert.ok(source.transformLog.contains(appliedTransform.id));
   });

--- a/packages/@orbit/indexeddb/src/source.ts
+++ b/packages/@orbit/indexeddb/src/source.ts
@@ -106,7 +106,7 @@ export default class IndexedDBSource extends Source
   async _sync(transform: Transform): Promise<void> {
     if (!this.transformLog.contains(transform.id)) {
       await this._cache.patch(transform.operations as RecordOperation[]);
-      await this._transformed([transform]);
+      await this.transformed([transform]);
     }
   }
 
@@ -120,7 +120,7 @@ export default class IndexedDBSource extends Source
     if (!this.transformLog.contains(transform.id)) {
       await this._cache.patch(transform.operations as RecordOperation[]);
       results = [transform];
-      await this._transformed(results);
+      await this.transformed(results);
     } else {
       results = [];
     }
@@ -158,7 +158,7 @@ export default class IndexedDBSource extends Source
 
     const transforms = [buildTransform(operations)];
 
-    await this._transformed(transforms);
+    await this.transformed(transforms);
 
     return transforms;
   }

--- a/packages/@orbit/jsonapi/src/jsonapi-source.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-source.ts
@@ -168,7 +168,7 @@ export default class JSONAPISource extends Source
       }
 
       transforms.unshift(transform);
-      await this._transformed(transforms);
+      await this.transformed(transforms);
     }
 
     return transforms;
@@ -182,7 +182,7 @@ export default class JSONAPISource extends Source
     const { requestProcessor } = this;
     const operator: QueryOperator = this.getQueryOperator(query);
     const response = await operator(requestProcessor, query);
-    await this._transformed(response.transforms);
+    await this.transformed(response.transforms);
     return response.transforms;
   }
 
@@ -194,7 +194,7 @@ export default class JSONAPISource extends Source
     const { requestProcessor } = this;
     const operator: QueryOperator = this.getQueryOperator(query);
     const response = await operator(requestProcessor, query);
-    await this._transformed(response.transforms);
+    await this.transformed(response.transforms);
     return response.primaryData;
   }
 
@@ -223,7 +223,7 @@ export default class JSONAPISource extends Source
       }
 
       transforms.unshift(transform);
-      await this._transformed(transforms);
+      await this.transformed(transforms);
 
       return transform.operations.length === 1 ? records[0] : records;
     }

--- a/packages/@orbit/local-storage/src/source.ts
+++ b/packages/@orbit/local-storage/src/source.ts
@@ -111,7 +111,7 @@ export default class LocalStorageSource extends Source
   async _sync(transform: Transform): Promise<void> {
     if (!this.transformLog.contains(transform.id)) {
       this._cache.patch(transform.operations as RecordOperation[]);
-      await this._transformed([transform]);
+      await this.transformed([transform]);
     }
   }
 
@@ -125,7 +125,7 @@ export default class LocalStorageSource extends Source
     if (!this.transformLog.contains(transform.id)) {
       this._cache.patch(transform.operations as RecordOperation[]);
       results = [transform];
-      await this._transformed(results);
+      await this.transformed(results);
     } else {
       results = [];
     }
@@ -162,7 +162,7 @@ export default class LocalStorageSource extends Source
 
     const transforms = [buildTransform(operations)];
 
-    await this._transformed(transforms);
+    await this.transformed(transforms);
 
     return transforms;
   }

--- a/packages/@orbit/memory/src/memory-source.ts
+++ b/packages/@orbit/memory/src/memory-source.ts
@@ -124,7 +124,7 @@ export default class MemorySource extends Source
   async _sync(transform: Transform): Promise<void> {
     if (!this.transformLog.contains(transform.id)) {
       this._applyTransform(transform);
-      await this._transformed([transform]);
+      await this.transformed([transform]);
     }
   }
 
@@ -137,7 +137,7 @@ export default class MemorySource extends Source
 
     if (!this.transformLog.contains(transform.id)) {
       results = this._applyTransform(transform);
-      await this._transformed([transform]);
+      await this.transformed([transform]);
     }
 
     if (hints && hints.data) {


### PR DESCRIPTION
Now that source implementations are more likely to be responsible for calling this method to let others receive `transform` events, the time is probably right to make it more ergonomic. It is a protected method in TS, which accomplishes the same goal of signaling to developers that it should only be invoked internally within sources.