### PR TITLE
Always ignore undefined values when filtering

### DIFF
--- a/packages/@orbit/memory/test/memory-cache-test.ts
+++ b/packages/@orbit/memory/test/memory-cache-test.ts
@@ -1267,7 +1267,7 @@ module('MemoryCache', function(hooks) {
           .findRecords('planet')
           .filter({ relation: 'moons', records: [ganymede], op: 'none' })
       ),
-      [earth, mars, mercury]
+      [earth, mars]
     );
   });
 

--- a/packages/@orbit/record-cache/src/operators/async-query-operators.ts
+++ b/packages/@orbit/record-cache/src/operators/async-query-operators.ts
@@ -112,9 +112,12 @@ function filterRecords(records: Record[], filters: any[]) {
   });
 }
 
-function applyFilter(record: Record, filter: any) {
+function applyFilter(record: Record, filter: any): boolean {
   if (filter.kind === 'attribute') {
     let actual = deepGet(record, ['attributes', filter.attribute]);
+    if (actual === undefined) {
+      return false;
+    }
     let expected = filter.value;
     switch (filter.op) {
       case 'equal':
@@ -134,8 +137,14 @@ function applyFilter(record: Record, filter: any) {
         );
     }
   } else if (filter.kind === 'relatedRecords') {
-    let relation = deepGet(record, ['relationships', filter.relation]);
-    let actual: RecordIdentity[] = relation === undefined ? [] : relation.data;
+    let actual: RecordIdentity[] = deepGet(record, [
+      'relationships',
+      filter.relation,
+      'data'
+    ]);
+    if (actual === undefined) {
+      return false;
+    }
     let expected: RecordIdentity[] = filter.records;
     switch (filter.op) {
       case 'equal':
@@ -165,12 +174,13 @@ function applyFilter(record: Record, filter: any) {
     }
   } else if (filter.kind === 'relatedRecord') {
     let actual = deepGet(record, ['relationships', filter.relation, 'data']);
+    if (actual === undefined) {
+      return false;
+    }
     let expected = filter.record;
     switch (filter.op) {
       case 'equal':
-        if (actual === undefined) {
-          return false;
-        } else if (actual === null) {
+        if (actual === null) {
           return expected === null;
         } else {
           if (Array.isArray(expected)) {

--- a/packages/@orbit/record-cache/src/operators/sync-query-operators.ts
+++ b/packages/@orbit/record-cache/src/operators/sync-query-operators.ts
@@ -101,9 +101,12 @@ function filterRecords(records: Record[], filters: any[]) {
   });
 }
 
-function applyFilter(record: Record, filter: any) {
+function applyFilter(record: Record, filter: any): boolean {
   if (filter.kind === 'attribute') {
     let actual = deepGet(record, ['attributes', filter.attribute]);
+    if (actual === undefined) {
+      return false;
+    }
     let expected = filter.value;
     switch (filter.op) {
       case 'equal':
@@ -123,8 +126,14 @@ function applyFilter(record: Record, filter: any) {
         );
     }
   } else if (filter.kind === 'relatedRecords') {
-    let relation = deepGet(record, ['relationships', filter.relation]);
-    let actual: RecordIdentity[] = relation === undefined ? [] : relation.data;
+    let actual: RecordIdentity[] = deepGet(record, [
+      'relationships',
+      filter.relation,
+      'data'
+    ]);
+    if (actual === undefined) {
+      return false;
+    }
     let expected: RecordIdentity[] = filter.records;
     switch (filter.op) {
       case 'equal':
@@ -154,12 +163,13 @@ function applyFilter(record: Record, filter: any) {
     }
   } else if (filter.kind === 'relatedRecord') {
     let actual = deepGet(record, ['relationships', filter.relation, 'data']);
+    if (actual === undefined) {
+      return false;
+    }
     let expected = filter.record;
     switch (filter.op) {
       case 'equal':
-        if (actual === undefined) {
-          return false;
-        } else if (actual === null) {
+        if (actual === null) {
           return expected === null;
         } else {
           if (Array.isArray(expected)) {

--- a/packages/@orbit/record-cache/test/async-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/async-record-cache-test.ts
@@ -1924,7 +1924,7 @@ module('AsyncRecordCache', function(hooks) {
           .findRecords('planet')
           .filter({ relation: 'moons', records: [ganymede], op: 'none' })
       ),
-      [earth, mars, mercury]
+      [earth, mars]
     );
   });
 
@@ -3075,7 +3075,7 @@ module('AsyncRecordCache', function(hooks) {
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'moons', records: [ganymede], op: 'none' })
       ),
-      [earth, mars, mercury]
+      [earth, mars]
     );
   });
 

--- a/packages/@orbit/record-cache/test/sync-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/sync-record-cache-test.ts
@@ -1897,7 +1897,7 @@ module('SyncRecordCache', function(hooks) {
           .findRecords('planet')
           .filter({ relation: 'moons', records: [ganymede], op: 'none' })
       ),
-      [earth, mars, mercury]
+      [earth, mars]
     );
   });
 
@@ -3051,7 +3051,7 @@ module('SyncRecordCache', function(hooks) {
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'moons', records: [ganymede], op: 'none' })
       ),
-      [earth, mars, mercury]
+      [earth, mars]
     );
   });
 


### PR DESCRIPTION
Continues the work started in #701. 

Since records can be sparse, always treat `undefined` values as `undefined` rather than `null` or `[]` when filtering them. In other words, filters should ignore `undefined` values and never return a match.

Notes: 

* There is still an option to allow a special filter type for `undefined`, but this case should be handled distinctly.

* A follow up PR should consolidate the logic shared across sync / async query operators.