### PR TITLE
Allow mergeOperations to set null for hasOne relationship

### DIFF
--- a/packages/@orbit/data/src/operation.ts
+++ b/packages/@orbit/data/src/operation.ts
@@ -320,12 +320,12 @@ function updateRecordReplaceAttribute(
 function updateRecordReplaceHasOne(
   record: Record,
   relationship: string,
-  relatedRecord: RecordIdentity
+  relatedRecord: RecordIdentity | null
 ) {
   deepSet(
     record,
     ['relationships', relationship, 'data'],
-    cloneRecordIdentity(relatedRecord)
+    relatedRecord ? cloneRecordIdentity(relatedRecord) : null
   );
 }
 

--- a/packages/@orbit/data/test/operation-test.ts
+++ b/packages/@orbit/data/test/operation-test.ts
@@ -205,18 +205,20 @@ module('Operation', function() {
             record: { type: 'contact', id: '1234' },
             relationship: 'address',
             relatedRecord: null
-          }, {
+          },
+          {
             op: 'replaceAttribute',
             record: { type: 'contact', id: '1234' },
             attribute: 'name',
             value: 'James'
-          },
+          }
         ]),
         [
           {
             op: 'updateRecord',
             record: {
-              type: 'contact', id: '1234',
+              type: 'contact',
+              id: '1234',
               attributes: {
                 name: 'James'
               },

--- a/packages/@orbit/data/test/operation-test.ts
+++ b/packages/@orbit/data/test/operation-test.ts
@@ -214,15 +214,18 @@ module('Operation', function() {
         ]),
         [
           {
-            op: 'replaceRelatedRecord',
-            record: { type: 'contact', id: '1234' },
-            relationship: 'address',
-            relatedRecord: null
-          }, {
-            op: 'replaceAttribute',
-            record: { type: 'contact', id: '1234' },
-            attribute: 'name',
-            value: 'James'
+            op: 'updateRecord',
+            record: {
+              type: 'contact', id: '1234',
+              attributes: {
+                name: 'James'
+              },
+              relationships: {
+                address: {
+                  data: null
+                }
+              }
+            }
           }
         ]
       );

--- a/packages/@orbit/data/test/operation-test.ts
+++ b/packages/@orbit/data/test/operation-test.ts
@@ -197,6 +197,37 @@ module('Operation', function() {
       );
     });
 
+    test('can coalesce replaceAttribute + replaceRelatedRecord with null', function(assert) {
+      assert.deepEqual(
+        coalesceRecordOperations([
+          {
+            op: 'replaceRelatedRecord',
+            record: { type: 'contact', id: '1234' },
+            relationship: 'address',
+            relatedRecord: null
+          }, {
+            op: 'replaceAttribute',
+            record: { type: 'contact', id: '1234' },
+            attribute: 'name',
+            value: 'James'
+          },
+        ]),
+        [
+          {
+            op: 'replaceRelatedRecord',
+            record: { type: 'contact', id: '1234' },
+            relationship: 'address',
+            relatedRecord: null
+          }, {
+            op: 'replaceAttribute',
+            record: { type: 'contact', id: '1234' },
+            attribute: 'name',
+            value: 'James'
+          }
+        ]
+      );
+    });
+
     test('can coalesce addRecord + addToRelatedRecords for the same record', function(assert) {
       assert.deepEqual(
         coalesceRecordOperations([

--- a/packages/@orbit/data/yarn.lock
+++ b/packages/@orbit/data/yarn.lock
@@ -453,6 +453,18 @@
     tslint "^5.18.0"
     typescript "~3.5.3"
 
+"@orbit/core@^0.16.1":
+  version "0.16.3"
+  resolved "https://registry.yarnpkg.com/@orbit/core/-/core-0.16.3.tgz#e172c28279cf8bd875957cb71317970aaa98aeb2"
+  integrity sha512-E4g4twgp8eg6440w3Mjc4+xP+SnyHx2UaDvxLrWx0rV579/jy7zxx98vQxW//lTuU/AXEycKZ3FVzrRDRN/3Cw==
+  dependencies:
+    "@orbit/utils" "^0.16.3"
+
+"@orbit/utils@^0.16.1", "@orbit/utils@^0.16.3":
+  version "0.16.3"
+  resolved "https://registry.yarnpkg.com/@orbit/utils/-/utils-0.16.3.tgz#fa94700191360c4c49fc9fdf464994cfe817dd0b"
+  integrity sha512-JSF9xVRUEWugGtcR9mFOCzsMLphWMh/8xAe0FOuEpyyBFxBlWLuovatg/cwvlHo7AJh3J5StiiJXmBecTk/m6A==
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"

--- a/packages/@orbit/data/yarn.lock
+++ b/packages/@orbit/data/yarn.lock
@@ -453,18 +453,6 @@
     tslint "^5.18.0"
     typescript "~3.5.3"
 
-"@orbit/core@^0.16.1":
-  version "0.16.3"
-  resolved "https://registry.yarnpkg.com/@orbit/core/-/core-0.16.3.tgz#e172c28279cf8bd875957cb71317970aaa98aeb2"
-  integrity sha512-E4g4twgp8eg6440w3Mjc4+xP+SnyHx2UaDvxLrWx0rV579/jy7zxx98vQxW//lTuU/AXEycKZ3FVzrRDRN/3Cw==
-  dependencies:
-    "@orbit/utils" "^0.16.3"
-
-"@orbit/utils@^0.16.1", "@orbit/utils@^0.16.3":
-  version "0.16.3"
-  resolved "https://registry.yarnpkg.com/@orbit/utils/-/utils-0.16.3.tgz#fa94700191360c4c49fc9fdf464994cfe817dd0b"
-  integrity sha512-JSF9xVRUEWugGtcR9mFOCzsMLphWMh/8xAe0FOuEpyyBFxBlWLuovatg/cwvlHo7AJh3J5StiiJXmBecTk/m6A==
-
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"


### PR DESCRIPTION
Sometimes when I tried to update related record with null on a forked store, I was encountering an error: `Cannot destructure property 'type' of 'identity' as it is null` in `cloneRecordIdentity`.

It seems like a bug - `updateRecordReplaceHasOne` should also accept nulls, right?

I've added a test for this failing case and fixed it. I'm not sure if that's the best place for this fix... maybe this should be done in the `cloneRecordIdentity`?