### PR TITLE
Bucket.clear()

### DIFF
--- a/packages/@orbit/core/src/bucket.ts
+++ b/packages/@orbit/core/src/bucket.ts
@@ -78,6 +78,11 @@ export abstract class Bucket implements Evented {
   abstract removeItem(key: string): Promise<void>;
 
   /**
+   * Clears all items from the bucket.
+   */
+  abstract clear(): Promise<void>;
+
+  /**
    * Name used for tracking and debugging a bucket instance.
    */
   get name(): string {

--- a/packages/@orbit/core/test/bucket-test.ts
+++ b/packages/@orbit/core/test/bucket-test.ts
@@ -18,6 +18,9 @@ module('Bucket', function() {
     removeItem(key: string): Promise<void> {
       return Promise.resolve();
     }
+    clear(): Promise<void> {
+      return Promise.resolve();
+    }
   }
 
   test('can be instantiated', function(assert) {

--- a/packages/@orbit/core/test/support/fake-bucket.ts
+++ b/packages/@orbit/core/test/support/fake-bucket.ts
@@ -25,4 +25,8 @@ export default class FakeBucket extends Bucket {
   async removeItem(key: string): Promise<void> {
     delete this.data[key];
   }
+
+  async clear(): Promise<void> {
+    this.data = {};
+  }
 }

--- a/packages/@orbit/data/test/support/fake-bucket.ts
+++ b/packages/@orbit/data/test/support/fake-bucket.ts
@@ -25,4 +25,8 @@ export default class FakeBucket extends Bucket {
   async removeItem(key: string): Promise<void> {
     delete this.data[key];
   }
+
+  async clear(): Promise<void> {
+    this.data = {};
+  }
 }

--- a/packages/@orbit/indexeddb-bucket/src/bucket.ts
+++ b/packages/@orbit/indexeddb-bucket/src/bucket.ts
@@ -223,4 +223,23 @@ export default class IndexedDBBucket extends Bucket {
       };
     });
   }
+
+  async clear(): Promise<void> {
+    await this.openDB();
+    await new Promise((resolve, reject) => {
+      const transaction = this._db.transaction([this.dbStoreName], 'readwrite');
+      const objectStore = transaction.objectStore(this.dbStoreName);
+      const request = objectStore.clear();
+
+      request.onerror = function(/* event */) {
+        console.error('error - clear', request.error);
+        reject(request.error);
+      };
+
+      request.onsuccess = function(/* event */) {
+        // console.log('success - clear');
+        resolve();
+      };
+    });
+  }
 }

--- a/packages/@orbit/indexeddb-bucket/test/bucket-test.ts
+++ b/packages/@orbit/indexeddb-bucket/test/bucket-test.ts
@@ -112,4 +112,21 @@ module('IndexedDBBucket', function(hooks) {
       .then(() => bucket.getItem('planet'))
       .then(item => assert.equal(item, null, 'bucket does not contain item'));
   });
+
+  test('#clear clears all keys', async function(assert) {
+    assert.expect(2);
+
+    let planet = {
+      type: 'planet',
+      id: 'jupiter'
+    };
+
+    return bucket
+      .setItem('planet', planet)
+      .then(() => bucket.getItem('planet'))
+      .then(item => assert.deepEqual(item, planet, 'bucket contains item'))
+      .then(() => bucket.clear())
+      .then(() => bucket.getItem('planet'))
+      .then(item => assert.equal(item, null, 'bucket does not contain item'));
+  });
 });

--- a/packages/@orbit/local-storage-bucket/src/bucket.ts
+++ b/packages/@orbit/local-storage-bucket/src/bucket.ts
@@ -65,4 +65,9 @@ export default class LocalStorageBucket extends Bucket {
     Orbit.globals.localStorage.removeItem(fullKey);
     return Promise.resolve();
   }
+
+  clear(): Promise<void> {
+    Orbit.globals.localStorage.clear();
+    return Promise.resolve();
+  }
 }

--- a/packages/@orbit/local-storage-bucket/test/bucket-test.ts
+++ b/packages/@orbit/local-storage-bucket/test/bucket-test.ts
@@ -55,4 +55,25 @@ module('LocalStorageBucket', function(hooks) {
     item = await bucket.getItem('planet');
     assert.equal(item, null, 'bucket does not contain item');
   });
+
+  test('#clear clears all keys', async function(assert) {
+    assert.expect(2);
+
+    let planet = {
+      type: 'planet',
+      id: 'jupiter',
+      attributes: {
+        name: 'Jupiter',
+        classification: 'gas giant'
+      }
+    };
+
+    await bucket.setItem('planet', planet);
+    let item = await bucket.getItem('planet');
+    assert.deepEqual(item, planet, 'bucket contains item');
+
+    await bucket.clear();
+    item = await bucket.getItem('planet');
+    assert.equal(item, null, 'bucket does not contain item');
+  });
 });


### PR DESCRIPTION
This adds an abstract `clear()` method to `Bucket`. Implementations of a bucket would clear all the entries within it.

From #460:
>  It would be useful for implementing log out in a mobile app.

---

Closes #460