### PR TITLE
Handle 304 responses in jsonapi-request-processor

### DIFF
--- a/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
@@ -261,6 +261,8 @@ export default class JSONAPIRequestProcessor {
       if (this.responseHasContent(response)) {
         return response.json();
       }
+    } else if (response.status === 304) {
+      return;
     } else {
       if (this.responseHasContent(response)) {
         return response

--- a/packages/@orbit/jsonapi/src/lib/query-requests.ts
+++ b/packages/@orbit/jsonapi/src/lib/query-requests.ts
@@ -186,15 +186,19 @@ export const QueryRequestProcessors: Dict<QueryRequestProcessor> = {
     );
     requestProcessor.preprocessResponseDocument(document, request);
 
-    const deserialized = requestProcessor.serializer.deserialize(document);
-    const operations = requestProcessor.operationsFromDeserializedDocument(
-      deserialized
-    );
+    if (document) {
+      const deserialized = requestProcessor.serializer.deserialize(document);
+      const operations = requestProcessor.operationsFromDeserializedDocument(
+        deserialized
+      );
 
-    const transforms = [buildTransform(operations)];
-    const { data: primaryData, meta, links } = deserialized;
+      const transforms = [buildTransform(operations)];
+      const { data: primaryData, meta, links } = deserialized;
 
-    return { transforms, primaryData, meta, links };
+      return { transforms, primaryData, meta, links };
+    } else {
+      return { transforms: [], primaryData: undefined };
+    }
   },
 
   async findRecords(
@@ -210,15 +214,19 @@ export const QueryRequestProcessors: Dict<QueryRequestProcessor> = {
     );
     requestProcessor.preprocessResponseDocument(document, request);
 
-    const deserialized = requestProcessor.serializer.deserialize(document);
-    const operations = requestProcessor.operationsFromDeserializedDocument(
-      deserialized
-    );
+    if (document) {
+      const deserialized = requestProcessor.serializer.deserialize(document);
+      const operations = requestProcessor.operationsFromDeserializedDocument(
+        deserialized
+      );
 
-    const transforms = [buildTransform(operations)];
-    const { data: primaryData, meta, links } = deserialized;
+      const transforms = [buildTransform(operations)];
+      const { data: primaryData, meta, links } = deserialized;
 
-    return { transforms, primaryData, meta, links };
+      return { transforms, primaryData, meta, links };
+    } else {
+      return { transforms: [], primaryData: undefined };
+    }
   },
 
   async findRelatedRecord(
@@ -238,22 +246,26 @@ export const QueryRequestProcessors: Dict<QueryRequestProcessor> = {
     );
     requestProcessor.preprocessResponseDocument(document, request);
 
-    const deserialized = requestProcessor.serializer.deserialize(document);
-    const { data: relatedRecord, meta, links } = deserialized;
-    const operations = requestProcessor.operationsFromDeserializedDocument(
-      deserialized
-    );
-    operations.push({
-      op: 'replaceRelatedRecord',
-      record,
-      relationship,
-      relatedRecord
-    } as ReplaceRelatedRecordOperation);
+    if (document) {
+      const deserialized = requestProcessor.serializer.deserialize(document);
+      const { data: relatedRecord, meta, links } = deserialized;
+      const operations = requestProcessor.operationsFromDeserializedDocument(
+        deserialized
+      );
+      operations.push({
+        op: 'replaceRelatedRecord',
+        record,
+        relationship,
+        relatedRecord
+      } as ReplaceRelatedRecordOperation);
 
-    const transforms = [buildTransform(operations)];
-    const primaryData = relatedRecord;
+      const transforms = [buildTransform(operations)];
+      const primaryData = relatedRecord;
 
-    return { transforms, primaryData, meta, links };
+      return { transforms, primaryData, meta, links };
+    } else {
+      return { transforms: [], primaryData: undefined };
+    }
   },
 
   async findRelatedRecords(
@@ -278,34 +290,38 @@ export const QueryRequestProcessors: Dict<QueryRequestProcessor> = {
     );
     requestProcessor.preprocessResponseDocument(document, request);
 
-    const deserialized = requestProcessor.serializer.deserialize(document);
-    const { data, meta, links } = deserialized;
-    const relatedRecords = data as Record[];
+    if (document) {
+      const deserialized = requestProcessor.serializer.deserialize(document);
+      const { data, meta, links } = deserialized;
+      const relatedRecords = data as Record[];
 
-    const operations = requestProcessor.operationsFromDeserializedDocument(
-      deserialized
-    );
-    if (isFiltered) {
-      for (let relatedRecord of relatedRecords) {
+      const operations = requestProcessor.operationsFromDeserializedDocument(
+        deserialized
+      );
+      if (isFiltered) {
+        for (let relatedRecord of relatedRecords) {
+          operations.push({
+            op: 'addToRelatedRecords',
+            record,
+            relationship,
+            relatedRecord
+          } as AddToRelatedRecordsOperation);
+        }
+      } else {
         operations.push({
-          op: 'addToRelatedRecords',
+          op: 'replaceRelatedRecords',
           record,
           relationship,
-          relatedRecord
-        } as AddToRelatedRecordsOperation);
+          relatedRecords
+        } as ReplaceRelatedRecordsOperation);
       }
+
+      const transforms = [buildTransform(operations)];
+      const primaryData = relatedRecords;
+
+      return { transforms, primaryData, meta, links };
     } else {
-      operations.push({
-        op: 'replaceRelatedRecords',
-        record,
-        relationship,
-        relatedRecords
-      } as ReplaceRelatedRecordsOperation);
+      return { transforms: [], primaryData: undefined };
     }
-
-    const transforms = [buildTransform(operations)];
-    const primaryData = relatedRecords;
-
-    return { transforms, primaryData, meta, links };
   }
 };


### PR DESCRIPTION
A response with status code 304 indicates that we already have the
latest, valid representation available.

Currently a response with this status results in an error. With this
change such a response is handled in a successful manner, which results
in a transform with no operations.

---

I am not fully familiar with all the concepts yet and pretty sure I am missing something. This is just my initial stab at addressing parts of #577 and putting this out there to get more input.
I am especially unsure about having a transform with no operations, which I guess should be no transform at all...

Appreciate pointers in any direction and happy to make changes.