### PR TITLE
Improve control of source and strategy activation and deactivation

### DIFF
--- a/packages/@orbit/coordinator/src/coordinator.ts
+++ b/packages/@orbit/coordinator/src/coordinator.ts
@@ -167,17 +167,36 @@ export default class Coordinator {
       await strategy.activate(this, options);
     }
 
+    for (let strategy of this.strategies) {
+      await strategy.beforeSourceActivation();
+    }
+
     for (let source of this.sources) {
       await source.activate();
+    }
+
+    for (let strategy of this.strategies) {
+      await strategy.afterSourceActivation();
     }
   }
 
   protected async _deactivate(): Promise<void> {
-    for (let source of this.sources) {
+    const strategies = this.strategies.reverse();
+    const sources = this.sources.reverse();
+
+    for (let strategy of strategies) {
+      await strategy.beforeSourceDeactivation();
+    }
+
+    for (let source of sources) {
       await source.deactivate();
     }
 
-    for (let strategy of this.strategies.reverse()) {
+    for (let strategy of strategies) {
+      await strategy.afterSourceDeactivation();
+    }
+
+    for (let strategy of strategies) {
       await strategy.deactivate();
     }
   }

--- a/packages/@orbit/coordinator/src/coordinator.ts
+++ b/packages/@orbit/coordinator/src/coordinator.ts
@@ -140,35 +140,45 @@ export default class Coordinator {
     return this._activated;
   }
 
-  activate(options: ActivationOptions = {}): Promise<void> {
+  async activate(options: ActivationOptions = {}): Promise<void> {
     if (!this._activated) {
-      if (options.logLevel === undefined) {
-        options.logLevel = this._defaultActivationOptions.logLevel;
-      }
-
-      this._currentActivationOptions = options;
-
-      this._activated = this.strategies.reduce((chain, strategy) => {
-        return chain.then(() => strategy.activate(this, options));
-      }, Promise.resolve());
+      this._activated = this._activate(options);
     }
-
-    return this._activated;
+    await this._activated;
   }
 
-  deactivate(): Promise<void> {
+  async deactivate(): Promise<void> {
     if (this._activated) {
-      return this._activated
-        .then(() => {
-          return this.strategies.reverse().reduce((chain, strategy) => {
-            return chain.then(() => strategy.deactivate());
-          }, Promise.resolve());
-        })
-        .then(() => {
-          this._activated = null;
-        });
-    } else {
-      return Promise.resolve();
+      await this._activated;
+      await this._deactivate();
+    }
+
+    this._activated = undefined;
+  }
+
+  protected async _activate(options: ActivationOptions = {}): Promise<void> {
+    if (options.logLevel === undefined) {
+      options.logLevel = this._defaultActivationOptions.logLevel;
+    }
+
+    this._currentActivationOptions = options;
+
+    for (let strategy of this.strategies) {
+      await strategy.activate(this, options);
+    }
+
+    for (let source of this.sources) {
+      await source.activate();
+    }
+  }
+
+  protected async _deactivate(): Promise<void> {
+    for (let source of this.sources) {
+      await source.deactivate();
+    }
+
+    for (let strategy of this.strategies.reverse()) {
+      await strategy.deactivate();
     }
   }
 }

--- a/packages/@orbit/coordinator/src/strategy.ts
+++ b/packages/@orbit/coordinator/src/strategy.ts
@@ -80,16 +80,9 @@ export abstract class Strategy {
     } else {
       this._sources = coordinator.sources;
     }
-
-    for (let source of this._sources) {
-      await source.activate();
-    }
   }
 
   async deactivate(): Promise<void> {
-    for (let source of this._sources) {
-      await source.deactivate();
-    }
     this._coordinator = null;
   }
 

--- a/packages/@orbit/coordinator/src/strategy.ts
+++ b/packages/@orbit/coordinator/src/strategy.ts
@@ -86,6 +86,12 @@ export abstract class Strategy {
     this._coordinator = null;
   }
 
+  async beforeSourceActivation(): Promise<void> {}
+  async afterSourceActivation(): Promise<void> {}
+
+  async beforeSourceDeactivation(): Promise<void> {}
+  async afterSourceDeactivation(): Promise<void> {}
+
   get name(): string {
     return this._name;
   }

--- a/packages/@orbit/data/test/source-test.ts
+++ b/packages/@orbit/data/test/source-test.ts
@@ -98,7 +98,7 @@ module('Source', function(hooks) {
     );
   });
 
-  test('overrides default requestQueue settings with injected requestQueueSettings', function(assert) {
+  test('overrides default requestQueue settings with injected requestQueueSettings', async function(assert) {
     assert.expect(3);
 
     const defaultBucket = new FakeBucket();
@@ -116,24 +116,26 @@ module('Source', function(hooks) {
       requestQueueSettings
     });
 
+    await source.activated;
+
     assert.equal(
       source.requestQueue.name,
       'my-request-queue',
-      'requestQueue has been assigned overriden name'
+      'requestQueue has been assigned overridden name'
     );
     assert.equal(
       source.requestQueue.autoProcess,
       false,
-      'requestQueue has been assigned overriden autoProcess'
+      'requestQueue has been assigned overridden autoProcess'
     );
     assert.equal(
       source.requestQueue.bucket,
       requestQueueBucket,
-      'requestQueue has been assigned overriden bucket'
+      'requestQueue has been assigned overridden bucket'
     );
   });
 
-  test('overrides default syncQueue settings with injected syncQueueSettings', function(assert) {
+  test('overrides default syncQueue settings with injected syncQueueSettings', async function(assert) {
     assert.expect(3);
 
     const defaultBucket = new FakeBucket();
@@ -151,20 +153,57 @@ module('Source', function(hooks) {
       syncQueueSettings
     });
 
+    await source.activated;
+
     assert.equal(
       source.syncQueue.name,
       'my-sync-queue',
-      'syncQueue has been assigned overriden name'
+      'syncQueue has been assigned overridden name'
     );
     assert.equal(
       source.syncQueue.autoProcess,
       false,
-      'syncQueue has been assigned overriden autoProcess'
+      'syncQueue has been assigned overridden autoProcess'
     );
     assert.equal(
       source.syncQueue.bucket,
       syncQueueBucket,
-      'syncQueue has been assigned overriden bucket'
+      'syncQueue has been assigned overridden bucket'
+    );
+  });
+
+  test('disables queue processing by default until activation', async function(assert) {
+    assert.expect(4);
+
+    source = new MySource({
+      name: 'src1',
+      autoActivate: false
+    });
+
+    assert.equal(
+      source.syncQueue.autoProcess,
+      false,
+      'syncQueue.autoProcess === false'
+    );
+
+    assert.equal(
+      source.requestQueue.autoProcess,
+      false,
+      'requestQueue.autoProcess === false'
+    );
+
+    await source.activate();
+
+    assert.equal(
+      source.syncQueue.autoProcess,
+      true,
+      'syncQueue.autoProcess === true'
+    );
+
+    assert.equal(
+      source.requestQueue.autoProcess,
+      true,
+      'requestQueue.autoProcess === true'
     );
   });
 


### PR DESCRIPTION
Implements the plan discussed in https://github.com/orbitjs/orbit/issues/725#issuecomment-590009540 to provide more deterministic control of source and strategy activation. Specifically, this PR does the following:

* When a source is configured with `autoActivate: false`, its request and sync queues are now instantiated with `autoProcess: false` by default. `Source#activate` will flip this flag and invoke `this.syncQueue.process()` and then `this.requestQueue.process()` (unless queue settings have been explicitly made that indicate that `autoProcess` should remain `false`).

* Strategies no longer activate sources by default in `activate`. Source activation is now done instead in `Coordinator#activate` after all strategies have been activated. Similarly, source deactivation is now done in `Coordinator#deactivate`.

* Hooks have been added to strategies to be run before and after source activation and deactivation - `beforeSourceActivation`, `afterSourceActivation`, `beforeSourceDeactivation`, `afterSourceDeactivation`

Closes #725 