### PR TITLE
Backport PR 735 to v0.16

### DIFF
--- a/packages/@orbit/data/src/record.ts
+++ b/packages/@orbit/data/src/record.ts
@@ -114,25 +114,60 @@ export function recordsIncludeAll(
 
 export function mergeRecords(current: Record | null, updates: Record): Record {
   if (current) {
-    let record: any = cloneRecordIdentity(current);
-    let currentRecord: any = current;
-    let updatedRecord: any = updates;
-    ['attributes', 'keys', 'relationships'].forEach(grouping => {
-      if (currentRecord[grouping] && updatedRecord[grouping]) {
-        record[grouping] = merge(
-          {},
-          currentRecord[grouping],
-          updatedRecord[grouping]
-        );
-      } else if (currentRecord[grouping]) {
-        record[grouping] = merge({}, currentRecord[grouping]);
-      } else if (updatedRecord[grouping]) {
-        record[grouping] = merge({}, updatedRecord[grouping]);
-      }
-    });
+    let record: Record = cloneRecordIdentity(current);
+
+    // Merge `meta` and `links`, replacing whole sections rather than merging
+    // individual members
+    mergeRecordSection(record, current, updates, 'meta', 0);
+    mergeRecordSection(record, current, updates, 'links', 0);
+
+    // Merge attributes and keys, replacing at the individual field level
+    mergeRecordSection(record, current, updates, 'attributes', 1);
+    mergeRecordSection(record, current, updates, 'keys', 1);
+
+    // Merge relationships, replacing at the `data`, `links`, and `meta` level
+    // for each relationship
+    mergeRecordSection(record, current, updates, 'relationships', 2);
+
     return record;
   } else {
     return clone(updates);
+  }
+}
+
+function mergeRecordSection(
+  record: any,
+  current: any,
+  update: any,
+  section: string,
+  replacementDepth: number
+): void {
+  if (current[section] && update[section]) {
+    if (replacementDepth === 0) {
+      record[section] = clone(update[section]);
+    } else if (replacementDepth === 1) {
+      record[section] = merge({}, current[section], update[section]);
+    } else {
+      record[section] = {};
+      for (let name of Object.keys(current[section])) {
+        mergeRecordSection(
+          record[section],
+          current[section],
+          update[section],
+          name,
+          replacementDepth - 1
+        );
+      }
+      for (let name of Object.keys(update[section])) {
+        if (!record[section][name]) {
+          record[section][name] = clone(update[section][name]);
+        }
+      }
+    }
+  } else if (current[section]) {
+    record[section] = clone(current[section]);
+  } else if (update[section]) {
+    record[section] = clone(update[section]);
   }
 }
 

--- a/packages/@orbit/data/src/record.ts
+++ b/packages/@orbit/data/src/record.ts
@@ -1,4 +1,4 @@
-import { Dict, isObject, isNone, merge } from '@orbit/utils';
+import { Dict, isObject, isNone, clone, merge } from '@orbit/utils';
 
 export interface LinkObject {
   href: string;
@@ -117,7 +117,6 @@ export function mergeRecords(current: Record | null, updates: Record): Record {
     let record: any = cloneRecordIdentity(current);
     let currentRecord: any = current;
     let updatedRecord: any = updates;
-
     ['attributes', 'keys', 'relationships'].forEach(grouping => {
       if (currentRecord[grouping] && updatedRecord[grouping]) {
         record[grouping] = merge(
@@ -131,10 +130,9 @@ export function mergeRecords(current: Record | null, updates: Record): Record {
         record[grouping] = merge({}, updatedRecord[grouping]);
       }
     });
-
     return record;
   } else {
-    return updates;
+    return clone(updates);
   }
 }
 

--- a/packages/@orbit/data/test/record-test.ts
+++ b/packages/@orbit/data/test/record-test.ts
@@ -201,4 +201,261 @@ module('Record', function() {
     assert.deepEqual(mergeRecords(null, earth), earth);
     assert.notStrictEqual(mergeRecords(null, earth), earth);
   });
+
+  test('`mergeRecords` merges individual attributes and keys', function(assert) {
+    let earth = {
+      type: 'planet',
+      id: 'earth',
+      keys: {
+        primaryId: 'a',
+        secondaryId: 'b'
+      },
+      attributes: {
+        name: 'Earth',
+        circumference: 25000
+      }
+    };
+
+    let updates = {
+      type: 'planet',
+      id: 'earth',
+      keys: {
+        secondaryId: 'c',
+        tertiaryId: 'd'
+      },
+      attributes: {
+        name: 'Mother Earth',
+        description: 'Home'
+      }
+    };
+
+    let expected = {
+      type: 'planet',
+      id: 'earth',
+      keys: {
+        primaryId: 'a',
+        secondaryId: 'c',
+        tertiaryId: 'd'
+      },
+      attributes: {
+        name: 'Mother Earth',
+        description: 'Home',
+        circumference: 25000
+      }
+    };
+
+    assert.deepEqual(mergeRecords(earth, updates), expected);
+  });
+
+  test("`mergeRecords` adds meta and links objects if they don't previously exist", function(assert) {
+    let earth = {
+      type: 'planet',
+      id: 'earth'
+    };
+
+    let updates = {
+      type: 'planet',
+      id: 'earth',
+      meta: {
+        bar: 'baz'
+      },
+      links: {
+        self: 'http://example.com/planets/earth',
+        next: 'http://example.com/planets/mars'
+      }
+    };
+
+    let expected = {
+      type: 'planet',
+      id: 'earth',
+      meta: {
+        bar: 'baz'
+      },
+      links: {
+        self: 'http://example.com/planets/earth',
+        next: 'http://example.com/planets/mars'
+      }
+    };
+
+    assert.deepEqual(mergeRecords(earth, updates), expected);
+  });
+
+  test('`mergeRecords` carries forward meta and links objects if they exist', function(assert) {
+    let earth = {
+      type: 'planet',
+      id: 'earth',
+      meta: {
+        bar: 'baz'
+      },
+      links: {
+        self: 'http://example.com/planets/earth',
+        next: 'http://example.com/planets/mars'
+      }
+    };
+
+    let updates = {
+      type: 'planet',
+      id: 'earth'
+    };
+
+    let expected = {
+      type: 'planet',
+      id: 'earth',
+      meta: {
+        bar: 'baz'
+      },
+      links: {
+        self: 'http://example.com/planets/earth',
+        next: 'http://example.com/planets/mars'
+      }
+    };
+
+    assert.deepEqual(mergeRecords(earth, updates), expected);
+  });
+
+  test('`mergeRecords` replaces existing meta and links objects completely', function(assert) {
+    let earth = {
+      type: 'planet',
+      id: 'earth',
+      meta: {
+        foo: 'bar'
+      },
+      links: {
+        self: 'http://example.com/planets/earth',
+        previous: 'http://example.com/planets/venus'
+      }
+    };
+
+    let updates = {
+      type: 'planet',
+      id: 'earth',
+      meta: {
+        bar: 'baz'
+      },
+      links: {
+        self: 'http://example.com/planets/earth',
+        next: 'http://example.com/planets/mars'
+      }
+    };
+
+    let expected = {
+      type: 'planet',
+      id: 'earth',
+      meta: {
+        bar: 'baz'
+      },
+      links: {
+        self: 'http://example.com/planets/earth',
+        next: 'http://example.com/planets/mars'
+      }
+    };
+
+    assert.deepEqual(mergeRecords(earth, updates), expected);
+  });
+
+  test('`mergeRecords` handles meta, links, and data within relationships separately', function(assert) {
+    let earth = {
+      type: 'planet',
+      id: 'earth',
+      relationships: {
+        moons: {
+          meta: {
+            foo: 'bar'
+          },
+          links: {
+            self: 'http://example.com/planets/earth',
+            previous: 'http://example.com/planets/venus'
+          }
+        },
+        sun: {
+          meta: {
+            foo: 'bar'
+          }
+        },
+        inhabitants: {
+          data: [
+            {
+              type: 'person',
+              id: '1'
+            }
+          ]
+        }
+      }
+    };
+
+    let updates = {
+      type: 'planet',
+      id: 'earth',
+      relationships: {
+        moons: {
+          meta: {
+            bar: 'baz'
+          },
+          links: {
+            self: 'http://example.com/planets/earth/relationships/moons',
+            related: 'http://example.com/planets/earth/moons'
+          }
+        },
+        inhabitants: {
+          meta: {
+            bar: 'baz'
+          },
+          links: {
+            self: 'http://example.com/planets/earth/relationships/inhabitants',
+            related: 'http://example.com/planets/earth/inhabitants'
+          }
+        },
+        elements: {
+          links: {
+            self: 'http://example.com/planets/earth/relationships/elements',
+            related: 'http://example.com/planets/earth/elements'
+          }
+        }
+      }
+    };
+
+    let expected = {
+      type: 'planet',
+      id: 'earth',
+      relationships: {
+        inhabitants: {
+          meta: {
+            bar: 'baz'
+          },
+          links: {
+            self: 'http://example.com/planets/earth/relationships/inhabitants',
+            related: 'http://example.com/planets/earth/inhabitants'
+          },
+          data: [
+            {
+              type: 'person',
+              id: '1'
+            }
+          ]
+        },
+        moons: {
+          meta: {
+            bar: 'baz'
+          },
+          links: {
+            self: 'http://example.com/planets/earth/relationships/moons',
+            related: 'http://example.com/planets/earth/moons'
+          }
+        },
+        sun: {
+          meta: {
+            foo: 'bar'
+          }
+        },
+        elements: {
+          links: {
+            self: 'http://example.com/planets/earth/relationships/elements',
+            related: 'http://example.com/planets/earth/elements'
+          }
+        }
+      }
+    };
+
+    assert.deepEqual(mergeRecords(earth, updates), expected);
+  });
 });

--- a/packages/@orbit/data/test/record-test.ts
+++ b/packages/@orbit/data/test/record-test.ts
@@ -6,7 +6,8 @@ import {
   recordsInclude,
   recordsIncludeAll,
   deserializeRecordIdentity,
-  serializeRecordIdentity
+  serializeRecordIdentity,
+  mergeRecords
 } from '../src/index';
 import './test-helper';
 
@@ -187,5 +188,17 @@ module('Record', function() {
       ),
       'unequal sets 2'
     );
+  });
+
+  test('`mergeRecords` returns a clone of the updates if no current record is supplied', function(assert) {
+    let earth = {
+      type: 'planet',
+      id: 'earth',
+      attributes: {
+        name: 'Earth'
+      }
+    };
+    assert.deepEqual(mergeRecords(null, earth), earth);
+    assert.notStrictEqual(mergeRecords(null, earth), earth);
   });
 });

--- a/packages/@orbit/memory/test/memory-cache-test.ts
+++ b/packages/@orbit/memory/test/memory-cache-test.ts
@@ -103,7 +103,7 @@ module('MemoryCache', function(hooks) {
   });
 
   test('#patch can replace records', function(assert) {
-    assert.expect(4);
+    assert.expect(5);
 
     let cache = new MemoryCache({ schema, keyMap });
 
@@ -124,10 +124,15 @@ module('MemoryCache', function(hooks) {
 
     cache.patch(t => t.updateRecord(earth));
 
-    assert.strictEqual(
+    assert.deepEqual(
       cache.getRecordSync({ type: 'planet', id: '1' }),
       earth,
-      'objects strictly match'
+      'objects deeply match'
+    );
+    assert.notStrictEqual(
+      cache.getRecordSync({ type: 'planet', id: '1' }),
+      earth,
+      'objects do not strictly match'
     );
     assert.equal(
       keyMap.keyToId('planet', 'remoteId', 'a'),

--- a/packages/@orbit/record-cache/test/async-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/async-record-cache-test.ts
@@ -125,7 +125,7 @@ module('AsyncRecordCache', function(hooks) {
   });
 
   test('#patch can replace records', async function(assert) {
-    assert.expect(4);
+    assert.expect(5);
 
     const cache = new Cache({ schema, keyMap });
 
@@ -146,10 +146,15 @@ module('AsyncRecordCache', function(hooks) {
 
     await cache.patch(t => t.updateRecord(earth));
 
-    assert.strictEqual(
+    assert.deepEqual(
       await cache.getRecordAsync({ type: 'planet', id: '1' }),
       earth,
-      'objects strictly match'
+      'objects deeply match'
+    );
+    assert.notStrictEqual(
+      await cache.getRecordAsync({ type: 'planet', id: '1' }),
+      earth,
+      'objects do not strictly match'
     );
     assert.equal(
       keyMap.keyToId('planet', 'remoteId', 'a'),

--- a/packages/@orbit/record-cache/test/sync-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/sync-record-cache-test.ts
@@ -125,7 +125,7 @@ module('SyncRecordCache', function(hooks) {
   });
 
   test('#patch can replace records', function(assert) {
-    assert.expect(4);
+    assert.expect(5);
 
     const cache = new Cache({ schema, keyMap });
 
@@ -146,10 +146,15 @@ module('SyncRecordCache', function(hooks) {
 
     cache.patch(t => t.updateRecord(earth));
 
-    assert.strictEqual(
+    assert.deepEqual(
       cache.getRecordSync({ type: 'planet', id: '1' }),
       earth,
-      'objects strictly match'
+      'objects deeply match'
+    );
+    assert.notStrictEqual(
+      cache.getRecordSync({ type: 'planet', id: '1' }),
+      earth,
+      'objects do not strictly match'
     );
     assert.equal(
       keyMap.keyToId('planet', 'remoteId', 'a'),


### PR DESCRIPTION
Improve `mergeRecords` to better handle links, meta, and relationships.