### PR TITLE
Standardize request option handling

### DIFF
--- a/packages/@orbit/data/src/index.ts
+++ b/packages/@orbit/data/src/index.ts
@@ -2,11 +2,13 @@ export { default } from './main';
 export * from './exception';
 export { default as KeyMap } from './key-map';
 export * from './operation';
+export * from './options';
 export { default as QueryBuilder } from './query-builder';
 export * from './query-expression';
 export * from './query-term';
 export * from './query';
 export * from './record';
+export * from './request';
 export {
   default as Schema,
   AttributeDefinition,

--- a/packages/@orbit/data/src/options.ts
+++ b/packages/@orbit/data/src/options.ts
@@ -1,0 +1,3 @@
+export interface Options {
+  [key: string]: unknown;
+}

--- a/packages/@orbit/data/src/query.ts
+++ b/packages/@orbit/data/src/query.ts
@@ -3,6 +3,7 @@ import { QueryExpression } from './query-expression';
 import { QueryTerm } from './query-term';
 import QueryBuilder from './query-builder';
 import { isObject } from '@orbit/utils';
+import { RequestOptions } from './request';
 
 export type QueryBuilderFunc = (
   QueryBuilder: QueryBuilder
@@ -21,7 +22,7 @@ export type QueryOrExpressions =
 export interface Query {
   id: string;
   expressions: QueryExpression[];
-  options?: any;
+  options?: RequestOptions;
 }
 
 /**
@@ -38,7 +39,7 @@ export interface Query {
  */
 export function buildQuery(
   queryOrExpressions: QueryOrExpressions,
-  queryOptions?: object,
+  queryOptions?: RequestOptions,
   queryId?: string,
   queryBuilder?: QueryBuilder
 ): Query {
@@ -47,7 +48,7 @@ export function buildQuery(
   } else {
     let query = queryOrExpressions as Query;
     let expressions: QueryExpression[];
-    let options: object;
+    let options: RequestOptions;
 
     if (isQuery(query)) {
       if (query.id && !queryOptions && !queryId) {

--- a/packages/@orbit/data/src/query.ts
+++ b/packages/@orbit/data/src/query.ts
@@ -20,7 +20,6 @@ export type QueryOrExpressions =
  */
 export interface Query {
   id: string;
-  expression?: QueryExpression;
   expressions: QueryExpression[];
   options?: any;
 }

--- a/packages/@orbit/data/src/request.ts
+++ b/packages/@orbit/data/src/request.ts
@@ -4,3 +4,26 @@ export interface RequestOptions extends Options {
   sources?: { [name: string]: { [key: string]: unknown } };
 }
 
+/**
+ * Merges general request options with those specific to a source. The more
+ * specific options override the general options.
+ */
+export function requestOptionsForSource(
+  options: RequestOptions,
+  source: string
+): Options {
+  if (options.sources) {
+    let { sources, ...rest } = options;
+
+    if (sources && sources[source]) {
+      return {
+        ...rest,
+        ...sources[source]
+      };
+    } else {
+      return rest;
+    }
+  } else {
+    return options;
+  }
+}

--- a/packages/@orbit/data/src/request.ts
+++ b/packages/@orbit/data/src/request.ts
@@ -1,0 +1,6 @@
+import { Options } from './options';
+
+export interface RequestOptions extends Options {
+  sources?: { [name: string]: { [key: string]: unknown } };
+}
+

--- a/packages/@orbit/data/src/source-interfaces/pullable.ts
+++ b/packages/@orbit/data/src/source-interfaces/pullable.ts
@@ -2,6 +2,7 @@ import Orbit, { settleInSeries, fulfillInSeries } from '@orbit/core';
 import { Source, SourceClass } from '../source';
 import { Query, QueryOrExpressions, buildQuery } from '../query';
 import { Transform } from '../transform';
+import { RequestOptions } from '../request';
 
 const { assert } = Orbit;
 
@@ -27,7 +28,7 @@ export interface Pullable {
    */
   pull(
     queryOrExpressions: QueryOrExpressions,
-    options?: object,
+    options?: RequestOptions,
     id?: string
   ): Promise<Transform[]>;
 
@@ -74,7 +75,7 @@ export default function pullable(Klass: SourceClass): void {
 
   proto.pull = async function(
     queryOrExpressions: QueryOrExpressions,
-    options?: object,
+    options?: RequestOptions,
     id?: string
   ): Promise<Transform[]> {
     await this.activated;

--- a/packages/@orbit/data/src/source-interfaces/pushable.ts
+++ b/packages/@orbit/data/src/source-interfaces/pushable.ts
@@ -1,6 +1,7 @@
 import Orbit, { settleInSeries, fulfillInSeries } from '@orbit/core';
 import { Source, SourceClass } from '../source';
 import { Transform, TransformOrOperations, buildTransform } from '../transform';
+import { RequestOptions } from '../request';
 
 const { assert } = Orbit;
 
@@ -30,7 +31,7 @@ export interface Pushable {
    */
   push(
     transformOrOperations: TransformOrOperations,
-    options?: object,
+    options?: RequestOptions,
     id?: string
   ): Promise<Transform[]>;
 
@@ -77,7 +78,7 @@ export default function pushable(Klass: SourceClass): void {
 
   proto.push = async function(
     transformOrOperations: TransformOrOperations,
-    options?: object,
+    options?: RequestOptions,
     id?: string
   ): Promise<Transform[]> {
     await this.activated;

--- a/packages/@orbit/data/src/source-interfaces/queryable.ts
+++ b/packages/@orbit/data/src/source-interfaces/queryable.ts
@@ -1,6 +1,7 @@
 import Orbit, { settleInSeries, fulfillInSeries } from '@orbit/core';
 import { Query, QueryOrExpressions, buildQuery } from '../query';
 import { Source, SourceClass } from '../source';
+import { RequestOptions } from '../request';
 
 const { assert } = Orbit;
 
@@ -24,7 +25,7 @@ export interface Queryable {
    */
   query(
     queryOrExpressions: QueryOrExpressions,
-    options?: object,
+    options?: RequestOptions,
     id?: string
   ): Promise<any>;
 
@@ -70,7 +71,7 @@ export default function queryable(Klass: SourceClass): void {
 
   proto.query = async function(
     queryOrExpressions: QueryOrExpressions,
-    options?: object,
+    options?: RequestOptions,
     id?: string
   ): Promise<any> {
     await this.activated;

--- a/packages/@orbit/data/src/source-interfaces/updatable.ts
+++ b/packages/@orbit/data/src/source-interfaces/updatable.ts
@@ -1,6 +1,7 @@
 import Orbit, { settleInSeries, fulfillInSeries } from '@orbit/core';
 import { Source, SourceClass } from '../source';
 import { Transform, TransformOrOperations, buildTransform } from '../transform';
+import { RequestOptions } from '../request';
 
 const { assert } = Orbit;
 
@@ -25,7 +26,7 @@ export interface Updatable {
    */
   update(
     transformOrOperations: TransformOrOperations,
-    options?: object,
+    options?: RequestOptions,
     id?: string
   ): Promise<any>;
 
@@ -71,7 +72,7 @@ export default function updatable(Klass: SourceClass): void {
 
   proto.update = async function(
     transformOrOperations: TransformOrOperations,
-    options?: object,
+    options?: RequestOptions,
     id?: string
   ): Promise<any> {
     await this.activated;

--- a/packages/@orbit/data/src/transform.ts
+++ b/packages/@orbit/data/src/transform.ts
@@ -3,6 +3,7 @@ import Orbit from './main';
 import { Operation } from './operation';
 import { isObject } from '@orbit/utils';
 import TransformBuilder from './transform-builder';
+import { RequestOptions } from './request';
 
 export type TransformBuilderFunc = (
   TransformBuilder: TransformBuilder
@@ -19,7 +20,7 @@ export type TransformOrOperations =
 export interface Transform {
   id: string;
   operations: Operation[];
-  options?: any;
+  options?: RequestOptions;
 }
 
 /**
@@ -36,7 +37,7 @@ export interface Transform {
  */
 export function buildTransform(
   transformOrOperations: TransformOrOperations,
-  transformOptions?: object,
+  transformOptions?: RequestOptions,
   transformId?: string,
   transformBuilder?: TransformBuilder
 ): Transform {
@@ -49,7 +50,7 @@ export function buildTransform(
   } else {
     let transform = transformOrOperations as Transform;
     let operations: Operation[];
-    let options: object;
+    let options: RequestOptions;
 
     if (isObject(transform) && transform.operations) {
       if (transform.id && !transformOptions && !transformId) {

--- a/packages/@orbit/data/test/request-test.ts
+++ b/packages/@orbit/data/test/request-test.ts
@@ -1,0 +1,55 @@
+import { requestOptionsForSource } from '../src/request';
+import './test-helper';
+
+const { module, test } = QUnit;
+
+///////////////////////////////////////////////////////////////////////////////
+
+module('Request', function() {
+  test('requestOptionsForSource merges any source-specific options with top-level options', function(assert) {
+    let vanilla = {
+      label: 'request',
+      counter: 10
+    };
+
+    let custom = {
+      label: 'request',
+      counter: 10,
+      sources: {
+        memory: {
+          label: 'memoryRequest',
+          memoryMeta: 'abc'
+        },
+        remote: {
+          label: 'remoteRequest',
+          url: 'http://example.com'
+        }
+      }
+    };
+
+    assert.strictEqual(
+      requestOptionsForSource(vanilla, 'memory'),
+      vanilla,
+      'identical options are returned if there are no source-specific options'
+    );
+
+    assert.deepEqual(
+      requestOptionsForSource(custom, 'backup'),
+      {
+        label: 'request',
+        counter: 10
+      },
+      'source-less options are returned if there are no options specific to the source'
+    );
+
+    assert.deepEqual(
+      requestOptionsForSource(custom, 'memory'),
+      {
+        label: 'memoryRequest',
+        memoryMeta: 'abc',
+        counter: 10
+      },
+      'options are merged with source-specific options'
+    );
+  });
+});

--- a/packages/@orbit/data/test/source-interfaces/pullable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/pullable-test.ts
@@ -6,7 +6,8 @@ import {
   pullable,
   isPullable,
   buildTransform,
-  Pullable
+  Pullable,
+  RequestOptions
 } from '../../src/index';
 import '../test-helper';
 
@@ -17,7 +18,7 @@ module('@pullable', function(hooks) {
   class MySource extends Source implements Pullable {
     pull: (
       queryOrExpressions: QueryOrExpressions,
-      options?: object,
+      options?: RequestOptions,
       id?: string
     ) => Promise<Transform[]>;
     _pull: (query: Query, hints?: any) => Promise<Transform[]>;

--- a/packages/@orbit/data/test/source-interfaces/pushable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/pushable-test.ts
@@ -5,7 +5,8 @@ import {
   isPushable,
   buildTransform,
   Transform,
-  TransformOrOperations
+  TransformOrOperations,
+  RequestOptions
 } from '../../src/index';
 import '../test-helper';
 
@@ -16,7 +17,7 @@ module('@pushable', function(hooks) {
   class MySource extends Source implements Pushable {
     push: (
       transformOrOperations: TransformOrOperations,
-      options?: object,
+      options?: RequestOptions,
       id?: string
     ) => Promise<Transform[]>;
     _push: (transform: Transform, hints?: any) => Promise<Transform[]>;

--- a/packages/@orbit/data/test/source-interfaces/queryable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/queryable-test.ts
@@ -4,7 +4,8 @@ import {
   isQueryable,
   Query,
   Queryable,
-  QueryOrExpressions
+  QueryOrExpressions,
+  RequestOptions
 } from '../../src/index';
 import '../test-helper';
 
@@ -15,7 +16,7 @@ module('@queryable', function(hooks) {
   class MySource extends Source implements Queryable {
     query: (
       queryOrExpressions: QueryOrExpressions,
-      options?: object,
+      options?: RequestOptions,
       id?: string
     ) => Promise<any>;
     _query: (query: Query, hints?: any) => Promise<any>;

--- a/packages/@orbit/data/test/source-interfaces/updatable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/updatable-test.ts
@@ -5,7 +5,8 @@ import {
   Updatable,
   buildTransform,
   Transform,
-  TransformOrOperations
+  TransformOrOperations,
+  RequestOptions
 } from '../../src/index';
 import '../test-helper';
 
@@ -16,7 +17,7 @@ module('@updatable', function(hooks) {
   class MySource extends Source implements Updatable {
     update: (
       transformOrOperations: TransformOrOperations,
-      options?: object,
+      options?: RequestOptions,
       id?: string
     ) => Promise<any>;
     _update: (transform: Transform, hints?: any) => Promise<any>;

--- a/packages/@orbit/indexeddb/src/indexeddb-source.ts
+++ b/packages/@orbit/indexeddb/src/indexeddb-source.ts
@@ -9,6 +9,7 @@ import Orbit, {
   Syncable,
   Query,
   QueryOrExpressions,
+  RequestOptions,
   Source,
   SourceSettings,
   Transform,
@@ -44,14 +45,14 @@ export default class IndexedDBSource extends Source
   // Pullable interface stubs
   pull: (
     queryOrExpressions: QueryOrExpressions,
-    options?: object,
+    options?: RequestOptions,
     id?: string
   ) => Promise<Transform[]>;
 
   // Pushable interface stubs
   push: (
     transformOrOperations: TransformOrOperations,
-    options?: object,
+    options?: RequestOptions,
     id?: string
   ) => Promise<Transform[]>;
 

--- a/packages/@orbit/jsonapi/src/index.ts
+++ b/packages/@orbit/jsonapi/src/index.ts
@@ -11,3 +11,6 @@ export {
 } from './jsonapi-url-builder';
 export * from './record-document';
 export * from './resource-document';
+export * from './lib/exceptions';
+export * from './lib/jsonapi-request-options';
+export * from './lib/query-params';

--- a/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
@@ -7,15 +7,19 @@ import Orbit, {
   Record,
   Schema,
   ServerError,
-  Transform
+  Transform,
+  requestOptionsForSource
 } from '@orbit/data';
 import { InvalidServerResponse } from './lib/exceptions';
 import { TransformRecordRequest } from './lib/transform-requests';
 import { QueryRequest } from './lib/query-requests';
-import { deepGet, deepMerge, toArray } from '@orbit/utils';
+import { deepMerge, toArray } from '@orbit/utils';
 import { RecordDocument } from './record-document';
 import { ResourceDocument } from './resource-document';
-import { RequestOptions, buildFetchSettings } from './lib/request-settings';
+import {
+  JSONAPIRequestOptions,
+  buildFetchSettings
+} from './lib/jsonapi-request-options';
 import JSONAPIURLBuilder, {
   JSONAPIURLBuilderSettings
 } from './jsonapi-url-builder';
@@ -181,14 +185,22 @@ export default class JSONAPIRequestProcessor {
   }
 
   buildFetchSettings(
-    options: RequestOptions = {},
+    options: JSONAPIRequestOptions = {},
     customSettings?: FetchSettings
   ): FetchSettings {
     return buildFetchSettings(options, customSettings);
   }
 
-  customRequestOptions(queryOrTransform: Query | Transform): RequestOptions {
-    return deepGet(queryOrTransform, ['options', 'sources', this.sourceName]);
+  customRequestOptions(
+    queryOrTransform: Query | Transform
+  ): JSONAPIRequestOptions {
+    let options = queryOrTransform.options;
+    if (options) {
+      return requestOptionsForSource(
+        options,
+        this.sourceName
+      ) as JSONAPIRequestOptions;
+    }
   }
 
   preprocessResponseDocument(

--- a/packages/@orbit/jsonapi/src/jsonapi-source.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-source.ts
@@ -6,6 +6,7 @@ import Orbit, {
   SourceSettings,
   Query,
   QueryOrExpressions,
+  RequestOptions,
   Pullable,
   pullable,
   Pushable,
@@ -98,28 +99,28 @@ export default class JSONAPISource extends Source
   // Pullable interface stubs
   pull: (
     queryOrExpressions: QueryOrExpressions,
-    options?: object,
+    options?: RequestOptions,
     id?: string
   ) => Promise<Transform[]>;
 
   // Pushable interface stubs
   push: (
     transformOrOperations: TransformOrOperations,
-    options?: object,
+    options?: RequestOptions,
     id?: string
   ) => Promise<Transform[]>;
 
   // Queryable interface stubs
   query: (
     queryOrExpressions: QueryOrExpressions,
-    options?: object,
+    options?: RequestOptions,
     id?: string
   ) => Promise<any>;
 
   // Updatable interface stubs
   update: (
     transformOrOperations: TransformOrOperations,
-    options?: object,
+    options?: RequestOptions,
     id?: string
   ) => Promise<any>;
 

--- a/packages/@orbit/jsonapi/src/jsonapi-url-builder.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-url-builder.ts
@@ -11,7 +11,7 @@ import {
 } from '@orbit/data';
 import { clone } from '@orbit/utils';
 import { JSONAPISerializer } from './jsonapi-serializer';
-import { Filter } from './lib/request-settings';
+import { Filter } from './lib/jsonapi-request-options';
 import { appendQueryParams } from './lib/query-params';
 
 export interface JSONAPIURLBuilderSettings {

--- a/packages/@orbit/jsonapi/src/lib/jsonapi-request-options.ts
+++ b/packages/@orbit/jsonapi/src/lib/jsonapi-request-options.ts
@@ -8,7 +8,7 @@ export interface Filter {
   [filterOn: string]: any;
 }
 
-export interface RequestOptions {
+export interface JSONAPIRequestOptions {
   filter?: Filter[];
   sort?: any;
   page?: any;
@@ -17,7 +17,7 @@ export interface RequestOptions {
 }
 
 export function buildFetchSettings(
-  options: RequestOptions = {},
+  options: JSONAPIRequestOptions = {},
   customSettings?: FetchSettings
 ): FetchSettings {
   let settings = options.settings ? clone(options.settings) : {};
@@ -46,12 +46,11 @@ export function buildFetchSettings(
   return settings;
 }
 
-export function mergeRequestOptions(
-  options: RequestOptions,
-  customOptions: RequestOptions
+export function mergeJSONAPIRequestOptions(
+  options: JSONAPIRequestOptions,
+  customOptions: JSONAPIRequestOptions
 ) {
-  let result: RequestOptions = {};
-  merge(result, options, customOptions);
+  let result: JSONAPIRequestOptions = merge({}, options, customOptions);
   if (options.include && customOptions.include) {
     result.include = mergeIncludePaths(options.include, customOptions.include);
   }

--- a/packages/@orbit/jsonapi/src/lib/query-requests.ts
+++ b/packages/@orbit/jsonapi/src/lib/query-requests.ts
@@ -16,11 +16,14 @@ import {
   cloneRecordIdentity
 } from '@orbit/data';
 import JSONAPIRequestProcessor from '../jsonapi-request-processor';
-import { RequestOptions, mergeRequestOptions } from './request-settings';
+import {
+  JSONAPIRequestOptions,
+  mergeJSONAPIRequestOptions
+} from './jsonapi-request-options';
 
 export interface QueryRequest {
   op: string;
-  options?: RequestOptions;
+  options?: JSONAPIRequestOptions;
 }
 
 export interface FindRecordRequest extends QueryRequest {
@@ -69,11 +72,11 @@ export function getQueryRequests(
       expression,
       requestProcessor
     );
-    let options = requestProcessor.customRequestOptions(query);
 
+    let options = requestProcessor.customRequestOptions(query);
     if (options) {
       if (request.options) {
-        request.options = mergeRequestOptions(request.options, options);
+        request.options = mergeJSONAPIRequestOptions(request.options, options);
       } else {
         request.options = options;
       }
@@ -106,7 +109,7 @@ const ExpressionToRequestMap: Dict<ExpressionToRequestConverter> = {
       op: 'findRecords',
       type: expression.type
     };
-    let options: RequestOptions = {};
+    let options: JSONAPIRequestOptions = {};
 
     if (expression.filter) {
       options.filter = requestProcessor.urlBuilder.buildFilterParam(
@@ -146,7 +149,7 @@ const ExpressionToRequestMap: Dict<ExpressionToRequestConverter> = {
       record: cloneRecordIdentity(expression.record),
       relationship: expression.relationship
     };
-    const options: RequestOptions = {};
+    const options: JSONAPIRequestOptions = {};
 
     if (expression.filter) {
       options.filter = requestProcessor.urlBuilder.buildFilterParam(

--- a/packages/@orbit/jsonapi/src/lib/transform-requests.ts
+++ b/packages/@orbit/jsonapi/src/lib/transform-requests.ts
@@ -21,11 +21,11 @@ import { clone, deepSet, Dict } from '@orbit/utils';
 import JSONAPIRequestProcessor from '../jsonapi-request-processor';
 import { ResourceDocument } from '../resource-document';
 import { RecordDocument } from '../record-document';
-import { RequestOptions } from './request-settings';
+import { JSONAPIRequestOptions } from './jsonapi-request-options';
 
 export interface TransformRecordRequest {
   op: string;
-  options?: RequestOptions;
+  options?: JSONAPIRequestOptions;
   record: RecordIdentity;
 }
 

--- a/packages/@orbit/jsonapi/test/lib/jsonapi-request-options-test.ts
+++ b/packages/@orbit/jsonapi/test/lib/jsonapi-request-options-test.ts
@@ -1,20 +1,20 @@
-import { mergeRequestOptions } from '../../src/lib/request-settings';
+import { mergeJSONAPIRequestOptions } from '../../src/lib/jsonapi-request-options';
 
 const { module, test } = QUnit;
 
-module('RequestSettings', function() {
-  module('mergeRequestOptions', function() {
+module('JSONAPIRequestOptions', function() {
+  module('mergeJSONAPIRequestOptions', function() {
     const OPTIONS = {
       filter: [{ foo: 'bar' }],
       include: ['baz.bay']
     };
 
     test('merge empty options', function(assert) {
-      assert.deepEqual(mergeRequestOptions(OPTIONS, {}), OPTIONS);
+      assert.deepEqual(mergeJSONAPIRequestOptions(OPTIONS, {}), OPTIONS);
     });
 
     test('add sort', function(assert) {
-      assert.deepEqual(mergeRequestOptions(OPTIONS, { sort: ['qay'] }), {
+      assert.deepEqual(mergeJSONAPIRequestOptions(OPTIONS, { sort: ['qay'] }), {
         filter: [{ foo: 'bar' }],
         include: ['baz.bay'],
         sort: ['qay']
@@ -23,7 +23,9 @@ module('RequestSettings', function() {
 
     test('merge includes', function(assert) {
       assert.deepEqual(
-        mergeRequestOptions(OPTIONS, { include: ['baz.bay', 'snoop.dog'] }),
+        mergeJSONAPIRequestOptions(OPTIONS, {
+          include: ['baz.bay', 'snoop.dog']
+        }),
         {
           filter: [{ foo: 'bar' }],
           include: ['baz.bay', 'snoop.dog']
@@ -33,7 +35,9 @@ module('RequestSettings', function() {
 
     test('merge filters', function(assert) {
       assert.deepEqual(
-        mergeRequestOptions(OPTIONS, { filter: [{ intelligence: 'low' }] }),
+        mergeJSONAPIRequestOptions(OPTIONS, {
+          filter: [{ intelligence: 'low' }]
+        }),
         {
           filter: [{ foo: 'bar' }, { intelligence: 'low' }],
           include: ['baz.bay']
@@ -43,7 +47,7 @@ module('RequestSettings', function() {
 
     test('override filter', function(assert) {
       assert.deepEqual(
-        mergeRequestOptions(OPTIONS, { filter: [{ foo: 'zaz' }] }),
+        mergeJSONAPIRequestOptions(OPTIONS, { filter: [{ foo: 'zaz' }] }),
         {
           filter: [{ foo: 'zaz' }],
           include: ['baz.bay']
@@ -53,7 +57,7 @@ module('RequestSettings', function() {
 
     test('add page', function(assert) {
       assert.deepEqual(
-        mergeRequestOptions(OPTIONS, {
+        mergeJSONAPIRequestOptions(OPTIONS, {
           page: {
             kind: 'offsetLimit',
             offset: 5,

--- a/packages/@orbit/local-storage/src/local-storage-source.ts
+++ b/packages/@orbit/local-storage/src/local-storage-source.ts
@@ -10,6 +10,7 @@ import Orbit, {
   Syncable,
   Query,
   QueryOrExpressions,
+  RequestOptions,
   Source,
   SourceSettings,
   Transform,
@@ -49,14 +50,14 @@ export default class LocalStorageSource extends Source
   // Pullable interface stubs
   pull: (
     queryOrExpressions: QueryOrExpressions,
-    options?: object,
+    options?: RequestOptions,
     id?: string
   ) => Promise<Transform[]>;
 
   // Pushable interface stubs
   push: (
     transformOrOperations: TransformOrOperations,
-    options?: object,
+    options?: RequestOptions,
     id?: string
   ) => Promise<Transform[]>;
 

--- a/packages/@orbit/memory/src/memory-source.ts
+++ b/packages/@orbit/memory/src/memory-source.ts
@@ -8,6 +8,7 @@ import Orbit, {
   syncable,
   Query,
   QueryOrExpressions,
+  RequestOptions,
   Queryable,
   queryable,
   Updatable,
@@ -32,7 +33,7 @@ export interface MemorySourceSettings extends SourceSettings {
 export interface MemorySourceMergeOptions {
   coalesce?: boolean;
   sinceTransformId?: string;
-  transformOptions?: object;
+  transformOptions?: RequestOptions;
 }
 
 @syncable
@@ -52,14 +53,14 @@ export default class MemorySource extends Source
   // Queryable interface stubs
   query: (
     queryOrExpressions: QueryOrExpressions,
-    options?: object,
+    options?: RequestOptions,
     id?: string
   ) => Promise<any>;
 
   // Updatable interface stubs
   update: (
     transformOrOperations: TransformOrOperations,
-    options?: object,
+    options?: RequestOptions,
     id?: string
   ) => Promise<any>;
 

--- a/packages/@orbit/record-cache/src/async-record-cache.ts
+++ b/packages/@orbit/record-cache/src/async-record-cache.ts
@@ -8,6 +8,7 @@ import {
   QueryBuilder,
   QueryOrExpressions,
   QueryExpression,
+  RequestOptions,
   buildQuery,
   TransformBuilder,
   TransformBuilderFunc,
@@ -194,7 +195,7 @@ export abstract class AsyncRecordCache implements Evented, AsyncRecordAccessor {
    */
   async query(
     queryOrExpressions: QueryOrExpressions,
-    options?: object,
+    options?: RequestOptions,
     id?: string
   ): Promise<QueryResult> {
     const query = buildQuery(
@@ -252,7 +253,7 @@ export abstract class AsyncRecordCache implements Evented, AsyncRecordAccessor {
 
   liveQuery(
     queryOrExpressions: QueryOrExpressions,
-    options?: object,
+    options?: RequestOptions,
     id?: string
   ): AsyncLiveQuery {
     const query = buildQuery(

--- a/packages/@orbit/record-cache/src/sync-record-cache.ts
+++ b/packages/@orbit/record-cache/src/sync-record-cache.ts
@@ -11,7 +11,8 @@ import {
   buildQuery,
   TransformBuilder,
   TransformBuilderFunc,
-  RecordIdentity
+  RecordIdentity,
+  RequestOptions
 } from '@orbit/data';
 import {
   SyncOperationProcessor,
@@ -190,7 +191,7 @@ export abstract class SyncRecordCache implements Evented, SyncRecordAccessor {
    */
   query(
     queryOrExpressions: QueryOrExpressions,
-    options?: object,
+    options?: RequestOptions,
     id?: string
   ): QueryResult {
     const query = buildQuery(
@@ -248,7 +249,7 @@ export abstract class SyncRecordCache implements Evented, SyncRecordAccessor {
 
   liveQuery(
     queryOrExpressions: QueryOrExpressions,
-    options?: object,
+    options?: RequestOptions,
     id?: string
   ): SyncLiveQuery {
     const query = buildQuery(


### PR DESCRIPTION
This PR formalizes a `RequestOptions` interface, which can include general options at the root-level, as well as source-specific options nested within `sources`.

For example:

```
{
  label: 'Find planets and their moons',
  sources: {
    remote: { include: 'moons' }
  }
}
```

All options in the request-flow are now typed as `RequestOptions`.

This also adds a `requestOptionsForSource` method that transforms a `RequestOptions` object into a simple source-specific, flattened `Options` object. When run for the `remote` source `('requestOptionsForSource(options, 'remote')` on the `options` above, this would transform them into:

```
{
  label: 'Find planets and their moons',
  include: 'moons'
}
```

The expectation is that each source implementation will use this method to merge options into only the general and specific options relevant to them.

This makes for less-verbose options objects and standardizes their usage.

The one potential footgun is that users will dump all options into the root level and different sources will interpret them differently. But hopefully users will understand the options available to the sources they're using and sources that share options will use them in a compatible way.