### PR TITLE
Prettier2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "lerna": "^3.20.2",
-    "typedoc": "^0.16.11",
+    "typedoc": "^0.17.3",
     "typedoc-plugin-lerna-packages": "^0.3.0"
   },
   "workspaces": [

--- a/packages/@orbit/coordinator/.prettierrc.js
+++ b/packages/@orbit/coordinator/.prettierrc.js
@@ -1,3 +1,4 @@
 module.exports = {
-  singleQuote: true
+  singleQuote: true,
+  trailingComma: 'none'
 };

--- a/packages/@orbit/coordinator/package.json
+++ b/packages/@orbit/coordinator/package.json
@@ -32,11 +32,11 @@
   },
   "devDependencies": {
     "@glimmer/build": "^0.10.3",
-    "@typescript-eslint/eslint-plugin": "^2.23.0",
-    "@typescript-eslint/parser": "^2.23.0",
+    "@typescript-eslint/eslint-plugin": "^2.26.0",
+    "@typescript-eslint/parser": "^2.26.0",
     "eslint": "^6.8.0",
-    "eslint-config-prettier": "^6.10.0",
+    "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-prettier": "^3.1.2",
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.2"
   }
 }

--- a/packages/@orbit/coordinator/src/coordinator.ts
+++ b/packages/@orbit/coordinator/src/coordinator.ts
@@ -37,11 +37,11 @@ export default class Coordinator {
     this._strategies = {};
 
     if (options.sources) {
-      options.sources.forEach(source => this.addSource(source));
+      options.sources.forEach((source) => this.addSource(source));
     }
 
     if (options.strategies) {
-      options.strategies.forEach(strategy => this.addStrategy(strategy));
+      options.strategies.forEach((strategy) => this.addStrategy(strategy));
     }
 
     this._defaultActivationOptions = options.defaultActivationOptions || {};

--- a/packages/@orbit/coordinator/src/strategies/event-logging-strategy.ts
+++ b/packages/@orbit/coordinator/src/strategies/event-logging-strategy.ts
@@ -38,23 +38,23 @@ export class EventLoggingStrategy extends Strategy {
   ): Promise<void> {
     await super.activate(coordinator, options);
     this._eventListeners = {};
-    this._sources.forEach(source => this._activateSource(source));
+    this._sources.forEach((source) => this._activateSource(source));
   }
 
   async deactivate(): Promise<void> {
     await super.deactivate();
-    this._sources.forEach(source => this._deactivateSource(source));
+    this._sources.forEach((source) => this._deactivateSource(source));
     this._eventListeners = null;
   }
 
   protected _activateSource(source: Source): void {
-    this._sourceEvents(source).forEach(event => {
+    this._sourceEvents(source).forEach((event) => {
       this._addListener(source, event);
     });
   }
 
   protected _deactivateSource(source: Source): void {
-    this._sourceEvents(source).forEach(event => {
+    this._sourceEvents(source).forEach((event) => {
       this._removeListener(source, event);
     });
   }
@@ -66,7 +66,7 @@ export class EventLoggingStrategy extends Strategy {
       let events: string[] = [];
       let interfaces = this._interfaces || this._sourceInterfaces(source);
 
-      interfaces.forEach(i => {
+      interfaces.forEach((i) => {
         Array.prototype.push.apply(events, this._interfaceEvents(i));
       });
 

--- a/packages/@orbit/coordinator/src/strategy.ts
+++ b/packages/@orbit/coordinator/src/strategy.ts
@@ -74,7 +74,7 @@ export abstract class Strategy {
     }
 
     if (this._sourceNames) {
-      this._sources = this._sourceNames.map(name =>
+      this._sources = this._sourceNames.map((name) =>
         coordinator.getSource(name)
       );
     } else {

--- a/packages/@orbit/coordinator/test/coordinator-test.ts
+++ b/packages/@orbit/coordinator/test/coordinator-test.ts
@@ -7,19 +7,19 @@ import { Source } from '@orbit/data';
 
 const { module, test } = QUnit;
 
-module('Coordinator', function(hooks) {
+module('Coordinator', function (hooks) {
   class MySource extends Source {}
   class MyStrategy extends Strategy {}
 
   let coordinator: Coordinator;
 
-  test('can be instantiated', function(assert) {
+  test('can be instantiated', function (assert) {
     coordinator = new Coordinator();
 
     assert.ok(coordinator);
   });
 
-  test('can add sources', function(assert) {
+  test('can add sources', function (assert) {
     let s1 = new MySource({ name: 's1' });
     let s2 = new MySource({ name: 's2' });
     let s3 = new MySource({ name: 's3' });
@@ -36,7 +36,7 @@ module('Coordinator', function(hooks) {
     assert.strictEqual(coordinator.getSource('s3'), s3);
   });
 
-  test('can not add a source without a name', function(assert) {
+  test('can not add a source without a name', function (assert) {
     let s1 = new MySource();
     coordinator = new Coordinator();
 
@@ -45,7 +45,7 @@ module('Coordinator', function(hooks) {
     }, new Error("Assertion failed: Sources require a 'name' to be added to a coordinator."));
   });
 
-  test('can not add a source with a duplicate name', function(assert) {
+  test('can not add a source with a duplicate name', function (assert) {
     let s1 = new MySource({ name: 's1' });
     let s2 = new MySource({ name: 's1' });
     coordinator = new Coordinator();
@@ -56,7 +56,7 @@ module('Coordinator', function(hooks) {
     }, new Error("Assertion failed: A source named 's1' has already been added to this coordinator."));
   });
 
-  test('can not add a source while activated', async function(assert) {
+  test('can not add a source while activated', async function (assert) {
     let s1 = new MySource({ name: 's1' });
     coordinator = new Coordinator();
 
@@ -67,7 +67,7 @@ module('Coordinator', function(hooks) {
     }, new Error("Assertion failed: A coordinator's sources can not be changed while it is active."));
   });
 
-  test('can not remove a source while activated', async function(assert) {
+  test('can not remove a source while activated', async function (assert) {
     let s1 = new MySource({ name: 's1' });
     coordinator = new Coordinator({ sources: [s1] });
 
@@ -78,7 +78,7 @@ module('Coordinator', function(hooks) {
     }, new Error("Assertion failed: A coordinator's sources can not be changed while it is active."));
   });
 
-  test('can not remove a source that has not been added', async function(assert) {
+  test('can not remove a source that has not been added', async function (assert) {
     let s1 = new MySource({ name: 's1' });
     coordinator = new Coordinator();
 
@@ -89,7 +89,7 @@ module('Coordinator', function(hooks) {
     }, new Error("Assertion failed: Source 's1' has not been added to this coordinator."));
   });
 
-  test('can remove a source while inactive', function(assert) {
+  test('can remove a source while inactive', function (assert) {
     let s1 = new MySource({ name: 's1' });
     let s2 = new MySource({ name: 's2' });
     let s3 = new MySource({ name: 's3' });
@@ -101,7 +101,7 @@ module('Coordinator', function(hooks) {
     assert.deepEqual(coordinator.sources, [s1, s3]);
   });
 
-  test('can add strategies', function(assert) {
+  test('can add strategies', function (assert) {
     let s1 = new MyStrategy({ name: 's1' });
     let s2 = new MyStrategy({ name: 's2' });
     let s3 = new MyStrategy({ name: 's3' });
@@ -118,7 +118,7 @@ module('Coordinator', function(hooks) {
     assert.strictEqual(coordinator.getStrategy('s3'), s3);
   });
 
-  test('can not add a strategy with a duplicate name', function(assert) {
+  test('can not add a strategy with a duplicate name', function (assert) {
     let s1 = new MyStrategy({ name: 's1' });
     let s2 = new MyStrategy({ name: 's1' });
     coordinator = new Coordinator();
@@ -129,7 +129,7 @@ module('Coordinator', function(hooks) {
     }, new Error("Assertion failed: A strategy named 's1' has already been added to this coordinator."));
   });
 
-  test('can not add a strategy while activated', async function(assert) {
+  test('can not add a strategy while activated', async function (assert) {
     let s1 = new MyStrategy({ name: 's1' });
     coordinator = new Coordinator();
 
@@ -140,7 +140,7 @@ module('Coordinator', function(hooks) {
     }, new Error("Assertion failed: A coordinator's strategies can not be changed while it is active."));
   });
 
-  test('can not remove a strategy while activated', async function(assert) {
+  test('can not remove a strategy while activated', async function (assert) {
     let s1 = new MyStrategy({ name: 's1' });
     coordinator = new Coordinator({ strategies: [s1] });
 
@@ -151,7 +151,7 @@ module('Coordinator', function(hooks) {
     }, new Error("Assertion failed: A coordinator's strategies can not be changed while it is active."));
   });
 
-  test('can not remove a strategy that has not been added', async function(assert) {
+  test('can not remove a strategy that has not been added', async function (assert) {
     let s1 = new MyStrategy({ name: 's1' });
     coordinator = new Coordinator();
 
@@ -162,7 +162,7 @@ module('Coordinator', function(hooks) {
     }, new Error("Assertion failed: Strategy 's1' has not been added to this coordinator."));
   });
 
-  test('can remove a strategy while inactive', function(assert) {
+  test('can remove a strategy while inactive', function (assert) {
     let s1 = new MyStrategy({ name: 's1' });
     let s2 = new MyStrategy({ name: 's2' });
     let s3 = new MyStrategy({ name: 's3' });
@@ -174,7 +174,7 @@ module('Coordinator', function(hooks) {
     assert.deepEqual(coordinator.strategies, [s1, s3]);
   });
 
-  test('can be activated and deactivated', async function(assert) {
+  test('can be activated and deactivated', async function (assert) {
     assert.expect(31);
 
     let activatedCount = 0;
@@ -408,7 +408,7 @@ module('Coordinator', function(hooks) {
     assert.equal(deactivatedCount, 3, 'all strategies have been deactivated');
   });
 
-  test('can be deactivated multiple times, without being activated', async function(assert) {
+  test('can be deactivated multiple times, without being activated', async function (assert) {
     assert.expect(2);
 
     class CustomStrategy extends Strategy {

--- a/packages/@orbit/coordinator/test/strategies/connection-strategy-test.ts
+++ b/packages/@orbit/coordinator/test/strategies/connection-strategy-test.ts
@@ -10,7 +10,7 @@ import {
 
 const { module, test } = QUnit;
 
-module('ConnectionStrategy', function(hooks) {
+module('ConnectionStrategy', function (hooks) {
   const t = new TransformBuilder();
   const tA = buildTransform(
     [t.addRecord({ type: 'planet', id: 'a', attributes: { name: 'a' } })],
@@ -28,7 +28,7 @@ module('ConnectionStrategy', function(hooks) {
   let s1: any;
   let s2: any;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     @pushable
     @updatable
     class MySource extends Source {}
@@ -37,7 +37,7 @@ module('ConnectionStrategy', function(hooks) {
     s2 = new MySource({ name: 's2' });
   });
 
-  test('can be instantiated', function(assert) {
+  test('can be instantiated', function (assert) {
     strategy = new ConnectionStrategy({
       source: 's1',
       target: 's2',
@@ -58,7 +58,7 @@ module('ConnectionStrategy', function(hooks) {
     );
   });
 
-  test('assigns source and target when activated', async function(assert) {
+  test('assigns source and target when activated', async function (assert) {
     strategy = new ConnectionStrategy({
       source: 's1',
       target: 's2',
@@ -76,7 +76,7 @@ module('ConnectionStrategy', function(hooks) {
     assert.strictEqual(strategy.target, s2, 'target is set');
   });
 
-  test('installs listeners on activate and removes them on deactivate', async function(assert) {
+  test('installs listeners on activate and removes them on deactivate', async function (assert) {
     assert.expect(6);
 
     strategy = new ConnectionStrategy({
@@ -121,7 +121,7 @@ module('ConnectionStrategy', function(hooks) {
     );
   });
 
-  test('observes source `on` event and invokes `action` on target', async function(assert) {
+  test('observes source `on` event and invokes `action` on target', async function (assert) {
     assert.expect(3);
 
     strategy = new ConnectionStrategy({
@@ -136,7 +136,7 @@ module('ConnectionStrategy', function(hooks) {
       strategies: [strategy]
     });
 
-    s1._update = async function(transform: Transform): Promise<any> {
+    s1._update = async function (transform: Transform): Promise<any> {
       assert.strictEqual(
         transform,
         tA,
@@ -144,7 +144,7 @@ module('ConnectionStrategy', function(hooks) {
       );
     };
 
-    s2._push = async function(transform: Transform): Promise<Transform[]> {
+    s2._push = async function (transform: Transform): Promise<Transform[]> {
       assert.strictEqual(
         transform,
         tA,
@@ -158,7 +158,7 @@ module('ConnectionStrategy', function(hooks) {
     await s1.update(tA);
   });
 
-  test('can apply a `filter` function', async function(assert) {
+  test('can apply a `filter` function', async function (assert) {
     assert.expect(4);
 
     strategy = new ConnectionStrategy({
@@ -177,9 +177,9 @@ module('ConnectionStrategy', function(hooks) {
       strategies: [strategy]
     });
 
-    s1._update = async function(transform: Transform): Promise<any> {};
+    s1._update = async function (transform: Transform): Promise<any> {};
 
-    s2._push = async function(transform: Transform): Promise<Transform[]> {
+    s2._push = async function (transform: Transform): Promise<Transform[]> {
       assert.strictEqual(
         transform,
         tB,

--- a/packages/@orbit/coordinator/test/strategies/event-logging-strategy-test.ts
+++ b/packages/@orbit/coordinator/test/strategies/event-logging-strategy-test.ts
@@ -3,16 +3,16 @@ import { Source, TransformBuilder } from '@orbit/data';
 
 const { module, test } = QUnit;
 
-module('EventLoggingStrategy', function(hooks) {
+module('EventLoggingStrategy', function (hooks) {
   let eventLoggingStrategy: EventLoggingStrategy;
 
-  test('can be instantiated', function(assert) {
+  test('can be instantiated', function (assert) {
     eventLoggingStrategy = new EventLoggingStrategy();
 
     assert.ok(eventLoggingStrategy);
   });
 
-  test('can be added to a coordinator', function(assert) {
+  test('can be added to a coordinator', function (assert) {
     let coordinator = new Coordinator();
 
     eventLoggingStrategy = new EventLoggingStrategy();
@@ -25,7 +25,7 @@ module('EventLoggingStrategy', function(hooks) {
     );
   });
 
-  test('for basic sources, installs `transform` listeners on activatation and removes them on deactivation', async function(assert) {
+  test('for basic sources, installs `transform` listeners on activatation and removes them on deactivation', async function (assert) {
     assert.expect(6);
 
     class MySource extends Source {}

--- a/packages/@orbit/coordinator/test/strategies/log-truncation-strategy-test.ts
+++ b/packages/@orbit/coordinator/test/strategies/log-truncation-strategy-test.ts
@@ -3,7 +3,7 @@ import { Source, TransformBuilder, buildTransform } from '@orbit/data';
 
 const { module, test } = QUnit;
 
-module('LogTruncationStrategy', function(hooks) {
+module('LogTruncationStrategy', function (hooks) {
   const t = new TransformBuilder();
   const tA = buildTransform(
     [t.addRecord({ type: 'planet', id: 'a', attributes: { name: 'a' } })],
@@ -32,7 +32,7 @@ module('LogTruncationStrategy', function(hooks) {
   let s2: any;
   let s3: any;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     class MySource extends Source {}
 
     s1 = new MySource({ name: 's1' });
@@ -40,13 +40,13 @@ module('LogTruncationStrategy', function(hooks) {
     s3 = new MySource({ name: 's3' });
   });
 
-  test('can be instantiated', function(assert) {
+  test('can be instantiated', function (assert) {
     logTruncationStrategy = new LogTruncationStrategy();
 
     assert.ok(logTruncationStrategy);
   });
 
-  test('installs listeners on activate and removes them on deactivate', async function(assert) {
+  test('installs listeners on activate and removes them on deactivate', async function (assert) {
     assert.expect(18);
 
     logTruncationStrategy = new LogTruncationStrategy();
@@ -154,7 +154,7 @@ module('LogTruncationStrategy', function(hooks) {
     );
   });
 
-  test('observes source transforms and truncates any common history up to the most recent match', async function(assert) {
+  test('observes source transforms and truncates any common history up to the most recent match', async function (assert) {
     assert.expect(3);
 
     logTruncationStrategy = new LogTruncationStrategy();
@@ -176,7 +176,7 @@ module('LogTruncationStrategy', function(hooks) {
     assert.ok(!s3.transformLog.contains('a'), 's3 has removed a');
   });
 
-  test('observes source transforms and truncates their history to after the most recent common entry', async function(assert) {
+  test('observes source transforms and truncates their history to after the most recent common entry', async function (assert) {
     assert.expect(10);
 
     logTruncationStrategy = new LogTruncationStrategy();

--- a/packages/@orbit/coordinator/test/strategies/request-strategy-test.ts
+++ b/packages/@orbit/coordinator/test/strategies/request-strategy-test.ts
@@ -10,7 +10,7 @@ import {
 
 const { module, test } = QUnit;
 
-module('RequestStrategy', function(hooks) {
+module('RequestStrategy', function (hooks) {
   const t = new TransformBuilder();
   const tA = buildTransform(
     [t.addRecord({ type: 'planet', id: 'a', attributes: { name: 'a' } })],
@@ -28,7 +28,7 @@ module('RequestStrategy', function(hooks) {
   let s1: any;
   let s2: any;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     @pushable
     @updatable
     class MySource extends Source {}
@@ -37,7 +37,7 @@ module('RequestStrategy', function(hooks) {
     s2 = new MySource({ name: 's2' });
   });
 
-  test('can be instantiated', function(assert) {
+  test('can be instantiated', function (assert) {
     strategy = new RequestStrategy({
       source: 's1',
       target: 's2',
@@ -58,7 +58,7 @@ module('RequestStrategy', function(hooks) {
     );
   });
 
-  test('assigns source and target when activated', async function(assert) {
+  test('assigns source and target when activated', async function (assert) {
     strategy = new RequestStrategy({
       source: 's1',
       target: 's2',
@@ -76,7 +76,7 @@ module('RequestStrategy', function(hooks) {
     assert.strictEqual(strategy.target, s2, 'target is set');
   });
 
-  test('installs listeners on activate and removes them on deactivate', async function(assert) {
+  test('installs listeners on activate and removes them on deactivate', async function (assert) {
     assert.expect(6);
 
     strategy = new RequestStrategy({
@@ -121,7 +121,7 @@ module('RequestStrategy', function(hooks) {
     );
   });
 
-  test('observes source `on` event and invokes `action` on target', async function(assert) {
+  test('observes source `on` event and invokes `action` on target', async function (assert) {
     assert.expect(3);
 
     strategy = new RequestStrategy({
@@ -136,7 +136,7 @@ module('RequestStrategy', function(hooks) {
       strategies: [strategy]
     });
 
-    s1._update = async function(transform: Transform): Promise<any> {
+    s1._update = async function (transform: Transform): Promise<any> {
       assert.strictEqual(
         transform,
         tA,
@@ -144,7 +144,7 @@ module('RequestStrategy', function(hooks) {
       );
     };
 
-    s2._push = async function(transform: Transform): Promise<Transform[]> {
+    s2._push = async function (transform: Transform): Promise<Transform[]> {
       assert.strictEqual(
         transform,
         tA,
@@ -158,7 +158,7 @@ module('RequestStrategy', function(hooks) {
     await s1.update(tA);
   });
 
-  test('with `passHints: true` and `blocking: true`, will pass `hints` that result from applying the target action', async function(assert) {
+  test('with `passHints: true` and `blocking: true`, will pass `hints` that result from applying the target action', async function (assert) {
     assert.expect(5);
 
     strategy = new RequestStrategy({
@@ -175,7 +175,7 @@ module('RequestStrategy', function(hooks) {
       strategies: [strategy]
     });
 
-    s1._update = async function(
+    s1._update = async function (
       transform: Transform,
       hints: any
     ): Promise<any> {
@@ -187,7 +187,7 @@ module('RequestStrategy', function(hooks) {
       assert.deepEqual(hints.data, [tA], 'result is passed as a hint');
     };
 
-    s2._push = async function(
+    s2._push = async function (
       transform: Transform,
       hints: any
     ): Promise<Transform[]> {
@@ -205,7 +205,7 @@ module('RequestStrategy', function(hooks) {
     await s1.update(tA);
   });
 
-  test('can apply a `filter` function', async function(assert) {
+  test('can apply a `filter` function', async function (assert) {
     assert.expect(4);
 
     strategy = new RequestStrategy({
@@ -224,9 +224,9 @@ module('RequestStrategy', function(hooks) {
       strategies: [strategy]
     });
 
-    s1._update = async function(): Promise<any> {};
+    s1._update = async function (): Promise<any> {};
 
-    s2._push = async function(transform: Transform): Promise<Transform[]> {
+    s2._push = async function (transform: Transform): Promise<Transform[]> {
       assert.strictEqual(
         transform,
         tB,
@@ -241,7 +241,7 @@ module('RequestStrategy', function(hooks) {
     await s1.update(tB);
   });
 
-  test('if `blocking` is a function it gets invoked with the query', async function(assert) {
+  test('if `blocking` is a function it gets invoked with the query', async function (assert) {
     assert.expect(5);
 
     strategy = new RequestStrategy({
@@ -268,7 +268,7 @@ module('RequestStrategy', function(hooks) {
       strategies: [strategy]
     });
 
-    s1._update = async function(transform: Transform): Promise<any> {
+    s1._update = async function (transform: Transform): Promise<any> {
       assert.strictEqual(
         transform,
         tA,
@@ -276,7 +276,7 @@ module('RequestStrategy', function(hooks) {
       );
     };
 
-    s2._push = async function(transform: Transform): Promise<Transform[]> {
+    s2._push = async function (transform: Transform): Promise<Transform[]> {
       assert.strictEqual(
         transform,
         tA,
@@ -290,7 +290,7 @@ module('RequestStrategy', function(hooks) {
     await s1.update(tA);
   });
 
-  test('for events that are invoked with more than one arg, pass all args to any custom handler functions', async function(assert) {
+  test('for events that are invoked with more than one arg, pass all args to any custom handler functions', async function (assert) {
     assert.expect(9);
 
     strategy = new RequestStrategy({

--- a/packages/@orbit/coordinator/test/strategies/sync-strategy-test.ts
+++ b/packages/@orbit/coordinator/test/strategies/sync-strategy-test.ts
@@ -10,7 +10,7 @@ import { Exception } from '@orbit/core';
 
 const { module, test } = QUnit;
 
-module('SyncStrategy', function(hooks) {
+module('SyncStrategy', function (hooks) {
   const t = new TransformBuilder();
   const tA = buildTransform(
     [t.addRecord({ type: 'planet', id: 'a', attributes: { name: 'a' } })],
@@ -28,7 +28,7 @@ module('SyncStrategy', function(hooks) {
   let s1: any;
   let s2: any;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     @syncable
     class MySource extends Source {}
 
@@ -36,7 +36,7 @@ module('SyncStrategy', function(hooks) {
     s2 = new MySource({ name: 's2' });
   });
 
-  test('can be instantiated', function(assert) {
+  test('can be instantiated', function (assert) {
     strategy = new SyncStrategy({ source: 's1', target: 's2' });
 
     assert.ok(strategy);
@@ -52,7 +52,7 @@ module('SyncStrategy', function(hooks) {
     );
   });
 
-  test('assigns source and target when activated', async function(assert) {
+  test('assigns source and target when activated', async function (assert) {
     strategy = new SyncStrategy({ source: 's1', target: 's2' });
 
     coordinator = new Coordinator({
@@ -66,7 +66,7 @@ module('SyncStrategy', function(hooks) {
     assert.strictEqual(strategy.target, s2, 'target is set');
   });
 
-  test('installs listeners on activate and removes them on deactivate', async function(assert) {
+  test('installs listeners on activate and removes them on deactivate', async function (assert) {
     assert.expect(6);
 
     strategy = new SyncStrategy({ source: 's1', target: 's2' });
@@ -106,7 +106,7 @@ module('SyncStrategy', function(hooks) {
     );
   });
 
-  test('observes source `transform` event and invokes `sync` on target', async function(assert) {
+  test('observes source `transform` event and invokes `sync` on target', async function (assert) {
     assert.expect(2);
 
     strategy = new SyncStrategy({ source: 's1', target: 's2' });
@@ -116,7 +116,7 @@ module('SyncStrategy', function(hooks) {
       strategies: [strategy]
     });
 
-    s2._sync = async function(transform: Transform): Promise<void> {
+    s2._sync = async function (transform: Transform): Promise<void> {
       assert.strictEqual(
         transform,
         tA,
@@ -129,7 +129,7 @@ module('SyncStrategy', function(hooks) {
     await s1.transformed([tA]);
   });
 
-  test('can apply a `filter` function', async function(assert) {
+  test('can apply a `filter` function', async function (assert) {
     assert.expect(4);
 
     strategy = new SyncStrategy({
@@ -146,7 +146,7 @@ module('SyncStrategy', function(hooks) {
       strategies: [strategy]
     });
 
-    s2._sync = async function(transform: Transform): Promise<void> {
+    s2._sync = async function (transform: Transform): Promise<void> {
       assert.strictEqual(
         transform,
         tB,
@@ -159,7 +159,7 @@ module('SyncStrategy', function(hooks) {
     await s1.transformed([tA, tB]);
   });
 
-  test('can catch errors with a `catch` function', async function(assert) {
+  test('can catch errors with a `catch` function', async function (assert) {
     assert.expect(6);
 
     strategy = new SyncStrategy({
@@ -182,7 +182,7 @@ module('SyncStrategy', function(hooks) {
       strategies: [strategy]
     });
 
-    s2._sync = async function(transform: Transform): Promise<void> {
+    s2._sync = async function (transform: Transform): Promise<void> {
       assert.strictEqual(
         transform,
         tA,
@@ -198,7 +198,7 @@ module('SyncStrategy', function(hooks) {
     assert.ok(true, 'transform event settled');
   });
 
-  test('errors rethrown within a `catch` function are not propagated', async function(assert) {
+  test('errors rethrown within a `catch` function are not propagated', async function (assert) {
     assert.expect(6);
 
     strategy = new SyncStrategy({
@@ -222,7 +222,7 @@ module('SyncStrategy', function(hooks) {
       strategies: [strategy]
     });
 
-    s2._sync = function(transform: Transform): Promise<void> {
+    s2._sync = function (transform: Transform): Promise<void> {
       assert.strictEqual(
         transform,
         tA,

--- a/packages/@orbit/coordinator/test/strategy-test.ts
+++ b/packages/@orbit/coordinator/test/strategy-test.ts
@@ -8,7 +8,7 @@ import { Source } from '@orbit/data';
 
 const { module, test } = QUnit;
 
-module('Strategy', function(hooks) {
+module('Strategy', function (hooks) {
   class MySource extends Source {}
 
   let coordinator: Coordinator;
@@ -17,7 +17,7 @@ module('Strategy', function(hooks) {
   let s2: MySource;
   let s3: MySource;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     s1 = new MySource({ name: 's1' });
     s2 = new MySource({ name: 's2' });
     s3 = new MySource({ name: 's3' });
@@ -25,12 +25,12 @@ module('Strategy', function(hooks) {
     coordinator = new Coordinator({ sources: [s1, s2, s3] });
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     coordinator = null;
     s1 = s2 = s3 = null;
   });
 
-  test('can be instantiated with a name', function(assert) {
+  test('can be instantiated with a name', function (assert) {
     class CustomStrategy extends Strategy {}
 
     strategy = new CustomStrategy({
@@ -40,11 +40,11 @@ module('Strategy', function(hooks) {
     assert.ok(strategy);
   });
 
-  test('requires a name', function(assert) {
+  test('requires a name', function (assert) {
     class CustomStrategy extends Strategy {}
 
     assert.throws(
-      function() {
+      function () {
         strategy = new CustomStrategy();
       },
       Error('Assertion failed: Strategy requires a name'),
@@ -52,7 +52,7 @@ module('Strategy', function(hooks) {
     );
   });
 
-  test('uses its name as the basis for a logPrefix', function(assert) {
+  test('uses its name as the basis for a logPrefix', function (assert) {
     class CustomStrategy extends Strategy {}
 
     strategy = new CustomStrategy({
@@ -62,7 +62,7 @@ module('Strategy', function(hooks) {
     assert.equal(strategy.logPrefix, '[custom]');
   });
 
-  test('can specify a custom logPrefix', function(assert) {
+  test('can specify a custom logPrefix', function (assert) {
     class CustomStrategy extends Strategy {}
 
     strategy = new CustomStrategy({
@@ -73,7 +73,7 @@ module('Strategy', function(hooks) {
     assert.equal(strategy.logPrefix, '[foo-bar]');
   });
 
-  test('applies to all sources by default', async function(assert) {
+  test('applies to all sources by default', async function (assert) {
     assert.expect(1);
 
     class CustomStrategy extends Strategy {
@@ -96,7 +96,7 @@ module('Strategy', function(hooks) {
     await strategy.activate(coordinator);
   });
 
-  test('can include only specific sources', async function(assert) {
+  test('can include only specific sources', async function (assert) {
     assert.expect(1);
 
     class CustomStrategy extends Strategy {
@@ -119,7 +119,7 @@ module('Strategy', function(hooks) {
     await strategy.activate(coordinator);
   });
 
-  test('#activate - receives the `logLevel` from the coordinator', async function(assert) {
+  test('#activate - receives the `logLevel` from the coordinator', async function (assert) {
     assert.expect(2);
 
     class CustomStrategy extends Strategy {
@@ -153,7 +153,7 @@ module('Strategy', function(hooks) {
     await coordinator.activate({ logLevel: LogLevel.Warnings });
   });
 
-  test('a custom `logLevel` will override the level from the coordinator', async function(assert) {
+  test('a custom `logLevel` will override the level from the coordinator', async function (assert) {
     assert.expect(2);
 
     class CustomStrategy extends Strategy {
@@ -183,7 +183,7 @@ module('Strategy', function(hooks) {
     await coordinator.activate({ logLevel: LogLevel.Warnings });
   });
 
-  test('activate sources', async function(assert) {
+  test('activate sources', async function (assert) {
     class CustomStrategy extends Strategy {}
 
     strategy = new CustomStrategy({
@@ -192,18 +192,18 @@ module('Strategy', function(hooks) {
     });
 
     assert.throws(() => {
-      strategy.sources.map(s => s.activated);
+      strategy.sources.map((s) => s.activated);
     });
 
     coordinator.addStrategy(strategy);
     await coordinator.activate();
 
-    assert.ok(strategy.sources.map(s => s.activated));
+    assert.ok(strategy.sources.map((s) => s.activated));
 
     await coordinator.deactivate();
 
     assert.throws(() => {
-      strategy.sources.map(s => s.activated);
+      strategy.sources.map((s) => s.activated);
     });
   });
 });

--- a/packages/@orbit/core/.prettierrc.js
+++ b/packages/@orbit/core/.prettierrc.js
@@ -1,3 +1,4 @@
 module.exports = {
-  singleQuote: true
+  singleQuote: true,
+  trailingComma: 'none'
 };

--- a/packages/@orbit/core/package.json
+++ b/packages/@orbit/core/package.json
@@ -30,11 +30,11 @@
   },
   "devDependencies": {
     "@glimmer/build": "^0.10.3",
-    "@typescript-eslint/eslint-plugin": "^2.23.0",
-    "@typescript-eslint/parser": "^2.23.0",
+    "@typescript-eslint/eslint-plugin": "^2.26.0",
+    "@typescript-eslint/parser": "^2.26.0",
     "eslint": "^6.8.0",
-    "eslint-config-prettier": "^6.10.0",
+    "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-prettier": "^3.1.2",
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.2"
   }
 }

--- a/packages/@orbit/core/src/evented.ts
+++ b/packages/@orbit/core/src/evented.ts
@@ -81,7 +81,7 @@ export default function evented(Klass: any): void {
 
   proto[EVENTED] = true;
 
-  proto.on = function(eventName: string, listener: Listener): () => void {
+  proto.on = function (eventName: string, listener: Listener): () => void {
     if (arguments.length > 2) {
       deprecate(
         '`binding` argument is no longer supported when configuring `Evented` listeners. Please pre-bind listeners before calling `on`.'
@@ -91,7 +91,7 @@ export default function evented(Klass: any): void {
     return notifierForEvent(this, eventName, true).addListener(listener);
   };
 
-  proto.off = function(eventName: string, listener: Listener) {
+  proto.off = function (eventName: string, listener: Listener) {
     if (arguments.length > 2) {
       deprecate(
         '`binding` argument is no longer supported when configuring `Evented` listeners. Please pre-bind listeners before calling `off`.'
@@ -109,7 +109,7 @@ export default function evented(Klass: any): void {
     }
   };
 
-  proto.one = function(eventName: string, listener: Listener): () => void {
+  proto.one = function (eventName: string, listener: Listener): () => void {
     if (arguments.length > 2) {
       deprecate(
         '`binding` argument is no longer supported when configuring `Evented` listeners. Please pre-bind listeners before calling `off`.'
@@ -118,7 +118,7 @@ export default function evented(Klass: any): void {
 
     const notifier = notifierForEvent(this, eventName, true);
 
-    const callOnce = function() {
+    const callOnce = function () {
       listener(...arguments);
       notifier.removeListener(callOnce);
     };
@@ -126,7 +126,7 @@ export default function evented(Klass: any): void {
     return notifier.addListener(callOnce);
   };
 
-  proto.emit = function(eventName: string, ...args: any[]) {
+  proto.emit = function (eventName: string, ...args: any[]) {
     let notifier = notifierForEvent(this, eventName);
 
     if (notifier) {
@@ -134,7 +134,7 @@ export default function evented(Klass: any): void {
     }
   };
 
-  proto.listeners = function(eventName: string) {
+  proto.listeners = function (eventName: string) {
     let notifier = notifierForEvent(this, eventName);
     return notifier ? notifier.listeners : [];
   };

--- a/packages/@orbit/core/src/log.ts
+++ b/packages/@orbit/core/src/log.ts
@@ -188,7 +188,7 @@ export default class Log implements Evented {
     if (!data && this._bucket) {
       this.reified = this._bucket
         .getItem(this._name)
-        .then(bucketData => this._initData(bucketData));
+        .then((bucketData) => this._initData(bucketData));
     } else {
       this._initData(data);
       this.reified = Promise.resolve();

--- a/packages/@orbit/core/src/notifier.ts
+++ b/packages/@orbit/core/src/notifier.ts
@@ -71,6 +71,6 @@ export default class Notifier {
    * Notify registered listeners.
    */
   emit(...args: any[]) {
-    this.listeners.slice(0).forEach(listener => listener(...args));
+    this.listeners.slice(0).forEach((listener) => listener(...args));
   }
 }

--- a/packages/@orbit/core/src/task-processor.ts
+++ b/packages/@orbit/core/src/task-processor.ts
@@ -38,12 +38,12 @@ export default class TaskProcessor {
     this._started = false;
     this._settled = false;
     this._settlement = new Promise((resolve, reject) => {
-      this._success = r => {
+      this._success = (r) => {
         this._settled = true;
         resolve(r);
       };
 
-      this._fail = e => {
+      this._fail = (e) => {
         this._settled = true;
         reject(e);
       };

--- a/packages/@orbit/core/src/task-queue.ts
+++ b/packages/@orbit/core/src/task-queue.ts
@@ -396,7 +396,7 @@ export default class TaskQueue implements Evented {
               .then(() => this._settleEach(resolution));
           }
         })
-        .catch(e => {
+        .catch((e) => {
           if (resolution === this._resolution) {
             return this._fail(task, e);
           }
@@ -413,7 +413,7 @@ export default class TaskQueue implements Evented {
         if (tasks) {
           this._tasks = tasks;
           this._processors = tasks.map(
-            task => new TaskProcessor(this._performer, task)
+            (task) => new TaskProcessor(this._performer, task)
           );
         }
       });

--- a/packages/@orbit/core/test/bucket-test.ts
+++ b/packages/@orbit/core/test/bucket-test.ts
@@ -2,7 +2,7 @@ import { Bucket } from '../src/bucket';
 
 const { module, test } = QUnit;
 
-module('Bucket', function() {
+module('Bucket', function () {
   // Extend Bucket because it's an abstract class
   class MyBucket extends Bucket {
     constructor(settings = {}) {
@@ -23,18 +23,18 @@ module('Bucket', function() {
     }
   }
 
-  test('can be instantiated', function(assert) {
+  test('can be instantiated', function (assert) {
     let bucket = new MyBucket();
     assert.ok(bucket, 'bucket exists');
   });
 
-  test('has a default namespace and version', function(assert) {
+  test('has a default namespace and version', function (assert) {
     let bucket = new MyBucket();
     assert.equal(bucket.namespace, 'orbit-bucket', 'default namespace');
     assert.equal(bucket.version, 1, 'default version');
   });
 
-  test('can be instantiated with a name, namespace, and version', function(assert) {
+  test('can be instantiated with a name, namespace, and version', function (assert) {
     let bucket = new MyBucket({
       name: 'my-bucket',
       namespace: 'app-settings',
@@ -45,7 +45,7 @@ module('Bucket', function() {
     assert.equal(bucket.version, 1, 'version matches');
   });
 
-  test('can be upgraded to a new version', function(assert) {
+  test('can be upgraded to a new version', function (assert) {
     const done = assert.async();
 
     assert.expect(5);
@@ -58,7 +58,7 @@ module('Bucket', function() {
     assert.equal(bucket.namespace, 'ns1', 'namespace matches');
     assert.equal(bucket.version, 1, 'version matches');
 
-    bucket.on('upgrade', version => {
+    bucket.on('upgrade', (version) => {
       assert.equal(
         version,
         2,

--- a/packages/@orbit/core/test/evented-test.ts
+++ b/packages/@orbit/core/test/evented-test.ts
@@ -10,18 +10,18 @@ import {
 const { module, test } = QUnit;
 
 function successfulOperation() {
-  return new Promise(function(resolve) {
+  return new Promise(function (resolve) {
     resolve(':)');
   });
 }
 
 function failedOperation() {
-  return new Promise(function(resolve, reject) {
+  return new Promise(function (resolve, reject) {
     reject(':(');
   });
 }
 
-module('Evented', function(hooks) {
+module('Evented', function (hooks) {
   @evented
   class Foo implements Evented {
     on: (event: string, listener: Listener) => () => void;
@@ -33,25 +33,25 @@ module('Evented', function(hooks) {
 
   let obj: Foo;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     obj = new Foo();
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     obj = null;
   });
 
-  test('isEvented - tests for the application of the @evented decorator', function(assert) {
+  test('isEvented - tests for the application of the @evented decorator', function (assert) {
     assert.ok(isEvented(obj));
   });
 
-  test('#emit - notifies listeners when emitting a simple message', function(assert) {
+  test('#emit - notifies listeners when emitting a simple message', function (assert) {
     assert.expect(2);
 
-    let listener1: Listener = function(message: string): void {
+    let listener1: Listener = function (message: string): void {
       assert.equal(message, 'hello', 'notification message should match');
     };
-    let listener2: Listener = function(message: string): void {
+    let listener2: Listener = function (message: string): void {
       assert.equal(message, 'hello', 'notification message should match');
     };
 
@@ -61,13 +61,13 @@ module('Evented', function(hooks) {
     obj.emit('greeting', 'hello');
   });
 
-  test('#emit - notifies listeners registered with `one` only once each', function(assert) {
+  test('#emit - notifies listeners registered with `one` only once each', function (assert) {
     assert.expect(2);
 
-    let listener1: Listener = function(message: string): void {
+    let listener1: Listener = function (message: string): void {
       assert.equal(message, 'hello', 'notification message should match');
     };
-    let listener2: Listener = function(message: string): void {
+    let listener2: Listener = function (message: string): void {
       assert.equal(message, 'hello', 'notification message should match');
     };
 
@@ -79,13 +79,13 @@ module('Evented', function(hooks) {
     obj.emit('greeting', 'hello');
   });
 
-  test('#on return off function', function(assert) {
+  test('#on return off function', function (assert) {
     assert.expect(1);
 
-    let listener1: Listener = function(): void {
+    let listener1: Listener = function (): void {
       assert.ok(false, 'this listener should not be triggered');
     };
-    let listener2: Listener = function(message: string): void {
+    let listener2: Listener = function (message: string): void {
       assert.equal(message, 'hello', 'notification message should match');
     };
 
@@ -96,13 +96,13 @@ module('Evented', function(hooks) {
     obj.emit('greeting', 'hello');
   });
 
-  test('#one return off function', function(assert) {
+  test('#one return off function', function (assert) {
     assert.expect(1);
 
-    let listener1: Listener = function(): void {
+    let listener1: Listener = function (): void {
       assert.ok(false, 'this listener should not be triggered');
     };
-    let listener2: Listener = function(message: string): void {
+    let listener2: Listener = function (message: string): void {
       assert.equal(message, 'hello', 'notification message should match');
     };
 
@@ -113,13 +113,13 @@ module('Evented', function(hooks) {
     obj.emit('greeting', 'hello');
   });
 
-  test('#off can unregister individual listeners from an event', function(assert) {
+  test('#off can unregister individual listeners from an event', function (assert) {
     assert.expect(1);
 
-    let listener1: Listener = function(): void {
+    let listener1: Listener = function (): void {
       assert.ok(false, 'this listener should not be triggered');
     };
-    let listener2: Listener = function(message: string): void {
+    let listener2: Listener = function (message: string): void {
       assert.equal(message, 'hello', 'notification message should match');
     };
 
@@ -130,11 +130,11 @@ module('Evented', function(hooks) {
     obj.emit('greeting', 'hello');
   });
 
-  test('#off - can unregister all listeners from an event', function(assert) {
+  test('#off - can unregister all listeners from an event', function (assert) {
     assert.expect(6);
 
-    let listener1 = function() {};
-    let listener2 = function() {};
+    let listener1 = function () {};
+    let listener2 = function () {};
 
     obj.on('greeting', listener1);
     obj.on('salutation', listener1);
@@ -154,13 +154,13 @@ module('Evented', function(hooks) {
     assert.equal(obj.listeners('salutation').length, 0);
   });
 
-  test('#emit - allows listeners to be registered for multiple events', function(assert) {
+  test('#emit - allows listeners to be registered for multiple events', function (assert) {
     assert.expect(3);
 
-    let listener1 = function(message: string) {
+    let listener1 = function (message: string) {
       assert.equal(message, 'hello', 'notification message should match');
     };
-    let listener2 = function(message: string) {
+    let listener2 = function (message: string) {
       assert.equal(message, 'hello', 'notification message should match');
     };
 
@@ -172,14 +172,14 @@ module('Evented', function(hooks) {
     obj.emit('salutation', 'hello');
   });
 
-  test('#emit - notifies listeners when emitting events with any number of arguments', function(assert) {
+  test('#emit - notifies listeners when emitting events with any number of arguments', function (assert) {
     assert.expect(4);
 
-    let listener1 = function() {
+    let listener1 = function () {
       assert.equal(arguments[0], 'hello', 'notification message should match');
       assert.equal(arguments[1], 'world', 'notification message should match');
     };
-    let listener2 = function() {
+    let listener2 = function () {
       assert.equal(arguments[0], 'hello', 'notification message should match');
       assert.equal(arguments[1], 'world', 'notification message should match');
     };
@@ -190,14 +190,14 @@ module('Evented', function(hooks) {
     obj.emit('greeting', 'hello', 'world');
   });
 
-  test('#listeners - can return all the listeners for an event', function(assert) {
+  test('#listeners - can return all the listeners for an event', function (assert) {
     assert.expect(1);
 
-    let greeting1 = function() {
+    let greeting1 = function () {
       return 'Hello';
     };
 
-    let greeting2 = function() {
+    let greeting2 = function () {
       return 'Bon jour';
     };
 
@@ -211,26 +211,26 @@ module('Evented', function(hooks) {
     );
   });
 
-  test('settleInSeries - can fulfill all promises returned by listeners to an event, in order, until all are settled', function(assert) {
+  test('settleInSeries - can fulfill all promises returned by listeners to an event, in order, until all are settled', function (assert) {
     assert.expect(10);
 
     let order = 0;
-    let listener1 = function(message: string) {
+    let listener1 = function (message: string) {
       assert.equal(message, 'hello', 'notification message should match');
       assert.equal(++order, 1, 'listener1 triggered first');
       // doesn't return anything
     };
-    let listener2 = function(message: string) {
+    let listener2 = function (message: string) {
       assert.equal(message, 'hello', 'notification message should match');
       assert.equal(++order, 2, 'listener2 triggered second');
       return failedOperation();
     };
-    let listener3 = function(message: string) {
+    let listener3 = function (message: string) {
       assert.equal(message, 'hello', 'notification message should match');
       assert.equal(++order, 3, 'listener3 triggered third');
       return successfulOperation();
     };
-    let listener4 = function(message: string) {
+    let listener4 = function (message: string) {
       assert.equal(message, 'hello', 'notification message should match');
       assert.equal(++order, 4, 'listener4 triggered fourth');
       return failedOperation();
@@ -241,13 +241,13 @@ module('Evented', function(hooks) {
     obj.on('greeting', listener3);
     obj.on('greeting', listener4);
 
-    return settleInSeries(obj, 'greeting', 'hello').then(result => {
+    return settleInSeries(obj, 'greeting', 'hello').then((result) => {
       assert.equal(result, undefined, 'no result returned');
       assert.equal(++order, 5, 'promise resolved last');
     });
   });
 
-  test('settleInSeries - resolves regardless of errors thrown in handlers', function(assert) {
+  test('settleInSeries - resolves regardless of errors thrown in handlers', function (assert) {
     assert.expect(1);
 
     obj.on('greeting', () => {
@@ -255,7 +255,7 @@ module('Evented', function(hooks) {
     });
 
     return settleInSeries(obj, 'greeting', 'hello')
-      .then(function(result) {
+      .then(function (result) {
         assert.equal(result, undefined, 'Completed');
       })
       .catch(() => {
@@ -263,16 +263,16 @@ module('Evented', function(hooks) {
       });
   });
 
-  test('fulfillInSeries - it can fulfill all promises returned by listeners to an event, in order, until all are settled', function(assert) {
+  test('fulfillInSeries - it can fulfill all promises returned by listeners to an event, in order, until all are settled', function (assert) {
     assert.expect(7);
 
     let order = 0;
-    let listener1 = function(message: string) {
+    let listener1 = function (message: string) {
       assert.equal(message, 'hello', 'notification message should match');
       assert.equal(++order, 1, 'listener1 triggered first');
       // doesn't return anything
     };
-    let listener2 = function(message: string) {
+    let listener2 = function (message: string) {
       assert.equal(message, 'hello', 'notification message should match');
       assert.equal(++order, 2, 'listener2 triggered third');
       return successfulOperation();
@@ -282,11 +282,11 @@ module('Evented', function(hooks) {
     obj.on('greeting', listener2);
 
     return fulfillInSeries(obj, 'greeting', 'hello')
-      .then(function(result) {
+      .then(function (result) {
         assert.equal(result, undefined, 'no result returned');
         assert.equal(++order, 3, 'promise resolved last');
       })
-      .then(function() {
+      .then(function () {
         const listeners = obj.listeners('greeting');
         assert.equal(
           listeners.length,
@@ -296,26 +296,26 @@ module('Evented', function(hooks) {
       });
   });
 
-  test('fulfillInSeries - it will fail when any listener fails and return the error', function(assert) {
+  test('fulfillInSeries - it will fail when any listener fails and return the error', function (assert) {
     assert.expect(8);
 
     let order = 0;
-    let listener1 = function(message: string) {
+    let listener1 = function (message: string) {
       assert.equal(message, 'hello', 'notification message should match');
       assert.equal(++order, 1, 'listener1 triggered first');
       // doesn't return anything
     };
-    let listener2 = function(message: string) {
+    let listener2 = function (message: string) {
       assert.equal(message, 'hello', 'notification message should match');
       assert.equal(++order, 2, 'listener2 triggered third');
       return successfulOperation();
     };
-    let listener3 = function(message: string) {
+    let listener3 = function (message: string) {
       assert.equal(message, 'hello', 'notification message should match');
       assert.equal(++order, 3, 'listener3 triggered second');
       return failedOperation();
     };
-    let listener4 = function() {
+    let listener4 = function () {
       assert.ok(false, 'listener4 should not be triggered');
     };
 
@@ -328,7 +328,7 @@ module('Evented', function(hooks) {
       .then(() => {
         assert.ok(false, 'success handler should not be reached');
       })
-      .catch(error => {
+      .catch((error) => {
         assert.equal(++order, 4, 'error handler triggered last');
         assert.equal(error, ':(', 'error result returned');
       });

--- a/packages/@orbit/core/test/log-test.ts
+++ b/packages/@orbit/core/test/log-test.ts
@@ -5,38 +5,38 @@ import { Bucket } from '../src/bucket';
 
 const { module, test } = QUnit;
 
-module('Log', function() {
+module('Log', function () {
   const transformAId = 'f8d2c75f-f758-4314-b5c5-ac7fb783ab26';
   const transformBId = '1d12dc84-0d03-4875-a4a6-0e389737d891';
   const transformCId = 'ea054670-8901-45c2-b908-4db2c5bb9c7d';
   const transformDId = '771b25ff-b971-42e0-aac3-c285aef75326';
   let log: Log;
 
-  test('can be instantiated with no params', function(assert) {
+  test('can be instantiated with no params', function (assert) {
     log = new Log();
     assert.ok(log, 'log instantiated');
     assert.equal(log.length, 0, 'log has expected size');
   });
 
-  test('can be instantiated with a name and array of ids', function(assert) {
+  test('can be instantiated with a name and array of ids', function (assert) {
     log = new Log({ name: 'log1', data: ['a', 'b'] });
     assert.ok(log, 'log instantiated');
     assert.equal(log.length, 2, 'log has expected data');
   });
 
-  module('when empty', function(assert) {
-    assert.beforeEach(function() {
+  module('when empty', function (assert) {
+    assert.beforeEach(function () {
       log = new Log();
     });
 
-    test('#length', function(assert) {
+    test('#length', function (assert) {
       assert.equal(log.length, 0, 'is zero');
     });
 
-    test('#append', function(assert) {
+    test('#append', function (assert) {
       assert.expect(3);
 
-      log.on('append', transformIds => {
+      log.on('append', (transformIds) => {
         assert.deepEqual(
           transformIds,
           [transformAId],
@@ -57,23 +57,23 @@ module('Log', function() {
       });
     });
 
-    test('#head', function(assert) {
+    test('#head', function (assert) {
       assert.equal(log.head, null, 'is null');
     });
   });
 
-  module('containing several transformIds', function(assert) {
-    assert.beforeEach(function() {
+  module('containing several transformIds', function (assert) {
+    assert.beforeEach(function () {
       log = new Log();
 
       return log.append(transformAId, transformBId, transformCId);
     });
 
-    test('#entries', function(assert) {
+    test('#entries', function (assert) {
       assert.equal(log.entries.length, 3, 'contains the expected transforms');
     });
 
-    test('#length', function(assert) {
+    test('#length', function (assert) {
       assert.equal(
         log.length,
         3,
@@ -81,7 +81,7 @@ module('Log', function() {
       );
     });
 
-    test('#before', function(assert) {
+    test('#before', function (assert) {
       assert.deepEqual(
         log.before(transformCId),
         [transformAId, transformBId],
@@ -89,11 +89,11 @@ module('Log', function() {
       );
     });
 
-    test("#before - transformId that hasn't been logged", function(assert) {
+    test("#before - transformId that hasn't been logged", function (assert) {
       assert.throws(() => log.before(transformDId), NotLoggedException);
     });
 
-    test('#before - specifying a -1 relativePosition', function(assert) {
+    test('#before - specifying a -1 relativePosition', function (assert) {
       assert.deepEqual(
         log.before(transformCId, -1),
         [transformAId],
@@ -101,15 +101,15 @@ module('Log', function() {
       );
     });
 
-    test('#before - specifying a relativePosition that is too low', function(assert) {
+    test('#before - specifying a relativePosition that is too low', function (assert) {
       assert.throws(() => log.before(transformCId, -3), OutOfRangeException);
     });
 
-    test('#before - specifying a relativePosition that is too high', function(assert) {
+    test('#before - specifying a relativePosition that is too high', function (assert) {
       assert.throws(() => log.before(transformCId, 1), OutOfRangeException);
     });
 
-    test('#after', function(assert) {
+    test('#after', function (assert) {
       assert.deepEqual(
         log.after(transformAId),
         [transformBId, transformCId],
@@ -117,11 +117,11 @@ module('Log', function() {
       );
     });
 
-    test("#after - transformId that hasn't been logged", function(assert) {
+    test("#after - transformId that hasn't been logged", function (assert) {
       assert.throws(() => log.after(transformDId), NotLoggedException);
     });
 
-    test('#after - specifying a +1 relativePosition', function(assert) {
+    test('#after - specifying a +1 relativePosition', function (assert) {
       assert.deepEqual(
         log.after(transformAId, 1),
         [transformCId],
@@ -129,7 +129,7 @@ module('Log', function() {
       );
     });
 
-    test('#after - specifying a -1 relativePosition', function(assert) {
+    test('#after - specifying a -1 relativePosition', function (assert) {
       assert.deepEqual(
         log.after(transformAId, -1),
         [transformAId, transformBId, transformCId],
@@ -137,20 +137,20 @@ module('Log', function() {
       );
     });
 
-    test('#after - head', function(assert) {
+    test('#after - head', function (assert) {
       log.after(log.head);
       assert.deepEqual(log.after(log.head), [], 'is empty');
     });
 
-    test('#after - specifying a relativePosition that is too low', function(assert) {
+    test('#after - specifying a relativePosition that is too low', function (assert) {
       assert.throws(() => log.after(transformAId, -2), OutOfRangeException);
     });
 
-    test('#after - specifying a relativePosition that is too high', function(assert) {
+    test('#after - specifying a relativePosition that is too high', function (assert) {
       assert.throws(() => log.after(transformCId, 1), OutOfRangeException);
     });
 
-    test('#clear', function(assert) {
+    test('#clear', function (assert) {
       assert.expect(3);
 
       log.on('clear', (removed: string[]) => {
@@ -170,7 +170,7 @@ module('Log', function() {
       });
     });
 
-    test('#truncate', function(assert) {
+    test('#truncate', function (assert) {
       assert.expect(5);
 
       log.on('truncate', (transformId, relativePosition, removed) => {
@@ -204,7 +204,7 @@ module('Log', function() {
       });
     });
 
-    test('#truncate - to head', function(assert) {
+    test('#truncate - to head', function (assert) {
       return log.truncate(log.head).then(() => {
         assert.deepEqual(
           log.entries,
@@ -214,20 +214,20 @@ module('Log', function() {
       });
     });
 
-    test('#truncate - just past head clears the log', function(assert) {
+    test('#truncate - just past head clears the log', function (assert) {
       return log.truncate(transformCId, +1).then(() => {
         assert.deepEqual(log.entries, [], 'clears log');
       });
     });
 
-    test("#truncate - to transformId that hasn't been logged", function(assert) {
-      return log.truncate(transformDId).catch(e => {
+    test("#truncate - to transformId that hasn't been logged", function (assert) {
+      return log.truncate(transformDId).catch((e) => {
         assert.ok(e instanceof NotLoggedException, 'NotLoggedException caught');
       });
     });
 
-    test('#truncate - specifying a relativePosition that is too low', function(assert) {
-      return log.truncate(transformAId, -1).catch(e => {
+    test('#truncate - specifying a relativePosition that is too low', function (assert) {
+      return log.truncate(transformAId, -1).catch((e) => {
         assert.ok(
           e instanceof OutOfRangeException,
           'OutOfRangeException caught'
@@ -235,8 +235,8 @@ module('Log', function() {
       });
     });
 
-    test('#truncate - specifying a relativePosition that is too high', function(assert) {
-      return log.truncate(transformCId, +2).catch(e => {
+    test('#truncate - specifying a relativePosition that is too high', function (assert) {
+      return log.truncate(transformCId, +2).catch((e) => {
         assert.ok(
           e instanceof OutOfRangeException,
           'OutOfRangeException caught'
@@ -244,7 +244,7 @@ module('Log', function() {
       });
     });
 
-    test('#rollback', function(assert) {
+    test('#rollback', function (assert) {
       assert.expect(5);
 
       log.on('rollback', (transformId, relativePosition, removed) => {
@@ -278,26 +278,26 @@ module('Log', function() {
       });
     });
 
-    test('#rollback - to head', function(assert) {
+    test('#rollback - to head', function (assert) {
       return log.rollback(log.head).then(() => {
         assert.deepEqual(log.head, transformCId, "doesn't change log");
       });
     });
 
-    test("#rollback - to transformId that hasn't been logged", function(assert) {
-      return log.rollback(transformDId).catch(e => {
+    test("#rollback - to transformId that hasn't been logged", function (assert) {
+      return log.rollback(transformDId).catch((e) => {
         assert.ok(e instanceof NotLoggedException, 'NotLoggedException caught');
       });
     });
 
-    test('#rollback - to just before first', function(assert) {
+    test('#rollback - to just before first', function (assert) {
       return log.rollback(transformAId, -1).then(() => {
         assert.deepEqual(log.entries, [], 'removes all entries');
       });
     });
 
-    test('#rollback - specifying a relativePosition that is too low', function(assert) {
-      return log.rollback(transformAId, -2).catch(e => {
+    test('#rollback - specifying a relativePosition that is too low', function (assert) {
+      return log.rollback(transformAId, -2).catch((e) => {
         assert.ok(
           e instanceof OutOfRangeException,
           'OutOfRangeException caught'
@@ -305,8 +305,8 @@ module('Log', function() {
       });
     });
 
-    test('#rollback - specifying a relativePosition that is too high', function(assert) {
-      return log.rollback(transformCId, +1).catch(e => {
+    test('#rollback - specifying a relativePosition that is too high', function (assert) {
+      return log.rollback(transformCId, +1).catch((e) => {
         assert.ok(
           e instanceof OutOfRangeException,
           'OutOfRangeException caught'
@@ -314,11 +314,11 @@ module('Log', function() {
       });
     });
 
-    test('#head', function(assert) {
+    test('#head', function (assert) {
       assert.equal(log.head, transformCId, 'is last transformId');
     });
 
-    test('#contains', function(assert) {
+    test('#contains', function (assert) {
       assert.ok(
         log.contains(transformAId),
         'identifies when log contains a transform'
@@ -326,20 +326,20 @@ module('Log', function() {
     });
   });
 
-  module('using a bucket', function(hooks) {
+  module('using a bucket', function (hooks) {
     let bucket: Bucket;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(function () {
       bucket = new FakeBucket({ name: 'fake-bucket' });
     });
 
-    hooks.afterEach(function() {
+    hooks.afterEach(function () {
       bucket = null;
     });
 
-    test('requires a name for lookups in the bucket', function(assert) {
+    test('requires a name for lookups in the bucket', function (assert) {
       assert.throws(
-        function() {
+        function () {
           let log = new Log({ bucket });
         },
         Error('Assertion failed: Log requires a name if it has a bucket'),
@@ -347,7 +347,7 @@ module('Log', function() {
       );
     });
 
-    test('will be reified from data in the bucket', function(assert) {
+    test('will be reified from data in the bucket', function (assert) {
       assert.expect(1);
       return bucket
         .setItem('log', [transformAId, transformBId])
@@ -360,7 +360,7 @@ module('Log', function() {
         });
     });
 
-    test('#append - changes appended to the log are persisted to its bucket', function(assert) {
+    test('#append - changes appended to the log are persisted to its bucket', function (assert) {
       assert.expect(2);
       log = new Log({ name: 'log', bucket });
 
@@ -370,7 +370,7 @@ module('Log', function() {
           assert.equal(log.length, 2, 'log contains the expected transforms');
           return bucket.getItem('log');
         })
-        .then(logged => {
+        .then((logged) => {
           assert.deepEqual(
             logged,
             [transformAId, transformBId],
@@ -379,7 +379,7 @@ module('Log', function() {
         });
     });
 
-    test('#truncate - truncations to the log are persisted to its bucket', function(assert) {
+    test('#truncate - truncations to the log are persisted to its bucket', function (assert) {
       assert.expect(2);
       log = new Log({ name: 'log', bucket });
 
@@ -390,7 +390,7 @@ module('Log', function() {
           assert.equal(log.length, 1, 'log contains the expected transforms');
           return bucket.getItem('log');
         })
-        .then(logged => {
+        .then((logged) => {
           assert.deepEqual(
             logged,
             [transformCId],
@@ -399,7 +399,7 @@ module('Log', function() {
         });
     });
 
-    test('#rollback - when the log is rolled back, it is persisted to its bucket', function(assert) {
+    test('#rollback - when the log is rolled back, it is persisted to its bucket', function (assert) {
       assert.expect(2);
       log = new Log({ name: 'log', bucket });
 
@@ -410,7 +410,7 @@ module('Log', function() {
           assert.equal(log.length, 2, 'log contains the expected transforms');
           return bucket.getItem('log');
         })
-        .then(logged => {
+        .then((logged) => {
           assert.deepEqual(
             logged,
             [transformAId, transformBId],
@@ -419,7 +419,7 @@ module('Log', function() {
         });
     });
 
-    test('#clear - when the log is cleared, it is persisted to its bucket', function(assert) {
+    test('#clear - when the log is cleared, it is persisted to its bucket', function (assert) {
       assert.expect(2);
       log = new Log({ name: 'log', bucket });
 
@@ -430,7 +430,7 @@ module('Log', function() {
           assert.equal(log.length, 0, 'log contains the expected transforms');
           return bucket.getItem('log');
         })
-        .then(logged => {
+        .then((logged) => {
           assert.deepEqual(
             logged,
             [],

--- a/packages/@orbit/core/test/notifier-test.ts
+++ b/packages/@orbit/core/test/notifier-test.ts
@@ -2,24 +2,24 @@ import Notifier from '../src/notifier';
 
 const { module, test } = QUnit;
 
-module('Notifier', function(hooks) {
+module('Notifier', function (hooks) {
   let notifier: Notifier;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     notifier = new Notifier();
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     notifier = null;
   });
 
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     assert.ok(notifier);
   });
 
-  test('it maintains a list of listeners', function(assert) {
-    let listener1 = function() {};
-    let listener2 = function() {};
+  test('it maintains a list of listeners', function (assert) {
+    let listener1 = function () {};
+    let listener2 = function () {};
 
     assert.equal(notifier.listeners.length, 0);
 
@@ -34,13 +34,13 @@ module('Notifier', function(hooks) {
     assert.equal(notifier.listeners.length, 0);
   });
 
-  test('it notifies listeners when emitting a simple message', function(assert) {
+  test('it notifies listeners when emitting a simple message', function (assert) {
     assert.expect(2);
 
-    let listener1 = function(message: string) {
+    let listener1 = function (message: string) {
       assert.equal(message, 'hello', 'notification message should match');
     };
-    let listener2 = function(message: string) {
+    let listener2 = function (message: string) {
       assert.equal(message, 'hello', 'notification message should match');
     };
 
@@ -50,14 +50,14 @@ module('Notifier', function(hooks) {
     notifier.emit('hello');
   });
 
-  test('it notifies listeners when publishing any number of arguments', function(assert) {
+  test('it notifies listeners when publishing any number of arguments', function (assert) {
     assert.expect(4);
 
-    let listener1 = function() {
+    let listener1 = function () {
       assert.equal(arguments[0], 'hello', 'notification message should match');
       assert.equal(arguments[1], 'world', 'notification message should match');
     };
-    let listener2 = function() {
+    let listener2 = function () {
       assert.equal(arguments[0], 'hello', 'notification message should match');
       assert.equal(arguments[1], 'world', 'notification message should match');
     };

--- a/packages/@orbit/core/test/task-processor-test.ts
+++ b/packages/@orbit/core/test/task-processor-test.ts
@@ -6,8 +6,8 @@ const { module, test } = QUnit;
 
 ///////////////////////////////////////////////////////////////////////////////
 
-module('TaskProcessor', function() {
-  test('can be instantiated', function(assert) {
+module('TaskProcessor', function () {
+  test('can be instantiated', function (assert) {
     const target: Performer = {
       perform(task: Task): Promise<void> {
         return Promise.resolve();
@@ -17,7 +17,7 @@ module('TaskProcessor', function() {
     assert.ok(processor);
   });
 
-  test('processes asynchronous tasks by calling `perform` on a target', async function(assert) {
+  test('processes asynchronous tasks by calling `perform` on a target', async function (assert) {
     assert.expect(5);
 
     const target: Performer = {
@@ -25,7 +25,7 @@ module('TaskProcessor', function() {
         assert.equal(task.type, 'doSomething', 'perform invoked with task');
         assert.ok(processor.started, 'processor started');
         assert.ok(!processor.settled, 'processor not settled');
-        return new Promise(function(resolve: (value?: string) => void) {
+        return new Promise(function (resolve: (value?: string) => void) {
           function respond() {
             resolve(':)');
           }
@@ -42,7 +42,7 @@ module('TaskProcessor', function() {
     assert.equal(response, ':)', 'response is returned');
   });
 
-  test('can be assigned an asynchronous function that rejects', async function(assert) {
+  test('can be assigned an asynchronous function that rejects', async function (assert) {
     assert.expect(6);
 
     const target: Performer = {
@@ -51,7 +51,7 @@ module('TaskProcessor', function() {
         assert.equal(task.data, '1', 'argument matches');
         assert.ok(processor.started, 'processor started');
         assert.ok(!processor.settled, 'processor not settled');
-        return new Promise(function(resolve, reject) {
+        return new Promise(function (resolve, reject) {
           Orbit.globals.setTimeout(reject(':('), 1);
         });
       }
@@ -70,7 +70,7 @@ module('TaskProcessor', function() {
     }
   });
 
-  test("it creates a promise immediately that won't be resolved until process is called", function(assert) {
+  test("it creates a promise immediately that won't be resolved until process is called", function (assert) {
     assert.expect(5);
 
     const target: Performer = {
@@ -87,14 +87,14 @@ module('TaskProcessor', function() {
       data: '1'
     });
 
-    processor.settle().then(function() {
+    processor.settle().then(function () {
       assert.ok(true, 'process resolved');
     });
 
     return processor.process();
   });
 
-  test('#reset returns to an unstarted, unsettled state', async function(assert) {
+  test('#reset returns to an unstarted, unsettled state', async function (assert) {
     assert.expect(8);
 
     const target: Performer = {
@@ -123,7 +123,7 @@ module('TaskProcessor', function() {
     assert.ok(!processor.settled, 'after reset, task has not settled');
   });
 
-  test('#reject rejects the processor promise and marks the processor state as settled', async function(assert) {
+  test('#reject rejects the processor promise and marks the processor state as settled', async function (assert) {
     assert.expect(5);
 
     const target: Performer = {
@@ -154,7 +154,7 @@ module('TaskProcessor', function() {
     assert.ok(!processor.settled, 'after reset, task has not settled');
   });
 
-  test('#reject can reject processing that has started', async function(assert) {
+  test('#reject can reject processing that has started', async function (assert) {
     assert.expect(5);
 
     let processor: TaskProcessor;
@@ -188,7 +188,7 @@ module('TaskProcessor', function() {
     assert.ok(!processor.settled, 'after reset, task has not settled');
   });
 
-  test('#reject will fail when processing has already settled', async function(assert) {
+  test('#reject will fail when processing has already settled', async function (assert) {
     assert.expect(5);
 
     let processor: TaskProcessor;

--- a/packages/@orbit/core/test/task-queue-test.ts
+++ b/packages/@orbit/core/test/task-queue-test.ts
@@ -5,8 +5,8 @@ const { module, test } = QUnit;
 
 ///////////////////////////////////////////////////////////////////////////////
 
-module('TaskQueue', function() {
-  test('can be instantiated', function(assert) {
+module('TaskQueue', function () {
+  test('can be instantiated', function (assert) {
     const performer: Performer = {
       perform(task: Task): Promise<void> {
         return Promise.resolve();
@@ -16,7 +16,7 @@ module('TaskQueue', function() {
     assert.ok(queue);
   });
 
-  test('#autoProcess is enabled by default', function(assert) {
+  test('#autoProcess is enabled by default', function (assert) {
     const performer: Performer = {
       perform(task: Task): Promise<void> {
         return Promise.resolve();
@@ -26,7 +26,7 @@ module('TaskQueue', function() {
     assert.equal(queue.autoProcess, true, 'autoProcess === true');
   });
 
-  test('auto-processes pushed tasks sequentially by default', function(assert) {
+  test('auto-processes pushed tasks sequentially by default', function (assert) {
     assert.expect(21);
     const done = assert.async();
     let order = 0;
@@ -59,7 +59,7 @@ module('TaskQueue', function() {
     let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
     let transformCount = 0;
 
-    queue.on('beforeTask', function(task: Task) {
+    queue.on('beforeTask', function (task: Task) {
       if (transformCount === 0) {
         assert.equal(order++, 0, 'op1 - order of beforeTask event');
         assert.strictEqual(task.data, op1, 'op1 - beforeTask - data correct');
@@ -79,7 +79,7 @@ module('TaskQueue', function() {
       }
     });
 
-    queue.on('task', function(task: Task) {
+    queue.on('task', function (task: Task) {
       if (transformCount === 1) {
         assert.equal(order++, 2, 'op1 - order of task event');
         assert.strictEqual(task.data, op1, 'op1 processed');
@@ -111,7 +111,7 @@ module('TaskQueue', function() {
       }
     });
 
-    queue.on('complete', function() {
+    queue.on('complete', function () {
       assert.equal(order++, 6, 'order of complete event');
       done();
     });
@@ -127,7 +127,7 @@ module('TaskQueue', function() {
     });
   });
 
-  test('with `autoProcess` disabled, will process pushed functions sequentially when `process` is called', function(assert) {
+  test('with `autoProcess` disabled, will process pushed functions sequentially when `process` is called', function (assert) {
     assert.expect(5);
 
     const performer: Performer = {
@@ -156,7 +156,7 @@ module('TaskQueue', function() {
     let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
     let transformCount = 0;
 
-    queue.on('task', function(task) {
+    queue.on('task', function (task) {
       if (transformCount === 1) {
         assert.strictEqual(task.data, op1, 'op1 processed');
       } else if (transformCount === 2) {
@@ -164,7 +164,7 @@ module('TaskQueue', function() {
       }
     });
 
-    queue.on('complete', function() {
+    queue.on('complete', function () {
       assert.ok(true, 'queue completed');
     });
 
@@ -181,7 +181,7 @@ module('TaskQueue', function() {
     return queue.process();
   });
 
-  test('can enqueue tasks while another task is being processed', function(assert) {
+  test('can enqueue tasks while another task is being processed', function (assert) {
     assert.expect(7);
 
     const performer: Performer = {
@@ -203,7 +203,7 @@ module('TaskQueue', function() {
     let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
     let order = 0;
 
-    queue.on('task', function(task) {
+    queue.on('task', function (task) {
       if (task.data === op1) {
         assert.equal(++order, 2, 'op1 completed');
       } else if (task.data === op2) {
@@ -211,7 +211,7 @@ module('TaskQueue', function() {
       }
     });
 
-    queue.on('complete', function() {
+    queue.on('complete', function () {
       assert.equal(++order, 5, 'queue completed');
     });
 
@@ -225,13 +225,13 @@ module('TaskQueue', function() {
       data: op2
     });
 
-    return queue.process().then(function() {
+    return queue.process().then(function () {
       assert.equal(queue.empty, true, 'queue processing complete');
       assert.equal(++order, 6, 'queue resolves last');
     });
   });
 
-  test('will stop processing when a task errors', function(assert) {
+  test('will stop processing when a task errors', function (assert) {
     assert.expect(9);
 
     const performer: Performer = {
@@ -259,7 +259,7 @@ module('TaskQueue', function() {
     let op3 = { op: 'add', path: ['planets', '345'], value: 'Mars' };
     let transformCount = 0;
 
-    queue.on('task', function(task) {
+    queue.on('task', function (task) {
       if (transformCount === 1) {
         assert.strictEqual(task.data, op1, 'task - op1 processed');
       } else {
@@ -267,12 +267,12 @@ module('TaskQueue', function() {
       }
     });
 
-    queue.on('fail', function(task, err) {
+    queue.on('fail', function (task, err) {
       assert.strictEqual(task.data, op2, 'fail - op2 failed processing');
       assert.equal(err.message, ':(', 'fail - error matches expectation');
     });
 
-    queue.on('complete', function() {
+    queue.on('complete', function () {
       assert.ok(false, 'queue should not complete');
     });
 
@@ -281,7 +281,7 @@ module('TaskQueue', function() {
         type: 'transform',
         data: op1
       })
-      .catch(e => {
+      .catch((e) => {
         assert.ok(false, 'successful transform should not error');
       });
 
@@ -290,7 +290,7 @@ module('TaskQueue', function() {
         type: 'transform',
         data: op2
       })
-      .catch(e => {
+      .catch((e) => {
         assert.equal(e.message, ':(', 'error can be caught from `push`');
       });
 
@@ -299,11 +299,11 @@ module('TaskQueue', function() {
         type: 'transform',
         data: op3
       })
-      .catch(e => {
+      .catch((e) => {
         assert.ok(false, 'additional transforms should not be performed');
       });
 
-    return queue.process().catch(e => {
+    return queue.process().catch((e) => {
       assert.equal(e.message, ':(', 'error can be caught from `process`');
       assert.equal(
         queue.empty,
@@ -319,7 +319,7 @@ module('TaskQueue', function() {
     });
   });
 
-  test('when autoprocessing, will stop processing when a task errors', function(assert) {
+  test('when autoprocessing, will stop processing when a task errors', function (assert) {
     assert.expect(9);
 
     const performer: Performer = {
@@ -347,7 +347,7 @@ module('TaskQueue', function() {
     let op3 = { op: 'add', path: ['planets', '345'], value: 'Mars' };
     let transformCount = 0;
 
-    queue.on('task', function(task) {
+    queue.on('task', function (task) {
       if (transformCount === 1) {
         assert.strictEqual(task.data, op1, 'task - op1 processed');
       } else {
@@ -355,12 +355,12 @@ module('TaskQueue', function() {
       }
     });
 
-    queue.on('fail', function(task, err) {
+    queue.on('fail', function (task, err) {
       assert.strictEqual(task.data, op2, 'fail - op2 failed processing');
       assert.equal(err.message, ':(', 'fail - error matches expectation');
     });
 
-    queue.on('complete', function() {
+    queue.on('complete', function () {
       assert.ok(false, 'queue should not complete');
     });
 
@@ -369,7 +369,7 @@ module('TaskQueue', function() {
         type: 'transform',
         data: op1
       })
-      .catch(e => {
+      .catch((e) => {
         assert.ok(false, 'successful transform should not error');
       });
 
@@ -378,7 +378,7 @@ module('TaskQueue', function() {
         type: 'transform',
         data: op2
       })
-      .catch(e => {
+      .catch((e) => {
         assert.equal(e.message, ':(', 'error can be caught from `push`');
       });
 
@@ -387,11 +387,11 @@ module('TaskQueue', function() {
         type: 'transform',
         data: op3
       })
-      .catch(e => {
+      .catch((e) => {
         assert.ok(false, 'additional transforms should not be performed');
       });
 
-    return queue.process().catch(e => {
+    return queue.process().catch((e) => {
       assert.equal(e.message, ':(', 'error can be caught from `process`');
       assert.equal(
         queue.empty,
@@ -407,7 +407,7 @@ module('TaskQueue', function() {
     });
   });
 
-  test('#retry resets the current task in an inactive queue and restarts processing', async function(assert) {
+  test('#retry resets the current task in an inactive queue and restarts processing', async function (assert) {
     assert.expect(14);
 
     const performer: Performer = {
@@ -434,7 +434,7 @@ module('TaskQueue', function() {
     let op3 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
     let transformCount = 0;
 
-    queue.on('task', function(task) {
+    queue.on('task', function (task) {
       if (transformCount === 1) {
         assert.strictEqual(task.data, op1, 'task - op1 processed');
       } else if (transformCount === 3) {
@@ -444,12 +444,12 @@ module('TaskQueue', function() {
       }
     });
 
-    queue.on('fail', function(task, err) {
+    queue.on('fail', function (task, err) {
       assert.strictEqual(task.data, op2, 'fail - op2 failed processing');
       assert.equal(err.message, ':(', 'fail - error matches expectation');
     });
 
-    queue.on('complete', function() {
+    queue.on('complete', function () {
       assert.ok(true, 'queue should complete after processing has restarted');
     });
 
@@ -499,7 +499,7 @@ module('TaskQueue', function() {
     } catch {}
   });
 
-  test('#skip removes the current task from an inactive queue', async function(assert) {
+  test('#skip removes the current task from an inactive queue', async function (assert) {
     assert.expect(9);
 
     const performer: Performer = {
@@ -523,7 +523,7 @@ module('TaskQueue', function() {
     let op3 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
     let transformCount = 0;
 
-    queue.on('task', function(task) {
+    queue.on('task', function (task) {
       if (transformCount === 1) {
         assert.strictEqual(task.data, op1, 'task - op1 processed');
       } else if (transformCount === 2) {
@@ -531,12 +531,12 @@ module('TaskQueue', function() {
       }
     });
 
-    queue.on('fail', function(task, err) {
+    queue.on('fail', function (task, err) {
       assert.strictEqual(task.data, op2, 'fail - op2 failed processing');
       assert.equal(err.message, ':(', 'fail - error matches expectation');
     });
 
-    queue.on('complete', function() {
+    queue.on('complete', function () {
       assert.ok(true, 'queue should complete after processing has restarted');
     });
 
@@ -557,7 +557,7 @@ module('TaskQueue', function() {
       .then(() => {
         assert.ok(false, 'op2 should fail');
       })
-      .catch(e => {
+      .catch((e) => {
         assert.ok(true, 'op2 should fail');
       });
 
@@ -598,7 +598,7 @@ module('TaskQueue', function() {
     } catch {}
   });
 
-  test('#skip removes the current task from an inactive queue and restarts processing if autoProcess=true', async function(assert) {
+  test('#skip removes the current task from an inactive queue and restarts processing if autoProcess=true', async function (assert) {
     assert.expect(10);
 
     const performer: Performer = {
@@ -622,7 +622,7 @@ module('TaskQueue', function() {
     let op3 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
     let transformCount = 0;
 
-    queue.on('task', function(task) {
+    queue.on('task', function (task) {
       if (transformCount === 1) {
         assert.strictEqual(task.data, op1, 'task - op1 processed');
       } else if (transformCount === 2) {
@@ -630,12 +630,12 @@ module('TaskQueue', function() {
       }
     });
 
-    queue.on('fail', function(task, err) {
+    queue.on('fail', function (task, err) {
       assert.strictEqual(task.data, op2, 'fail - op2 failed processing');
       assert.equal(err.message, ':(', 'fail - error matches expectation');
     });
 
-    queue.on('complete', function() {
+    queue.on('complete', function () {
       assert.ok(true, 'queue should complete after processing has restarted');
     });
 
@@ -684,7 +684,7 @@ module('TaskQueue', function() {
     }
   });
 
-  test('#skip will cancel tasks with a default error message', async function(assert) {
+  test('#skip will cancel tasks with a default error message', async function (assert) {
     assert.expect(2);
 
     const performer: Performer = {
@@ -699,11 +699,11 @@ module('TaskQueue', function() {
     let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
     let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
 
-    queue.on('task', function() {
+    queue.on('task', function () {
       assert.ok(false, 'no tasks should be processed');
     });
 
-    queue.on('complete', function() {
+    queue.on('complete', function () {
       assert.ok(true, 'queue completed after clear');
     });
 
@@ -732,7 +732,7 @@ module('TaskQueue', function() {
     assert.equal(queue.length, 1, 'queue now has one member');
   });
 
-  test('#skip can cancel tasks with a custom error message', async function(assert) {
+  test('#skip can cancel tasks with a custom error message', async function (assert) {
     assert.expect(2);
 
     const performer: Performer = {
@@ -747,11 +747,11 @@ module('TaskQueue', function() {
     let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
     let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
 
-    queue.on('task', function() {
+    queue.on('task', function () {
       assert.ok(false, 'no tasks should be processed');
     });
 
-    queue.on('complete', function() {
+    queue.on('complete', function () {
       assert.ok(true, 'queue completed after clear');
     });
 
@@ -776,7 +776,7 @@ module('TaskQueue', function() {
     assert.equal(queue.length, 1, 'queue now has one member');
   });
 
-  test('#skip just restarts processing if there are no tasks in the queue', async function(assert) {
+  test('#skip just restarts processing if there are no tasks in the queue', async function (assert) {
     assert.expect(2);
 
     const performer: Performer = {
@@ -789,11 +789,11 @@ module('TaskQueue', function() {
 
     let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
 
-    queue.on('complete', function() {
+    queue.on('complete', function () {
       assert.ok(true, 'queue completed');
     });
 
-    queue.on('task', function(task) {
+    queue.on('task', function (task) {
       assert.strictEqual(task.data, op1, 'op1 processed');
     });
 
@@ -803,7 +803,7 @@ module('TaskQueue', function() {
     });
   });
 
-  test('#shift can remove failed tasks from an inactive queue, allowing processing to be restarted', async function(assert) {
+  test('#shift can remove failed tasks from an inactive queue, allowing processing to be restarted', async function (assert) {
     assert.expect(11);
 
     const performer: Performer = {
@@ -827,7 +827,7 @@ module('TaskQueue', function() {
     let op3 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
     let transformCount = 0;
 
-    queue.on('task', function(task) {
+    queue.on('task', function (task) {
       if (transformCount === 1) {
         assert.strictEqual(task.data, op1, 'task - op1 processed');
       } else if (transformCount === 2) {
@@ -835,12 +835,12 @@ module('TaskQueue', function() {
       }
     });
 
-    queue.on('fail', function(task, err) {
+    queue.on('fail', function (task, err) {
       assert.strictEqual(task.data, op2, 'fail - op2 failed processing');
       assert.equal(err.message, ':(', 'fail - error matches expectation');
     });
 
-    queue.on('complete', function() {
+    queue.on('complete', function () {
       assert.ok(true, 'queue should complete after processing has restarted');
     });
 
@@ -896,7 +896,7 @@ module('TaskQueue', function() {
     }
   });
 
-  test('#shift will cancel the current task with a default error message', async function(assert) {
+  test('#shift will cancel the current task with a default error message', async function (assert) {
     assert.expect(2);
 
     const performer: Performer = {
@@ -911,11 +911,11 @@ module('TaskQueue', function() {
     let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
     let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
 
-    queue.on('task', function() {
+    queue.on('task', function () {
       assert.ok(false, 'no tasks should be processed');
     });
 
-    queue.on('complete', function() {
+    queue.on('complete', function () {
       assert.ok(true, 'queue completed after clear');
     });
 
@@ -944,7 +944,7 @@ module('TaskQueue', function() {
     assert.equal(queue.length, 1, 'queue now has one member');
   });
 
-  test('#shift can cancel the current task with a custom error message', async function(assert) {
+  test('#shift can cancel the current task with a custom error message', async function (assert) {
     assert.expect(2);
 
     const performer: Performer = {
@@ -959,11 +959,11 @@ module('TaskQueue', function() {
     let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
     let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
 
-    queue.on('task', function() {
+    queue.on('task', function () {
       assert.ok(false, 'no tasks should be processed');
     });
 
-    queue.on('complete', function() {
+    queue.on('complete', function () {
       assert.ok(true, 'queue completed after clear');
     });
 
@@ -988,7 +988,7 @@ module('TaskQueue', function() {
     assert.equal(queue.length, 1, 'queue now has one member');
   });
 
-  test('#shift just restarts processing if there are no tasks in the queue', async function(assert) {
+  test('#shift just restarts processing if there are no tasks in the queue', async function (assert) {
     assert.expect(2);
 
     const performer: Performer = {
@@ -1001,11 +1001,11 @@ module('TaskQueue', function() {
 
     let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
 
-    queue.on('complete', function() {
+    queue.on('complete', function () {
       assert.ok(true, 'queue completed');
     });
 
-    queue.on('task', function(task) {
+    queue.on('task', function (task) {
       assert.strictEqual(task.data, op1, 'op1 processed');
     });
 
@@ -1015,7 +1015,7 @@ module('TaskQueue', function() {
     });
   });
 
-  test('#unshift can add a new task to the beginning of an inactive queue', function(assert) {
+  test('#unshift can add a new task to the beginning of an inactive queue', function (assert) {
     assert.expect(9);
 
     const performer: Performer = {
@@ -1038,7 +1038,7 @@ module('TaskQueue', function() {
     let transformCount = 0;
 
     let changeCount = 0;
-    queue.on('change', function() {
+    queue.on('change', function () {
       changeCount++;
       if (changeCount === 1) {
         assert.equal(queue.entries.length, 1);
@@ -1053,7 +1053,7 @@ module('TaskQueue', function() {
       }
     });
 
-    queue.on('task', function(task) {
+    queue.on('task', function (task) {
       if (transformCount === 1) {
         assert.strictEqual(task.data, op2, 'op2 processed');
       } else if (transformCount === 2) {
@@ -1061,7 +1061,7 @@ module('TaskQueue', function() {
       }
     });
 
-    queue.on('complete', function() {
+    queue.on('complete', function () {
       assert.ok(true, 'queue completed');
     });
 
@@ -1072,7 +1072,7 @@ module('TaskQueue', function() {
     return queue.process();
   });
 
-  test('#clear removes all tasks from an inactive queue', async function(assert) {
+  test('#clear removes all tasks from an inactive queue', async function (assert) {
     assert.expect(4);
 
     const performer: Performer = {
@@ -1087,11 +1087,11 @@ module('TaskQueue', function() {
     let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
     let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
 
-    queue.on('task', function() {
+    queue.on('task', function () {
       assert.ok(false, 'no tasks should be processed');
     });
 
-    queue.on('complete', function() {
+    queue.on('complete', function () {
       assert.ok(true, 'queue completed after clear');
     });
 
@@ -1130,7 +1130,7 @@ module('TaskQueue', function() {
     assert.ok(true, 'queue was cleared');
   });
 
-  test('#clear can cancel tasks with a custom error message', async function(assert) {
+  test('#clear can cancel tasks with a custom error message', async function (assert) {
     assert.expect(4);
 
     const performer: Performer = {
@@ -1145,11 +1145,11 @@ module('TaskQueue', function() {
     let op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
     let op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
 
-    queue.on('task', function() {
+    queue.on('task', function () {
       assert.ok(false, 'no tasks should be processed');
     });
 
-    queue.on('complete', function() {
+    queue.on('complete', function () {
       assert.ok(true, 'queue completed after clear');
     });
 
@@ -1180,23 +1180,23 @@ module('TaskQueue', function() {
     assert.ok(true, 'queue was cleared');
   });
 
-  module('assigned a bucket', function(hooks) {
+  module('assigned a bucket', function (hooks) {
     const op1 = { op: 'add', path: ['planets', '123'], value: 'Mercury' };
     const op2 = { op: 'add', path: ['planets', '234'], value: 'Venus' };
 
     let bucket: Bucket;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(function () {
       bucket = new FakeBucket({ name: 'fake-bucket' });
     });
 
-    hooks.afterEach(function() {
+    hooks.afterEach(function () {
       bucket = null;
     });
 
-    test('requires a name for lookups in the bucket', function(assert) {
+    test('requires a name for lookups in the bucket', function (assert) {
       assert.throws(
-        function() {
+        function () {
           const performer: Performer = {
             perform(task: Task): Promise<void> {
               return Promise.resolve();
@@ -1209,7 +1209,7 @@ module('TaskQueue', function() {
       );
     });
 
-    test('will be reified with the tasks serialized in its bucket and immediately process them', async function(assert) {
+    test('will be reified with the tasks serialized in its bucket and immediately process them', async function (assert) {
       assert.expect(3);
 
       const performer: Performer = {
@@ -1238,7 +1238,7 @@ module('TaskQueue', function() {
 
       assert.equal(queue.length, 2, 'queue has two tasks');
 
-      queue.on('complete', async function() {
+      queue.on('complete', async function () {
         assert.ok(true, 'queue completed');
 
         let serialized = await bucket.getItem('queue');
@@ -1247,7 +1247,7 @@ module('TaskQueue', function() {
       });
     });
 
-    test('if `autoActivate = false`, will wait for `activate` to begin processing', async function(assert) {
+    test('if `autoActivate = false`, will wait for `activate` to begin processing', async function (assert) {
       assert.expect(3);
 
       const performer: Performer = {
@@ -1283,7 +1283,7 @@ module('TaskQueue', function() {
 
       await queue.activate();
 
-      queue.on('complete', async function() {
+      queue.on('complete', async function () {
         assert.ok(true, 'queue completed');
 
         let serialized = await bucket.getItem('queue');
@@ -1292,7 +1292,7 @@ module('TaskQueue', function() {
       });
     });
 
-    test('#push - tasks pushed to a queue are persisted to its bucket', function(assert) {
+    test('#push - tasks pushed to a queue are persisted to its bucket', function (assert) {
       const done = assert.async();
       assert.expect(9);
 
@@ -1306,29 +1306,29 @@ module('TaskQueue', function() {
 
       let transformCount = 0;
 
-      queue.on('beforeTask', function(task) {
+      queue.on('beforeTask', function (task) {
         transformCount++;
 
         if (transformCount === 1) {
           assert.strictEqual(task.data, op1, 'op1 processed');
-          bucket.getItem('queue').then(serialized => {
+          bucket.getItem('queue').then((serialized) => {
             assert.equal(serialized.length, 2);
             assert.deepEqual(serialized[0].data, op1);
             assert.deepEqual(serialized[1].data, op2);
           });
         } else if (transformCount === 2) {
           assert.strictEqual(task.data, op2, 'op2 processed');
-          bucket.getItem('queue').then(serialized => {
+          bucket.getItem('queue').then((serialized) => {
             assert.equal(serialized.length, 1);
             assert.deepEqual(serialized[0].data, op2);
           });
         }
       });
 
-      queue.on('complete', function() {
+      queue.on('complete', function () {
         assert.ok(true, 'queue completed');
 
-        bucket.getItem('queue').then(serialized => {
+        bucket.getItem('queue').then((serialized) => {
           assert.deepEqual(serialized, [], 'no serialized ops remain');
           done();
         });

--- a/packages/@orbit/data/.prettierrc.js
+++ b/packages/@orbit/data/.prettierrc.js
@@ -1,3 +1,4 @@
 module.exports = {
-  singleQuote: true
+  singleQuote: true,
+  trailingComma: 'none'
 };

--- a/packages/@orbit/data/package.json
+++ b/packages/@orbit/data/package.json
@@ -31,11 +31,11 @@
   },
   "devDependencies": {
     "@glimmer/build": "^0.10.3",
-    "@typescript-eslint/eslint-plugin": "^2.23.0",
-    "@typescript-eslint/parser": "^2.23.0",
+    "@typescript-eslint/eslint-plugin": "^2.26.0",
+    "@typescript-eslint/parser": "^2.26.0",
     "eslint": "^6.8.0",
-    "eslint-config-prettier": "^6.10.0",
+    "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-prettier": "^3.1.2",
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.2"
   }
 }

--- a/packages/@orbit/data/src/key-map.ts
+++ b/packages/@orbit/data/src/key-map.ts
@@ -44,7 +44,7 @@ export default class KeyMap {
       return;
     }
 
-    Object.keys(keys).forEach(keyName => {
+    Object.keys(keys).forEach((keyName) => {
       let keyValue = keys[keyName];
       if (keyValue) {
         deepSet(this._idsToKeys, [type, keyName, id], keyValue);
@@ -59,7 +59,7 @@ export default class KeyMap {
   idFromKeys(type: string, keys: Dict<string>): string {
     let keyNames = Object.keys(keys);
 
-    return firstResult(keyNames, keyName => {
+    return firstResult(keyNames, (keyName) => {
       let keyValue = keys[keyName];
       if (keyValue) {
         return this.keyToId(type, keyName, keyValue);

--- a/packages/@orbit/data/src/operation.ts
+++ b/packages/@orbit/data/src/operation.ts
@@ -398,7 +398,7 @@ export function coalesceRecordOperations(
     }
   }
 
-  return operations.filter(o => !isOperationMarkedToDelete(o));
+  return operations.filter((o) => !isOperationMarkedToDelete(o));
 }
 
 /**
@@ -415,7 +415,7 @@ export function recordDiffs(
     const recordIdentity = cloneRecordIdentity(record);
 
     if (updatedRecord.attributes) {
-      Object.keys(updatedRecord.attributes).forEach(attribute => {
+      Object.keys(updatedRecord.attributes).forEach((attribute) => {
         let value = updatedRecord.attributes[attribute];
 
         if (
@@ -435,7 +435,7 @@ export function recordDiffs(
     }
 
     if (updatedRecord.keys) {
-      Object.keys(updatedRecord.keys).forEach(key => {
+      Object.keys(updatedRecord.keys).forEach((key) => {
         let value = updatedRecord.keys[key];
         if (record.keys === undefined || !eq(record.keys[key], value)) {
           let op: ReplaceKeyOperation = {

--- a/packages/@orbit/data/src/record.ts
+++ b/packages/@orbit/data/src/record.ts
@@ -85,7 +85,7 @@ export function uniqueRecordIdentities(
   return exclusiveIdentities(
     serializeRecordIdentities(set1),
     serializeRecordIdentities(set2)
-  ).map(id => deserializeRecordIdentity(id));
+  ).map((id) => deserializeRecordIdentity(id));
 }
 
 export function recordsInclude(
@@ -183,12 +183,12 @@ export function deserializeRecordIdentity(identity: string): RecordIdentity {
 function serializeRecordIdentities(
   recordIdentities: RecordIdentity[]
 ): string[] {
-  return recordIdentities.map(r => serializeRecordIdentity(r));
+  return recordIdentities.map((r) => serializeRecordIdentity(r));
 }
 
 function exclusiveIdentities(
   identities1: string[],
   identities2: string[]
 ): string[] {
-  return identities1.filter(i => !identities2.includes(i));
+  return identities1.filter((i) => !identities2.includes(i));
 }

--- a/packages/@orbit/data/src/schema.ts
+++ b/packages/@orbit/data/src/schema.ts
@@ -246,9 +246,9 @@ export default class Schema implements Evented, RecordInitializer {
   }
 
   _deprecateRelationshipModel(models: Dict<ModelDefinition>) {
-    Object.keys(models).forEach(type => {
+    Object.keys(models).forEach((type) => {
       if (models[type].relationships) {
-        Object.keys(models[type].relationships).forEach(name => {
+        Object.keys(models[type].relationships).forEach((name) => {
           let relationship = models[type].relationships[name];
           if (relationship.model) {
             Orbit.deprecate(

--- a/packages/@orbit/data/src/source-interfaces/pullable.ts
+++ b/packages/@orbit/data/src/source-interfaces/pullable.ts
@@ -73,7 +73,7 @@ export default function pullable(Klass: SourceClass): void {
 
   proto[PULLABLE] = true;
 
-  proto.pull = async function(
+  proto.pull = async function (
     queryOrExpressions: QueryOrExpressions,
     options?: RequestOptions,
     id?: string
@@ -88,7 +88,7 @@ export default function pullable(Klass: SourceClass): void {
     return this._enqueueRequest('pull', query);
   };
 
-  proto.__pull__ = async function(query: Query): Promise<Transform[]> {
+  proto.__pull__ = async function (query: Query): Promise<Transform[]> {
     try {
       const hints: any = {};
 

--- a/packages/@orbit/data/src/source-interfaces/pushable.ts
+++ b/packages/@orbit/data/src/source-interfaces/pushable.ts
@@ -76,7 +76,7 @@ export default function pushable(Klass: SourceClass): void {
 
   proto[PUSHABLE] = true;
 
-  proto.push = async function(
+  proto.push = async function (
     transformOrOperations: TransformOrOperations,
     options?: RequestOptions,
     id?: string
@@ -96,7 +96,7 @@ export default function pushable(Klass: SourceClass): void {
     return this._enqueueRequest('push', transform);
   };
 
-  proto.__push__ = async function(transform: Transform): Promise<Transform[]> {
+  proto.__push__ = async function (transform: Transform): Promise<Transform[]> {
     if (this.transformLog.contains(transform.id)) {
       return [];
     }

--- a/packages/@orbit/data/src/source-interfaces/queryable.ts
+++ b/packages/@orbit/data/src/source-interfaces/queryable.ts
@@ -69,7 +69,7 @@ export default function queryable(Klass: SourceClass): void {
 
   proto[QUERYABLE] = true;
 
-  proto.query = async function(
+  proto.query = async function (
     queryOrExpressions: QueryOrExpressions,
     options?: RequestOptions,
     id?: string
@@ -84,7 +84,7 @@ export default function queryable(Klass: SourceClass): void {
     return this._enqueueRequest('query', query);
   };
 
-  proto.__query__ = async function(query: Query): Promise<any> {
+  proto.__query__ = async function (query: Query): Promise<any> {
     try {
       const hints: any = {};
 

--- a/packages/@orbit/data/src/source-interfaces/syncable.ts
+++ b/packages/@orbit/data/src/source-interfaces/syncable.ts
@@ -52,7 +52,7 @@ export default function syncable(Klass: SourceClass): void {
 
   proto[SYNCABLE] = true;
 
-  proto.sync = async function(
+  proto.sync = async function (
     transformOrTransforms: Transform | Transform[]
   ): Promise<void> {
     await this.activated;
@@ -73,7 +73,7 @@ export default function syncable(Klass: SourceClass): void {
     }
   };
 
-  proto.__sync__ = async function(transform: Transform): Promise<void> {
+  proto.__sync__ = async function (transform: Transform): Promise<void> {
     if (this.transformLog.contains(transform.id)) {
       return;
     }

--- a/packages/@orbit/data/src/source-interfaces/updatable.ts
+++ b/packages/@orbit/data/src/source-interfaces/updatable.ts
@@ -70,7 +70,7 @@ export default function updatable(Klass: SourceClass): void {
 
   proto[UPDATABLE] = true;
 
-  proto.update = async function(
+  proto.update = async function (
     transformOrOperations: TransformOrOperations,
     options?: RequestOptions,
     id?: string
@@ -90,7 +90,7 @@ export default function updatable(Klass: SourceClass): void {
     return this._enqueueRequest('update', transform);
   };
 
-  proto.__update__ = async function(transform: Transform): Promise<any> {
+  proto.__update__ = async function (transform: Transform): Promise<any> {
     if (this.transformLog.contains(transform.id)) {
       return;
     }

--- a/packages/@orbit/data/test/key-map-test.ts
+++ b/packages/@orbit/data/test/key-map-test.ts
@@ -3,8 +3,8 @@ import './test-helper';
 
 const { module, test } = QUnit;
 
-module('KeyMap', function(hooks) {
-  test('#pushRecord adds mappings; #keyToId and #idToKey access them', function(assert) {
+module('KeyMap', function (hooks) {
+  test('#pushRecord adds mappings; #keyToId and #idToKey access them', function (assert) {
     let keyMap = new KeyMap();
 
     keyMap.pushRecord({ type: 'planet', id: '1', keys: { remoteId: 'a' } });
@@ -24,7 +24,7 @@ module('KeyMap', function(hooks) {
     assert.equal(keyMap.idToKey('planet', 'remoteId', 'bogus'), undefined);
   });
 
-  test('#reset clears mappings', function(assert) {
+  test('#reset clears mappings', function (assert) {
     let keyMap = new KeyMap();
 
     keyMap.pushRecord({ type: 'planet', id: '1', keys: { remoteId: 'a' } });
@@ -38,7 +38,7 @@ module('KeyMap', function(hooks) {
     assert.equal(keyMap.idToKey('planet', 'remoteId', '1'), undefined);
   });
 
-  test('#pushRecord does not set incomplete records', function(assert) {
+  test('#pushRecord does not set incomplete records', function (assert) {
     let keyMap = new KeyMap();
 
     keyMap.pushRecord({ type: 'planet', id: null, keys: { remoteId: 'a' } });
@@ -48,7 +48,7 @@ module('KeyMap', function(hooks) {
     assert.strictEqual(keyMap.idToKey('planet', 'remoteId', '1'), undefined);
   });
 
-  test('#idFromKeys retrieves an id given a set of keys', function(assert) {
+  test('#idFromKeys retrieves an id given a set of keys', function (assert) {
     let keyMap = new KeyMap();
 
     keyMap.pushRecord({ type: 'planet', id: '1', keys: { remoteId: 'a' } });

--- a/packages/@orbit/data/test/operation-test.ts
+++ b/packages/@orbit/data/test/operation-test.ts
@@ -3,9 +3,9 @@ import './test-helper';
 
 const { module, test } = QUnit;
 
-module('Operation', function() {
-  module('`coalesceRecordOperations`', function() {
-    test('can coalesce replaceAttribute + replaceAttribute for the same record', function(assert) {
+module('Operation', function () {
+  module('`coalesceRecordOperations`', function () {
+    test('can coalesce replaceAttribute + replaceAttribute for the same record', function (assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -32,7 +32,7 @@ module('Operation', function() {
       );
     });
 
-    test('will not coalesce replaceAttribute + replaceAttribute for different records', function(assert) {
+    test('will not coalesce replaceAttribute + replaceAttribute for different records', function (assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -65,7 +65,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce addRecord + replaceAttribute for the same record', function(assert) {
+    test('can coalesce addRecord + replaceAttribute for the same record', function (assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -88,7 +88,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce addRecord + replaceAttribute for a couple records', function(assert) {
+    test('can coalesce addRecord + replaceAttribute for a couple records', function (assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -133,7 +133,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce addRecord + replaceRelatedRecords for the same record', function(assert) {
+    test('can coalesce addRecord + replaceRelatedRecords for the same record', function (assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -165,7 +165,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce addRecord + replaceRelatedRecord for the same record', function(assert) {
+    test('can coalesce addRecord + replaceRelatedRecord for the same record', function (assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -197,7 +197,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce replaceAttribute + replaceRelatedRecord with null', function(assert) {
+    test('can coalesce replaceAttribute + replaceRelatedRecord with null', function (assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -233,7 +233,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce addRecord + addToRelatedRecords for the same record', function(assert) {
+    test('can coalesce addRecord + addToRelatedRecords for the same record', function (assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -265,7 +265,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce addRecord + replaceRelatedRecord for the same record', function(assert) {
+    test('can coalesce addRecord + replaceRelatedRecord for the same record', function (assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -297,7 +297,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce addRecord + replaceRelatedRecord for the same record + relationship', function(assert) {
+    test('can coalesce addRecord + replaceRelatedRecord for the same record + relationship', function (assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -338,7 +338,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce replaceRelatedRecord + replaceRelatedRecord for the same record + relationship', function(assert) {
+    test('can coalesce replaceRelatedRecord + replaceRelatedRecord for the same record + relationship', function (assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -365,7 +365,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce addRecord + removeRecord for the same record', function(assert) {
+    test('can coalesce addRecord + removeRecord for the same record', function (assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -381,7 +381,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce addRecord + replaceRelatedRecord + removeRecord for the same record', function(assert) {
+    test('can coalesce addRecord + replaceRelatedRecord + removeRecord for the same record', function (assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -412,7 +412,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce addRecord + replaceRelatedRecord + removeRecord for the same record in non-contiguous ops', function(assert) {
+    test('can coalesce addRecord + replaceRelatedRecord + removeRecord for the same record in non-contiguous ops', function (assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -452,7 +452,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce addRecord + addToRelatedRecords + removeRecord for the same record', function(assert) {
+    test('can coalesce addRecord + addToRelatedRecords + removeRecord for the same record', function (assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -474,7 +474,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce removeRecord + removeRecord for the same record', function(assert) {
+    test('can coalesce removeRecord + removeRecord for the same record', function (assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -495,7 +495,7 @@ module('Operation', function() {
       );
     });
 
-    test("coalesces operations, but doesn't allow reordering of ops that affect relationships", function(assert) {
+    test("coalesces operations, but doesn't allow reordering of ops that affect relationships", function (assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -558,7 +558,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce addToRelatedRecords + removeFromRelatedRecords for the same record + relationship', function(assert) {
+    test('can coalesce addToRelatedRecords + removeFromRelatedRecords for the same record + relationship', function (assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -578,7 +578,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce addRecord + addToRelatedRecords for the same record', function(assert) {
+    test('can coalesce addRecord + addToRelatedRecords for the same record', function (assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -622,7 +622,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce updateRecord + addToRelatedRecords for the same record', function(assert) {
+    test('can coalesce updateRecord + addToRelatedRecords for the same record', function (assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -666,7 +666,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce removeFromRelatedRecords + addToRelatedRecords for the same record + relationship', function(assert) {
+    test('can coalesce removeFromRelatedRecords + addToRelatedRecords for the same record + relationship', function (assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {
@@ -686,7 +686,7 @@ module('Operation', function() {
       );
     });
 
-    test('can coalesce addRecord + removeFromRelatedRecords for the same record', function(assert) {
+    test('can coalesce addRecord + removeFromRelatedRecords for the same record', function (assert) {
       assert.deepEqual(
         coalesceRecordOperations([
           {

--- a/packages/@orbit/data/test/query-builder-test.ts
+++ b/packages/@orbit/data/test/query-builder-test.ts
@@ -8,14 +8,14 @@ import {
 
 const { module, test } = QUnit;
 
-module('QueryBuilder', function(hooks) {
+module('QueryBuilder', function (hooks) {
   let oqb: QueryBuilder;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     oqb = new QueryBuilder();
   });
 
-  test('findRecord', function(assert) {
+  test('findRecord', function (assert) {
     assert.deepEqual(
       oqb.findRecord({ type: 'planet', id: '123' }).toQueryExpression(),
       {
@@ -28,14 +28,14 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRecords by type', function(assert) {
+  test('findRecords by type', function (assert) {
     assert.deepEqual(oqb.findRecords('planet').toQueryExpression(), {
       op: 'findRecords',
       type: 'planet'
     } as FindRecords);
   });
 
-  test('findRecords by identities', function(assert) {
+  test('findRecords by identities', function (assert) {
     assert.deepEqual(
       oqb
         .findRecords([
@@ -53,7 +53,7 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRecords + attribute filter', function(assert) {
+  test('findRecords + attribute filter', function (assert) {
     assert.deepEqual(
       oqb
         .findRecords('planet')
@@ -74,7 +74,7 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRecords + attribute filters', function(assert) {
+  test('findRecords + attribute filters', function (assert) {
     assert.deepEqual(
       oqb
         .findRecords('planet')
@@ -104,7 +104,7 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRecords + filter (invalid filter expression)', function(assert) {
+  test('findRecords + filter (invalid filter expression)', function (assert) {
     assert.throws(() => {
       oqb
         .findRecords('planet')
@@ -114,7 +114,7 @@ module('QueryBuilder', function(hooks) {
     }, new Error('Unrecognized filter param.'));
   });
 
-  test('findRecords + attribute filter', function(assert) {
+  test('findRecords + attribute filter', function (assert) {
     assert.deepEqual(
       oqb
         .findRecords('planet')
@@ -135,7 +135,7 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRecords + hasOne filter', function(assert) {
+  test('findRecords + hasOne filter', function (assert) {
     assert.deepEqual(
       oqb
         .findRecords('planet')
@@ -156,7 +156,7 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRecords + hasMany filter', function(assert) {
+  test('findRecords + hasMany filter', function (assert) {
     assert.deepEqual(
       oqb
         .findRecords('planet')
@@ -187,12 +187,9 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRecords + sort (one field, compact)', function(assert) {
+  test('findRecords + sort (one field, compact)', function (assert) {
     assert.deepEqual(
-      oqb
-        .findRecords('planet')
-        .sort('name')
-        .toQueryExpression(),
+      oqb.findRecords('planet').sort('name').toQueryExpression(),
       {
         op: 'findRecords',
         type: 'planet',
@@ -207,12 +204,9 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRecords + sort (one field descending, compact)', function(assert) {
+  test('findRecords + sort (one field descending, compact)', function (assert) {
     assert.deepEqual(
-      oqb
-        .findRecords('planet')
-        .sort('-name')
-        .toQueryExpression(),
+      oqb.findRecords('planet').sort('-name').toQueryExpression(),
       {
         op: 'findRecords',
         type: 'planet',
@@ -227,12 +221,9 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRecords + sort (multiple fields, compact)', function(assert) {
+  test('findRecords + sort (multiple fields, compact)', function (assert) {
     assert.deepEqual(
-      oqb
-        .findRecords('planet')
-        .sort('name', 'age')
-        .toQueryExpression(),
+      oqb.findRecords('planet').sort('name', 'age').toQueryExpression(),
       {
         op: 'findRecords',
         type: 'planet',
@@ -252,12 +243,9 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRecords + sort (one field, verbose)', function(assert) {
+  test('findRecords + sort (one field, verbose)', function (assert) {
     assert.deepEqual(
-      oqb
-        .findRecords('planet')
-        .sort({ attribute: 'name' })
-        .toQueryExpression(),
+      oqb.findRecords('planet').sort({ attribute: 'name' }).toQueryExpression(),
       {
         op: 'findRecords',
         type: 'planet',
@@ -272,7 +260,7 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRecords + sort (one field, specified order, verbose)', function(assert) {
+  test('findRecords + sort (one field, specified order, verbose)', function (assert) {
     assert.deepEqual(
       oqb
         .findRecords('planet')
@@ -292,7 +280,7 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRecords + sort (one field, specified order, verbose)', function(assert) {
+  test('findRecords + sort (one field, specified order, verbose)', function (assert) {
     assert.deepEqual(
       oqb
         .findRecords('planet')
@@ -320,13 +308,13 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRecords + sort (invalid sort expression)', function(assert) {
+  test('findRecords + sort (invalid sort expression)', function (assert) {
     assert.throws(() => {
       oqb.findRecords('planet').sort(null);
     }, new Error('Unrecognized sort param.'));
   });
 
-  test('findRecords + page', function(assert) {
+  test('findRecords + page', function (assert) {
     assert.deepEqual(
       oqb
         .findRecords('planet')
@@ -344,7 +332,7 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRecords + filter + sort + page', function(assert) {
+  test('findRecords + filter + sort + page', function (assert) {
     assert.deepEqual(
       oqb
         .findRecords('planet')
@@ -388,7 +376,7 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRelatedRecords', function(assert) {
+  test('findRelatedRecords', function (assert) {
     assert.deepEqual(
       oqb
         .findRelatedRecords({ type: 'planet', id: '123' }, 'moons')
@@ -404,7 +392,7 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRelatedRecords + attribute filter', function(assert) {
+  test('findRelatedRecords + attribute filter', function (assert) {
     assert.deepEqual(
       oqb
         .findRelatedRecords({ type: 'planet', id: '123' }, 'moons')
@@ -429,7 +417,7 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRelatedRecords + attribute filters', function(assert) {
+  test('findRelatedRecords + attribute filters', function (assert) {
     assert.deepEqual(
       oqb
         .findRelatedRecords({ type: 'planet', id: '123' }, 'moons')
@@ -463,7 +451,7 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRelatedRecords + filter (invalid filter expression)', function(assert) {
+  test('findRelatedRecords + filter (invalid filter expression)', function (assert) {
     assert.throws(() => {
       oqb
         .findRelatedRecords({ type: 'planet', id: '123' }, 'moons')
@@ -473,7 +461,7 @@ module('QueryBuilder', function(hooks) {
     }, new Error('Unrecognized filter param.'));
   });
 
-  test('findRelatedRecords + attribute filter', function(assert) {
+  test('findRelatedRecords + attribute filter', function (assert) {
     assert.deepEqual(
       oqb
         .findRelatedRecords({ type: 'planet', id: '123' }, 'moons')
@@ -498,7 +486,7 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRelatedRecords + hasOne filter', function(assert) {
+  test('findRelatedRecords + hasOne filter', function (assert) {
     assert.deepEqual(
       oqb
         .findRelatedRecords({ type: 'planet', id: '123' }, 'moons')
@@ -523,7 +511,7 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRelatedRecords + hasMany filter', function(assert) {
+  test('findRelatedRecords + hasMany filter', function (assert) {
     assert.deepEqual(
       oqb
         .findRelatedRecords({ type: 'planet', id: '123' }, 'moons')
@@ -558,7 +546,7 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRelatedRecords + sort (one field, compact)', function(assert) {
+  test('findRelatedRecords + sort (one field, compact)', function (assert) {
     assert.deepEqual(
       oqb
         .findRelatedRecords({ type: 'planet', id: '123' }, 'moons')
@@ -582,7 +570,7 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRelatedRecords + sort (one field descending, compact)', function(assert) {
+  test('findRelatedRecords + sort (one field descending, compact)', function (assert) {
     assert.deepEqual(
       oqb
         .findRelatedRecords({ type: 'planet', id: '123' }, 'moons')
@@ -606,7 +594,7 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRelatedRecords + sort (multiple fields, compact)', function(assert) {
+  test('findRelatedRecords + sort (multiple fields, compact)', function (assert) {
     assert.deepEqual(
       oqb
         .findRelatedRecords({ type: 'planet', id: '123' }, 'moons')
@@ -635,7 +623,7 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRelatedRecords + sort (one field, verbose)', function(assert) {
+  test('findRelatedRecords + sort (one field, verbose)', function (assert) {
     assert.deepEqual(
       oqb
         .findRelatedRecords({ type: 'planet', id: '123' }, 'moons')
@@ -659,7 +647,7 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRelatedRecords + sort (one field, specified order, verbose)', function(assert) {
+  test('findRelatedRecords + sort (one field, specified order, verbose)', function (assert) {
     assert.deepEqual(
       oqb
         .findRelatedRecords({ type: 'planet', id: '123' }, 'moons')
@@ -683,7 +671,7 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRelatedRecords + sort (one field, specified order, verbose)', function(assert) {
+  test('findRelatedRecords + sort (one field, specified order, verbose)', function (assert) {
     assert.deepEqual(
       oqb
         .findRelatedRecords({ type: 'planet', id: '123' }, 'moons')
@@ -715,13 +703,13 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRelatedRecords + sort (invalid sort expression)', function(assert) {
+  test('findRelatedRecords + sort (invalid sort expression)', function (assert) {
     assert.throws(() => {
       oqb.findRelatedRecords({ type: 'planet', id: '123' }, 'moons').sort(null);
     }, new Error('Unrecognized sort param.'));
   });
 
-  test('findRelatedRecords + page', function(assert) {
+  test('findRelatedRecords + page', function (assert) {
     assert.deepEqual(
       oqb
         .findRelatedRecords({ type: 'planet', id: '123' }, 'moons')
@@ -743,7 +731,7 @@ module('QueryBuilder', function(hooks) {
     );
   });
 
-  test('findRelatedRecords + filter + sort + page', function(assert) {
+  test('findRelatedRecords + filter + sort + page', function (assert) {
     assert.deepEqual(
       oqb
         .findRelatedRecords({ type: 'planet', id: '123' }, 'moons')

--- a/packages/@orbit/data/test/query-test.ts
+++ b/packages/@orbit/data/test/query-test.ts
@@ -8,8 +8,8 @@ const { module, test } = QUnit;
 
 ///////////////////////////////////////////////////////////////////////////////
 
-module('buildQuery', function() {
-  test('can instantiate a query from an expression', function(assert) {
+module('buildQuery', function () {
+  test('can instantiate a query from an expression', function (assert) {
     let expression: FindRecords = {
       op: 'findRecords'
     };
@@ -17,7 +17,7 @@ module('buildQuery', function() {
     assert.ok(query);
   });
 
-  test('can instantiate a query that will be assigned an `id`', function(assert) {
+  test('can instantiate a query that will be assigned an `id`', function (assert) {
     let expression: FindRecords = {
       op: 'findRecords'
     };
@@ -25,7 +25,7 @@ module('buildQuery', function() {
     assert.ok(query.id, 'query has an id');
   });
 
-  test('can instantiate a query with an expression, options, and an id', function(assert) {
+  test('can instantiate a query with an expression, options, and an id', function (assert) {
     let expression: FindRecords = {
       op: 'findRecords'
     };
@@ -41,7 +41,7 @@ module('buildQuery', function() {
     assert.strictEqual(query.options, options, 'options was populated');
   });
 
-  test('will return a query passed into it', function(assert) {
+  test('will return a query passed into it', function (assert) {
     let expression: FindRecords = {
       op: 'findRecords'
     };
@@ -49,13 +49,13 @@ module('buildQuery', function() {
     assert.strictEqual(buildQuery(query), query);
   });
 
-  test('will create a query using a QueryBuilder if a function is passed into it', function(assert) {
+  test('will create a query using a QueryBuilder if a function is passed into it', function (assert) {
     let qb = new QueryBuilder();
     let expression: FindRecords = {
       op: 'findRecords',
       type: 'planet'
     };
-    let query = buildQuery(q => q.findRecords('planet'), null, null, qb);
+    let query = buildQuery((q) => q.findRecords('planet'), null, null, qb);
     assert.deepEqual(
       query.expressions[0],
       expression,
@@ -63,7 +63,7 @@ module('buildQuery', function() {
     );
   });
 
-  test('should call toQueryExpression() if available', function(assert) {
+  test('should call toQueryExpression() if available', function (assert) {
     let expression: FindRecords = {
       op: 'findRecords',
       type: 'planet'
@@ -77,7 +77,7 @@ module('buildQuery', function() {
     );
   });
 
-  test('will create a query with multiple expressions', function(assert) {
+  test('will create a query with multiple expressions', function (assert) {
     let expression1: FindRecords = {
       op: 'findRecords'
     };

--- a/packages/@orbit/data/test/record-test.ts
+++ b/packages/@orbit/data/test/record-test.ts
@@ -13,29 +13,29 @@ import './test-helper';
 
 const { module, test } = QUnit;
 
-module('Record', function() {
-  test('`cloneRecordIdentity` returns a simple { type, id } identity object from any object with a `type` and `id`', function(assert) {
+module('Record', function () {
+  test('`cloneRecordIdentity` returns a simple { type, id } identity object from any object with a `type` and `id`', function (assert) {
     assert.deepEqual(cloneRecordIdentity({ type: 'planet', id: '1' }), {
       type: 'planet',
       id: '1'
     });
   });
 
-  test('`serializeRecordIdentity` - serializes type:id of a record into a string', function(assert) {
+  test('`serializeRecordIdentity` - serializes type:id of a record into a string', function (assert) {
     assert.equal(
       serializeRecordIdentity({ type: 'planet', id: '1' }),
       'planet:1'
     );
   });
 
-  test('`deserializeRecordIdentity` - deserializes type:id string into an identity object', function(assert) {
+  test('`deserializeRecordIdentity` - deserializes type:id string into an identity object', function (assert) {
     assert.deepEqual(deserializeRecordIdentity('planet:1'), {
       type: 'planet',
       id: '1'
     });
   });
 
-  test('`equalRecordIdentities` compares the type/id identity of two objects', function(assert) {
+  test('`equalRecordIdentities` compares the type/id identity of two objects', function (assert) {
     assert.ok(
       equalRecordIdentities(
         { type: 'planet', id: '1' },
@@ -61,7 +61,7 @@ module('Record', function() {
     );
   });
 
-  test('`equalRecordIdentitySets` compares the membership of two arrays of identity objects', function(assert) {
+  test('`equalRecordIdentitySets` compares the membership of two arrays of identity objects', function (assert) {
     assert.ok(equalRecordIdentitySets([], []), 'empty sets are equal');
     assert.ok(
       equalRecordIdentitySets(
@@ -105,7 +105,7 @@ module('Record', function() {
     );
   });
 
-  test('`uniqueRecordIdentities` returns the identities in the first set that are not in the second', function(assert) {
+  test('`uniqueRecordIdentities` returns the identities in the first set that are not in the second', function (assert) {
     assert.deepEqual(
       uniqueRecordIdentities([], []),
       [],
@@ -157,7 +157,7 @@ module('Record', function() {
     );
   });
 
-  test('`recordsInclude` checks for the presence of an identity in an array of records', function(assert) {
+  test('`recordsInclude` checks for the presence of an identity in an array of records', function (assert) {
     assert.notOk(recordsInclude([], { type: 'planet', id: 'p1' }), 'empty set');
     assert.ok(
       recordsInclude([{ type: 'planet', id: 'p1' }], {
@@ -188,7 +188,7 @@ module('Record', function() {
     );
   });
 
-  test('`recordsIncludeAll` checks for the presence of all identities in an array of records', function(assert) {
+  test('`recordsIncludeAll` checks for the presence of all identities in an array of records', function (assert) {
     assert.ok(recordsIncludeAll([], []), 'empty sets are equal');
     assert.ok(
       recordsIncludeAll(
@@ -232,7 +232,7 @@ module('Record', function() {
     );
   });
 
-  test('`mergeRecords` returns a clone of the updates if no current record is supplied', function(assert) {
+  test('`mergeRecords` returns a clone of the updates if no current record is supplied', function (assert) {
     let earth = {
       type: 'planet',
       id: 'earth',
@@ -244,7 +244,7 @@ module('Record', function() {
     assert.notStrictEqual(mergeRecords(null, earth), earth);
   });
 
-  test('`mergeRecords` merges individual attributes and keys', function(assert) {
+  test('`mergeRecords` merges individual attributes and keys', function (assert) {
     let earth = {
       type: 'planet',
       id: 'earth',
@@ -289,7 +289,7 @@ module('Record', function() {
     assert.deepEqual(mergeRecords(earth, updates), expected);
   });
 
-  test("`mergeRecords` adds meta and links objects if they don't previously exist", function(assert) {
+  test("`mergeRecords` adds meta and links objects if they don't previously exist", function (assert) {
     let earth = {
       type: 'planet',
       id: 'earth'
@@ -322,7 +322,7 @@ module('Record', function() {
     assert.deepEqual(mergeRecords(earth, updates), expected);
   });
 
-  test('`mergeRecords` carries forward meta and links objects if they exist', function(assert) {
+  test('`mergeRecords` carries forward meta and links objects if they exist', function (assert) {
     let earth = {
       type: 'planet',
       id: 'earth',
@@ -355,7 +355,7 @@ module('Record', function() {
     assert.deepEqual(mergeRecords(earth, updates), expected);
   });
 
-  test('`mergeRecords` replaces existing meta and links objects completely', function(assert) {
+  test('`mergeRecords` replaces existing meta and links objects completely', function (assert) {
     let earth = {
       type: 'planet',
       id: 'earth',
@@ -395,7 +395,7 @@ module('Record', function() {
     assert.deepEqual(mergeRecords(earth, updates), expected);
   });
 
-  test('`mergeRecords` handles meta, links, and data within relationships separately', function(assert) {
+  test('`mergeRecords` handles meta, links, and data within relationships separately', function (assert) {
     let earth = {
       type: 'planet',
       id: 'earth',

--- a/packages/@orbit/data/test/request-test.ts
+++ b/packages/@orbit/data/test/request-test.ts
@@ -5,8 +5,8 @@ const { module, test } = QUnit;
 
 ///////////////////////////////////////////////////////////////////////////////
 
-module('Request', function() {
-  test('requestOptionsForSource merges any source-specific options with top-level options', function(assert) {
+module('Request', function () {
+  test('requestOptionsForSource merges any source-specific options with top-level options', function (assert) {
     let vanilla = {
       label: 'request',
       counter: 10

--- a/packages/@orbit/data/test/schema-test.ts
+++ b/packages/@orbit/data/test/schema-test.ts
@@ -6,18 +6,18 @@ const { module, test } = QUnit;
 
 ///////////////////////////////////////////////////////////////////////////////
 
-module('Schema', function() {
-  test('can be instantiated', function(assert) {
+module('Schema', function () {
+  test('can be instantiated', function (assert) {
     const schema = new Schema();
     assert.ok(schema);
   });
 
-  test('#version is assigned `1` by default', function(assert) {
+  test('#version is assigned `1` by default', function (assert) {
     const schema = new Schema();
     assert.equal(schema.version, 1, 'version === 1');
   });
 
-  test('#upgrade bumps the current version', function(assert) {
+  test('#upgrade bumps the current version', function (assert) {
     const done = assert.async();
 
     const schema = new Schema({
@@ -27,7 +27,7 @@ module('Schema', function() {
     });
     assert.equal(schema.version, 1, 'version === 1');
 
-    schema.on('upgrade', version => {
+    schema.on('upgrade', (version) => {
       assert.equal(version, 2, 'version is passed as argument');
       assert.equal(schema.version, 2, 'version === 2');
       assert.ok(
@@ -48,7 +48,7 @@ module('Schema', function() {
     });
   });
 
-  test('#models provides access to model definitions', function(assert) {
+  test('#models provides access to model definitions', function (assert) {
     const planetDefinition = {
       attributes: {
         name: { type: 'string' }
@@ -67,7 +67,7 @@ module('Schema', function() {
     );
   });
 
-  test('#getModel provides access to a model definition', function(assert) {
+  test('#getModel provides access to a model definition', function (assert) {
     const planetDefinition = {
       attributes: {
         name: { type: 'string' }
@@ -86,15 +86,15 @@ module('Schema', function() {
     );
   });
 
-  test('#getModel throws an exception if a model definition is not found', function(assert) {
+  test('#getModel throws an exception if a model definition is not found', function (assert) {
     const schema = new Schema();
 
-    assert.throws(function() {
+    assert.throws(function () {
       schema.getModel('planet');
     }, /Schema error: Model definition for planet not found/);
   });
 
-  test('#hasAttribute', function(assert) {
+  test('#hasAttribute', function (assert) {
     const schema = new Schema({
       models: {
         planet: {
@@ -109,7 +109,7 @@ module('Schema', function() {
     assert.equal(schema.hasAttribute('planet', 'unknown'), false);
   });
 
-  test('#hasRelationship', function(assert) {
+  test('#hasRelationship', function (assert) {
     const schema = new Schema({
       models: {
         planet: {
@@ -125,7 +125,7 @@ module('Schema', function() {
     assert.equal(schema.hasRelationship('planet', 'unknown'), false);
   });
 
-  test('#getAttribute', function(assert) {
+  test('#getAttribute', function (assert) {
     const schema = new Schema({
       models: {
         planet: {
@@ -139,7 +139,7 @@ module('Schema', function() {
     assert.deepEqual(schema.getAttribute('planet', 'name'), { type: 'string' });
   });
 
-  test('#eachAttribute', function(assert) {
+  test('#eachAttribute', function (assert) {
     const schema = new Schema({
       models: {
         planet: {
@@ -165,7 +165,7 @@ module('Schema', function() {
     });
   });
 
-  test('#getRelationship', function(assert) {
+  test('#getRelationship', function (assert) {
     const schema = new Schema({
       models: {
         planet: {
@@ -183,7 +183,7 @@ module('Schema', function() {
     });
   });
 
-  test('#eachRelationship', function(assert) {
+  test('#eachRelationship', function (assert) {
     const schema = new Schema({
       models: {
         planet: {
@@ -209,20 +209,20 @@ module('Schema', function() {
     });
   });
 
-  test('#pluralize simply adds an `s` to the end of words', function(assert) {
+  test('#pluralize simply adds an `s` to the end of words', function (assert) {
     const schema = new Schema();
     assert.equal(schema.pluralize('cow'), 'cows', 'no kine here');
   });
 
-  test('#singularize simply removes a trailing `s` if present at the end of words', function(assert) {
+  test('#singularize simply removes a trailing `s` if present at the end of words', function (assert) {
     const schema = new Schema();
     assert.equal(schema.singularize('cows'), 'cow', 'no kine here');
     assert.equal(schema.singularize('data'), 'data', 'no Latin knowledge here');
   });
 
-  test('#generateId', function(assert) {
+  test('#generateId', function (assert) {
     const schema = new Schema({
-      generateId: modelName => `${modelName}-123`,
+      generateId: (modelName) => `${modelName}-123`,
 
       models: {
         moon: {}
@@ -236,9 +236,9 @@ module('Schema', function() {
     );
   });
 
-  test('#initializeRecord', function(assert) {
+  test('#initializeRecord', function (assert) {
     const schema = new Schema({
-      generateId: modelName => `${modelName}-123`,
+      generateId: (modelName) => `${modelName}-123`,
 
       models: {
         moon: {}

--- a/packages/@orbit/data/test/source-interfaces/pullable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/pullable-test.ts
@@ -13,7 +13,7 @@ import '../test-helper';
 
 const { module, test } = QUnit;
 
-module('@pullable', function(hooks) {
+module('@pullable', function (hooks) {
   @pullable
   class MySource extends Source implements Pullable {
     pull: (
@@ -26,15 +26,15 @@ module('@pullable', function(hooks) {
 
   let source: MySource;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     source = new MySource();
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     source = null;
   });
 
-  test('isPullable - tests for the application of the @pullable decorator', function(assert) {
+  test('isPullable - tests for the application of the @pullable decorator', function (assert) {
     assert.ok(isPullable(source));
   });
 
@@ -48,22 +48,22 @@ module('@pullable', function(hooks) {
   //   'assertion raised');
   // });
 
-  test('#pull should resolve as a failure when _pull fails', async function(assert) {
+  test('#pull should resolve as a failure when _pull fails', async function (assert) {
     assert.expect(2);
 
-    source._pull = async function() {
+    source._pull = async function () {
       return Promise.reject(':(');
     };
 
     try {
-      await source.pull(q => q.findRecords('planet'));
+      await source.pull((q) => q.findRecords('planet'));
     } catch (error) {
       assert.ok(true, 'pull promise resolved as a failure');
       assert.equal(error, ':(', 'failure');
     }
   });
 
-  test('#pull should trigger `pull` event after a successful action in which `_pull` returns an array of transforms', async function(assert) {
+  test('#pull should trigger `pull` event after a successful action in which `_pull` returns an array of transforms', async function (assert) {
     assert.expect(9);
 
     let order = 0;
@@ -74,7 +74,7 @@ module('@pullable', function(hooks) {
       buildTransform({ op: 'replaceRecordAttribute' })
     ];
 
-    source._pull = async function(query) {
+    source._pull = async function (query) {
       assert.equal(++order, 1, 'action performed after willPull');
       assert.strictEqual(query.expressions[0], qe, 'query object matches');
       await this.transformed(resultingTransforms);
@@ -82,7 +82,7 @@ module('@pullable', function(hooks) {
     };
 
     let transformCount = 0;
-    source.on('transform', transform => {
+    source.on('transform', (transform) => {
       assert.strictEqual(
         transform,
         resultingTransforms[transformCount++],
@@ -107,7 +107,7 @@ module('@pullable', function(hooks) {
     assert.strictEqual(result, resultingTransforms, 'success!');
   });
 
-  test('#pull should resolve all promises returned from `beforePull` before calling `_transform`', async function(assert) {
+  test('#pull should resolve all promises returned from `beforePull` before calling `_transform`', async function (assert) {
     assert.expect(12);
 
     let order = 0;
@@ -133,7 +133,7 @@ module('@pullable', function(hooks) {
       return Promise.resolve();
     });
 
-    source._pull = async function(query) {
+    source._pull = async function (query) {
       assert.equal(++order, 4, 'action performed after willPull');
       assert.strictEqual(query.expressions[0], qe, 'query object matches');
       await this.transformed(resultingTransforms);
@@ -141,7 +141,7 @@ module('@pullable', function(hooks) {
     };
 
     let transformCount = 0;
-    source.on('transform', transform => {
+    source.on('transform', (transform) => {
       assert.strictEqual(
         transform,
         resultingTransforms[transformCount++],
@@ -166,7 +166,7 @@ module('@pullable', function(hooks) {
     assert.strictEqual(result, resultingTransforms, 'success!');
   });
 
-  test('#pull should resolve all promises returned from `beforePull` and fail if any fail', async function(assert) {
+  test('#pull should resolve all promises returned from `beforePull` and fail if any fail', async function (assert) {
     assert.expect(7);
 
     let order = 0;
@@ -182,7 +182,7 @@ module('@pullable', function(hooks) {
       return Promise.reject(':(');
     });
 
-    source._pull = async function(query: Query): Promise<Transform[]> {
+    source._pull = async function (query: Query): Promise<Transform[]> {
       assert.ok(false, '_pull should not be invoked');
       return [];
     };
@@ -209,13 +209,13 @@ module('@pullable', function(hooks) {
     }
   });
 
-  test('#pull should trigger `pullFail` event after an unsuccessful pull', async function(assert) {
+  test('#pull should trigger `pullFail` event after an unsuccessful pull', async function (assert) {
     assert.expect(7);
 
     let order = 0;
     let qe = { op: 'findRecords', type: 'planet' };
 
-    source._pull = function(query) {
+    source._pull = function (query) {
       assert.equal(++order, 1, 'action performed after willPull');
       assert.strictEqual(query.expressions[0], qe, 'query object matches');
       return Promise.reject(':(');
@@ -239,7 +239,7 @@ module('@pullable', function(hooks) {
     }
   });
 
-  test('#pull should pass a common `hints` object to all `beforePull` events and forward it to `_pull`', async function(assert) {
+  test('#pull should pass a common `hints` object to all `beforePull` events and forward it to `_pull`', async function (assert) {
     assert.expect(16);
 
     let order = 0;
@@ -250,24 +250,24 @@ module('@pullable', function(hooks) {
       buildTransform({ op: 'replaceRecordAttribute' })
     ];
 
-    source.on('beforePull', async function(query: Query, hints: any) {
+    source.on('beforePull', async function (query: Query, hints: any) {
       assert.equal(++order, 1, 'beforePull triggered first');
       assert.deepEqual(hints, {}, 'beforePull is passed empty `hints` object');
       h = hints;
       hints.data = resultingTransforms;
     });
 
-    source.on('beforePull', async function(query: Query, hints: any) {
+    source.on('beforePull', async function (query: Query, hints: any) {
       assert.equal(++order, 2, 'beforePull triggered second');
       assert.strictEqual(hints, h, 'beforePull is passed same hints instance');
     });
 
-    source.on('beforePull', async function(query: Query, hints: any) {
+    source.on('beforePull', async function (query: Query, hints: any) {
       assert.equal(++order, 3, 'beforePull triggered third');
       assert.strictEqual(hints, h, 'beforePull is passed same hints instance');
     });
 
-    source._pull = async function(query: Query, hints: any) {
+    source._pull = async function (query: Query, hints: any) {
       assert.equal(++order, 4, 'action performed after willPull');
       assert.strictEqual(query.expressions[0], qe, 'query object matches');
       assert.strictEqual(hints, h, '_pull is passed same hints instance');
@@ -276,7 +276,7 @@ module('@pullable', function(hooks) {
     };
 
     let transformCount = 0;
-    source.on('transform', async function(transform) {
+    source.on('transform', async function (transform) {
       assert.strictEqual(
         transform,
         resultingTransforms[transformCount++],

--- a/packages/@orbit/data/test/source-interfaces/pushable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/pushable-test.ts
@@ -12,7 +12,7 @@ import '../test-helper';
 
 const { module, test } = QUnit;
 
-module('@pushable', function(hooks) {
+module('@pushable', function (hooks) {
   @pushable
   class MySource extends Source implements Pushable {
     push: (
@@ -25,15 +25,15 @@ module('@pushable', function(hooks) {
 
   let source: MySource;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     source = new MySource({ name: 'src1' });
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     source = null;
   });
 
-  test('isPushable - tests for the application of the @pushable decorator', function(assert) {
+  test('isPushable - tests for the application of the @pushable decorator', function (assert) {
     assert.ok(isPushable(source));
   });
 
@@ -47,10 +47,10 @@ module('@pushable', function(hooks) {
   //   'assertion raised');
   // });
 
-  test('#push should resolve as a failure when `transform` fails', async function(assert) {
+  test('#push should resolve as a failure when `transform` fails', async function (assert) {
     assert.expect(2);
 
-    source._push = function() {
+    source._push = function () {
       return Promise.reject(':(');
     };
 
@@ -62,7 +62,7 @@ module('@pushable', function(hooks) {
     }
   });
 
-  test('#push should trigger `push` event after a successful action in which `transform` returns an array of transforms', async function(assert) {
+  test('#push should trigger `push` event after a successful action in which `transform` returns an array of transforms', async function (assert) {
     assert.expect(12);
 
     let order = 0;
@@ -74,12 +74,12 @@ module('@pushable', function(hooks) {
 
     const resultingTransforms = [addRecordTransform, replaceAttributeTransform];
 
-    source.on('beforePush', transform => {
+    source.on('beforePush', (transform) => {
       assert.equal(++order, 1, 'beforePush triggered first');
       assert.strictEqual(transform, addRecordTransform, 'transform matches');
     });
 
-    source._push = async function(transform) {
+    source._push = async function (transform) {
       assert.equal(++order, 2, 'action performed after beforePush');
       assert.strictEqual(
         transform,
@@ -91,7 +91,7 @@ module('@pushable', function(hooks) {
     };
 
     let transformCount = 0;
-    source.on('transform', transform => {
+    source.on('transform', (transform) => {
       assert.equal(
         ++order,
         3 + transformCount,
@@ -105,7 +105,7 @@ module('@pushable', function(hooks) {
       return Promise.resolve();
     });
 
-    source.on('push', transform => {
+    source.on('push', (transform) => {
       assert.equal(
         ++order,
         5,
@@ -124,14 +124,14 @@ module('@pushable', function(hooks) {
     );
   });
 
-  test('#push should trigger `pushFail` event after an unsuccessful push', async function(assert) {
+  test('#push should trigger `pushFail` event after an unsuccessful push', async function (assert) {
     assert.expect(7);
 
     const addRecordTransform = buildTransform({ op: 'addRecord' });
 
     let order = 0;
 
-    source._push = function(transform) {
+    source._push = function (transform) {
       assert.equal(++order, 1, 'action performed after willPush');
       assert.strictEqual(transform, addRecordTransform, 'transform matches');
       return Promise.reject(':(');
@@ -155,7 +155,7 @@ module('@pushable', function(hooks) {
     }
   });
 
-  test('#push should resolve all promises returned from `beforePush` before calling `_push`', async function(assert) {
+  test('#push should resolve all promises returned from `beforePush` before calling `_push`', async function (assert) {
     assert.expect(7);
 
     let order = 0;
@@ -182,7 +182,7 @@ module('@pushable', function(hooks) {
       return Promise.resolve();
     });
 
-    source._push = async function() {
+    source._push = async function () {
       assert.equal(++order, 4, '_push invoked after all `beforePush` handlers');
       return resultingTransforms;
     };
@@ -205,7 +205,7 @@ module('@pushable', function(hooks) {
     );
   });
 
-  test('#push should still call `_push` if the transform has been applied as a result of `beforePush` resolution', async function(assert) {
+  test('#push should still call `_push` if the transform has been applied as a result of `beforePush` resolution', async function (assert) {
     assert.expect(5);
 
     let order = 0;
@@ -221,7 +221,7 @@ module('@pushable', function(hooks) {
       return Promise.resolve();
     });
 
-    source._push = async function(): Promise<Transform[]> {
+    source._push = async function (): Promise<Transform[]> {
       assert.ok(true, '_push should still be reached');
       assert.ok(
         this.transformLog.contains(addRecordTransform.id),
@@ -239,7 +239,7 @@ module('@pushable', function(hooks) {
     assert.equal(++order, 2, 'promise resolved last');
   });
 
-  test('#push should resolve all promises returned from `beforePush` and fail if any fail', async function(assert) {
+  test('#push should resolve all promises returned from `beforePush` and fail if any fail', async function (assert) {
     assert.expect(5);
 
     let order = 0;
@@ -256,7 +256,7 @@ module('@pushable', function(hooks) {
       return Promise.reject(':(');
     });
 
-    source._push = async function(): Promise<Transform[]> {
+    source._push = async function (): Promise<Transform[]> {
       assert.ok(false, '_push should not be invoked');
       return [];
     };
@@ -277,7 +277,7 @@ module('@pushable', function(hooks) {
     }
   });
 
-  test('#push should pass a common `hints` object to all `beforePush` events and forward it to `_push`', async function(assert) {
+  test('#push should pass a common `hints` object to all `beforePush` events and forward it to `_push`', async function (assert) {
     assert.expect(11);
 
     let order = 0;
@@ -289,24 +289,24 @@ module('@pushable', function(hooks) {
     let h: any;
     const resultingTransforms = [addRecordTransform, replaceAttributeTransform];
 
-    source.on('beforePush', async function(transform: Transform, hints: any) {
+    source.on('beforePush', async function (transform: Transform, hints: any) {
       assert.equal(++order, 1, 'beforePush triggered first');
       assert.deepEqual(hints, {}, 'beforePush is passed empty `hints` object');
       h = hints;
       hints.foo = 'bar';
     });
 
-    source.on('beforePush', async function(transform: Transform, hints: any) {
+    source.on('beforePush', async function (transform: Transform, hints: any) {
       assert.equal(++order, 2, 'beforePush triggered second');
       assert.strictEqual(hints, h, 'beforePush is passed same hints instance');
     });
 
-    source.on('beforePush', async function(transform: Transform, hints: any) {
+    source.on('beforePush', async function (transform: Transform, hints: any) {
       assert.equal(++order, 3, 'beforePush triggered third');
       assert.strictEqual(hints, h, 'beforePush is passed same hints instance');
     });
 
-    source._push = async function(transform: Transform, hints: any) {
+    source._push = async function (transform: Transform, hints: any) {
       assert.equal(++order, 4, '_push invoked after all `beforePush` handlers');
       assert.strictEqual(hints, h, '_push is passed same hints instance');
       return resultingTransforms;

--- a/packages/@orbit/data/test/source-interfaces/queryable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/queryable-test.ts
@@ -11,7 +11,7 @@ import '../test-helper';
 
 const { module, test } = QUnit;
 
-module('@queryable', function(hooks) {
+module('@queryable', function (hooks) {
   @queryable
   class MySource extends Source implements Queryable {
     query: (
@@ -24,15 +24,15 @@ module('@queryable', function(hooks) {
 
   let source: MySource;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     source = new MySource({ name: 'src1' });
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     source = null;
   });
 
-  test('isQueryable - tests for the application of the @queryable decorator', function(assert) {
+  test('isQueryable - tests for the application of the @queryable decorator', function (assert) {
     assert.ok(isQueryable(source));
   });
 
@@ -46,28 +46,28 @@ module('@queryable', function(hooks) {
   //   'assertion raised');
   // });
 
-  test('#query should resolve as a failure when _query fails', async function(assert) {
+  test('#query should resolve as a failure when _query fails', async function (assert) {
     assert.expect(2);
 
-    source._query = function() {
+    source._query = function () {
       return Promise.reject(':(');
     };
 
     try {
-      await source.query(q => q.findRecords('planet'));
+      await source.query((q) => q.findRecords('planet'));
     } catch (error) {
       assert.ok(true, 'query promise resolved as a failure');
       assert.equal(error, ':(', 'failure');
     }
   });
 
-  test('#query should trigger `query` event after a successful action in which `_query` resolves successfully', async function(assert) {
+  test('#query should trigger `query` event after a successful action in which `_query` resolves successfully', async function (assert) {
     assert.expect(7);
 
     let order = 0;
     let qe = { op: 'findRecords', type: 'planet' };
 
-    source._query = function(query) {
+    source._query = function (query) {
       assert.equal(++order, 1, 'action performed after willQuery');
       assert.strictEqual(query.expressions[0], qe, 'query object matches');
       return Promise.resolve(':)');
@@ -89,13 +89,13 @@ module('@queryable', function(hooks) {
     assert.equal(result, ':)', 'success!');
   });
 
-  test('#query should trigger `query` event after a successful action in which `_query` just returns (not a promise)', async function(assert) {
+  test('#query should trigger `query` event after a successful action in which `_query` just returns (not a promise)', async function (assert) {
     assert.expect(7);
 
     let order = 0;
     let qe = { op: 'findRecords', type: 'planet' };
 
-    source._query = async function(query) {
+    source._query = async function (query) {
       assert.equal(++order, 1, 'action performed after willQuery');
       assert.strictEqual(query.expressions[0], qe, 'query object matches');
     };
@@ -116,13 +116,13 @@ module('@queryable', function(hooks) {
     assert.equal(result, undefined, 'undefined result');
   });
 
-  test('`query` event should receive results as the last argument, even if they are an array', async function(assert) {
+  test('`query` event should receive results as the last argument, even if they are an array', async function (assert) {
     assert.expect(7);
 
     let order = 0;
     let qe = { op: 'findRecords', type: 'planet' };
 
-    source._query = async function(query) {
+    source._query = async function (query) {
       assert.equal(++order, 1, 'action performed after willQuery');
       assert.strictEqual(query.expressions[0], qe, 'query object matches');
       return ['a', 'b', 'c'];
@@ -144,13 +144,13 @@ module('@queryable', function(hooks) {
     assert.deepEqual(result, ['a', 'b', 'c'], 'success!');
   });
 
-  test('#query should trigger `queryFail` event after an unsuccessful query', async function(assert) {
+  test('#query should trigger `queryFail` event after an unsuccessful query', async function (assert) {
     assert.expect(7);
 
     let order = 0;
     let qe = { op: 'findRecords', type: 'planet' };
 
-    source._query = function(query) {
+    source._query = function (query) {
       assert.equal(++order, 1, 'action performed after willQuery');
       assert.strictEqual(query.expressions[0], qe, 'query object matches');
       return Promise.reject(':(');
@@ -178,7 +178,7 @@ module('@queryable', function(hooks) {
     }
   });
 
-  test('#query should resolve all promises returned from `beforeQuery` before calling `_query`', async function(assert) {
+  test('#query should resolve all promises returned from `beforeQuery` before calling `_query`', async function (assert) {
     assert.expect(7);
 
     let order = 0;
@@ -199,7 +199,7 @@ module('@queryable', function(hooks) {
       return Promise.resolve();
     });
 
-    source._query = function() {
+    source._query = function () {
       assert.equal(
         ++order,
         4,
@@ -222,7 +222,7 @@ module('@queryable', function(hooks) {
     assert.equal(result, ':)', 'success!');
   });
 
-  test('#query should resolve all promises returned from `beforeQuery` and fail if any fail', async function(assert) {
+  test('#query should resolve all promises returned from `beforeQuery` and fail if any fail', async function (assert) {
     assert.expect(5);
 
     let order = 0;
@@ -238,7 +238,7 @@ module('@queryable', function(hooks) {
       return Promise.reject(':(');
     });
 
-    source._query = async function() {
+    source._query = async function () {
       assert.ok(false, '_query should not be invoked');
     };
 
@@ -258,14 +258,14 @@ module('@queryable', function(hooks) {
     }
   });
 
-  test('#query should pass a common `hints` object to all `beforeQuery` events and forward it to `_query`', async function(assert) {
+  test('#query should pass a common `hints` object to all `beforeQuery` events and forward it to `_query`', async function (assert) {
     assert.expect(11);
 
     let order = 0;
     let qe = { op: 'findRecords', type: 'planet' };
     let h: any;
 
-    source.on('beforeQuery', async function(query: Query, hints: any) {
+    source.on('beforeQuery', async function (query: Query, hints: any) {
       assert.equal(++order, 1, 'beforeQuery triggered first');
       assert.deepEqual(hints, {}, 'beforeQuery is passed empty `hints` object');
       h = hints;
@@ -275,17 +275,17 @@ module('@queryable', function(hooks) {
       ];
     });
 
-    source.on('beforeQuery', async function(query: Query, hints: any) {
+    source.on('beforeQuery', async function (query: Query, hints: any) {
       assert.equal(++order, 2, 'beforeQuery triggered second');
       assert.strictEqual(hints, h, 'beforeQuery is passed same hints instance');
     });
 
-    source.on('beforeQuery', async function(query: Query, hints: any) {
+    source.on('beforeQuery', async function (query: Query, hints: any) {
       assert.equal(++order, 3, 'beforeQuery triggered third');
       assert.strictEqual(hints, h, 'beforeQuery is passed same hints instance');
     });
 
-    source._query = async function(query: Query, hints: any) {
+    source._query = async function (query: Query, hints: any) {
       assert.equal(
         ++order,
         4,
@@ -295,7 +295,7 @@ module('@queryable', function(hooks) {
       return hints.data;
     };
 
-    source.on('query', async function() {
+    source.on('query', async function () {
       assert.equal(
         ++order,
         5,

--- a/packages/@orbit/data/test/source-interfaces/syncable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/syncable-test.ts
@@ -10,7 +10,7 @@ import '../test-helper';
 
 const { module, test } = QUnit;
 
-module('@syncable', function(hooks) {
+module('@syncable', function (hooks) {
   @syncable
   class MySource extends Source implements Syncable {
     sync: (transformOrTransforms: Transform | Transform[]) => Promise<void>;
@@ -19,15 +19,15 @@ module('@syncable', function(hooks) {
 
   let source: MySource;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     source = new MySource({ name: 'src1' });
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     source = null;
   });
 
-  test('isSyncable - tests for the application of the @syncable decorator', function(assert) {
+  test('isSyncable - tests for the application of the @syncable decorator', function (assert) {
     assert.ok(isSyncable(source));
   });
 
@@ -41,7 +41,7 @@ module('@syncable', function(hooks) {
   //   'assertion raised');
   // });
 
-  test('#sync accepts a Transform and calls internal method `_sync`', async function(assert) {
+  test('#sync accepts a Transform and calls internal method `_sync`', async function (assert) {
     assert.expect(2);
 
     const addPlanet = {
@@ -50,7 +50,7 @@ module('@syncable', function(hooks) {
     };
     const addRecordTransform = buildTransform(addPlanet);
 
-    source._sync = async function(transform: Transform) {
+    source._sync = async function (transform: Transform) {
       assert.strictEqual(
         transform,
         addRecordTransform,
@@ -63,7 +63,7 @@ module('@syncable', function(hooks) {
     assert.ok(true, 'transformed promise resolved');
   });
 
-  test('#sync should resolve as a failure when `_sync` fails', async function(assert) {
+  test('#sync should resolve as a failure when `_sync` fails', async function (assert) {
     assert.expect(2);
 
     const addPlanet = {
@@ -72,7 +72,7 @@ module('@syncable', function(hooks) {
     };
     const addRecordTransform = buildTransform(addPlanet);
 
-    source._sync = async function(transform: Transform) {
+    source._sync = async function (transform: Transform) {
       return Promise.reject(':(');
     };
 
@@ -84,7 +84,7 @@ module('@syncable', function(hooks) {
     }
   });
 
-  test('#sync should trigger `sync` event after a successful action in which `_sync` returns an array of transforms', async function(assert) {
+  test('#sync should trigger `sync` event after a successful action in which `_sync` returns an array of transforms', async function (assert) {
     assert.expect(9);
 
     let order = 0;
@@ -95,12 +95,12 @@ module('@syncable', function(hooks) {
     };
     const addRecordTransform = buildTransform(addPlanet);
 
-    source.on('beforeSync', transform => {
+    source.on('beforeSync', (transform) => {
       assert.equal(++order, 1, 'beforeSync triggered first');
       assert.strictEqual(transform, addRecordTransform, 'transform matches');
     });
 
-    source._sync = async function(transform) {
+    source._sync = async function (transform) {
       assert.equal(++order, 2, 'action performed after beforeSync');
       assert.strictEqual(
         transform,
@@ -110,7 +110,7 @@ module('@syncable', function(hooks) {
       await this.transformed([transform]);
     };
 
-    source.on('transform', transform => {
+    source.on('transform', (transform) => {
       assert.equal(
         ++order,
         3,
@@ -120,7 +120,7 @@ module('@syncable', function(hooks) {
       return Promise.resolve();
     });
 
-    source.on('sync', transform => {
+    source.on('sync', (transform) => {
       assert.equal(
         ++order,
         4,
@@ -138,7 +138,7 @@ module('@syncable', function(hooks) {
     assert.equal(++order, 5, 'promise resolved last');
   });
 
-  test('#sync should trigger `syncFail` event after an unsuccessful sync', async function(assert) {
+  test('#sync should trigger `syncFail` event after an unsuccessful sync', async function (assert) {
     assert.expect(7);
 
     const addPlanet = {
@@ -149,7 +149,7 @@ module('@syncable', function(hooks) {
 
     let order = 0;
 
-    source._sync = async function(transform: Transform) {
+    source._sync = async function (transform: Transform) {
       assert.equal(++order, 1, 'action performed first');
       assert.strictEqual(transform, addRecordTransform, 'transform matches');
       throw new Error(':(');
@@ -173,7 +173,7 @@ module('@syncable', function(hooks) {
     }
   });
 
-  test('#sync should still call `_sync` if the transform has been applied as a result of `beforeSync` resolution', async function(assert) {
+  test('#sync should still call `_sync` if the transform has been applied as a result of `beforeSync` resolution', async function (assert) {
     assert.expect(5);
 
     let order = 0;
@@ -193,7 +193,7 @@ module('@syncable', function(hooks) {
       return Promise.resolve();
     });
 
-    source._sync = async function(transform: Transform) {
+    source._sync = async function (transform: Transform) {
       assert.ok(true, '_sync should still be reached');
       assert.ok(
         this.transformLog.contains(transform.id),
@@ -210,7 +210,7 @@ module('@syncable', function(hooks) {
     assert.equal(++order, 2, 'promise resolved last');
   });
 
-  test('#sync should resolve all promises returned from `beforeSync` before calling `_sync`', async function(assert) {
+  test('#sync should resolve all promises returned from `beforeSync` before calling `_sync`', async function (assert) {
     assert.expect(6);
 
     let order = 0;
@@ -236,7 +236,7 @@ module('@syncable', function(hooks) {
       return Promise.resolve();
     });
 
-    source._sync = async function(transform: Transform) {
+    source._sync = async function (transform: Transform) {
       assert.equal(++order, 4, '_sync invoked after all `beforeSync` handlers');
     };
 
@@ -253,7 +253,7 @@ module('@syncable', function(hooks) {
     assert.equal(++order, 6, 'promise resolved last');
   });
 
-  test('#sync should resolve all promises returned from `beforeSync` and fail if any fail', async function(assert) {
+  test('#sync should resolve all promises returned from `beforeSync` and fail if any fail', async function (assert) {
     assert.expect(5);
 
     let order = 0;
@@ -270,7 +270,7 @@ module('@syncable', function(hooks) {
       return Promise.reject(':(');
     });
 
-    source._sync = async function(transform: Transform) {
+    source._sync = async function (transform: Transform) {
       assert.ok(false, '_sync should not be invoked');
     };
 

--- a/packages/@orbit/data/test/source-interfaces/updatable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/updatable-test.ts
@@ -12,7 +12,7 @@ import '../test-helper';
 
 const { module, test } = QUnit;
 
-module('@updatable', function(hooks) {
+module('@updatable', function (hooks) {
   @updatable
   class MySource extends Source implements Updatable {
     update: (
@@ -25,15 +25,15 @@ module('@updatable', function(hooks) {
 
   let source: MySource;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     source = new MySource({ name: 'src1' });
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     source = null;
   });
 
-  test('isUpdatable - tests for the application of the @updatable decorator', function(assert) {
+  test('isUpdatable - tests for the application of the @updatable decorator', function (assert) {
     assert.ok(isUpdatable(source));
   });
 
@@ -47,10 +47,10 @@ module('@updatable', function(hooks) {
   //   'assertion raised');
   // });
 
-  test('#update should resolve as a failure when `transform` fails', async function(assert) {
+  test('#update should resolve as a failure when `transform` fails', async function (assert) {
     assert.expect(2);
 
-    source._update = function() {
+    source._update = function () {
       return Promise.reject(':(');
     };
 
@@ -62,19 +62,19 @@ module('@updatable', function(hooks) {
     }
   });
 
-  test('#update should trigger `update` event after a successful action in which `_update` returns an array of transforms', async function(assert) {
+  test('#update should trigger `update` event after a successful action in which `_update` returns an array of transforms', async function (assert) {
     assert.expect(11);
 
     let order = 0;
 
     const addRecordTransform = buildTransform({ op: 'addRecord' });
 
-    source.on('beforeUpdate', transform => {
+    source.on('beforeUpdate', (transform) => {
       assert.equal(++order, 1, 'beforeUpdate triggered first');
       assert.strictEqual(transform, addRecordTransform, 'transform matches');
     });
 
-    source._update = async function(transform) {
+    source._update = async function (transform) {
       assert.equal(++order, 2, 'action performed after beforeUpdate');
       assert.strictEqual(
         transform,
@@ -85,7 +85,7 @@ module('@updatable', function(hooks) {
       return ':)';
     };
 
-    source.on('transform', transform => {
+    source.on('transform', (transform) => {
       assert.equal(
         ++order,
         3,
@@ -115,19 +115,19 @@ module('@updatable', function(hooks) {
     assert.equal(result, ':)', 'success!');
   });
 
-  test('`update` event should receive results as the last argument, even if they are an array', async function(assert) {
+  test('`update` event should receive results as the last argument, even if they are an array', async function (assert) {
     assert.expect(11);
 
     let order = 0;
 
     const addRecordTransform = buildTransform({ op: 'addRecord' });
 
-    source.on('beforeUpdate', transform => {
+    source.on('beforeUpdate', (transform) => {
       assert.equal(++order, 1, 'beforeUpdate triggered first');
       assert.strictEqual(transform, addRecordTransform, 'transform matches');
     });
 
-    source._update = async function(transform) {
+    source._update = async function (transform) {
       assert.equal(++order, 2, 'action performed after beforeUpdate');
       assert.strictEqual(
         transform,
@@ -138,7 +138,7 @@ module('@updatable', function(hooks) {
       return ['a', 'b', 'c'];
     };
 
-    source.on('transform', transform => {
+    source.on('transform', (transform) => {
       assert.equal(
         ++order,
         3,
@@ -168,14 +168,14 @@ module('@updatable', function(hooks) {
     assert.deepEqual(result, ['a', 'b', 'c'], 'success!');
   });
 
-  test('#update should trigger `updateFail` event after an unsuccessful update', async function(assert) {
+  test('#update should trigger `updateFail` event after an unsuccessful update', async function (assert) {
     assert.expect(7);
 
     const addRecordTransform = buildTransform({ op: 'addRecord' });
 
     let order = 0;
 
-    source._update = function(transform) {
+    source._update = function (transform) {
       assert.equal(++order, 1, 'action performed after beforeUpdate');
       assert.strictEqual(transform, addRecordTransform, 'transform matches');
       return Promise.reject(':(');
@@ -203,7 +203,7 @@ module('@updatable', function(hooks) {
     }
   });
 
-  test('#update should resolve all promises returned from `beforeUpdate` before calling `_update`', async function(assert) {
+  test('#update should resolve all promises returned from `beforeUpdate` before calling `_update`', async function (assert) {
     assert.expect(6);
 
     let order = 0;
@@ -225,7 +225,7 @@ module('@updatable', function(hooks) {
       return Promise.resolve();
     });
 
-    source._update = async function() {
+    source._update = async function () {
       assert.equal(
         ++order,
         4,
@@ -246,7 +246,7 @@ module('@updatable', function(hooks) {
     assert.equal(++order, 6, 'promise resolved last');
   });
 
-  test('#update should still call `_update` if the transform has been applied as a result of `beforeUpdate` resolution', async function(assert) {
+  test('#update should still call `_update` if the transform has been applied as a result of `beforeUpdate` resolution', async function (assert) {
     assert.expect(5);
 
     let order = 0;
@@ -262,7 +262,7 @@ module('@updatable', function(hooks) {
       return Promise.resolve();
     });
 
-    source._update = async function(transform) {
+    source._update = async function (transform) {
       assert.ok(true, '_update should still be reached');
       assert.ok(
         this.transformLog.contains(transform.id),
@@ -279,7 +279,7 @@ module('@updatable', function(hooks) {
     assert.equal(++order, 2, 'promise resolved last');
   });
 
-  test('#update should resolve all promises returned from `beforeUpdate` and fail if any fail', async function(assert) {
+  test('#update should resolve all promises returned from `beforeUpdate` and fail if any fail', async function (assert) {
     assert.expect(5);
 
     let order = 0;
@@ -296,7 +296,7 @@ module('@updatable', function(hooks) {
       return Promise.reject(':(');
     });
 
-    source._update = async function() {
+    source._update = async function () {
       assert.ok(false, '_update should not be invoked');
     };
 
@@ -316,7 +316,7 @@ module('@updatable', function(hooks) {
     }
   });
 
-  test('#update should pass a common `hints` object to all `beforeUpdate` events and forward it to `_update`', async function(assert) {
+  test('#update should pass a common `hints` object to all `beforeUpdate` events and forward it to `_update`', async function (assert) {
     assert.expect(11);
 
     let order = 0;
@@ -328,7 +328,10 @@ module('@updatable', function(hooks) {
     let h: any;
     const resultingTransforms = [addRecordTransform, replaceAttributeTransform];
 
-    source.on('beforeUpdate', async function(transform: Transform, hints: any) {
+    source.on('beforeUpdate', async function (
+      transform: Transform,
+      hints: any
+    ) {
       assert.equal(++order, 1, 'beforeUpdate triggered first');
       assert.deepEqual(
         hints,
@@ -339,7 +342,10 @@ module('@updatable', function(hooks) {
       hints.foo = 'bar';
     });
 
-    source.on('beforeUpdate', async function(transform: Transform, hints: any) {
+    source.on('beforeUpdate', async function (
+      transform: Transform,
+      hints: any
+    ) {
       assert.equal(++order, 2, 'beforeUpdate triggered second');
       assert.strictEqual(
         hints,
@@ -348,7 +354,10 @@ module('@updatable', function(hooks) {
       );
     });
 
-    source.on('beforeUpdate', async function(transform: Transform, hints: any) {
+    source.on('beforeUpdate', async function (
+      transform: Transform,
+      hints: any
+    ) {
       assert.equal(++order, 3, 'beforeUpdate triggered third');
       assert.strictEqual(
         hints,
@@ -357,7 +366,7 @@ module('@updatable', function(hooks) {
       );
     });
 
-    source._update = async function(transform: Transform, hints: any) {
+    source._update = async function (transform: Transform, hints: any) {
       assert.equal(
         ++order,
         4,

--- a/packages/@orbit/data/test/source-test.ts
+++ b/packages/@orbit/data/test/source-test.ts
@@ -10,23 +10,23 @@ import { FakeBucket } from './test-helper';
 
 const { module, test } = QUnit;
 
-module('Source', function(hooks) {
+module('Source', function (hooks) {
   let source: any;
   let schema: Schema;
 
   class MySource extends Source {}
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     schema = new Schema();
   });
 
-  test('it can be instantiated', function(assert) {
+  test('it can be instantiated', function (assert) {
     source = new MySource();
     assert.ok(source);
     assert.ok(source.transformLog, 'has a transform log');
   });
 
-  test('it can be assigned a schema, which will be observed for upgrades by default', async function(assert) {
+  test('it can be assigned a schema, which will be observed for upgrades by default', async function (assert) {
     assert.expect(2);
 
     class MyDynamicSource extends Source {
@@ -42,7 +42,7 @@ module('Source', function(hooks) {
     assert.ok(true, 'after upgrade');
   });
 
-  test('it will not be auto-upgraded if autoUpgrade: false option is specified', function(assert) {
+  test('it will not be auto-upgraded if autoUpgrade: false option is specified', function (assert) {
     assert.expect(1);
 
     class MyDynamicSource extends Source {
@@ -56,7 +56,7 @@ module('Source', function(hooks) {
     assert.ok(true, 'after upgrade');
   });
 
-  test('creates a `transformLog`, `requestQueue`, and `syncQueue`, and assigns each the same bucket as the Source', function(assert) {
+  test('creates a `transformLog`, `requestQueue`, and `syncQueue`, and assigns each the same bucket as the Source', function (assert) {
     assert.expect(8);
     const bucket = new FakeBucket();
     source = new MySource({ name: 'src1', schema, bucket });
@@ -98,7 +98,7 @@ module('Source', function(hooks) {
     );
   });
 
-  test('overrides default requestQueue settings with injected requestQueueSettings', async function(assert) {
+  test('overrides default requestQueue settings with injected requestQueueSettings', async function (assert) {
     assert.expect(3);
 
     const defaultBucket = new FakeBucket();
@@ -135,7 +135,7 @@ module('Source', function(hooks) {
     );
   });
 
-  test('overrides default syncQueue settings with injected syncQueueSettings', async function(assert) {
+  test('overrides default syncQueue settings with injected syncQueueSettings', async function (assert) {
     assert.expect(3);
 
     const defaultBucket = new FakeBucket();
@@ -172,7 +172,7 @@ module('Source', function(hooks) {
     );
   });
 
-  test('disables queue activation by default until source activation', async function(assert) {
+  test('disables queue activation by default until source activation', async function (assert) {
     assert.expect(4);
 
     const bucket = new FakeBucket();
@@ -198,7 +198,7 @@ module('Source', function(hooks) {
     });
 
     let i = 0;
-    source.perform = async function(task) {
+    source.perform = async function (task) {
       i++;
       if (i === 1) {
         assert.strictEqual(task.data, op1, 'op1 - first task in sync queue');
@@ -216,7 +216,7 @@ module('Source', function(hooks) {
     await source.activate();
   });
 
-  test('creates a `queryBuilder` upon first access', function(assert) {
+  test('creates a `queryBuilder` upon first access', function (assert) {
     const qb = source.queryBuilder;
     assert.ok(qb, 'queryBuilder created');
     assert.strictEqual(
@@ -226,7 +226,7 @@ module('Source', function(hooks) {
     );
   });
 
-  test('creates a `transformBuilder` upon first access', function(assert) {
+  test('creates a `transformBuilder` upon first access', function (assert) {
     const tb = source.transformBuilder;
     assert.ok(tb, 'transformBuilder created');
     assert.strictEqual(
@@ -241,7 +241,7 @@ module('Source', function(hooks) {
     );
   });
 
-  test('it can be instantiated with a `queryBuilder` and/or `transformBuilder`', function(assert) {
+  test('it can be instantiated with a `queryBuilder` and/or `transformBuilder`', function (assert) {
     const queryBuilder = new QueryBuilder();
     const transformBuilder = new TransformBuilder();
     source = new MySource({ queryBuilder, transformBuilder });
@@ -257,7 +257,7 @@ module('Source', function(hooks) {
     );
   });
 
-  test('#transformed should trigger `transform` event BEFORE resolving', async function(assert) {
+  test('#transformed should trigger `transform` event BEFORE resolving', async function (assert) {
     assert.expect(3);
 
     source = new MySource();
@@ -282,7 +282,7 @@ module('Source', function(hooks) {
     assert.equal(++order, 2, 'transformed promise resolved last');
   });
 
-  test('#transformLog contains transforms applied', async function(assert) {
+  test('#transformLog contains transforms applied', async function (assert) {
     assert.expect(2);
 
     source = new MySource();
@@ -295,7 +295,7 @@ module('Source', function(hooks) {
     assert.ok(source.transformLog.contains(appliedTransform.id));
   });
 
-  test('autoActivate', async function(assert) {
+  test('autoActivate', async function (assert) {
     assert.expect(2);
 
     source = new MySource({ autoActivate: false });

--- a/packages/@orbit/data/test/transform-builder-test.ts
+++ b/packages/@orbit/data/test/transform-builder-test.ts
@@ -3,32 +3,32 @@ import './test-helper';
 
 const { module, test } = QUnit;
 
-module('TransformBuilder', function(hooks) {
+module('TransformBuilder', function (hooks) {
   let tb: TransformBuilder;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     tb = new TransformBuilder();
   });
 
-  test('#addRecord', function(assert) {
+  test('#addRecord', function (assert) {
     let record = { type: 'planet', id: 'jupiter' };
 
     assert.deepEqual(tb.addRecord(record), { op: 'addRecord', record });
   });
 
-  test('#updateRecord', function(assert) {
+  test('#updateRecord', function (assert) {
     let record = { type: 'planet', id: 'jupiter' };
 
     assert.deepEqual(tb.updateRecord(record), { op: 'updateRecord', record });
   });
 
-  test('#removeRecord', function(assert) {
+  test('#removeRecord', function (assert) {
     let record = { type: 'planet', id: 'jupiter' };
 
     assert.deepEqual(tb.removeRecord(record), { op: 'removeRecord', record });
   });
 
-  test('#replaceKey', function(assert) {
+  test('#replaceKey', function (assert) {
     let record = { type: 'planet', id: 'jupiter' };
 
     assert.deepEqual(tb.replaceKey(record, 'remoteId', '123'), {
@@ -39,7 +39,7 @@ module('TransformBuilder', function(hooks) {
     });
   });
 
-  test('#replaceAttribute', function(assert) {
+  test('#replaceAttribute', function (assert) {
     let record = { type: 'planet', id: 'jupiter' };
 
     assert.deepEqual(tb.replaceAttribute(record, 'name', 'Earth'), {
@@ -50,7 +50,7 @@ module('TransformBuilder', function(hooks) {
     });
   });
 
-  test('#addToRelatedRecords', function(assert) {
+  test('#addToRelatedRecords', function (assert) {
     let record = { type: 'planet', id: 'jupiter' };
     let relatedRecord = { type: 'moon', id: 'Io' };
 
@@ -62,7 +62,7 @@ module('TransformBuilder', function(hooks) {
     });
   });
 
-  test('#removeFromRelatedRecords', function(assert) {
+  test('#removeFromRelatedRecords', function (assert) {
     let record = { type: 'planet', id: 'jupiter' };
     let relatedRecord = { type: 'moon', id: 'Io' };
 
@@ -77,7 +77,7 @@ module('TransformBuilder', function(hooks) {
     );
   });
 
-  test('#replaceRelatedRecords', function(assert) {
+  test('#replaceRelatedRecords', function (assert) {
     let record = { type: 'planet', id: 'jupiter' };
     let relatedRecords = [{ type: 'moon', id: 'Io' }];
 
@@ -92,7 +92,7 @@ module('TransformBuilder', function(hooks) {
     );
   });
 
-  test('#replaceRelatedRecord', function(assert) {
+  test('#replaceRelatedRecord', function (assert) {
     let record = { type: 'moon', id: 'Io' };
     let relatedRecord = { type: 'planet', id: 'Jupiter' };
 
@@ -104,7 +104,7 @@ module('TransformBuilder', function(hooks) {
     });
   });
 
-  test('#addRecord - when a recordInitializer has been set', function(assert) {
+  test('#addRecord - when a recordInitializer has been set', function (assert) {
     const recordInitializer = {
       initializeRecord(record: Record) {
         if (record.id === undefined) {

--- a/packages/@orbit/data/test/transform-test.ts
+++ b/packages/@orbit/data/test/transform-test.ts
@@ -5,18 +5,18 @@ const { module, test } = QUnit;
 
 ///////////////////////////////////////////////////////////////////////////////
 
-module('buildTransform', function() {
-  test('can instantiate a transform from an empty array of operations', function(assert) {
+module('buildTransform', function () {
+  test('can instantiate a transform from an empty array of operations', function (assert) {
     let transform = buildTransform([]);
     assert.ok(transform);
   });
 
-  test('can instantiate a transform that will be assigned an `id`', function(assert) {
+  test('can instantiate a transform that will be assigned an `id`', function (assert) {
     let transform = buildTransform([]);
     assert.ok(transform.id, 'transform has an id');
   });
 
-  test('can instantiate a transform with operations, options, and an id', function(assert) {
+  test('can instantiate a transform with operations, options, and an id', function (assert) {
     let operations = [{ op: 'addRecord' }];
     let options = { sources: { jsonapi: { include: 'comments' } } };
     let id = 'abc123';
@@ -32,12 +32,12 @@ module('buildTransform', function() {
     assert.strictEqual(transform.options, options, 'options was populated');
   });
 
-  test('will return a transform passed into it', function(assert) {
+  test('will return a transform passed into it', function (assert) {
     let transform = buildTransform([]);
     assert.strictEqual(buildTransform(transform), transform);
   });
 
-  test('will create a transform using a TransformBuilder if a function is passed into it', function(assert) {
+  test('will create a transform using a TransformBuilder if a function is passed into it', function (assert) {
     let tb = new TransformBuilder();
     let planet = { type: 'planet', id: 'earth' };
     let operation = {
@@ -45,7 +45,7 @@ module('buildTransform', function() {
       record: planet
     };
 
-    let query = buildTransform(t => t.addRecord(planet), null, null, tb);
+    let query = buildTransform((t) => t.addRecord(planet), null, null, tb);
     assert.deepEqual(query.operations, [operation], 'operations was populated');
   });
 });

--- a/packages/@orbit/identity-map/.prettierrc.js
+++ b/packages/@orbit/identity-map/.prettierrc.js
@@ -1,3 +1,4 @@
 module.exports = {
-  singleQuote: true
+  singleQuote: true,
+  trailingComma: 'none'
 };

--- a/packages/@orbit/identity-map/package.json
+++ b/packages/@orbit/identity-map/package.json
@@ -31,11 +31,11 @@
     "@orbit/core": "^0.17.0-beta.2",
     "@orbit/data": "^0.17.0-beta.2",
     "@orbit/utils": "^0.17.0-beta.2",
-    "@typescript-eslint/eslint-plugin": "^2.23.0",
-    "@typescript-eslint/parser": "^2.23.0",
+    "@typescript-eslint/eslint-plugin": "^2.26.0",
+    "@typescript-eslint/parser": "^2.26.0",
     "eslint": "^6.8.0",
-    "eslint-config-prettier": "^6.10.0",
+    "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-prettier": "^3.1.2",
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.2"
   }
 }

--- a/packages/@orbit/identity-map/test/identity-map-test.ts
+++ b/packages/@orbit/identity-map/test/identity-map-test.ts
@@ -4,24 +4,24 @@ import RecordIdentitySerializer from './support/record-identity-serializer';
 
 const { module, test } = QUnit;
 
-module('IdentityMap', function(hooks) {
+module('IdentityMap', function (hooks) {
   class Model {}
   const serializer = new RecordIdentitySerializer();
   let identityMap: IdentityMap<RecordIdentity, Model>;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     identityMap = new IdentityMap({ serializer });
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     identityMap = null;
   });
 
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     assert.ok(identityMap);
   });
 
-  test('get/set/has/delete', function(assert) {
+  test('get/set/has/delete', function (assert) {
     const identity = { type: 'person', id: '1' };
     const identity2 = { type: 'person', id: '2' };
     const record = new Model();
@@ -40,7 +40,7 @@ module('IdentityMap', function(hooks) {
     assert.equal(identityMap.get(identity), undefined);
   });
 
-  test('iterable', function(assert) {
+  test('iterable', function (assert) {
     const identity = { type: 'person', id: '1' };
     const record = new Model();
     const identity2 = { type: 'person', id: '2' };
@@ -64,7 +64,7 @@ module('IdentityMap', function(hooks) {
     assert.deepEqual(Array.from(identityMap.keys()), [identity, identity2]);
   });
 
-  test('clear', function(assert) {
+  test('clear', function (assert) {
     const identity = { type: 'person', id: '1' };
     const record = new Model();
     const identity2 = { type: 'person', id: '2' };

--- a/packages/@orbit/identity-map/test/record-identity-serializer-test.ts
+++ b/packages/@orbit/identity-map/test/record-identity-serializer-test.ts
@@ -2,27 +2,27 @@ import RecordIdentitySerializer from './support/record-identity-serializer';
 
 const { module, test } = QUnit;
 
-module('RecordIdentitySerializer', function(hooks) {
+module('RecordIdentitySerializer', function (hooks) {
   class Model {}
   let serializer: RecordIdentitySerializer;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     serializer = new RecordIdentitySerializer();
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     serializer = null;
   });
 
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     assert.ok(serializer);
   });
 
-  test('serialize', function(assert) {
+  test('serialize', function (assert) {
     assert.equal(serializer.serialize({ type: 'person', id: '1' }), 'person:1');
   });
 
-  test('deserialize', function(assert) {
+  test('deserialize', function (assert) {
     assert.deepEqual(serializer.deserialize('person:1'), {
       type: 'person',
       id: '1'

--- a/packages/@orbit/immutable/.prettierrc.js
+++ b/packages/@orbit/immutable/.prettierrc.js
@@ -1,3 +1,4 @@
 module.exports = {
-  singleQuote: true
+  singleQuote: true,
+  trailingComma: 'none'
 };

--- a/packages/@orbit/immutable/package.json
+++ b/packages/@orbit/immutable/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@glimmer/build": "^0.10.3",
-    "@typescript-eslint/eslint-plugin": "^2.23.0",
-    "@typescript-eslint/parser": "^2.23.0",
+    "@typescript-eslint/eslint-plugin": "^2.26.0",
+    "@typescript-eslint/parser": "^2.26.0",
     "eslint": "^6.8.0",
-    "eslint-config-prettier": "^6.10.0",
+    "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-prettier": "^3.1.2",
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.2"
   }
 }

--- a/packages/@orbit/immutable/src/immutable-map.ts
+++ b/packages/@orbit/immutable/src/immutable-map.ts
@@ -29,7 +29,7 @@ export default class ImmutableMap<K, V> {
 
   setMany(entries: [K, V][]): void {
     let data = this._data.beginMutation();
-    entries.forEach(entry => {
+    entries.forEach((entry) => {
       data.set(entry[0], entry[1]);
     });
     this._data = data.endMutation();
@@ -41,7 +41,7 @@ export default class ImmutableMap<K, V> {
 
   removeMany(keys: K[]): void {
     let data = this._data.beginMutation();
-    keys.forEach(key => {
+    keys.forEach((key) => {
       data.remove(key);
     });
     this._data = data.endMutation();

--- a/packages/@orbit/immutable/test/immutable-map-test.ts
+++ b/packages/@orbit/immutable/test/immutable-map-test.ts
@@ -2,13 +2,13 @@ import ImmutableMap from '../src/immutable-map';
 
 const { module, test } = QUnit;
 
-module('ImmutableMap', function() {
-  test('it can be instantiated with no data', function(assert) {
+module('ImmutableMap', function () {
+  test('it can be instantiated with no data', function (assert) {
     let map = new ImmutableMap<string, object>();
     assert.ok(map, 'map exists');
   });
 
-  test('records can be added and removed', function(assert) {
+  test('records can be added and removed', function (assert) {
     let map = new ImmutableMap<string, object>();
 
     assert.equal(map.size, 0, 'size matches expectations');
@@ -72,7 +72,7 @@ module('ImmutableMap', function() {
     assert.equal(map.size, 0, 'size matches expectations');
   });
 
-  test('maps can be instantiated based on other maps and their contents will be equal (but then will diverge)', function(assert) {
+  test('maps can be instantiated based on other maps and their contents will be equal (but then will diverge)', function (assert) {
     let map = new ImmutableMap<string, object>();
 
     let jupiter = {
@@ -139,7 +139,7 @@ module('ImmutableMap', function() {
     );
   });
 
-  test('maps can set and remove multiple items at once', function(assert) {
+  test('maps can set and remove multiple items at once', function (assert) {
     let jupiter = {
       type: 'planet',
       id: 'jupiter',

--- a/packages/@orbit/indexeddb-bucket/.prettierrc.js
+++ b/packages/@orbit/indexeddb-bucket/.prettierrc.js
@@ -1,3 +1,4 @@
 module.exports = {
-  singleQuote: true
+  singleQuote: true,
+  trailingComma: 'none'
 };

--- a/packages/@orbit/indexeddb-bucket/package.json
+++ b/packages/@orbit/indexeddb-bucket/package.json
@@ -30,11 +30,11 @@
   },
   "devDependencies": {
     "@glimmer/build": "^0.10.3",
-    "@typescript-eslint/eslint-plugin": "^2.23.0",
-    "@typescript-eslint/parser": "^2.23.0",
+    "@typescript-eslint/eslint-plugin": "^2.26.0",
+    "@typescript-eslint/parser": "^2.26.0",
     "eslint": "^6.8.0",
-    "eslint-config-prettier": "^6.10.0",
+    "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-prettier": "^3.1.2",
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.2"
   }
 }

--- a/packages/@orbit/indexeddb-bucket/src/bucket.ts
+++ b/packages/@orbit/indexeddb-bucket/src/bucket.ts
@@ -171,12 +171,12 @@ export default class IndexedDBBucket extends Bucket {
         const objectStore = transaction.objectStore(this.dbStoreName);
         const request = objectStore.get(key);
 
-        request.onerror = function(/* event */) {
+        request.onerror = function (/* event */) {
           console.error('error - getItem', request.error);
           reject(request.error);
         };
 
-        request.onsuccess = function(/* event */) {
+        request.onsuccess = function (/* event */) {
           // console.log('success - getItem', request.result);
           resolve(request.result);
         };
@@ -193,12 +193,12 @@ export default class IndexedDBBucket extends Bucket {
     await new Promise((resolve, reject) => {
       const request = objectStore.put(value, key);
 
-      request.onerror = function(/* event */) {
+      request.onerror = function (/* event */) {
         console.error('error - setItem', request.error);
         reject(request.error);
       };
 
-      request.onsuccess = function(/* event */) {
+      request.onsuccess = function (/* event */) {
         // console.log('success - setItem');
         resolve();
       };
@@ -212,12 +212,12 @@ export default class IndexedDBBucket extends Bucket {
       const objectStore = transaction.objectStore(this.dbStoreName);
       const request = objectStore.delete(key);
 
-      request.onerror = function(/* event */) {
+      request.onerror = function (/* event */) {
         console.error('error - removeItem', request.error);
         reject(request.error);
       };
 
-      request.onsuccess = function(/* event */) {
+      request.onsuccess = function (/* event */) {
         // console.log('success - removeItem');
         resolve();
       };
@@ -231,12 +231,12 @@ export default class IndexedDBBucket extends Bucket {
       const objectStore = transaction.objectStore(this.dbStoreName);
       const request = objectStore.clear();
 
-      request.onerror = function(/* event */) {
+      request.onerror = function (/* event */) {
         console.error('error - clear', request.error);
         reject(request.error);
       };
 
-      request.onsuccess = function(/* event */) {
+      request.onsuccess = function (/* event */) {
         // console.log('success - clear');
         resolve();
       };

--- a/packages/@orbit/indexeddb-bucket/test/bucket-test.ts
+++ b/packages/@orbit/indexeddb-bucket/test/bucket-test.ts
@@ -3,7 +3,7 @@ import IndexedDBBucket from '../src/bucket';
 
 const { module, test } = QUnit;
 
-module('IndexedDBBucket', function(hooks) {
+module('IndexedDBBucket', function (hooks) {
   let bucket: IndexedDBBucket;
 
   hooks.beforeEach(() => {
@@ -14,15 +14,15 @@ module('IndexedDBBucket', function(hooks) {
     return bucket.deleteDB();
   });
 
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     assert.ok(bucket);
   });
 
-  test('its prototype chain is correct', function(assert) {
+  test('its prototype chain is correct', function (assert) {
     assert.ok(bucket instanceof Bucket, 'instanceof Bucket');
   });
 
-  test('is assigned a default `name`, `namespace`, and `version`', function(assert) {
+  test('is assigned a default `name`, `namespace`, and `version`', function (assert) {
     assert.equal(bucket.name, 'indexedDB', '`name` is `indexedDB` by default');
     assert.equal(
       bucket.namespace,
@@ -32,7 +32,7 @@ module('IndexedDBBucket', function(hooks) {
     assert.equal(bucket.version, 1, '`version` is `1` by default');
   });
 
-  test('is assigned a default `dbName` and `dbStoreName`', function(assert) {
+  test('is assigned a default `dbName` and `dbStoreName`', function (assert) {
     assert.equal(
       bucket.dbName,
       'orbit-bucket',
@@ -45,7 +45,7 @@ module('IndexedDBBucket', function(hooks) {
     );
   });
 
-  test('can override `dbName` and `dbStoreName` via `namespace` and `storeName` settings', function(assert) {
+  test('can override `dbName` and `dbStoreName` via `namespace` and `storeName` settings', function (assert) {
     const custom = new IndexedDBBucket({
       namespace: 'orbit-settings',
       storeName: 'settings'
@@ -62,10 +62,10 @@ module('IndexedDBBucket', function(hooks) {
     );
   });
 
-  test('#upgrade changes the version, calls migrateDB, and then reopens the DB', function(assert) {
+  test('#upgrade changes the version, calls migrateDB, and then reopens the DB', function (assert) {
     assert.expect(5);
 
-    bucket.migrateDB = function(db, event) {
+    bucket.migrateDB = function (db, event) {
       assert.equal(
         event.oldVersion,
         1,
@@ -90,7 +90,7 @@ module('IndexedDBBucket', function(hooks) {
       });
   });
 
-  test('#setItem sets a value, #getItem gets a value, #removeItem removes a value', function(assert) {
+  test('#setItem sets a value, #getItem gets a value, #removeItem removes a value', function (assert) {
     assert.expect(3);
 
     let planet = {
@@ -104,16 +104,16 @@ module('IndexedDBBucket', function(hooks) {
 
     return bucket
       .getItem('planet')
-      .then(item => assert.equal(item, null, 'bucket does not contain item'))
+      .then((item) => assert.equal(item, null, 'bucket does not contain item'))
       .then(() => bucket.setItem('planet', planet))
       .then(() => bucket.getItem('planet'))
-      .then(item => assert.deepEqual(item, planet, 'bucket contains item'))
+      .then((item) => assert.deepEqual(item, planet, 'bucket contains item'))
       .then(() => bucket.removeItem('planet'))
       .then(() => bucket.getItem('planet'))
-      .then(item => assert.equal(item, null, 'bucket does not contain item'));
+      .then((item) => assert.equal(item, null, 'bucket does not contain item'));
   });
 
-  test('#clear clears all keys', async function(assert) {
+  test('#clear clears all keys', async function (assert) {
     assert.expect(2);
 
     let planet = {
@@ -124,9 +124,9 @@ module('IndexedDBBucket', function(hooks) {
     return bucket
       .setItem('planet', planet)
       .then(() => bucket.getItem('planet'))
-      .then(item => assert.deepEqual(item, planet, 'bucket contains item'))
+      .then((item) => assert.deepEqual(item, planet, 'bucket contains item'))
       .then(() => bucket.clear())
       .then(() => bucket.getItem('planet'))
-      .then(item => assert.equal(item, null, 'bucket does not contain item'));
+      .then((item) => assert.equal(item, null, 'bucket does not contain item'));
   });
 });

--- a/packages/@orbit/indexeddb/.prettierrc.js
+++ b/packages/@orbit/indexeddb/.prettierrc.js
@@ -1,3 +1,4 @@
 module.exports = {
-  singleQuote: true
+  singleQuote: true,
+  trailingComma: 'none'
 };

--- a/packages/@orbit/indexeddb/package.json
+++ b/packages/@orbit/indexeddb/package.json
@@ -32,11 +32,11 @@
   },
   "devDependencies": {
     "@glimmer/build": "^0.10.3",
-    "@typescript-eslint/eslint-plugin": "^2.23.0",
-    "@typescript-eslint/parser": "^2.23.0",
+    "@typescript-eslint/eslint-plugin": "^2.26.0",
+    "@typescript-eslint/parser": "^2.26.0",
     "eslint": "^6.8.0",
-    "eslint-config-prettier": "^6.10.0",
+    "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-prettier": "^3.1.2",
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.2"
   }
 }

--- a/packages/@orbit/indexeddb/src/indexeddb-cache.ts
+++ b/packages/@orbit/indexeddb/src/indexeddb-cache.ts
@@ -129,7 +129,7 @@ export default class IndexedDBCache extends AsyncRecordCache {
 
   createDB(db: IDBDatabase): void {
     // console.log('createDB');
-    Object.keys(this.schema.models).forEach(model => {
+    Object.keys(this.schema.models).forEach((model) => {
       this.registerModel(db, model);
     });
 
@@ -187,12 +187,12 @@ export default class IndexedDBCache extends AsyncRecordCache {
       const objectStore = transaction.objectStore(type);
       const request = objectStore.clear();
 
-      request.onerror = function(/* event */) {
+      request.onerror = function (/* event */) {
         // console.error('error - removeRecords', request.error);
         reject(request.error);
       };
 
-      request.onsuccess = function(/* event */) {
+      request.onsuccess = function (/* event */) {
         // console.log('success - removeRecords');
         resolve();
       };
@@ -207,7 +207,7 @@ export default class IndexedDBCache extends AsyncRecordCache {
       const objectStore = transaction.objectStore(record.type);
       const request = objectStore.get(record.id);
 
-      request.onerror = function(/* event */) {
+      request.onerror = function (/* event */) {
         // console.error('error - getRecord', request.error);
         reject(request.error);
       };
@@ -244,7 +244,7 @@ export default class IndexedDBCache extends AsyncRecordCache {
         const request = objectStore.openCursor();
         const records: Record[] = [];
 
-        request.onerror = function(/* event */) {
+        request.onerror = function (/* event */) {
           // console.error('error - getRecords', request.error);
           reject(request.error);
         };
@@ -301,7 +301,7 @@ export default class IndexedDBCache extends AsyncRecordCache {
                 }
                 getNext();
               };
-              request.onerror = function(/* event */) {
+              request.onerror = function (/* event */) {
                 // console.error('error - getRecords', request.error);
                 reject(request.error);
               };
@@ -325,7 +325,7 @@ export default class IndexedDBCache extends AsyncRecordCache {
     return new Promise((resolve, reject) => {
       const request = objectStore.put(record);
 
-      request.onerror = function(/* event */) {
+      request.onerror = function (/* event */) {
         // console.error('error - putRecord', request.error);
         reject(request.error);
       };
@@ -360,7 +360,7 @@ export default class IndexedDBCache extends AsyncRecordCache {
             let objectStore = transaction.objectStore(record.type);
             let request = objectStore.put(record);
             request.onsuccess = putNext();
-            request.onerror = function(/* event */) {
+            request.onerror = function (/* event */) {
               // console.error('error - setRecordsAsync', request.error);
               reject(request.error);
             };
@@ -383,12 +383,12 @@ export default class IndexedDBCache extends AsyncRecordCache {
       const objectStore = transaction.objectStore(recordIdentity.type);
       const request = objectStore.delete(recordIdentity.id);
 
-      request.onerror = function(/* event */) {
+      request.onerror = function (/* event */) {
         // console.error('error - removeRecord', request.error);
         reject(request.error);
       };
 
-      request.onsuccess = function(/* event */) {
+      request.onsuccess = function (/* event */) {
         // console.log('success - removeRecord');
         resolve();
       };
@@ -414,7 +414,7 @@ export default class IndexedDBCache extends AsyncRecordCache {
             let objectStore = transaction.objectStore(record.type);
             let request = objectStore.delete(record.id);
             request.onsuccess = removeNext();
-            request.onerror = function(/* event */) {
+            request.onerror = function (/* event */) {
               // console.error('error - addInverseRelationshipsAsync', request.error);
               reject(request.error);
             };
@@ -442,7 +442,7 @@ export default class IndexedDBCache extends AsyncRecordCache {
       );
       const request = objectStore.index('recordIdentity').openCursor(keyRange);
 
-      request.onerror = function(/* event */) {
+      request.onerror = function (/* event */) {
         // console.error('error - getRecords', request.error);
         reject(request.error);
       };
@@ -479,7 +479,7 @@ export default class IndexedDBCache extends AsyncRecordCache {
             let ir = this._toInverseRelationshipForIDB(relationship);
             let request = objectStore.put(ir);
             request.onsuccess = putNext();
-            request.onerror = function(/* event */) {
+            request.onerror = function (/* event */) {
               // console.error('error - addInverseRelationshipsAsync', request.error);
               reject(request.error);
             };
@@ -513,7 +513,7 @@ export default class IndexedDBCache extends AsyncRecordCache {
             let id = this._serializeInverseRelationshipIdentity(relationship);
             let request = objectStore.delete(id);
             request.onsuccess = removeNext();
-            request.onerror = function(/* event */) {
+            request.onerror = function (/* event */) {
               // console.error('error - removeInverseRelationshipsAsync');
               reject(request.error);
             };
@@ -548,7 +548,7 @@ export default class IndexedDBCache extends AsyncRecordCache {
     return types
       .reduce((chain, type) => {
         return chain.then(() => {
-          return this.getRecordsAsync(type).then(records => {
+          return this.getRecordsAsync(type).then((records) => {
             Array.prototype.push.apply(allRecords, records);
           });
         });

--- a/packages/@orbit/indexeddb/src/indexeddb-source.ts
+++ b/packages/@orbit/indexeddb/src/indexeddb-source.ts
@@ -172,7 +172,7 @@ export default class IndexedDBSource extends Source
 
   _operationsFromQueryResult(result: QueryResultData): Operation[] {
     if (Array.isArray(result)) {
-      return result.map(r => {
+      return result.map((r) => {
         return {
           op: 'updateRecord',
           record: r

--- a/packages/@orbit/indexeddb/test/indexeddb-cache-test.ts
+++ b/packages/@orbit/indexeddb/test/indexeddb-cache-test.ts
@@ -4,7 +4,7 @@ import Cache from '../src/indexeddb-cache';
 
 const { module, test } = QUnit;
 
-module('Cache', function(hooks) {
+module('Cache', function (hooks) {
   let schema: Schema, cache: Cache, keyMap: KeyMap;
 
   hooks.beforeEach(async () => {
@@ -61,17 +61,17 @@ module('Cache', function(hooks) {
     return cache.deleteDB();
   });
 
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     assert.ok(cache);
     assert.strictEqual(cache.schema, schema, 'schema has been assigned');
     assert.strictEqual(cache.keyMap, keyMap, 'keyMap has been assigned');
   });
 
-  test('is assigned a default dbName', function(assert) {
+  test('is assigned a default dbName', function (assert) {
     assert.equal(cache.dbName, 'orbit', '`dbName` is `orbit` by default');
   });
 
-  test('sets/gets records individually', async function(assert) {
+  test('sets/gets records individually', async function (assert) {
     const jupiter = {
       type: 'planet',
       id: 'jupiter',
@@ -101,7 +101,7 @@ module('Cache', function(hooks) {
     assert.deepEqual(await cache.getRecordAsync(europa), undefined);
   });
 
-  test('sets/gets records in bulk', async function(assert) {
+  test('sets/gets records in bulk', async function (assert) {
     const jupiter = {
       type: 'planet',
       id: 'jupiter',
@@ -127,7 +127,7 @@ module('Cache', function(hooks) {
     assert.deepEqual(await cache.getRecordsAsync([jupiter, io, europa]), []);
   });
 
-  test('sets/gets inverse relationships', async function(assert) {
+  test('sets/gets inverse relationships', async function (assert) {
     const jupiter = { type: 'planet', id: 'jupiter' };
     const io = { type: 'moon', id: 'io' };
     const europa = { type: 'moon', id: 'europa' };
@@ -168,7 +168,7 @@ module('Cache', function(hooks) {
     );
   });
 
-  test('#patch - addRecord', async function(assert) {
+  test('#patch - addRecord', async function (assert) {
     assert.expect(2);
 
     let planet: Record = {
@@ -183,7 +183,7 @@ module('Cache', function(hooks) {
       }
     };
 
-    await cache.patch(t => t.addRecord(planet));
+    await cache.patch((t) => t.addRecord(planet));
 
     assert.deepEqual(
       await getRecordFromIndexedDB(cache, planet),
@@ -198,7 +198,7 @@ module('Cache', function(hooks) {
     );
   });
 
-  test('#patch - updateRecord', async function(assert) {
+  test('#patch - updateRecord', async function (assert) {
     assert.expect(2);
 
     let original: Record = {
@@ -250,8 +250,8 @@ module('Cache', function(hooks) {
       }
     };
 
-    await cache.patch(t => t.addRecord(original));
-    await cache.patch(t => t.updateRecord(updates));
+    await cache.patch((t) => t.addRecord(original));
+    await cache.patch((t) => t.updateRecord(updates));
     assert.deepEqual(
       await getRecordFromIndexedDB(cache, expected),
       expected,
@@ -264,7 +264,7 @@ module('Cache', function(hooks) {
     );
   });
 
-  test('#patch - updateRecord - when record does not exist', async function(assert) {
+  test('#patch - updateRecord - when record does not exist', async function (assert) {
     assert.expect(1);
 
     let revised = {
@@ -277,7 +277,7 @@ module('Cache', function(hooks) {
       }
     };
 
-    await cache.patch(t => t.updateRecord(revised));
+    await cache.patch((t) => t.updateRecord(revised));
     assert.deepEqual(
       await getRecordFromIndexedDB(cache, revised),
       revised,
@@ -285,7 +285,7 @@ module('Cache', function(hooks) {
     );
   });
 
-  test('#patch - removeRecord', async function(assert) {
+  test('#patch - removeRecord', async function (assert) {
     assert.expect(1);
 
     let planet: Record = {
@@ -297,8 +297,8 @@ module('Cache', function(hooks) {
       }
     };
 
-    await cache.patch(t => t.addRecord(planet));
-    await cache.patch(t => t.removeRecord(planet));
+    await cache.patch((t) => t.addRecord(planet));
+    await cache.patch((t) => t.removeRecord(planet));
     assert.equal(
       await getRecordFromIndexedDB(cache, planet),
       null,
@@ -306,7 +306,7 @@ module('Cache', function(hooks) {
     );
   });
 
-  test('#patch - removeRecord - when record does not exist', async function(assert) {
+  test('#patch - removeRecord - when record does not exist', async function (assert) {
     assert.expect(1);
 
     let planet = {
@@ -314,7 +314,7 @@ module('Cache', function(hooks) {
       id: 'jupiter'
     };
 
-    await cache.patch(t => t.removeRecord(planet));
+    await cache.patch((t) => t.removeRecord(planet));
     assert.equal(
       await getRecordFromIndexedDB(cache, planet),
       null,
@@ -322,7 +322,7 @@ module('Cache', function(hooks) {
     );
   });
 
-  test('#patch - replaceKey', async function(assert) {
+  test('#patch - replaceKey', async function (assert) {
     assert.expect(2);
 
     let original: Record = {
@@ -346,8 +346,8 @@ module('Cache', function(hooks) {
       }
     };
 
-    await cache.patch(t => t.addRecord(original));
-    await cache.patch(t => t.replaceKey(original, 'remoteId', '123'));
+    await cache.patch((t) => t.addRecord(original));
+    await cache.patch((t) => t.replaceKey(original, 'remoteId', '123'));
     assert.deepEqual(
       await getRecordFromIndexedDB(cache, revised),
       revised,
@@ -361,7 +361,7 @@ module('Cache', function(hooks) {
     );
   });
 
-  test('#patch - replaceKey - when base record does not exist', async function(assert) {
+  test('#patch - replaceKey - when base record does not exist', async function (assert) {
     assert.expect(2);
 
     let revised: Record = {
@@ -372,7 +372,7 @@ module('Cache', function(hooks) {
       }
     };
 
-    await cache.patch(t =>
+    await cache.patch((t) =>
       t.replaceKey({ type: 'planet', id: 'jupiter' }, 'remoteId', '123')
     );
     assert.deepEqual(
@@ -388,7 +388,7 @@ module('Cache', function(hooks) {
     );
   });
 
-  test('#patch - replaceAttribute', async function(assert) {
+  test('#patch - replaceAttribute', async function (assert) {
     assert.expect(1);
 
     let original: Record = {
@@ -410,8 +410,8 @@ module('Cache', function(hooks) {
       }
     };
 
-    await cache.patch(t => t.addRecord(original));
-    await cache.patch(t => t.replaceAttribute(original, 'order', 5));
+    await cache.patch((t) => t.addRecord(original));
+    await cache.patch((t) => t.replaceAttribute(original, 'order', 5));
     assert.deepEqual(
       await getRecordFromIndexedDB(cache, revised),
       revised,
@@ -419,7 +419,7 @@ module('Cache', function(hooks) {
     );
   });
 
-  test('#patch - replaceAttribute - when base record does not exist', async function(assert) {
+  test('#patch - replaceAttribute - when base record does not exist', async function (assert) {
     assert.expect(1);
 
     let revised: Record = {
@@ -430,7 +430,7 @@ module('Cache', function(hooks) {
       }
     };
 
-    await cache.patch(t =>
+    await cache.patch((t) =>
       t.replaceAttribute({ type: 'planet', id: 'jupiter' }, 'order', 5)
     );
     assert.deepEqual(
@@ -440,7 +440,7 @@ module('Cache', function(hooks) {
     );
   });
 
-  test('#patch - addToRelatedRecords', async function(assert) {
+  test('#patch - addToRelatedRecords', async function (assert) {
     assert.expect(1);
 
     let original: Record = {
@@ -471,8 +471,8 @@ module('Cache', function(hooks) {
       }
     };
 
-    await cache.patch(t => t.addRecord(original));
-    await cache.patch(t =>
+    await cache.patch((t) => t.addRecord(original));
+    await cache.patch((t) =>
       t.addToRelatedRecords(original, 'moons', { type: 'moon', id: 'moon1' })
     );
     assert.deepEqual(
@@ -482,7 +482,7 @@ module('Cache', function(hooks) {
     );
   });
 
-  test('#patch - addToRelatedRecords - when base record does not exist', async function(assert) {
+  test('#patch - addToRelatedRecords - when base record does not exist', async function (assert) {
     assert.expect(1);
 
     let revised: Record = {
@@ -495,7 +495,7 @@ module('Cache', function(hooks) {
       }
     };
 
-    await cache.patch(t =>
+    await cache.patch((t) =>
       t.addToRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons', {
         type: 'moon',
         id: 'moon1'
@@ -508,7 +508,7 @@ module('Cache', function(hooks) {
     );
   });
 
-  test('#patch - removeFromRelatedRecords', async function(assert) {
+  test('#patch - removeFromRelatedRecords', async function (assert) {
     assert.expect(1);
 
     let original: Record = {
@@ -542,8 +542,8 @@ module('Cache', function(hooks) {
       }
     };
 
-    await cache.patch(t => t.addRecord(original));
-    await cache.patch(t =>
+    await cache.patch((t) => t.addRecord(original));
+    await cache.patch((t) =>
       t.removeFromRelatedRecords(original, 'moons', {
         type: 'moon',
         id: 'moon2'
@@ -556,7 +556,7 @@ module('Cache', function(hooks) {
     );
   });
 
-  test('#patch - removeFromRelatedRecords - when base record does not exist', async function(assert) {
+  test('#patch - removeFromRelatedRecords - when base record does not exist', async function (assert) {
     assert.expect(1);
 
     let revised: Record = {
@@ -569,7 +569,7 @@ module('Cache', function(hooks) {
       }
     };
 
-    await cache.patch(t =>
+    await cache.patch((t) =>
       t.removeFromRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons', {
         type: 'moon',
         id: 'moon2'
@@ -582,7 +582,7 @@ module('Cache', function(hooks) {
     );
   });
 
-  test('#patch - replaceRelatedRecords', async function(assert) {
+  test('#patch - replaceRelatedRecords', async function (assert) {
     assert.expect(1);
 
     let original: Record = {
@@ -616,8 +616,8 @@ module('Cache', function(hooks) {
       }
     };
 
-    await cache.patch(t => t.addRecord(original));
-    await cache.patch(t =>
+    await cache.patch((t) => t.addRecord(original));
+    await cache.patch((t) =>
       t.replaceRelatedRecords(original, 'moons', [
         { type: 'moon', id: 'moon2' },
         { type: 'moon', id: 'moon3' }
@@ -630,7 +630,7 @@ module('Cache', function(hooks) {
     );
   });
 
-  test('#patch - replaceRelatedRecords - when base record does not exist', async function(assert) {
+  test('#patch - replaceRelatedRecords - when base record does not exist', async function (assert) {
     assert.expect(1);
 
     let revised: Record = {
@@ -646,7 +646,7 @@ module('Cache', function(hooks) {
       }
     };
 
-    await cache.patch(t =>
+    await cache.patch((t) =>
       t.replaceRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons', [
         { type: 'moon', id: 'moon2' },
         { type: 'moon', id: 'moon3' }
@@ -659,7 +659,7 @@ module('Cache', function(hooks) {
     );
   });
 
-  test('#patch - replaceRelatedRecord - with record', async function(assert) {
+  test('#patch - replaceRelatedRecord - with record', async function (assert) {
     assert.expect(1);
 
     let original: Record = {
@@ -690,8 +690,8 @@ module('Cache', function(hooks) {
       }
     };
 
-    await cache.patch(t => t.addRecord(original));
-    await cache.patch(t =>
+    await cache.patch((t) => t.addRecord(original));
+    await cache.patch((t) =>
       t.replaceRelatedRecord(original, 'solarSystem', {
         type: 'solarSystem',
         id: 'ss1'
@@ -704,7 +704,7 @@ module('Cache', function(hooks) {
     );
   });
 
-  test('#patch - replaceRelatedRecord - with record - when base record does not exist', async function(assert) {
+  test('#patch - replaceRelatedRecord - with record - when base record does not exist', async function (assert) {
     assert.expect(1);
 
     let revised: Record = {
@@ -717,7 +717,7 @@ module('Cache', function(hooks) {
       }
     };
 
-    await cache.patch(t =>
+    await cache.patch((t) =>
       t.replaceRelatedRecord({ type: 'planet', id: 'jupiter' }, 'solarSystem', {
         type: 'solarSystem',
         id: 'ss1'
@@ -730,7 +730,7 @@ module('Cache', function(hooks) {
     );
   });
 
-  test('#patch - replaceRelatedRecord - with null', async function(assert) {
+  test('#patch - replaceRelatedRecord - with null', async function (assert) {
     assert.expect(1);
 
     let original: Record = {
@@ -761,8 +761,8 @@ module('Cache', function(hooks) {
       }
     };
 
-    await cache.patch(t => t.addRecord(original));
-    await cache.patch(t =>
+    await cache.patch((t) => t.addRecord(original));
+    await cache.patch((t) =>
       t.replaceRelatedRecord(original, 'solarSystem', null)
     );
     assert.deepEqual(
@@ -772,7 +772,7 @@ module('Cache', function(hooks) {
     );
   });
 
-  test('#patch - replaceRelatedRecord - with null - when base record does not exist', async function(assert) {
+  test('#patch - replaceRelatedRecord - with null - when base record does not exist', async function (assert) {
     assert.expect(1);
 
     let revised: Record = {
@@ -785,7 +785,7 @@ module('Cache', function(hooks) {
       }
     };
 
-    await cache.patch(t =>
+    await cache.patch((t) =>
       t.replaceRelatedRecord(
         { type: 'planet', id: 'jupiter' },
         'solarSystem',
@@ -799,7 +799,7 @@ module('Cache', function(hooks) {
     );
   });
 
-  test('#query - all records', async function(assert) {
+  test('#query - all records', async function (assert) {
     assert.expect(4);
 
     let earth: Record = {
@@ -837,7 +837,7 @@ module('Cache', function(hooks) {
       }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(earth),
       t.addRecord(jupiter),
       t.addRecord(io)
@@ -846,7 +846,7 @@ module('Cache', function(hooks) {
     // reset keyMap to verify that querying records also adds keys
     keyMap.reset();
 
-    let records = await cache.query(q => q.findRecords());
+    let records = await cache.query((q) => q.findRecords());
     assert.deepEqual(
       records,
       [io, earth, jupiter],
@@ -870,7 +870,7 @@ module('Cache', function(hooks) {
     );
   });
 
-  test('#query - records of one type', async function(assert) {
+  test('#query - records of one type', async function (assert) {
     assert.expect(1);
 
     let earth: Record = {
@@ -899,17 +899,17 @@ module('Cache', function(hooks) {
       }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(earth),
       t.addRecord(jupiter),
       t.addRecord(io)
     ]);
 
-    let records = await cache.query(q => q.findRecords('planet'));
+    let records = await cache.query((q) => q.findRecords('planet'));
     assert.deepEqual(records, [earth, jupiter], 'query results are expected');
   });
 
-  test('#query - records by identity', async function(assert) {
+  test('#query - records by identity', async function (assert) {
     assert.expect(1);
 
     let earth: Record = {
@@ -938,19 +938,19 @@ module('Cache', function(hooks) {
       }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(earth),
       t.addRecord(jupiter),
       t.addRecord(io)
     ]);
 
-    let records = await cache.query(q =>
+    let records = await cache.query((q) =>
       q.findRecords([earth, io, { type: 'planet', id: 'FAKE' }])
     );
     assert.deepEqual(records, [earth, io], 'only matches are returned');
   });
 
-  test('#query - a specific record', async function(assert) {
+  test('#query - a specific record', async function (assert) {
     assert.expect(2);
 
     let earth: Record = {
@@ -982,7 +982,7 @@ module('Cache', function(hooks) {
       }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(earth),
       t.addRecord(jupiter),
       t.addRecord(io)
@@ -991,7 +991,7 @@ module('Cache', function(hooks) {
     // reset keyMap to verify that pulling records also adds keys
     keyMap.reset();
 
-    let record = await cache.query(q => q.findRecord(jupiter));
+    let record = await cache.query((q) => q.findRecord(jupiter));
 
     assert.deepEqual(record, jupiter, 'query results are expected');
 

--- a/packages/@orbit/indexeddb/test/indexeddb-source-test.ts
+++ b/packages/@orbit/indexeddb/test/indexeddb-source-test.ts
@@ -11,7 +11,7 @@ import IndexedDBSource from '../src/indexeddb-source';
 
 const { module, test, skip } = QUnit;
 
-module('IndexedDBSource', function(hooks) {
+module('IndexedDBSource', function (hooks) {
   let schema: Schema, source: IndexedDBSource, keyMap: KeyMap;
 
   hooks.beforeEach(async () => {
@@ -69,13 +69,13 @@ module('IndexedDBSource', function(hooks) {
     await source.cache.deleteDB();
   });
 
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     assert.ok(source);
     assert.strictEqual(source.schema, schema, 'schema has been assigned');
     assert.strictEqual(source.keyMap, keyMap, 'keyMap has been assigned');
   });
 
-  test('is assigned a default dbName', function(assert) {
+  test('is assigned a default dbName', function (assert) {
     assert.equal(
       source.cache.dbName,
       'orbit',
@@ -84,14 +84,14 @@ module('IndexedDBSource', function(hooks) {
   });
 
   // TODO: Skipped for CI
-  skip('will reopen the database when the schema is upgraded', async function(assert) {
+  skip('will reopen the database when the schema is upgraded', async function (assert) {
     const done = assert.async();
 
     assert.expect(5);
 
     assert.equal(source.cache.dbVersion, 1, 'db starts with version == 1');
 
-    source.cache.migrateDB = function(db, event) {
+    source.cache.migrateDB = function (db, event) {
       assert.equal(
         event.oldVersion,
         1,
@@ -105,7 +105,7 @@ module('IndexedDBSource', function(hooks) {
       done();
     };
 
-    schema.on('upgrade', version => {
+    schema.on('upgrade', (version) => {
       assert.equal(version, 2, 'schema has upgraded to v2');
       assert.equal(source.cache.dbVersion, 2, 'db has the correct version');
     });
@@ -128,7 +128,7 @@ module('IndexedDBSource', function(hooks) {
     });
   });
 
-  test('#reset is idempotent', async function(assert) {
+  test('#reset is idempotent', async function (assert) {
     await source.cache.openDB();
     await source.reset();
     await source.reset();
@@ -137,7 +137,7 @@ module('IndexedDBSource', function(hooks) {
     assert.ok(true, 'db has been reset twice and can still be reopened');
   });
 
-  test('data persists across re-instantiating source', async function(assert) {
+  test('data persists across re-instantiating source', async function (assert) {
     assert.expect(2);
 
     let planet: Record = {
@@ -152,7 +152,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    await source.push(t => t.addRecord(planet));
+    await source.push((t) => t.addRecord(planet));
     assert.deepEqual(
       await getRecordFromIndexedDB(source.cache, planet),
       planet,
@@ -171,7 +171,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#sync - addRecord', async function(assert) {
+  test('#sync - addRecord', async function (assert) {
     assert.expect(3);
 
     let planet: Record = {
@@ -206,7 +206,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#push - addRecord', async function(assert) {
+  test('#push - addRecord', async function (assert) {
     assert.expect(3);
 
     let planet: Record = {
@@ -241,7 +241,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#push - addRecord - with beforePush listener that syncs transform', async function(assert) {
+  test('#push - addRecord - with beforePush listener that syncs transform', async function (assert) {
     assert.expect(4);
 
     let planet: Record = {
@@ -261,7 +261,7 @@ module('IndexedDBSource', function(hooks) {
       record: planet
     } as AddRecordOperation);
 
-    source.on('beforePush', async function(transform: Transform) {
+    source.on('beforePush', async function (transform: Transform) {
       await source.sync(transform);
     });
 
@@ -281,7 +281,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#push - updateRecord', async function(assert) {
+  test('#push - updateRecord', async function (assert) {
     assert.expect(2);
 
     let original: Record = {
@@ -333,8 +333,8 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    await source.push(t => t.addRecord(original));
-    await source.push(t => t.updateRecord(updates));
+    await source.push((t) => t.addRecord(original));
+    await source.push((t) => t.updateRecord(updates));
     assert.deepEqual(
       await getRecordFromIndexedDB(source.cache, expected),
       expected,
@@ -347,7 +347,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#push - updateRecord - when record does not exist', async function(assert) {
+  test('#push - updateRecord - when record does not exist', async function (assert) {
     assert.expect(1);
 
     let revised: Record = {
@@ -360,7 +360,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    await source.push(t => t.updateRecord(revised));
+    await source.push((t) => t.updateRecord(revised));
     assert.deepEqual(
       await getRecordFromIndexedDB(source.cache, revised),
       revised,
@@ -368,7 +368,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#push - removeRecord', async function(assert) {
+  test('#push - removeRecord', async function (assert) {
     assert.expect(1);
 
     let planet: Record = {
@@ -380,8 +380,8 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    await source.push(t => t.addRecord(planet));
-    await source.push(t => t.removeRecord(planet));
+    await source.push((t) => t.addRecord(planet));
+    await source.push((t) => t.removeRecord(planet));
     assert.equal(
       await getRecordFromIndexedDB(source.cache, planet),
       undefined,
@@ -389,7 +389,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#push - removeRecord when part of has many relationship', async function(assert) {
+  test('#push - removeRecord when part of has many relationship', async function (assert) {
     assert.expect(2);
 
     let moon1 = { type: 'moon', id: 'moon1' };
@@ -408,7 +408,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    await source.push(t => [
+    await source.push((t) => [
       t.addRecord(moon1),
       t.addRecord(moon2),
       t.addRecord(planet)
@@ -419,7 +419,7 @@ module('IndexedDBSource', function(hooks) {
       2,
       'record has 2 moons'
     );
-    await source.push(t => t.removeRecord(moon1));
+    await source.push((t) => t.removeRecord(moon1));
     assert.deepEqual(
       (await getRecordFromIndexedDB(source.cache, planet)).relationships.moons
         .data.length,
@@ -428,7 +428,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#push - removeRecord - when record does not exist', async function(assert) {
+  test('#push - removeRecord - when record does not exist', async function (assert) {
     assert.expect(1);
 
     let planet: Record = {
@@ -436,7 +436,7 @@ module('IndexedDBSource', function(hooks) {
       id: 'jupiter'
     };
 
-    await source.push(t => t.removeRecord(planet));
+    await source.push((t) => t.removeRecord(planet));
     assert.equal(
       await getRecordFromIndexedDB(source.cache, planet),
       undefined,
@@ -444,7 +444,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#push - replaceKey', async function(assert) {
+  test('#push - replaceKey', async function (assert) {
     assert.expect(2);
 
     let original: Record = {
@@ -468,8 +468,8 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    await source.push(t => t.addRecord(original));
-    await source.push(t => t.replaceKey(original, 'remoteId', '123'));
+    await source.push((t) => t.addRecord(original));
+    await source.push((t) => t.replaceKey(original, 'remoteId', '123'));
     assert.deepEqual(
       await getRecordFromIndexedDB(source.cache, revised),
       revised,
@@ -483,7 +483,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#push - replaceKey - when base record does not exist', async function(assert) {
+  test('#push - replaceKey - when base record does not exist', async function (assert) {
     assert.expect(2);
 
     let revised: Record = {
@@ -494,7 +494,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    await source.push(t =>
+    await source.push((t) =>
       t.replaceKey({ type: 'planet', id: 'jupiter' }, 'remoteId', '123')
     );
     assert.deepEqual(
@@ -510,7 +510,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#push - replaceAttribute', async function(assert) {
+  test('#push - replaceAttribute', async function (assert) {
     assert.expect(1);
 
     let original: Record = {
@@ -532,8 +532,8 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    await source.push(t => t.addRecord(original));
-    await source.push(t => t.replaceAttribute(original, 'order', 5));
+    await source.push((t) => t.addRecord(original));
+    await source.push((t) => t.replaceAttribute(original, 'order', 5));
     assert.deepEqual(
       await getRecordFromIndexedDB(source.cache, revised),
       revised,
@@ -541,7 +541,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#push - replaceAttribute - when base record does not exist', async function(assert) {
+  test('#push - replaceAttribute - when base record does not exist', async function (assert) {
     assert.expect(1);
 
     let revised: Record = {
@@ -552,7 +552,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    await source.push(t =>
+    await source.push((t) =>
       t.replaceAttribute({ type: 'planet', id: 'jupiter' }, 'order', 5)
     );
     assert.deepEqual(
@@ -562,7 +562,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#push - addToRelatedRecords', async function(assert) {
+  test('#push - addToRelatedRecords', async function (assert) {
     assert.expect(1);
 
     let original: Record = {
@@ -593,8 +593,8 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    await source.push(t => t.addRecord(original));
-    await source.push(t =>
+    await source.push((t) => t.addRecord(original));
+    await source.push((t) =>
       t.addToRelatedRecords(original, 'moons', { type: 'moon', id: 'moon1' })
     );
     assert.deepEqual(
@@ -604,7 +604,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#push - addToRelatedRecords - when base record does not exist', async function(assert) {
+  test('#push - addToRelatedRecords - when base record does not exist', async function (assert) {
     assert.expect(1);
 
     let revised: Record = {
@@ -617,7 +617,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    await source.push(t =>
+    await source.push((t) =>
       t.addToRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons', {
         type: 'moon',
         id: 'moon1'
@@ -630,7 +630,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#push - removeFromRelatedRecords', async function(assert) {
+  test('#push - removeFromRelatedRecords', async function (assert) {
     assert.expect(1);
 
     let original: Record = {
@@ -664,8 +664,8 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    await source.push(t => t.addRecord(original));
-    await source.push(t =>
+    await source.push((t) => t.addRecord(original));
+    await source.push((t) =>
       t.removeFromRelatedRecords(original, 'moons', {
         type: 'moon',
         id: 'moon2'
@@ -678,7 +678,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#push - removeFromRelatedRecords - when base record does not exist', async function(assert) {
+  test('#push - removeFromRelatedRecords - when base record does not exist', async function (assert) {
     assert.expect(1);
 
     let revised: Record = {
@@ -691,7 +691,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    await source.push(t =>
+    await source.push((t) =>
       t.removeFromRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons', {
         type: 'moon',
         id: 'moon2'
@@ -704,7 +704,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#push - replaceRelatedRecords', async function(assert) {
+  test('#push - replaceRelatedRecords', async function (assert) {
     assert.expect(1);
 
     let original: Record = {
@@ -738,8 +738,8 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    await source.push(t => t.addRecord(original));
-    await source.push(t =>
+    await source.push((t) => t.addRecord(original));
+    await source.push((t) =>
       t.replaceRelatedRecords(original, 'moons', [
         { type: 'moon', id: 'moon2' },
         { type: 'moon', id: 'moon3' }
@@ -752,7 +752,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#push - replaceRelatedRecords - when base record does not exist', async function(assert) {
+  test('#push - replaceRelatedRecords - when base record does not exist', async function (assert) {
     assert.expect(1);
 
     let revised: Record = {
@@ -768,7 +768,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    await source.push(t =>
+    await source.push((t) =>
       t.replaceRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons', [
         { type: 'moon', id: 'moon2' },
         { type: 'moon', id: 'moon3' }
@@ -781,7 +781,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#push - replaceRelatedRecord - with record', async function(assert) {
+  test('#push - replaceRelatedRecord - with record', async function (assert) {
     assert.expect(1);
 
     let original: Record = {
@@ -812,8 +812,8 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    await source.push(t => t.addRecord(original));
-    await source.push(t =>
+    await source.push((t) => t.addRecord(original));
+    await source.push((t) =>
       t.replaceRelatedRecord(original, 'solarSystem', {
         type: 'solarSystem',
         id: 'ss1'
@@ -826,7 +826,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#push - replaceRelatedRecord - with record - when base record does not exist', async function(assert) {
+  test('#push - replaceRelatedRecord - with record - when base record does not exist', async function (assert) {
     assert.expect(1);
 
     let revised: Record = {
@@ -839,7 +839,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    await source.push(t =>
+    await source.push((t) =>
       t.replaceRelatedRecord({ type: 'planet', id: 'jupiter' }, 'solarSystem', {
         type: 'solarSystem',
         id: 'ss1'
@@ -852,7 +852,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#push - replaceRelatedRecord - with null', async function(assert) {
+  test('#push - replaceRelatedRecord - with null', async function (assert) {
     assert.expect(1);
 
     let original: Record = {
@@ -883,8 +883,8 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    await source.push(t => t.addRecord(original));
-    await source.push(t =>
+    await source.push((t) => t.addRecord(original));
+    await source.push((t) =>
       t.replaceRelatedRecord(original, 'solarSystem', null)
     );
     assert.deepEqual(
@@ -894,7 +894,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#push - replaceRelatedRecord - with null - when base record does not exist', async function(assert) {
+  test('#push - replaceRelatedRecord - with null - when base record does not exist', async function (assert) {
     assert.expect(1);
 
     let revised: Record = {
@@ -907,7 +907,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    await source.push(t =>
+    await source.push((t) =>
       t.replaceRelatedRecord(
         { type: 'planet', id: 'jupiter' },
         'solarSystem',
@@ -921,7 +921,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#push - inverse relationships are created', async function(assert) {
+  test('#push - inverse relationships are created', async function (assert) {
     assert.expect(2);
 
     let ss = {
@@ -970,7 +970,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    await source.push(t => [
+    await source.push((t) => [
       t.addRecord(ss),
       t.addRecord(earth),
       t.addRecord(jupiter),
@@ -1020,7 +1020,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#pull - all records', async function(assert) {
+  test('#pull - all records', async function (assert) {
     assert.expect(5);
 
     let earth: Record = {
@@ -1058,7 +1058,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    await source.push(t => [
+    await source.push((t) => [
       t.addRecord(earth),
       t.addRecord(jupiter),
       t.addRecord(io)
@@ -1067,11 +1067,11 @@ module('IndexedDBSource', function(hooks) {
     // reset keyMap to verify that pulling records also adds keys
     keyMap.reset();
 
-    let transforms = await source.pull(q => q.findRecords());
+    let transforms = await source.pull((q) => q.findRecords());
 
     assert.equal(transforms.length, 1, 'one transform returned');
     assert.deepEqual(
-      transforms[0].operations.map(o => o.op),
+      transforms[0].operations.map((o) => o.op),
       ['updateRecord', 'updateRecord', 'updateRecord'],
       'operations match expectations'
     );
@@ -1092,7 +1092,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#pull - records of one type', async function(assert) {
+  test('#pull - records of one type', async function (assert) {
     assert.expect(4);
 
     let earth: Record = {
@@ -1121,13 +1121,13 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    await source.push(t => [
+    await source.push((t) => [
       t.addRecord(earth),
       t.addRecord(jupiter),
       t.addRecord(io)
     ]);
 
-    let transforms = await source.pull(q => q.findRecords('planet'));
+    let transforms = await source.pull((q) => q.findRecords('planet'));
 
     assert.equal(transforms.length, 1, 'one transform returned');
     assert.ok(
@@ -1135,7 +1135,7 @@ module('IndexedDBSource', function(hooks) {
       'log contains transform'
     );
     assert.deepEqual(
-      transforms[0].operations.map(o => o.op),
+      transforms[0].operations.map((o) => o.op),
       ['updateRecord', 'updateRecord'],
       'operations match expectations'
     );
@@ -1146,7 +1146,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#pull - specific records', async function(assert) {
+  test('#pull - specific records', async function (assert) {
     assert.expect(4);
 
     let earth: Record = {
@@ -1175,13 +1175,13 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    await source.push(t => [
+    await source.push((t) => [
       t.addRecord(earth),
       t.addRecord(jupiter),
       t.addRecord(io)
     ]);
 
-    let transforms = await source.pull(q =>
+    let transforms = await source.pull((q) =>
       q.findRecords([earth, io, { type: 'moon', id: 'FAKE' }])
     );
 
@@ -1191,7 +1191,7 @@ module('IndexedDBSource', function(hooks) {
       'log contains transform'
     );
     assert.deepEqual(
-      transforms[0].operations.map(o => o.op),
+      transforms[0].operations.map((o) => o.op),
       ['updateRecord', 'updateRecord'],
       'operations match expectations'
     );
@@ -1202,7 +1202,7 @@ module('IndexedDBSource', function(hooks) {
     );
   });
 
-  test('#pull - a specific record', async function(assert) {
+  test('#pull - a specific record', async function (assert) {
     assert.expect(4);
 
     let earth: Record = {
@@ -1234,7 +1234,7 @@ module('IndexedDBSource', function(hooks) {
       }
     };
 
-    await source.push(t => [
+    await source.push((t) => [
       t.addRecord(earth),
       t.addRecord(jupiter),
       t.addRecord(io)
@@ -1243,7 +1243,7 @@ module('IndexedDBSource', function(hooks) {
     // reset keyMap to verify that pulling records also adds keys
     keyMap.reset();
 
-    let transforms = await source.pull(q => q.findRecord(jupiter));
+    let transforms = await source.pull((q) => q.findRecord(jupiter));
 
     assert.equal(transforms.length, 1, 'one transform returned');
     assert.ok(
@@ -1251,7 +1251,7 @@ module('IndexedDBSource', function(hooks) {
       'log contains transform'
     );
     assert.deepEqual(
-      transforms[0].operations.map(o => o.op),
+      transforms[0].operations.map((o) => o.op),
       ['updateRecord'],
       'operations match expectations'
     );

--- a/packages/@orbit/indexeddb/test/support/indexeddb.ts
+++ b/packages/@orbit/indexeddb/test/support/indexeddb.ts
@@ -12,12 +12,12 @@ export async function getRecordFromIndexedDB(
   return new Promise((resolve: (record: Record) => void, reject) => {
     const request = objectStore.get(record.id);
 
-    request.onerror = function(/* event */) {
+    request.onerror = function (/* event */) {
       console.error('error - getRecord', request.error);
       reject(request.error);
     };
 
-    request.onsuccess = function(/* event */) {
+    request.onsuccess = function (/* event */) {
       // console.log('success - getRecord', request.result);
       resolve(request.result as Record);
     };

--- a/packages/@orbit/integration-tests/.prettierrc.js
+++ b/packages/@orbit/integration-tests/.prettierrc.js
@@ -1,3 +1,4 @@
 module.exports = {
-  singleQuote: true
+  singleQuote: true,
+  trailingComma: 'none'
 };

--- a/packages/@orbit/integration-tests/package.json
+++ b/packages/@orbit/integration-tests/package.json
@@ -36,13 +36,13 @@
   },
   "devDependencies": {
     "@glimmer/build": "^0.10.3",
-    "@types/sinon": "7.5.2",
-    "@typescript-eslint/eslint-plugin": "^2.23.0",
-    "@typescript-eslint/parser": "^2.23.0",
+    "@types/sinon": "9.0.0",
+    "@typescript-eslint/eslint-plugin": "^2.26.0",
+    "@typescript-eslint/parser": "^2.26.0",
     "eslint": "^6.8.0",
-    "eslint-config-prettier": "^6.10.0",
+    "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-prettier": "^3.1.2",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.2",
     "sinon": "^9.0.1",
     "whatwg-fetch": "^3.0.0"
   }

--- a/packages/@orbit/integration-tests/test/memory-bucket-test.ts
+++ b/packages/@orbit/integration-tests/test/memory-bucket-test.ts
@@ -4,7 +4,7 @@ import IndexedDBBucket from '@orbit/indexeddb-bucket';
 
 const { module, test } = QUnit;
 
-module('MemorySource + IndexdDBBucket', function(hooks) {
+module('MemorySource + IndexdDBBucket', function (hooks) {
   let schema: Schema;
   let bucket: IndexedDBBucket;
   let memory: MemorySource;
@@ -32,7 +32,7 @@ module('MemorySource + IndexdDBBucket', function(hooks) {
     schema = memory = bucket = null;
   });
 
-  test('push before pull', async function(assert) {
+  test('push before pull', async function (assert) {
     const theMoon = {
       id: undefined,
       type: 'moon',
@@ -41,7 +41,7 @@ module('MemorySource + IndexdDBBucket', function(hooks) {
       }
     };
 
-    await memory.update(t => t.addRecord(theMoon));
+    await memory.update((t) => t.addRecord(theMoon));
     assert.ok(true);
   });
 });

--- a/packages/@orbit/integration-tests/test/store-jsonapi-clientid-pessimistic-test.ts
+++ b/packages/@orbit/integration-tests/test/store-jsonapi-clientid-pessimistic-test.ts
@@ -10,7 +10,7 @@ const { module, test } = QUnit;
 
 module(
   'Store + JSONAPISource + client-generated IDs + pessimistic coordination',
-  function(hooks) {
+  function (hooks) {
     let fetchStub: SinonStub;
     let schema: Schema;
     let remote: JSONAPISource;
@@ -110,7 +110,7 @@ module(
       fetchStub.restore();
     });
 
-    test('Adding a record to the memory source immediately pushes the update to the remote', async function(assert) {
+    test('Adding a record to the memory source immediately pushes the update to the remote', async function (assert) {
       assert.expect(2);
 
       await coordinator.activate();
@@ -131,8 +131,8 @@ module(
         })
       );
 
-      let createdRecord = await memory.update(t => t.addRecord(planet));
-      let result = memory.cache.query(q => q.findRecord(planet));
+      let createdRecord = await memory.update((t) => t.addRecord(planet));
+      let result = memory.cache.query((q) => q.findRecord(planet));
 
       assert.deepEqual(result, {
         type: 'planet',

--- a/packages/@orbit/integration-tests/test/store-jsonapi-remoteid-optimistic-test.ts
+++ b/packages/@orbit/integration-tests/test/store-jsonapi-remoteid-optimistic-test.ts
@@ -8,165 +8,166 @@ import { SinonStatic, SinonStub } from 'sinon';
 declare const sinon: SinonStatic;
 const { module, test } = QUnit;
 
-module('Store + JSONAPISource + remote IDs + optimistic coordination', function(
-  hooks
-) {
-  let fetchStub: SinonStub;
-  let keyMap: KeyMap;
-  let schema: Schema;
-  let remote: JSONAPISource;
-  let memory: MemorySource;
-  let coordinator: Coordinator;
+module(
+  'Store + JSONAPISource + remote IDs + optimistic coordination',
+  function (hooks) {
+    let fetchStub: SinonStub;
+    let keyMap: KeyMap;
+    let schema: Schema;
+    let remote: JSONAPISource;
+    let memory: MemorySource;
+    let coordinator: Coordinator;
 
-  hooks.beforeEach(() => {
-    fetchStub = sinon.stub(self, 'fetch');
+    hooks.beforeEach(() => {
+      fetchStub = sinon.stub(self, 'fetch');
 
-    schema = new Schema({
-      models: {
-        planet: {
-          keys: {
-            remoteId: {}
-          },
-          attributes: {
-            name: { type: 'string' },
-            classification: { type: 'string' },
-            lengthOfDay: { type: 'number' }
-          },
-          relationships: {
-            moons: { kind: 'hasMany', type: 'moon', inverse: 'planet' },
-            solarSystem: {
-              kind: 'hasOne',
-              type: 'solarSystem',
-              inverse: 'planets'
+      schema = new Schema({
+        models: {
+          planet: {
+            keys: {
+              remoteId: {}
+            },
+            attributes: {
+              name: { type: 'string' },
+              classification: { type: 'string' },
+              lengthOfDay: { type: 'number' }
+            },
+            relationships: {
+              moons: { kind: 'hasMany', type: 'moon', inverse: 'planet' },
+              solarSystem: {
+                kind: 'hasOne',
+                type: 'solarSystem',
+                inverse: 'planets'
+              }
             }
-          }
-        },
-        moon: {
-          keys: {
-            remoteId: {}
           },
-          attributes: {
-            name: { type: 'string' }
+          moon: {
+            keys: {
+              remoteId: {}
+            },
+            attributes: {
+              name: { type: 'string' }
+            },
+            relationships: {
+              planet: { kind: 'hasOne', type: 'planet', inverse: 'moons' }
+            }
           },
-          relationships: {
-            planet: { kind: 'hasOne', type: 'planet', inverse: 'moons' }
-          }
-        },
-        solarSystem: {
-          keys: {
-            remoteId: {}
-          },
-          attributes: {
-            name: { type: 'string' }
-          },
-          relationships: {
-            planets: {
-              kind: 'hasMany',
-              type: 'planet',
-              inverse: 'solarSystem'
+          solarSystem: {
+            keys: {
+              remoteId: {}
+            },
+            attributes: {
+              name: { type: 'string' }
+            },
+            relationships: {
+              planets: {
+                kind: 'hasMany',
+                type: 'planet',
+                inverse: 'solarSystem'
+              }
             }
           }
         }
-      }
+      });
+
+      keyMap = new KeyMap();
+
+      memory = new MemorySource({ schema, keyMap });
+
+      remote = new JSONAPISource({ schema, keyMap, name: 'remote' });
+      remote.requestProcessor.serializer.resourceKey = function () {
+        return 'remoteId';
+      };
+
+      coordinator = new Coordinator({
+        sources: [memory, remote]
+      });
+
+      // Query the remote server whenever the memory source is queried
+      coordinator.addStrategy(
+        new RequestStrategy({
+          source: 'memory',
+          on: 'beforeQuery',
+          target: 'remote',
+          action: 'pull',
+          blocking: false
+        })
+      );
+
+      // Update the remote server whenever the memory source is updated
+      coordinator.addStrategy(
+        new RequestStrategy({
+          source: 'memory',
+          on: 'beforeUpdate',
+          target: 'remote',
+          action: 'push',
+          blocking: false
+        })
+      );
+
+      // Sync all changes received from the remote server to the memory source
+      coordinator.addStrategy(
+        new SyncStrategy({
+          source: 'remote',
+          target: 'memory',
+          blocking: true
+        })
+      );
     });
 
-    keyMap = new KeyMap();
+    hooks.afterEach(() => {
+      keyMap = schema = remote = memory = coordinator = null;
 
-    memory = new MemorySource({ schema, keyMap });
-
-    remote = new JSONAPISource({ schema, keyMap, name: 'remote' });
-    remote.requestProcessor.serializer.resourceKey = function() {
-      return 'remoteId';
-    };
-
-    coordinator = new Coordinator({
-      sources: [memory, remote]
+      fetchStub.restore();
     });
 
-    // Query the remote server whenever the memory source is queried
-    coordinator.addStrategy(
-      new RequestStrategy({
-        source: 'memory',
-        on: 'beforeQuery',
-        target: 'remote',
-        action: 'pull',
-        blocking: false
-      })
-    );
+    test('Adding a record to the memory source queues an update request which will be pushed to the remote', async function (assert) {
+      assert.expect(3);
 
-    // Update the remote server whenever the memory source is updated
-    coordinator.addStrategy(
-      new RequestStrategy({
-        source: 'memory',
-        on: 'beforeUpdate',
-        target: 'remote',
-        action: 'push',
-        blocking: false
-      })
-    );
+      await coordinator.activate();
 
-    // Sync all changes received from the remote server to the memory source
-    coordinator.addStrategy(
-      new SyncStrategy({
-        source: 'remote',
-        target: 'memory',
-        blocking: true
-      })
-    );
-  });
+      fetchStub.withArgs('/planets').returns(
+        jsonapiResponse(201, {
+          data: {
+            id: '12345',
+            type: 'planets',
+            attributes: { name: 'Jupiter', classification: 'gas giant' }
+          }
+        })
+      );
 
-  hooks.afterEach(() => {
-    keyMap = schema = remote = memory = coordinator = null;
+      let planet: Record = {
+        type: 'planet',
+        id: schema.generateId(),
+        attributes: { name: 'Jupiter', classification: 'gas giant' }
+      };
 
-    fetchStub.restore();
-  });
+      let createdRecord = await memory.update((t) => t.addRecord(planet));
+      let result = memory.cache.query((q) => q.findRecord(planet));
 
-  test('Adding a record to the memory source queues an update request which will be pushed to the remote', async function(assert) {
-    assert.expect(3);
-
-    await coordinator.activate();
-
-    fetchStub.withArgs('/planets').returns(
-      jsonapiResponse(201, {
-        data: {
-          id: '12345',
-          type: 'planets',
+      assert.deepEqual(
+        result,
+        {
+          type: 'planet',
+          id: planet.id,
           attributes: { name: 'Jupiter', classification: 'gas giant' }
-        }
-      })
-    );
+        },
+        'keys have not been syncd up yet - remote source still needs to process request'
+      );
+      assert.deepEqual(createdRecord, result);
 
-    let planet: Record = {
-      type: 'planet',
-      id: schema.generateId(),
-      attributes: { name: 'Jupiter', classification: 'gas giant' }
-    };
+      await remote.requestQueue.process();
 
-    let createdRecord = await memory.update(t => t.addRecord(planet));
-    let result = memory.cache.query(q => q.findRecord(planet));
-
-    assert.deepEqual(
-      result,
-      {
-        type: 'planet',
-        id: planet.id,
-        attributes: { name: 'Jupiter', classification: 'gas giant' }
-      },
-      'keys have not been syncd up yet - remote source still needs to process request'
-    );
-    assert.deepEqual(createdRecord, result);
-
-    await remote.requestQueue.process();
-
-    assert.deepEqual(
-      memory.cache.query(q => q.findRecord(planet)),
-      {
-        type: 'planet',
-        id: planet.id,
-        keys: { remoteId: '12345' },
-        attributes: { name: 'Jupiter', classification: 'gas giant' }
-      },
-      'keys are syncd up after remote source finishes processing requests'
-    );
-  });
-});
+      assert.deepEqual(
+        memory.cache.query((q) => q.findRecord(planet)),
+        {
+          type: 'planet',
+          id: planet.id,
+          keys: { remoteId: '12345' },
+          attributes: { name: 'Jupiter', classification: 'gas giant' }
+        },
+        'keys are syncd up after remote source finishes processing requests'
+      );
+    });
+  }
+);

--- a/packages/@orbit/integration-tests/test/store-jsonapi-remoteid-pessimistic-test.ts
+++ b/packages/@orbit/integration-tests/test/store-jsonapi-remoteid-pessimistic-test.ts
@@ -10,7 +10,7 @@ const { module, test } = QUnit;
 
 module(
   'Store + JSONAPISource + remote IDs + pessimistic coordination',
-  function(hooks) {
+  function (hooks) {
     let fetchStub: SinonStub;
     let keyMap: KeyMap;
     let schema: Schema;
@@ -75,7 +75,7 @@ module(
       memory = new MemorySource({ schema, keyMap });
 
       remote = new JSONAPISource({ schema, keyMap, name: 'remote' });
-      remote.requestProcessor.serializer.resourceKey = function() {
+      remote.requestProcessor.serializer.resourceKey = function () {
         return 'remoteId';
       };
 
@@ -122,7 +122,7 @@ module(
       fetchStub.restore();
     });
 
-    test('Adding a record to the memory source immediately pushes the update to the remote', async function(assert) {
+    test('Adding a record to the memory source immediately pushes the update to the remote', async function (assert) {
       assert.expect(4);
 
       await coordinator.activate();
@@ -143,8 +143,8 @@ module(
         attributes: { name: 'Jupiter', classification: 'gas giant' }
       };
 
-      let createdRecord = await memory.update(t => t.addRecord(planet));
-      let result = memory.cache.query(q => q.findRecord(planet));
+      let createdRecord = await memory.update((t) => t.addRecord(planet));
+      let result = memory.cache.query((q) => q.findRecord(planet));
 
       assert.deepEqual(result, {
         type: 'planet',

--- a/packages/@orbit/jsonapi/.prettierrc.js
+++ b/packages/@orbit/jsonapi/.prettierrc.js
@@ -1,3 +1,4 @@
 module.exports = {
-  singleQuote: true
+  singleQuote: true,
+  trailingComma: 'none'
 };

--- a/packages/@orbit/jsonapi/package.json
+++ b/packages/@orbit/jsonapi/package.json
@@ -35,13 +35,13 @@
   },
   "devDependencies": {
     "@glimmer/build": "^0.10.3",
-    "@types/sinon": "7.5.2",
-    "@typescript-eslint/eslint-plugin": "^2.23.0",
-    "@typescript-eslint/parser": "^2.23.0",
+    "@types/sinon": "9.0.0",
+    "@typescript-eslint/eslint-plugin": "^2.26.0",
+    "@typescript-eslint/parser": "^2.26.0",
     "eslint": "^6.8.0",
-    "eslint-config-prettier": "^6.10.0",
+    "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-prettier": "^3.1.2",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.2",
     "sinon": "^9.0.1",
     "whatwg-fetch": "^3.0.0"
   }

--- a/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
@@ -176,7 +176,7 @@ export default class JSONAPIRequestProcessor {
       Array.prototype.push.apply(records, deserialized.included);
     }
 
-    return records.map(record => {
+    return records.map((record) => {
       return {
         op: 'updateRecord',
         record

--- a/packages/@orbit/jsonapi/src/jsonapi-serializer.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-serializer.ts
@@ -101,7 +101,7 @@ export class JSONAPISerializer
   }
 
   resourceIds(type: string, ids: string[]): string[] {
-    return ids.map(id => this.resourceId(type, id));
+    return ids.map((id) => this.resourceId(type, id));
   }
 
   resourceId(type: string, id: string): string {
@@ -170,7 +170,7 @@ export class JSONAPISerializer
   }
 
   serializeOperations(operations: RecordOperation[]): ResourceOperation[] {
-    return operations.map(operation => this.serializeOperation(operation));
+    return operations.map((operation) => this.serializeOperation(operation));
   }
 
   serializeOperation(operation: RecordOperation): ResourceOperation {
@@ -259,7 +259,7 @@ export class JSONAPISerializer
     return {
       op: 'update',
       ref: { relationship: operation.relationship, ...ref },
-      data: operation.relatedRecords.map(record =>
+      data: operation.relatedRecords.map((record) =>
         this.serializeIdentity(record)
       )
     };
@@ -309,7 +309,7 @@ export class JSONAPISerializer
   }
 
   serializeRecords(records: Record[]): Resource[] {
-    return records.map(record => this.serializeRecord(record));
+    return records.map((record) => this.serializeRecord(record));
   }
 
   serializeRecord(record: Record): Resource {
@@ -349,7 +349,7 @@ export class JSONAPISerializer
     model: ModelDefinition
   ): void {
     if (record.attributes) {
-      Object.keys(record.attributes).forEach(attr => {
+      Object.keys(record.attributes).forEach((attr) => {
         this.serializeAttribute(resource, record, attr, model);
       });
     }
@@ -389,7 +389,7 @@ export class JSONAPISerializer
     model: ModelDefinition
   ): void {
     if (record.relationships) {
-      Object.keys(record.relationships).forEach(relationship => {
+      Object.keys(record.relationships).forEach((relationship) => {
         this.serializeRelationship(resource, record, relationship, model);
       });
     }
@@ -413,7 +413,7 @@ export class JSONAPISerializer
     let data;
 
     if (Array.isArray(value)) {
-      data = (value as RecordIdentity[]).map(id => this.resourceIdentity(id));
+      data = (value as RecordIdentity[]).map((id) => this.resourceIdentity(id));
     } else if (value !== null) {
       data = this.resourceIdentity(value as RecordIdentity);
     } else {
@@ -442,7 +442,7 @@ export class JSONAPISerializer
           return this.deserializeResource(entry, primaryRecords[i]);
         });
       } else {
-        data = (document.data as Resource[]).map(entry =>
+        data = (document.data as Resource[]).map((entry) =>
           this.deserializeResource(entry)
         );
       }
@@ -462,7 +462,9 @@ export class JSONAPISerializer
     result = { data };
 
     if (document.included) {
-      result.included = document.included.map(e => this.deserializeResource(e));
+      result.included = document.included.map((e) =>
+        this.deserializeResource(e)
+      );
     }
 
     if (document.links) {
@@ -483,7 +485,7 @@ export class JSONAPISerializer
   }
 
   deserializeOperations(operations: ResourceOperation[]): RecordOperation[] {
-    return operations.map(operation => this.deserializeOperation(operation));
+    return operations.map((operation) => this.deserializeOperation(operation));
   }
 
   deserializeOperation(operation: ResourceOperation): RecordOperation {
@@ -543,7 +545,7 @@ export class JSONAPISerializer
           op: 'replaceRelatedRecords',
           relationship: operation.ref.relationship,
           record: this.deserializeResourceIdentity(operation.ref),
-          relatedRecords: (operation.data as RecordIdentity[]).map(record =>
+          relatedRecords: (operation.data as RecordIdentity[]).map((record) =>
             this.deserializeResourceIdentity(record)
           )
         };
@@ -668,7 +670,7 @@ export class JSONAPISerializer
     model: ModelDefinition
   ): void {
     if (resource.attributes) {
-      Object.keys(resource.attributes).forEach(resourceAttribute => {
+      Object.keys(resource.attributes).forEach((resourceAttribute) => {
         let attribute = this.recordAttribute(record.type, resourceAttribute);
         if (this.schema.hasAttribute(record.type, attribute)) {
           let value = resource.attributes[resourceAttribute];
@@ -704,7 +706,7 @@ export class JSONAPISerializer
     model: ModelDefinition
   ): void {
     if (resource.relationships) {
-      Object.keys(resource.relationships).forEach(resourceRel => {
+      Object.keys(resource.relationships).forEach((resourceRel) => {
         let relationship = this.recordRelationship(record.type, resourceRel);
         if (this.schema.hasRelationship(record.type, relationship)) {
           let value = resource.relationships[resourceRel];
@@ -728,7 +730,7 @@ export class JSONAPISerializer
       if (resourceData === null) {
         data = null;
       } else if (Array.isArray(resourceData)) {
-        data = (resourceData as ResourceIdentity[]).map(resourceIdentity =>
+        data = (resourceData as ResourceIdentity[]).map((resourceIdentity) =>
           this.recordIdentity(resourceIdentity)
         );
       } else {

--- a/packages/@orbit/jsonapi/src/jsonapi-url-builder.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-url-builder.ts
@@ -96,7 +96,7 @@ export default class JSONAPIURLBuilder {
   buildFilterParam(filterSpecifiers: FilterSpecifier[]): Filter[] {
     const filters: Filter[] = [];
 
-    filterSpecifiers.forEach(filterSpecifier => {
+    filterSpecifiers.forEach((filterSpecifier) => {
       if (
         filterSpecifier.kind === 'attribute' &&
         filterSpecifier.op === 'equal'
@@ -114,7 +114,7 @@ export default class JSONAPIURLBuilder {
         if (Array.isArray(relatedRecordFilter.record)) {
           filters.push({
             [relatedRecordFilter.relation]: relatedRecordFilter.record
-              .map(e => e.id)
+              .map((e) => e.id)
               .join(',')
           });
         } else {
@@ -131,7 +131,7 @@ export default class JSONAPIURLBuilder {
         const relatedRecordsFilter = filterSpecifier as RelatedRecordsFilterSpecifier;
         filters.push({
           [relatedRecordsFilter.relation]: relatedRecordsFilter.records
-            .map(e => e.id)
+            .map((e) => e.id)
             .join(',')
         });
       } else {
@@ -147,7 +147,7 @@ export default class JSONAPIURLBuilder {
 
   buildSortParam(sortSpecifiers: SortSpecifier[]): string {
     return sortSpecifiers
-      .map(sortSpecifier => {
+      .map((sortSpecifier) => {
         if (sortSpecifier.kind === 'attribute') {
           const attributeSort = sortSpecifier as AttributeSortSpecifier;
 

--- a/packages/@orbit/jsonapi/src/lib/jsonapi-request-options.ts
+++ b/packages/@orbit/jsonapi/src/lib/jsonapi-request-options.ts
@@ -26,7 +26,7 @@ export function buildFetchSettings(
     deepMerge(settings, customSettings);
   }
 
-  ['filter', 'include', 'page', 'sort'].forEach(param => {
+  ['filter', 'include', 'page', 'sort'].forEach((param) => {
     let value = (options as any)[param];
     if (value) {
       if (param === 'include' && Array.isArray(value)) {
@@ -72,12 +72,12 @@ function mergeIncludePaths(paths: string[], customPaths: string[]) {
 
 function mergeFilters(filters: Filter[], customFilters: Filter[]) {
   let result: Filter[] = clone(filters);
-  let filterKeys: string[] = filters.map(f => filterKey(f));
+  let filterKeys: string[] = filters.map((f) => filterKey(f));
   for (let customFilter of customFilters) {
     let customerFilterKey = filterKey(customFilter);
     if (filterKeys.includes(customerFilterKey)) {
       let filterToOverride = result.find(
-        f => filterKey(f) === customerFilterKey
+        (f) => filterKey(f) === customerFilterKey
       );
       setFilterValue(filterToOverride, filterValue(customFilter));
     } else {

--- a/packages/@orbit/jsonapi/src/lib/query-params.ts
+++ b/packages/@orbit/jsonapi/src/lib/query-params.ts
@@ -11,7 +11,7 @@ export interface Param {
 function flattenObjectToParams(obj: any, path: string[] = []): RawParam[] {
   let params: RawParam[] = [];
 
-  Object.keys(obj).forEach(key => {
+  Object.keys(obj).forEach((key) => {
     if (!obj.hasOwnProperty(key)) {
       return;
     }
@@ -37,7 +37,7 @@ function flattenObjectToParams(obj: any, path: string[] = []): RawParam[] {
 
 export function encodeQueryParams(obj: any) {
   return flattenObjectToParams(obj)
-    .map(rawParam => {
+    .map((rawParam) => {
       let path: string;
       let val = rawParam.val;
 
@@ -51,7 +51,7 @@ export function encodeQueryParams(obj: any) {
       return { path, val };
     })
     .map(
-      param =>
+      (param) =>
         encodeURIComponent(param.path) + '=' + encodeURIComponent(param.val)
     )
     .join('&');

--- a/packages/@orbit/jsonapi/src/lib/transform-requests.ts
+++ b/packages/@orbit/jsonapi/src/lib/transform-requests.ts
@@ -164,7 +164,7 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     const { relationship, record, options } = request;
     const { type, id } = record;
     const json = {
-      data: request.relatedRecords.map(r =>
+      data: request.relatedRecords.map((r) =>
         requestProcessor.serializer.resourceIdentity(r)
       )
     };
@@ -191,7 +191,7 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     const { relationship, record, options } = request;
     const { type, id } = record;
     const json = {
-      data: request.relatedRecords.map(r =>
+      data: request.relatedRecords.map((r) =>
         requestProcessor.serializer.resourceIdentity(r)
       )
     };
@@ -245,7 +245,7 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     const { relationship, relatedRecords, record, options } = request;
     const { type, id } = record;
     const json = {
-      data: relatedRecords.map(r =>
+      data: relatedRecords.map((r) =>
         requestProcessor.serializer.resourceIdentity(r)
       )
     };
@@ -480,7 +480,7 @@ function replaceRecordHasMany(
   deepSet(
     record,
     ['relationships', relationship, 'data'],
-    relatedRecords.map(r => cloneRecordIdentity(r))
+    relatedRecords.map((r) => cloneRecordIdentity(r))
   );
 }
 
@@ -496,7 +496,7 @@ function handleChanges(
     transforms.push(buildTransform(updateOps));
   }
   if (responseDoc.included && responseDoc.included.length > 0) {
-    let includedOps = responseDoc.included.map(record => {
+    let includedOps = responseDoc.included.map((record) => {
       return { op: 'updateRecord', record };
     });
     transforms.push(buildTransform(includedOps));

--- a/packages/@orbit/jsonapi/test/jsonapi-request-processor-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-request-processor-test.ts
@@ -6,7 +6,7 @@ import { SinonStatic, SinonStub } from 'sinon';
 
 declare const sinon: SinonStatic;
 
-module('JSONAPIRequestProcessor', function(hooks) {
+module('JSONAPIRequestProcessor', function (hooks) {
   let fetchStub: SinonStub;
   let keyMap: KeyMap;
   let schema: Schema;
@@ -69,7 +69,7 @@ module('JSONAPIRequestProcessor', function(hooks) {
       keyMap,
       sourceName: 'foo'
     });
-    processor.serializer.resourceKey = function() {
+    processor.serializer.resourceKey = function () {
       return 'remoteId';
     };
   });
@@ -79,11 +79,11 @@ module('JSONAPIRequestProcessor', function(hooks) {
     fetchStub.restore();
   });
 
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     assert.ok(processor);
   });
 
-  test('processor has default settings', function(assert) {
+  test('processor has default settings', function (assert) {
     assert.deepEqual(
       processor.allowedContentTypes,
       ['application/vnd.api+json', 'application/json'],
@@ -91,7 +91,7 @@ module('JSONAPIRequestProcessor', function(hooks) {
     );
   });
 
-  test('#initFetchSettings will override defaults with custom settings provided', function(assert) {
+  test('#initFetchSettings will override defaults with custom settings provided', function (assert) {
     assert.deepEqual(
       processor.initFetchSettings({
         headers: {
@@ -113,7 +113,7 @@ module('JSONAPIRequestProcessor', function(hooks) {
     );
   });
 
-  test('#initFetchSettings will convert json to a stringified body', function(assert) {
+  test('#initFetchSettings will convert json to a stringified body', function (assert) {
     assert.deepEqual(
       processor.initFetchSettings({
         headers: {
@@ -135,7 +135,7 @@ module('JSONAPIRequestProcessor', function(hooks) {
     );
   });
 
-  test('#initFetchSettings will not include a `Content-Type` header with no body', function(assert) {
+  test('#initFetchSettings will not include a `Content-Type` header with no body', function (assert) {
     assert.deepEqual(
       processor.initFetchSettings({
         method: 'GET'
@@ -150,7 +150,7 @@ module('JSONAPIRequestProcessor', function(hooks) {
     );
   });
 
-  test('#fetch - successful if one of the `allowedContentTypes` appears anywhere in `Content-Type` header', async function(assert) {
+  test('#fetch - successful if one of the `allowedContentTypes` appears anywhere in `Content-Type` header', async function (assert) {
     assert.expect(6);
     fetchStub.withArgs('/planets/12345/relationships/moons').returns(
       jsonapiResponse(

--- a/packages/@orbit/jsonapi/test/jsonapi-serializer-operations-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-serializer-operations-test.ts
@@ -5,7 +5,7 @@ import { JSONAPISerializer, ResourceOperationsDocument } from '../src/index';
 
 const { module, test } = QUnit;
 
-module('JSONAPISerializer', function(hooks) {
+module('JSONAPISerializer', function (hooks) {
   const modelDefinitions: Dict<ModelDefinition> = {
     planet: {
       keys: {
@@ -137,16 +137,16 @@ module('JSONAPISerializer', function(hooks) {
 
   let serializer: JSONAPISerializer;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     let schema: Schema = new Schema({ models: modelDefinitions });
     serializer = new JSONAPISerializer({ schema });
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     serializer = null;
   });
 
-  test('deserializeOperationsDocument', function(assert) {
+  test('deserializeOperationsDocument', function (assert) {
     const operations = serializer.deserializeOperationsDocument(
       operationsDocument
     );
@@ -228,7 +228,7 @@ module('JSONAPISerializer', function(hooks) {
     ]);
   });
 
-  test('deserializeOperations', function(assert) {
+  test('deserializeOperations', function (assert) {
     const operations = serializer.deserializeOperations([
       {
         op: 'update',
@@ -283,7 +283,7 @@ module('JSONAPISerializer', function(hooks) {
     ]);
   });
 
-  test('deserializeOperation', function(assert) {
+  test('deserializeOperation', function (assert) {
     const operation = serializer.deserializeOperation({
       op: 'update',
       ref: {
@@ -310,7 +310,7 @@ module('JSONAPISerializer', function(hooks) {
     });
   });
 
-  test('deserializeOperation throws on get', function(assert) {
+  test('deserializeOperation throws on get', function (assert) {
     assert.throws(() => {
       serializer.deserializeOperation({
         op: 'get',
@@ -322,7 +322,7 @@ module('JSONAPISerializer', function(hooks) {
     }, '"get" operation recieved');
   });
 
-  test('serializeOperation', function(assert) {
+  test('serializeOperation', function (assert) {
     const operation = serializer.serializeOperation({
       op: 'updateRecord',
       record: {
@@ -350,7 +350,7 @@ module('JSONAPISerializer', function(hooks) {
     });
   });
 
-  test('serializeOperations', function(assert) {
+  test('serializeOperations', function (assert) {
     const operations = serializer.serializeOperations([
       {
         op: 'updateRecord',

--- a/packages/@orbit/jsonapi/test/jsonapi-serializer-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-serializer-test.ts
@@ -6,7 +6,7 @@ import { Serializer } from '../../serializers/dist/types';
 
 const { module, test } = QUnit;
 
-module('JSONAPISerializer', function(hooks) {
+module('JSONAPISerializer', function (hooks) {
   const modelDefinitions: Dict<ModelDefinition> = {
     planet: {
       keys: {
@@ -49,7 +49,7 @@ module('JSONAPISerializer', function(hooks) {
     }
   };
 
-  module('Using custom serializers', function(hooks) {
+  module('Using custom serializers', function (hooks) {
     const modelDefinitions: Dict<ModelDefinition> = {
       person: {
         attributes: {
@@ -93,7 +93,7 @@ module('JSONAPISerializer', function(hooks) {
 
     let serializer: JSONAPISerializer;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(function () {
       let schema: Schema = new Schema({ models: modelDefinitions });
       serializer = new JSONAPISerializer({
         schema,
@@ -103,11 +103,11 @@ module('JSONAPISerializer', function(hooks) {
       });
     });
 
-    hooks.afterEach(function() {
+    hooks.afterEach(function () {
       serializer = null;
     });
 
-    test('serializer is assigned some standard serializers by default, and any custom serializers passed as settings', function(assert) {
+    test('serializer is assigned some standard serializers by default, and any custom serializers passed as settings', function (assert) {
       // default serializers
       assert.ok(serializer.serializerFor('boolean'));
       assert.ok(serializer.serializerFor('string'));
@@ -122,7 +122,7 @@ module('JSONAPISerializer', function(hooks) {
       assert.notOk(serializer.serializerFor('fake'));
     });
 
-    test('#serialize will use available serializers for attribute values', function(assert) {
+    test('#serialize will use available serializers for attribute values', function (assert) {
       assert.deepEqual(
         serializer.serialize({
           data: {
@@ -154,7 +154,7 @@ module('JSONAPISerializer', function(hooks) {
       );
     });
 
-    test('#serialize will pass null values without throwing', function(assert) {
+    test('#serialize will pass null values without throwing', function (assert) {
       assert.deepEqual(
         serializer.serialize({
           data: {
@@ -186,7 +186,7 @@ module('JSONAPISerializer', function(hooks) {
       );
     });
 
-    test('#deserialize will use available serializers for attribute values', function(assert) {
+    test('#deserialize will use available serializers for attribute values', function (assert) {
       let result = serializer.deserialize({
         data: {
           type: 'persons',
@@ -215,7 +215,7 @@ module('JSONAPISerializer', function(hooks) {
       });
     });
 
-    test('#deserialize will pass null values', function(assert) {
+    test('#deserialize will pass null values', function (assert) {
       let result = serializer.deserialize({
         data: {
           type: 'persons',
@@ -239,71 +239,71 @@ module('JSONAPISerializer', function(hooks) {
     });
   });
 
-  module('Using local ids', function(hooks) {
+  module('Using local ids', function (hooks) {
     let serializer: JSONAPISerializer;
     let keyMap: KeyMap;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(function () {
       keyMap = new KeyMap();
 
       let schema: Schema = new Schema({ models: modelDefinitions });
       serializer = new JSONAPISerializer({ schema, keyMap });
-      serializer.resourceKey = function() {
+      serializer.resourceKey = function () {
         return 'remoteId';
       };
     });
 
-    hooks.afterEach(function() {
+    hooks.afterEach(function () {
       keyMap = serializer = null;
     });
 
-    test('it exists', function(assert) {
+    test('it exists', function (assert) {
       assert.ok(serializer);
     });
 
-    test('#resourceType returns the pluralized, dasherized type by default', function(assert) {
+    test('#resourceType returns the pluralized, dasherized type by default', function (assert) {
       assert.equal(
         serializer.resourceType('planetaryObject'),
         'planetary-objects'
       );
     });
 
-    test('#resourceRelationship returns the dasherized relationship by default', function(assert) {
+    test('#resourceRelationship returns the dasherized relationship by default', function (assert) {
       assert.equal(
         serializer.resourceRelationship('planet', 'surfaceElements'),
         'surface-elements'
       );
     });
 
-    test('#resourceAttr returns the dasherized attribute by default', function(assert) {
+    test('#resourceAttr returns the dasherized attribute by default', function (assert) {
       assert.equal(
         serializer.resourceRelationship('planet', 'fullName'),
         'full-name'
       );
     });
 
-    test('#recordType returns the singularized, camelized type by default', function(assert) {
+    test('#recordType returns the singularized, camelized type by default', function (assert) {
       assert.equal(
         serializer.recordType('planetary-objects'),
         'planetaryObject'
       );
     });
 
-    test('#recordAttribute returns the camelized attribute by default', function(assert) {
+    test('#recordAttribute returns the camelized attribute by default', function (assert) {
       assert.equal(
         serializer.recordAttribute('planet', 'full-name'),
         'fullName'
       );
     });
 
-    test('#recordRelationship returns the camelized relationship by default', function(assert) {
+    test('#recordRelationship returns the camelized relationship by default', function (assert) {
       assert.equal(
         serializer.recordRelationship('planet', 'surface-elements'),
         'surfaceElements'
       );
     });
 
-    test('#resourceId returns a matching resource id given an orbit id', function(assert) {
+    test('#resourceId returns a matching resource id given an orbit id', function (assert) {
       keyMap.pushRecord({ type: 'planet', id: '1', keys: { remoteId: 'a' } });
       keyMap.pushRecord({ type: 'planet', id: '2', keys: { remoteId: 'b' } });
 
@@ -311,7 +311,7 @@ module('JSONAPISerializer', function(hooks) {
       assert.equal(serializer.resourceId('planet', '2'), 'b');
     });
 
-    test('#resourceIds returns an array of matching resource ids given an array of orbit ids', function(assert) {
+    test('#resourceIds returns an array of matching resource ids given an array of orbit ids', function (assert) {
       keyMap.pushRecord({ type: 'planet', id: '1', keys: { remoteId: 'a' } });
       keyMap.pushRecord({ type: 'planet', id: '2', keys: { remoteId: 'b' } });
 
@@ -322,7 +322,7 @@ module('JSONAPISerializer', function(hooks) {
       );
     });
 
-    test('#recordId returns a matching orbit id given a resource id', function(assert) {
+    test('#recordId returns a matching orbit id given a resource id', function (assert) {
       keyMap.pushRecord({ type: 'planet', id: '1', keys: { remoteId: 'a' } });
       keyMap.pushRecord({ type: 'planet', id: '2', keys: { remoteId: 'b' } });
 
@@ -330,7 +330,7 @@ module('JSONAPISerializer', function(hooks) {
       assert.equal(serializer.recordId('planet', 'b'), '2');
     });
 
-    test('#serialize - can serialize a simple resource with only attributes', function(assert) {
+    test('#serialize - can serialize a simple resource with only attributes', function (assert) {
       assert.deepEqual(
         serializer.serialize({
           data: {
@@ -355,7 +355,7 @@ module('JSONAPISerializer', function(hooks) {
       );
     });
 
-    test('#serialize - can serialize a resource with attributes and has-many relationships', function(assert) {
+    test('#serialize - can serialize a resource with attributes and has-many relationships', function (assert) {
       keyMap.pushRecord({
         type: 'planet',
         id: 'p1',
@@ -413,7 +413,7 @@ module('JSONAPISerializer', function(hooks) {
       );
     });
 
-    test('#serialize - can serialize a resource with attributes and a null has-one relationship', function(assert) {
+    test('#serialize - can serialize a resource with attributes and a null has-one relationship', function (assert) {
       keyMap.pushRecord({
         type: 'planet',
         id: 'p0',
@@ -456,7 +456,7 @@ module('JSONAPISerializer', function(hooks) {
       );
     });
 
-    test('#serialize - can serialize a resource with attributes and a has-one relationships', function(assert) {
+    test('#serialize - can serialize a resource with attributes and a has-one relationships', function (assert) {
       keyMap.pushRecord({
         type: 'planet',
         id: 'p1',
@@ -501,7 +501,7 @@ module('JSONAPISerializer', function(hooks) {
       );
     });
 
-    test('#deserialize - can deserialize a simple resource with only type and id - using local IDs', function(assert) {
+    test('#deserialize - can deserialize a simple resource with only type and id - using local IDs', function (assert) {
       let result = serializer.deserialize({
         data: {
           type: 'planets',
@@ -523,7 +523,7 @@ module('JSONAPISerializer', function(hooks) {
       );
     });
 
-    test('#deserialize - can deserialize a simple resource and associate it with a local record', function(assert) {
+    test('#deserialize - can deserialize a simple resource and associate it with a local record', function (assert) {
       let localRecord = {
         id: '1a2b3c',
         type: 'planet'
@@ -556,7 +556,7 @@ module('JSONAPISerializer', function(hooks) {
       );
     });
 
-    test('#deserialize - can deserialize a compound document', function(assert) {
+    test('#deserialize - can deserialize a compound document', function (assert) {
       let result = serializer.deserialize({
         data: {
           id: '12345',
@@ -657,7 +657,7 @@ module('JSONAPISerializer', function(hooks) {
       );
     });
 
-    test('#deserialize - can deserialize null as primary data', function(assert) {
+    test('#deserialize - can deserialize null as primary data', function (assert) {
       let result = serializer.deserialize({
         data: null
       });
@@ -666,7 +666,7 @@ module('JSONAPISerializer', function(hooks) {
       assert.equal(record, null, 'deserialized document matches');
     });
 
-    test('#deserialize - can deserialize an array of records', function(assert) {
+    test('#deserialize - can deserialize an array of records', function (assert) {
       let result = serializer.deserialize({
         data: [
           { type: 'planets', id: '123' },
@@ -693,7 +693,7 @@ module('JSONAPISerializer', function(hooks) {
       );
     });
 
-    test('#deserialize - can deserialize an array of records and associate them with local records', function(assert) {
+    test('#deserialize - can deserialize an array of records and associate them with local records', function (assert) {
       let localRecords = [{ id: '1a2b3c' }, { id: '4d5e6f' }] as Record[];
       let result = serializer.deserialize(
         {
@@ -727,27 +727,27 @@ module('JSONAPISerializer', function(hooks) {
     });
   });
 
-  module('Using shared UUIDs', function(hooks) {
+  module('Using shared UUIDs', function (hooks) {
     let serializer: JSONAPISerializer;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(function () {
       let schema = new Schema({ models: modelDefinitions });
       serializer = new JSONAPISerializer({ schema });
     });
 
-    hooks.afterEach(function() {
+    hooks.afterEach(function () {
       serializer = null;
     });
 
-    test('it exists', function(assert) {
+    test('it exists', function (assert) {
       assert.ok(serializer);
     });
 
-    test("#resourceKey returns 'id' by default", function(assert) {
+    test("#resourceKey returns 'id' by default", function (assert) {
       assert.equal(serializer.resourceKey('planet'), 'id');
     });
 
-    test('#resourceId returns a matching resource id given an orbit id', function(assert) {
+    test('#resourceId returns a matching resource id given an orbit id', function (assert) {
       serializer.deserialize({ data: { type: 'planet', id: 'a' } });
       serializer.deserialize({ data: { type: 'planet', id: 'b' } });
 
@@ -755,7 +755,7 @@ module('JSONAPISerializer', function(hooks) {
       assert.equal(serializer.resourceId('planet', 'b'), 'b');
     });
 
-    test('#resourceIds returns an array of matching resource ids given an array of orbit ids', function(assert) {
+    test('#resourceIds returns an array of matching resource ids given an array of orbit ids', function (assert) {
       serializer.deserialize({ data: { type: 'planet', id: 'a' } });
       serializer.deserialize({ data: { type: 'planet', id: 'b' } });
 
@@ -766,7 +766,7 @@ module('JSONAPISerializer', function(hooks) {
       );
     });
 
-    test('#recordId returns a matching orbit id given a resource id - using UUIDs', function(assert) {
+    test('#recordId returns a matching orbit id given a resource id - using UUIDs', function (assert) {
       serializer.deserialize({ data: { type: 'planet', id: 'a' } });
       serializer.deserialize({ data: { type: 'planet', id: 'b' } });
 
@@ -774,7 +774,7 @@ module('JSONAPISerializer', function(hooks) {
       assert.equal(serializer.recordId('planet', 'b'), 'b');
     });
 
-    test('#serialize - can serialize a simple resource with only type and id', function(assert) {
+    test('#serialize - can serialize a simple resource with only type and id', function (assert) {
       assert.deepEqual(
         serializer.serialize({
           data: {
@@ -792,7 +792,7 @@ module('JSONAPISerializer', function(hooks) {
       );
     });
 
-    test('#serialize - ignores attributes and relationships not defined in the schema', function(assert) {
+    test('#serialize - ignores attributes and relationships not defined in the schema', function (assert) {
       assert.deepEqual(
         serializer.serialize({
           data: {
@@ -821,7 +821,7 @@ module('JSONAPISerializer', function(hooks) {
       );
     });
 
-    test('#deserialize - can deserialize a simple resource with only type and id', function(assert) {
+    test('#deserialize - can deserialize a simple resource with only type and id', function (assert) {
       let result = serializer.deserialize({
         data: {
           type: 'planets',
@@ -840,7 +840,7 @@ module('JSONAPISerializer', function(hooks) {
       );
     });
 
-    test('#deserialize - can deserialize a compound document', function(assert) {
+    test('#deserialize - can deserialize a compound document', function (assert) {
       let result = serializer.deserialize({
         data: {
           id: '12345',
@@ -902,7 +902,7 @@ module('JSONAPISerializer', function(hooks) {
       );
     });
 
-    test('#deserialize - ignores attributes and relationships not defined in the schema', function(assert) {
+    test('#deserialize - ignores attributes and relationships not defined in the schema', function (assert) {
       let result = serializer.deserialize({
         data: {
           id: '12345',
@@ -935,23 +935,23 @@ module('JSONAPISerializer', function(hooks) {
     });
   });
 
-  module('Deserialize links and meta', function(hooks) {
+  module('Deserialize links and meta', function (hooks) {
     let serializer: JSONAPISerializer;
 
-    hooks.beforeEach(function() {
+    hooks.beforeEach(function () {
       let schema = new Schema({ models: modelDefinitions });
       serializer = new JSONAPISerializer({ schema });
     });
 
-    hooks.afterEach(function() {
+    hooks.afterEach(function () {
       serializer = null;
     });
 
-    test('it exists', function(assert) {
+    test('it exists', function (assert) {
       assert.ok(serializer);
     });
 
-    test('it deserializes links and meta at the document-level', function(assert) {
+    test('it deserializes links and meta at the document-level', function (assert) {
       let result = serializer.deserialize({
         links: {
           self: 'https://example.com/planets/12345/moons'
@@ -975,7 +975,7 @@ module('JSONAPISerializer', function(hooks) {
       });
     });
 
-    test('it deserializes links and meta in records', function(assert) {
+    test('it deserializes links and meta in records', function (assert) {
       let result = serializer.deserialize({
         data: {
           id: '12345',
@@ -1025,7 +1025,7 @@ module('JSONAPISerializer', function(hooks) {
       });
     });
 
-    test('it deserializes links and meta in hasOne relationship', function(assert) {
+    test('it deserializes links and meta in hasOne relationship', function (assert) {
       let result = serializer.deserialize({
         data: {
           id: '12345',
@@ -1087,7 +1087,7 @@ module('JSONAPISerializer', function(hooks) {
       });
     });
 
-    test('it deserializes links and meta in hasMany relationship', function(assert) {
+    test('it deserializes links and meta in hasMany relationship', function (assert) {
       let result = serializer.deserialize({
         data: {
           id: '12345',
@@ -1151,7 +1151,7 @@ module('JSONAPISerializer', function(hooks) {
       });
     });
 
-    test('it deserializes links and meta in hasOne relationship without data', function(assert) {
+    test('it deserializes links and meta in hasOne relationship without data', function (assert) {
       let result = serializer.deserialize({
         data: {
           id: '12345',
@@ -1211,7 +1211,7 @@ module('JSONAPISerializer', function(hooks) {
       });
     });
 
-    test('it deserializes links in hasMany relationship without data', function(assert) {
+    test('it deserializes links in hasMany relationship without data', function (assert) {
       let result = serializer.deserialize({
         data: {
           id: '12345',

--- a/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
@@ -25,13 +25,13 @@ import { ResourceDocument } from '../dist/types';
 declare const sinon: SinonStatic;
 const { module, test } = QUnit;
 
-module('JSONAPISource', function() {
+module('JSONAPISource', function () {
   let fetchStub: SinonStub;
   let keyMap: KeyMap;
   let schema: Schema;
   let source: JSONAPISource;
 
-  module('with a secondary key', function(hooks) {
+  module('with a secondary key', function (hooks) {
     hooks.beforeEach(() => {
       fetchStub = sinon.stub(self, 'fetch');
 
@@ -92,7 +92,7 @@ module('JSONAPISource', function() {
       keyMap = new KeyMap();
       source = new JSONAPISource({ schema, keyMap });
 
-      source.requestProcessor.serializer.resourceKey = function() {
+      source.requestProcessor.serializer.resourceKey = function () {
         return 'remoteId';
       };
     });
@@ -102,15 +102,15 @@ module('JSONAPISource', function() {
       fetchStub.restore();
     });
 
-    test('it exists', function(assert) {
+    test('it exists', function (assert) {
       assert.ok(source);
     });
 
-    test('its prototype chain is correct', function(assert) {
+    test('its prototype chain is correct', function (assert) {
       assert.ok(source instanceof Source, 'instanceof Source');
     });
 
-    test('source has default settings', function(assert) {
+    test('source has default settings', function (assert) {
       assert.expect(2);
 
       let schema = new Schema({} as SchemaSettings);
@@ -123,7 +123,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('source saves options', function(assert) {
+    test('source saves options', function (assert) {
       assert.expect(5);
 
       let schema = new Schema({} as SchemaSettings);
@@ -163,7 +163,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#defaultFetchSettings - include JSONAPI Accept and Content-Type headers and a 5000ms timeout by default', function(assert) {
+    test('#defaultFetchSettings - include JSONAPI Accept and Content-Type headers and a 5000ms timeout by default', function (assert) {
       assert.deepEqual(source.defaultFetchSettings, {
         headers: {
           Accept: 'application/vnd.api+json',
@@ -173,7 +173,7 @@ module('JSONAPISource', function() {
       });
     });
 
-    test('#defaultFetchSettings can be passed and will override any defaults set', function(assert) {
+    test('#defaultFetchSettings can be passed and will override any defaults set', function (assert) {
       let customSource = new JSONAPISource({
         schema,
         defaultFetchSettings: {
@@ -192,7 +192,7 @@ module('JSONAPISource', function() {
       });
     });
 
-    test('#push - can add records', async function(assert) {
+    test('#push - can add records', async function (assert) {
       assert.expect(9);
 
       let transformCount = 0;
@@ -223,7 +223,7 @@ module('JSONAPISource', function() {
         value: '12345'
       } as ReplaceKeyOperation;
 
-      source.on('transform', function(transform: Transform) {
+      source.on('transform', function (transform: Transform) {
         transformCount++;
 
         if (transformCount === 1) {
@@ -288,7 +288,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#push - will not issue fetch if beforePush listener logs transform', async function(assert) {
+    test('#push - will not issue fetch if beforePush listener logs transform', async function (assert) {
       assert.expect(2);
 
       let planet: Record = source.requestProcessor.serializer.deserializeResource(
@@ -303,7 +303,7 @@ module('JSONAPISource', function() {
         record: planet
       } as AddRecordOperation);
 
-      source.on('beforePush', async function(transform: Transform) {
+      source.on('beforePush', async function (transform: Transform) {
         await source.transformLog.append(t.id);
       });
 
@@ -313,7 +313,7 @@ module('JSONAPISource', function() {
       assert.ok(source.transformLog.contains(t.id), 'log contains transform');
     });
 
-    test('#push - can add sideloaded records', async function(assert) {
+    test('#push - can add sideloaded records', async function (assert) {
       assert.expect(8);
 
       let transformCount = 0;
@@ -374,7 +374,7 @@ module('JSONAPISource', function() {
             'transform event then returns add-remote-id op'
           );
         } else if (transformCount === 3) {
-          let operationsWithoutId = transform.operations.map(op => {
+          let operationsWithoutId = transform.operations.map((op) => {
             let clonedOp = Object.assign({}, op) as RecordOperation;
             delete clonedOp.record.id;
             return clonedOp;
@@ -407,7 +407,7 @@ module('JSONAPISource', function() {
         })
       );
 
-      await source.push(t => t.addRecord(planet));
+      await source.push((t) => t.addRecord(planet));
 
       assert.ok(true, 'transform resolves successfully');
       assert.equal(fetchStub.callCount, 1, 'fetch called once');
@@ -436,7 +436,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#push - options can be passed in at the root level or source-specific level', async function(assert) {
+    test('#push - options can be passed in at the root level or source-specific level', async function (assert) {
       assert.expect(1);
 
       let planet: Record = source.requestProcessor.serializer.deserializeResource(
@@ -466,14 +466,14 @@ module('JSONAPISource', function() {
         })
       );
 
-      await source.push(t => t.addRecord(planet), {
+      await source.push((t) => t.addRecord(planet), {
         include: ['moons']
       });
 
       assert.equal(fetchStub.callCount, 1, 'fetch called once');
     });
 
-    test('#push - can transform records', async function(assert) {
+    test('#push - can transform records', async function (assert) {
       assert.expect(6);
 
       let transformCount = 0;
@@ -524,7 +524,7 @@ module('JSONAPISource', function() {
         })
       );
 
-      await source.push(t => t.updateRecord(planet));
+      await source.push((t) => t.updateRecord(planet));
 
       assert.ok(true, 'transform resolves successfully');
 
@@ -555,7 +555,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#push - can replace a single attribute', async function(assert) {
+    test('#push - can replace a single attribute', async function (assert) {
       assert.expect(5);
 
       let planet = source.requestProcessor.serializer.deserializeResource({
@@ -569,7 +569,7 @@ module('JSONAPISource', function() {
 
       fetchStub.withArgs('/planets/12345').returns(jsonapiResponse(204));
 
-      await source.push(t =>
+      await source.push((t) =>
         t.replaceAttribute(planet, 'classification', 'terrestrial')
       );
 
@@ -601,7 +601,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#push - can accept remote changes', async function(assert) {
+    test('#push - can accept remote changes', async function (assert) {
       assert.expect(2);
 
       let planet = source.requestProcessor.serializer.deserializeResource({
@@ -626,12 +626,12 @@ module('JSONAPISource', function() {
         })
       );
 
-      let transforms = await source.push(t =>
+      let transforms = await source.push((t) =>
         t.replaceAttribute(planet, 'classification', 'terrestrial')
       );
 
       assert.deepEqual(
-        transforms[1].operations.map(o => o.op),
+        transforms[1].operations.map((o) => o.op),
         ['replaceAttribute', 'replaceKey']
       );
       assert.deepEqual(
@@ -640,7 +640,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#push - can delete records', async function(assert) {
+    test('#push - can delete records', async function (assert) {
       assert.expect(4);
 
       let planet = source.requestProcessor.serializer.deserializeResource({
@@ -650,7 +650,7 @@ module('JSONAPISource', function() {
 
       fetchStub.withArgs('/planets/12345').returns(jsonapiResponse(200));
 
-      await source.push(t => t.removeRecord(planet));
+      await source.push((t) => t.removeRecord(planet));
 
       assert.ok(true, 'record deleted');
       assert.equal(fetchStub.callCount, 1, 'fetch called once');
@@ -666,7 +666,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#push - can add a hasMany relationship with POST', async function(assert) {
+    test('#push - can add a hasMany relationship with POST', async function (assert) {
       assert.expect(5);
 
       let planet = source.requestProcessor.serializer.deserializeResource({
@@ -683,7 +683,7 @@ module('JSONAPISource', function() {
         .withArgs('/planets/12345/relationships/moons')
         .returns(jsonapiResponse(204));
 
-      await source.push(t => t.addToRelatedRecords(planet, 'moons', moon));
+      await source.push((t) => t.addToRelatedRecords(planet, 'moons', moon));
 
       assert.ok(true, 'records linked');
       assert.equal(fetchStub.callCount, 1, 'fetch called once');
@@ -704,7 +704,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#push - can remove a relationship with DELETE', async function(assert) {
+    test('#push - can remove a relationship with DELETE', async function (assert) {
       assert.expect(4);
 
       let planet = source.requestProcessor.serializer.deserializeResource({
@@ -721,7 +721,9 @@ module('JSONAPISource', function() {
         .withArgs('/planets/12345/relationships/moons')
         .returns(jsonapiResponse(200));
 
-      await source.push(t => t.removeFromRelatedRecords(planet, 'moons', moon));
+      await source.push((t) =>
+        t.removeFromRelatedRecords(planet, 'moons', moon)
+      );
 
       assert.ok(true, 'records unlinked');
       assert.equal(fetchStub.callCount, 1, 'fetch called once');
@@ -737,7 +739,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#push - can update a hasOne relationship with PATCH', async function(assert) {
+    test('#push - can update a hasOne relationship with PATCH', async function (assert) {
       assert.expect(5);
 
       let planet = source.requestProcessor.serializer.deserializeResource({
@@ -752,7 +754,7 @@ module('JSONAPISource', function() {
 
       fetchStub.withArgs('/moons/987').returns(jsonapiResponse(200));
 
-      await source.push(t => t.replaceRelatedRecord(moon, 'planet', planet));
+      await source.push((t) => t.replaceRelatedRecord(moon, 'planet', planet));
 
       assert.ok(true, 'relationship replaced');
 
@@ -782,7 +784,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#push - can update a hasOne relationship with PATCH with newly created record', async function(assert) {
+    test('#push - can update a hasOne relationship with PATCH with newly created record', async function (assert) {
       assert.expect(5);
 
       let planet = {
@@ -808,7 +810,7 @@ module('JSONAPISource', function() {
 
       fetchStub.withArgs('/moons/987').returns(jsonapiResponse(200));
 
-      await source.push(t => [
+      await source.push((t) => [
         t.addRecord(planet),
         t.replaceRelatedRecord(moon, 'planet', planet)
       ]);
@@ -841,7 +843,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#push - can clear a hasOne relationship with PATCH', async function(assert) {
+    test('#push - can clear a hasOne relationship with PATCH', async function (assert) {
       assert.expect(5);
 
       let moon = source.requestProcessor.serializer.deserializeResource({
@@ -851,7 +853,7 @@ module('JSONAPISource', function() {
 
       fetchStub.withArgs('/moons/987').returns(jsonapiResponse(200));
 
-      await source.push(t => t.replaceRelatedRecord(moon, 'planet', null));
+      await source.push((t) => t.replaceRelatedRecord(moon, 'planet', null));
 
       assert.ok(true, 'relationship replaced');
 
@@ -879,7 +881,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#push - can replace a hasMany relationship with PATCH', async function(assert) {
+    test('#push - can replace a hasMany relationship with PATCH', async function (assert) {
       assert.expect(5);
 
       let planet = source.requestProcessor.serializer.deserializeResource({
@@ -894,7 +896,9 @@ module('JSONAPISource', function() {
 
       fetchStub.withArgs('/planets/12345').returns(jsonapiResponse(200));
 
-      await source.push(t => t.replaceRelatedRecords(planet, 'moons', [moon]));
+      await source.push((t) =>
+        t.replaceRelatedRecords(planet, 'moons', [moon])
+      );
 
       assert.ok(true, 'relationship replaced');
 
@@ -922,7 +926,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#push - a single transform can result in multiple requests', async function(assert) {
+    test('#push - a single transform can result in multiple requests', async function (assert) {
       assert.expect(6);
 
       let planet1 = source.requestProcessor.serializer.deserializeResource({
@@ -938,7 +942,7 @@ module('JSONAPISource', function() {
 
       fetchStub.withArgs('/planets/2').returns(jsonapiResponse(200));
 
-      await source.push(t => [
+      await source.push((t) => [
         t.removeRecord(planet1),
         t.removeRecord(planet2)
       ]);
@@ -970,7 +974,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#push - source can limit the number of allowed requests per transform with `maxRequestsPerTransform`', async function(assert) {
+    test('#push - source can limit the number of allowed requests per transform with `maxRequestsPerTransform`', async function (assert) {
       assert.expect(1);
 
       let planet1 = source.requestProcessor.serializer.deserializeResource({
@@ -985,7 +989,7 @@ module('JSONAPISource', function() {
       source.maxRequestsPerTransform = 1;
 
       try {
-        await source.push(t => [
+        await source.push((t) => [
           t.removeRecord(planet1),
           t.removeRecord(planet2)
         ]);
@@ -997,7 +1001,7 @@ module('JSONAPISource', function() {
       }
     });
 
-    test('#push - request can timeout', async function(assert) {
+    test('#push - request can timeout', async function (assert) {
       assert.expect(2);
 
       let planet = source.requestProcessor.serializer.deserializeResource({
@@ -1017,7 +1021,7 @@ module('JSONAPISource', function() {
         .returns(jsonapiResponse(200, null, 20)); // 20ms delay
 
       try {
-        await source.push(t =>
+        await source.push((t) =>
           t.replaceAttribute(planet, 'classification', 'terrestrial')
         );
         assert.ok(false, 'should not be reached');
@@ -1027,7 +1031,7 @@ module('JSONAPISource', function() {
       }
     });
 
-    test('#push - allowed timeout can be specified per-request', async function(assert) {
+    test('#push - allowed timeout can be specified per-request', async function (assert) {
       assert.expect(2);
 
       let planet = source.requestProcessor.serializer.deserializeResource({
@@ -1055,7 +1059,7 @@ module('JSONAPISource', function() {
 
       try {
         await source.push(
-          t => t.replaceAttribute(planet, 'classification', 'terrestrial'),
+          (t) => t.replaceAttribute(planet, 'classification', 'terrestrial'),
           options
         );
         assert.ok(false, 'should not be reached');
@@ -1065,7 +1069,7 @@ module('JSONAPISource', function() {
       }
     });
 
-    test('#push - fetch can reject with a NetworkError', async function(assert) {
+    test('#push - fetch can reject with a NetworkError', async function (assert) {
       assert.expect(2);
 
       let planet = source.requestProcessor.serializer.deserializeResource({
@@ -1080,7 +1084,7 @@ module('JSONAPISource', function() {
       fetchStub.withArgs('/planets/12345').returns(Promise.reject(':('));
 
       try {
-        await source.push(t =>
+        await source.push((t) =>
           t.replaceAttribute(planet, 'classification', 'terrestrial')
         );
         assert.ok(false, 'should not be reached');
@@ -1090,7 +1094,7 @@ module('JSONAPISource', function() {
       }
     });
 
-    test('#push - response can trigger a ClientError', async function(assert) {
+    test('#push - response can trigger a ClientError', async function (assert) {
       assert.expect(3);
 
       let planet = source.requestProcessor.serializer.deserializeResource({
@@ -1114,7 +1118,7 @@ module('JSONAPISource', function() {
         .returns(jsonapiResponse(422, { errors }));
 
       try {
-        await source.push(t =>
+        await source.push((t) =>
           t.replaceAttribute(planet, 'classification', 'terrestrial')
         );
         assert.ok(false, 'should not be reached');
@@ -1125,7 +1129,7 @@ module('JSONAPISource', function() {
       }
     });
 
-    test('#update - can add records', async function(assert) {
+    test('#update - can add records', async function (assert) {
       assert.expect(7);
 
       let transformCount = 0;
@@ -1156,7 +1160,7 @@ module('JSONAPISource', function() {
         value: '12345'
       } as ReplaceKeyOperation;
 
-      source.on('transform', function(transform: Transform) {
+      source.on('transform', function (transform: Transform) {
         transformCount++;
 
         if (transformCount === 1) {
@@ -1185,7 +1189,7 @@ module('JSONAPISource', function() {
         })
       );
 
-      await source.update(t => t.addRecord(planet));
+      await source.update((t) => t.addRecord(planet));
 
       assert.ok(true, 'transform resolves successfully');
 
@@ -1215,7 +1219,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#update - can add sideloaded records', async function(assert) {
+    test('#update - can add sideloaded records', async function (assert) {
       assert.expect(8);
 
       let transformCount = 0;
@@ -1276,7 +1280,7 @@ module('JSONAPISource', function() {
             'transform event then returns add-remote-id op'
           );
         } else if (transformCount === 3) {
-          let operationsWithoutId = transform.operations.map(op => {
+          let operationsWithoutId = transform.operations.map((op) => {
             let clonedOp = Object.assign({}, op) as RecordOperation;
             delete clonedOp.record.id;
             return clonedOp;
@@ -1309,7 +1313,7 @@ module('JSONAPISource', function() {
         })
       );
 
-      await source.update(t => t.addRecord(planet));
+      await source.update((t) => t.addRecord(planet));
 
       assert.ok(true, 'transform resolves successfully');
       assert.equal(fetchStub.callCount, 1, 'fetch called once');
@@ -1338,7 +1342,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#update - can transform records', async function(assert) {
+    test('#update - can transform records', async function (assert) {
       assert.expect(6);
 
       let transformCount = 0;
@@ -1389,7 +1393,7 @@ module('JSONAPISource', function() {
         })
       );
 
-      await source.update(t => t.updateRecord(planet));
+      await source.update((t) => t.updateRecord(planet));
 
       assert.ok(true, 'transform resolves successfully');
 
@@ -1420,7 +1424,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#update - can replace a single attribute', async function(assert) {
+    test('#update - can replace a single attribute', async function (assert) {
       assert.expect(5);
 
       let planet = source.requestProcessor.serializer.deserializeResource({
@@ -1434,7 +1438,7 @@ module('JSONAPISource', function() {
 
       fetchStub.withArgs('/planets/12345').returns(jsonapiResponse(204));
 
-      await source.update(t =>
+      await source.update((t) =>
         t.replaceAttribute(planet, 'classification', 'terrestrial')
       );
 
@@ -1466,7 +1470,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#update - can accept remote changes', async function(assert) {
+    test('#update - can accept remote changes', async function (assert) {
       assert.expect(3);
 
       let planet = source.requestProcessor.serializer.deserializeResource({
@@ -1496,12 +1500,12 @@ module('JSONAPISource', function() {
         transforms.push(transform);
       });
 
-      let data = await source.update(t =>
+      let data = await source.update((t) =>
         t.replaceAttribute(planet, 'classification', 'terrestrial')
       );
 
       assert.deepEqual(
-        transforms[1].operations.map(o => o.op),
+        transforms[1].operations.map((o) => o.op),
         ['replaceAttribute', 'replaceKey']
       );
       assert.deepEqual(
@@ -1521,7 +1525,7 @@ module('JSONAPISource', function() {
       });
     });
 
-    test('#update - can delete records', async function(assert) {
+    test('#update - can delete records', async function (assert) {
       assert.expect(4);
 
       let planet = source.requestProcessor.serializer.deserializeResource({
@@ -1531,7 +1535,7 @@ module('JSONAPISource', function() {
 
       fetchStub.withArgs('/planets/12345').returns(jsonapiResponse(200));
 
-      await source.update(t => t.removeRecord(planet));
+      await source.update((t) => t.removeRecord(planet));
 
       assert.ok(true, 'record deleted');
       assert.equal(fetchStub.callCount, 1, 'fetch called once');
@@ -1547,7 +1551,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#update - can add a hasMany relationship with POST', async function(assert) {
+    test('#update - can add a hasMany relationship with POST', async function (assert) {
       assert.expect(5);
 
       let planet = source.requestProcessor.serializer.deserializeResource({
@@ -1564,7 +1568,7 @@ module('JSONAPISource', function() {
         .withArgs('/planets/12345/relationships/moons')
         .returns(jsonapiResponse(204));
 
-      await source.update(t => t.addToRelatedRecords(planet, 'moons', moon));
+      await source.update((t) => t.addToRelatedRecords(planet, 'moons', moon));
 
       assert.ok(true, 'records linked');
       assert.equal(fetchStub.callCount, 1, 'fetch called once');
@@ -1585,7 +1589,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#update - can remove a relationship with DELETE', async function(assert) {
+    test('#update - can remove a relationship with DELETE', async function (assert) {
       assert.expect(4);
 
       let planet = source.requestProcessor.serializer.deserializeResource({
@@ -1602,7 +1606,7 @@ module('JSONAPISource', function() {
         .withArgs('/planets/12345/relationships/moons')
         .returns(jsonapiResponse(200));
 
-      await source.update(t =>
+      await source.update((t) =>
         t.removeFromRelatedRecords(planet, 'moons', moon)
       );
 
@@ -1620,7 +1624,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#update - can update a hasOne relationship with PATCH', async function(assert) {
+    test('#update - can update a hasOne relationship with PATCH', async function (assert) {
       assert.expect(5);
 
       let planet = source.requestProcessor.serializer.deserializeResource({
@@ -1635,7 +1639,9 @@ module('JSONAPISource', function() {
 
       fetchStub.withArgs('/moons/987').returns(jsonapiResponse(200));
 
-      await source.update(t => t.replaceRelatedRecord(moon, 'planet', planet));
+      await source.update((t) =>
+        t.replaceRelatedRecord(moon, 'planet', planet)
+      );
 
       assert.ok(true, 'relationship replaced');
 
@@ -1665,7 +1671,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#update - can update a hasOne relationship with PATCH with newly created record', async function(assert) {
+    test('#update - can update a hasOne relationship with PATCH with newly created record', async function (assert) {
       assert.expect(5);
 
       let planet = {
@@ -1691,7 +1697,7 @@ module('JSONAPISource', function() {
 
       fetchStub.withArgs('/moons/987').returns(jsonapiResponse(200));
 
-      await source.update(t => [
+      await source.update((t) => [
         t.addRecord(planet),
         t.replaceRelatedRecord(moon, 'planet', planet)
       ]);
@@ -1724,7 +1730,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#update - can clear a hasOne relationship with PATCH', async function(assert) {
+    test('#update - can clear a hasOne relationship with PATCH', async function (assert) {
       assert.expect(5);
 
       let moon = source.requestProcessor.serializer.deserializeResource({
@@ -1734,7 +1740,7 @@ module('JSONAPISource', function() {
 
       fetchStub.withArgs('/moons/987').returns(jsonapiResponse(200));
 
-      await source.update(t => t.replaceRelatedRecord(moon, 'planet', null));
+      await source.update((t) => t.replaceRelatedRecord(moon, 'planet', null));
 
       assert.ok(true, 'relationship replaced');
 
@@ -1762,7 +1768,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#update - can replace a hasMany relationship with PATCH', async function(assert) {
+    test('#update - can replace a hasMany relationship with PATCH', async function (assert) {
       assert.expect(5);
 
       let planet = source.requestProcessor.serializer.deserializeResource({
@@ -1777,7 +1783,7 @@ module('JSONAPISource', function() {
 
       fetchStub.withArgs('/planets/12345').returns(jsonapiResponse(200));
 
-      await source.update(t =>
+      await source.update((t) =>
         t.replaceRelatedRecords(planet, 'moons', [moon])
       );
 
@@ -1807,7 +1813,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#update - a single transform can result in multiple requests', async function(assert) {
+    test('#update - a single transform can result in multiple requests', async function (assert) {
       assert.expect(6);
 
       let planet1 = source.requestProcessor.serializer.deserializeResource({
@@ -1823,7 +1829,7 @@ module('JSONAPISource', function() {
 
       fetchStub.withArgs('/planets/2').returns(jsonapiResponse(200));
 
-      await source.update(t => [
+      await source.update((t) => [
         t.removeRecord(planet1),
         t.removeRecord(planet2)
       ]);
@@ -1855,7 +1861,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#update - source can limit the number of allowed requests per transform with `maxRequestsPerTransform`', async function(assert) {
+    test('#update - source can limit the number of allowed requests per transform with `maxRequestsPerTransform`', async function (assert) {
       assert.expect(1);
 
       let planet1 = source.requestProcessor.serializer.deserializeResource({
@@ -1870,7 +1876,7 @@ module('JSONAPISource', function() {
       source.maxRequestsPerTransform = 1;
 
       try {
-        await source.update(t => [
+        await source.update((t) => [
           t.removeRecord(planet1),
           t.removeRecord(planet2)
         ]);
@@ -1882,7 +1888,7 @@ module('JSONAPISource', function() {
       }
     });
 
-    test('#update - request can timeout', async function(assert) {
+    test('#update - request can timeout', async function (assert) {
       assert.expect(2);
 
       let planet = source.requestProcessor.serializer.deserializeResource({
@@ -1902,7 +1908,7 @@ module('JSONAPISource', function() {
         .returns(jsonapiResponse(200, null, 20)); // 20ms delay
 
       try {
-        await source.update(t =>
+        await source.update((t) =>
           t.replaceAttribute(planet, 'classification', 'terrestrial')
         );
         assert.ok(false, 'should not be reached');
@@ -1912,7 +1918,7 @@ module('JSONAPISource', function() {
       }
     });
 
-    test('#update - allowed timeout can be specified per-request', async function(assert) {
+    test('#update - allowed timeout can be specified per-request', async function (assert) {
       assert.expect(2);
 
       let planet = source.requestProcessor.serializer.deserializeResource({
@@ -1940,7 +1946,7 @@ module('JSONAPISource', function() {
 
       try {
         await source.update(
-          t => t.replaceAttribute(planet, 'classification', 'terrestrial'),
+          (t) => t.replaceAttribute(planet, 'classification', 'terrestrial'),
           options
         );
         assert.ok(false, 'should not be reached');
@@ -1950,7 +1956,7 @@ module('JSONAPISource', function() {
       }
     });
 
-    test('#update - fetch can reject with a NetworkError', async function(assert) {
+    test('#update - fetch can reject with a NetworkError', async function (assert) {
       assert.expect(2);
 
       let planet = source.requestProcessor.serializer.deserializeResource({
@@ -1965,7 +1971,7 @@ module('JSONAPISource', function() {
       fetchStub.withArgs('/planets/12345').returns(Promise.reject(':('));
 
       try {
-        await source.update(t =>
+        await source.update((t) =>
           t.replaceAttribute(planet, 'classification', 'terrestrial')
         );
         assert.ok(false, 'should not be reached');
@@ -1975,7 +1981,7 @@ module('JSONAPISource', function() {
       }
     });
 
-    test('#update - response can trigger a ClientError', async function(assert) {
+    test('#update - response can trigger a ClientError', async function (assert) {
       assert.expect(3);
 
       let planet = source.requestProcessor.serializer.deserializeResource({
@@ -1999,7 +2005,7 @@ module('JSONAPISource', function() {
         .returns(jsonapiResponse(422, { errors }));
 
       try {
-        await source.update(t =>
+        await source.update((t) =>
           t.replaceAttribute(planet, 'classification', 'terrestrial')
         );
         assert.ok(false, 'should not be reached');
@@ -2010,7 +2016,7 @@ module('JSONAPISource', function() {
       }
     });
 
-    test('#pull - record', async function(assert) {
+    test('#pull - record', async function (assert) {
       assert.expect(6);
 
       const data: Resource = {
@@ -2028,7 +2034,7 @@ module('JSONAPISource', function() {
         .withArgs('/planets/12345')
         .returns(jsonapiResponse(200, { data }));
 
-      let transforms = await source.pull(q =>
+      let transforms = await source.pull((q) =>
         q.findRecord({ type: 'planet', id: planet.id })
       );
 
@@ -2038,7 +2044,7 @@ module('JSONAPISource', function() {
         'log contains transform'
       );
       assert.deepEqual(
-        transforms[0].operations.map(o => o.op),
+        transforms[0].operations.map((o) => o.op),
         ['updateRecord']
       );
       assert.deepEqual(
@@ -2056,7 +2062,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - record (with a 304 response)', async function(assert) {
+    test('#pull - record (with a 304 response)', async function (assert) {
       assert.expect(3);
 
       const planet = source.requestProcessor.serializer.deserializeResource({
@@ -2066,7 +2072,7 @@ module('JSONAPISource', function() {
 
       fetchStub.withArgs('/planets/12345').returns(jsonapiResponse(304));
 
-      let transforms = await source.pull(q =>
+      let transforms = await source.pull((q) =>
         q.findRecord({ type: 'planet', id: planet.id })
       );
 
@@ -2079,7 +2085,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - request can timeout', async function(assert) {
+    test('#pull - request can timeout', async function (assert) {
       assert.expect(2);
 
       const data: Resource = {
@@ -2102,7 +2108,9 @@ module('JSONAPISource', function() {
         .returns(jsonapiResponse(200, { data }, 20)); // 20ms delay
 
       try {
-        await source.pull(q => q.findRecord({ type: 'planet', id: planet.id }));
+        await source.pull((q) =>
+          q.findRecord({ type: 'planet', id: planet.id })
+        );
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof NetworkError, 'Network error raised');
@@ -2110,7 +2118,7 @@ module('JSONAPISource', function() {
       }
     });
 
-    test('#pull - allowed timeout can be specified per-request', async function(assert) {
+    test('#pull - allowed timeout can be specified per-request', async function (assert) {
       assert.expect(2);
 
       const data: Resource = {
@@ -2141,7 +2149,7 @@ module('JSONAPISource', function() {
 
       try {
         await source.pull(
-          q => q.findRecord({ type: 'planet', id: planet.id }),
+          (q) => q.findRecord({ type: 'planet', id: planet.id }),
           options
         );
         assert.ok(false, 'should not be reached');
@@ -2151,7 +2159,7 @@ module('JSONAPISource', function() {
       }
     });
 
-    test('#pull - fetch can reject with a NetworkError', async function(assert) {
+    test('#pull - fetch can reject with a NetworkError', async function (assert) {
       assert.expect(2);
 
       const planet = source.requestProcessor.serializer.deserializeResource({
@@ -2162,7 +2170,9 @@ module('JSONAPISource', function() {
       fetchStub.withArgs('/planets/12345').returns(Promise.reject(':('));
 
       try {
-        await source.pull(q => q.findRecord({ type: 'planet', id: planet.id }));
+        await source.pull((q) =>
+          q.findRecord({ type: 'planet', id: planet.id })
+        );
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof NetworkError, 'Network error raised');
@@ -2170,7 +2180,7 @@ module('JSONAPISource', function() {
       }
     });
 
-    test('#pull - record with include', async function(assert) {
+    test('#pull - record with include', async function (assert) {
       assert.expect(2);
 
       const data: Resource = {
@@ -2198,7 +2208,7 @@ module('JSONAPISource', function() {
         .returns(jsonapiResponse(200, { data }));
 
       await source.pull(
-        q => q.findRecord({ type: 'planet', id: planet.id }),
+        (q) => q.findRecord({ type: 'planet', id: planet.id }),
         options
       );
 
@@ -2210,7 +2220,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - records', async function(assert) {
+    test('#pull - records', async function (assert) {
       assert.expect(6);
 
       const data: Resource[] = [
@@ -2230,7 +2240,7 @@ module('JSONAPISource', function() {
 
       fetchStub.withArgs('/planets').returns(jsonapiResponse(200, { data }));
 
-      let transforms = await source.pull(q => q.findRecords('planet'));
+      let transforms = await source.pull((q) => q.findRecords('planet'));
 
       assert.equal(transforms.length, 1, 'one transform returned');
       assert.ok(
@@ -2238,7 +2248,7 @@ module('JSONAPISource', function() {
         'log contains transform'
       );
       assert.deepEqual(
-        transforms[0].operations.map(o => o.op),
+        transforms[0].operations.map((o) => o.op),
         ['updateRecord', 'updateRecord', 'updateRecord']
       );
       assert.deepEqual(
@@ -2256,12 +2266,12 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - records (with a 304 response)', async function(assert) {
+    test('#pull - records (with a 304 response)', async function (assert) {
       assert.expect(3);
 
       fetchStub.withArgs('/planets').returns(jsonapiResponse(304));
 
-      let transforms = await source.pull(q => q.findRecords('planet'));
+      let transforms = await source.pull((q) => q.findRecords('planet'));
 
       assert.equal(transforms.length, 0, 'no transforms returned');
 
@@ -2273,7 +2283,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - records with attribute filter', async function(assert) {
+    test('#pull - records with attribute filter', async function (assert) {
       assert.expect(5);
 
       const data: Resource[] = [
@@ -2291,13 +2301,13 @@ module('JSONAPISource', function() {
         .withArgs(`/planets?${encodeURIComponent('filter[length-of-day]')}=24`)
         .returns(jsonapiResponse(200, { data }));
 
-      let transforms = await source.pull(q =>
+      let transforms = await source.pull((q) =>
         q.findRecords('planet').filter({ attribute: 'lengthOfDay', value: 24 })
       );
 
       assert.equal(transforms.length, 1, 'one transform returned');
       assert.deepEqual(
-        transforms[0].operations.map(o => o.op),
+        transforms[0].operations.map((o) => o.op),
         ['updateRecord']
       );
       assert.deepEqual(
@@ -2315,7 +2325,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - records with attribute filters', async function(assert) {
+    test('#pull - records with attribute filters', async function (assert) {
       assert.expect(6);
 
       const data: Resource[] = [
@@ -2336,7 +2346,7 @@ module('JSONAPISource', function() {
 
       fetchStub.withArgs(expectedUrl).returns(jsonapiResponse(200, { data }));
 
-      let transforms = await source.pull(q =>
+      let transforms = await source.pull((q) =>
         q
           .findRecords('planet')
           .filter(
@@ -2351,7 +2361,7 @@ module('JSONAPISource', function() {
         'log contains transform'
       );
       assert.deepEqual(
-        transforms[0].operations.map(o => o.op),
+        transforms[0].operations.map((o) => o.op),
         ['updateRecord']
       );
       assert.deepEqual(
@@ -2369,7 +2379,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - records with relatedRecord filter (single value)', async function(assert) {
+    test('#pull - records with relatedRecord filter (single value)', async function (assert) {
       assert.expect(6);
 
       const data: Resource[] = [
@@ -2387,7 +2397,7 @@ module('JSONAPISource', function() {
         .withArgs(`/moons?${encodeURIComponent('filter[planet]')}=earth`)
         .returns(jsonapiResponse(200, { data }));
 
-      let transforms = await source.pull(q =>
+      let transforms = await source.pull((q) =>
         q.findRecords('moon').filter({
           relation: 'planet',
           record: { id: 'earth', type: 'planets' }
@@ -2400,7 +2410,7 @@ module('JSONAPISource', function() {
         'log contains transform'
       );
       assert.deepEqual(
-        transforms[0].operations.map(o => o.op),
+        transforms[0].operations.map((o) => o.op),
         ['updateRecord']
       );
       assert.deepEqual(
@@ -2418,7 +2428,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - records with relatedRecord filter (multiple values)', async function(assert) {
+    test('#pull - records with relatedRecord filter (multiple values)', async function (assert) {
       assert.expect(6);
 
       const data: Resource[] = [
@@ -2456,7 +2466,7 @@ module('JSONAPISource', function() {
         )
         .returns(jsonapiResponse(200, { data }));
 
-      let transforms = await source.pull(q =>
+      let transforms = await source.pull((q) =>
         q.findRecords('moon').filter({
           relation: 'planet',
           record: [
@@ -2472,7 +2482,7 @@ module('JSONAPISource', function() {
         'log contains transform'
       );
       assert.deepEqual(
-        transforms[0].operations.map(o => o.op),
+        transforms[0].operations.map((o) => o.op),
         ['updateRecord', 'updateRecord', 'updateRecord']
       );
       assert.deepEqual(
@@ -2490,7 +2500,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - records with relatedRecords filter', async function(assert) {
+    test('#pull - records with relatedRecords filter', async function (assert) {
       assert.expect(6);
 
       const data: Resource[] = [
@@ -2517,7 +2527,7 @@ module('JSONAPISource', function() {
         )
         .returns(jsonapiResponse(200, { data }));
 
-      let transforms = await source.pull(q =>
+      let transforms = await source.pull((q) =>
         q.findRecords('planet').filter({
           relation: 'moons',
           records: [
@@ -2534,7 +2544,7 @@ module('JSONAPISource', function() {
         'log contains transform'
       );
       assert.deepEqual(
-        transforms[0].operations.map(o => o.op),
+        transforms[0].operations.map((o) => o.op),
         ['updateRecord']
       );
       assert.deepEqual(
@@ -2552,7 +2562,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - records with sort by an attribute in ascending order', async function(assert) {
+    test('#pull - records with sort by an attribute in ascending order', async function (assert) {
       assert.expect(6);
 
       const data: Resource[] = [
@@ -2574,7 +2584,7 @@ module('JSONAPISource', function() {
         .withArgs('/planets?sort=name')
         .returns(jsonapiResponse(200, { data }));
 
-      let transforms = await source.pull(q =>
+      let transforms = await source.pull((q) =>
         q.findRecords('planet').sort('name')
       );
 
@@ -2584,7 +2594,7 @@ module('JSONAPISource', function() {
         'log contains transform'
       );
       assert.deepEqual(
-        transforms[0].operations.map(o => o.op),
+        transforms[0].operations.map((o) => o.op),
         ['updateRecord', 'updateRecord', 'updateRecord']
       );
       assert.deepEqual(
@@ -2602,7 +2612,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - records with sort by an attribute in descending order', async function(assert) {
+    test('#pull - records with sort by an attribute in descending order', async function (assert) {
       assert.expect(6);
 
       const data: Resource[] = [
@@ -2624,7 +2634,7 @@ module('JSONAPISource', function() {
         .withArgs('/planets?sort=-name')
         .returns(jsonapiResponse(200, { data }));
 
-      let transforms = await source.pull(q =>
+      let transforms = await source.pull((q) =>
         q.findRecords('planet').sort('-name')
       );
 
@@ -2634,7 +2644,7 @@ module('JSONAPISource', function() {
         'log contains transform'
       );
       assert.deepEqual(
-        transforms[0].operations.map(o => o.op),
+        transforms[0].operations.map((o) => o.op),
         ['updateRecord', 'updateRecord', 'updateRecord']
       );
       assert.deepEqual(
@@ -2652,7 +2662,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - records with sort by multiple fields', async function(assert) {
+    test('#pull - records with sort by multiple fields', async function (assert) {
       assert.expect(6);
 
       const data: Resource[] = [
@@ -2686,7 +2696,7 @@ module('JSONAPISource', function() {
         .withArgs(`/planets?sort=${encodeURIComponent('length-of-day,name')}`)
         .returns(jsonapiResponse(200, { data }));
 
-      let transforms = await source.pull(q =>
+      let transforms = await source.pull((q) =>
         q.findRecords('planet').sort('lengthOfDay', 'name')
       );
 
@@ -2696,7 +2706,7 @@ module('JSONAPISource', function() {
         'log contains transform'
       );
       assert.deepEqual(
-        transforms[0].operations.map(o => o.op),
+        transforms[0].operations.map((o) => o.op),
         ['updateRecord', 'updateRecord', 'updateRecord']
       );
       assert.deepEqual(
@@ -2714,7 +2724,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - records with pagination', async function(assert) {
+    test('#pull - records with pagination', async function (assert) {
       assert.expect(6);
 
       const data: Resource[] = [
@@ -2740,7 +2750,7 @@ module('JSONAPISource', function() {
         )
         .returns(jsonapiResponse(200, { data }));
 
-      let transforms = await source.pull(q =>
+      let transforms = await source.pull((q) =>
         q.findRecords('planet').page({ offset: 1, limit: 10 })
       );
 
@@ -2750,7 +2760,7 @@ module('JSONAPISource', function() {
         'log contains transform'
       );
       assert.deepEqual(
-        transforms[0].operations.map(o => o.op),
+        transforms[0].operations.map((o) => o.op),
         ['updateRecord', 'updateRecord', 'updateRecord']
       );
       assert.deepEqual(
@@ -2768,7 +2778,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - related records with attribute filter', async function(assert) {
+    test('#pull - related records with attribute filter', async function (assert) {
       assert.expect(6);
 
       const solarSystem = source.requestProcessor.serializer.deserializeResource(
@@ -2805,7 +2815,7 @@ module('JSONAPISource', function() {
         )
         .returns(jsonapiResponse(200, { data }));
 
-      let transforms = await source.pull(q =>
+      let transforms = await source.pull((q) =>
         q
           .findRelatedRecords(solarSystem, 'planets')
           .filter({ attribute: 'lengthOfDay', value: 24 })
@@ -2817,7 +2827,7 @@ module('JSONAPISource', function() {
         'log contains transform'
       );
       assert.deepEqual(
-        transforms[0].operations.map(o => o.op),
+        transforms[0].operations.map((o) => o.op),
         ['updateRecord', 'addToRelatedRecords']
       );
 
@@ -2833,7 +2843,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - related records with attribute filters', async function(assert) {
+    test('#pull - related records with attribute filters', async function (assert) {
       assert.expect(6);
 
       const solarSystem = source.requestProcessor.serializer.deserializeResource(
@@ -2861,7 +2871,7 @@ module('JSONAPISource', function() {
 
       fetchStub.withArgs(expectedUrl).returns(jsonapiResponse(200, { data }));
 
-      let transforms = await source.pull(q =>
+      let transforms = await source.pull((q) =>
         q
           .findRelatedRecords(solarSystem, 'planets')
           .filter(
@@ -2876,7 +2886,7 @@ module('JSONAPISource', function() {
         'log contains transform'
       );
       assert.deepEqual(
-        transforms[0].operations.map(o => o.op),
+        transforms[0].operations.map((o) => o.op),
         ['updateRecord', 'addToRelatedRecords']
       );
 
@@ -2892,7 +2902,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - records with relatedRecord filter (single value)', async function(assert) {
+    test('#pull - records with relatedRecord filter (single value)', async function (assert) {
       assert.expect(6);
 
       const solarSystem = source.requestProcessor.serializer.deserializeResource(
@@ -2921,7 +2931,7 @@ module('JSONAPISource', function() {
         )
         .returns(jsonapiResponse(200, { data }));
 
-      let transforms = await source.pull(q =>
+      let transforms = await source.pull((q) =>
         q.findRelatedRecords(solarSystem, 'moons').filter({
           relation: 'planet',
           record: { id: 'earth', type: 'planet' }
@@ -2934,7 +2944,7 @@ module('JSONAPISource', function() {
         'log contains transform'
       );
       assert.deepEqual(
-        transforms[0].operations.map(o => o.op),
+        transforms[0].operations.map((o) => o.op),
         ['updateRecord', 'addToRelatedRecords']
       );
 
@@ -2950,7 +2960,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - records with relatedRecord filter (multiple values)', async function(assert) {
+    test('#pull - records with relatedRecord filter (multiple values)', async function (assert) {
       assert.expect(6);
 
       const solarSystem = source.requestProcessor.serializer.deserializeResource(
@@ -2995,7 +3005,7 @@ module('JSONAPISource', function() {
         )
         .returns(jsonapiResponse(200, { data }));
 
-      let transforms = await source.pull(q =>
+      let transforms = await source.pull((q) =>
         q.findRelatedRecords(solarSystem, 'moons').filter({
           relation: 'planet',
           record: [
@@ -3011,7 +3021,7 @@ module('JSONAPISource', function() {
         'log contains transform'
       );
       assert.deepEqual(
-        transforms[0].operations.map(o => o.op),
+        transforms[0].operations.map((o) => o.op),
         [
           'updateRecord',
           'updateRecord',
@@ -3027,7 +3037,7 @@ module('JSONAPISource', function() {
       let op3 = transforms[0].operations[2] as UpdateRecordOperation;
 
       assert.deepEqual(
-        [op1, op2, op3].map(o => o.record.attributes.name),
+        [op1, op2, op3].map((o) => o.record.attributes.name),
         ['Moon', 'Phobos', 'Deimos']
       );
 
@@ -3039,7 +3049,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - records with relatedRecords filter', async function(assert) {
+    test('#pull - records with relatedRecords filter', async function (assert) {
       assert.expect(6);
 
       const solarSystem = source.requestProcessor.serializer.deserializeResource(
@@ -3073,7 +3083,7 @@ module('JSONAPISource', function() {
         )
         .returns(jsonapiResponse(200, { data }));
 
-      let transforms = await source.pull(q =>
+      let transforms = await source.pull((q) =>
         q.findRelatedRecords(solarSystem, 'planets').filter({
           relation: 'moons',
           records: [
@@ -3090,7 +3100,7 @@ module('JSONAPISource', function() {
         'log contains transform'
       );
       assert.deepEqual(
-        transforms[0].operations.map(o => o.op),
+        transforms[0].operations.map((o) => o.op),
         ['updateRecord', 'addToRelatedRecords']
       );
 
@@ -3106,7 +3116,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - records with sort by an attribute in ascending order', async function(assert) {
+    test('#pull - records with sort by an attribute in ascending order', async function (assert) {
       assert.expect(6);
 
       const solarSystem = source.requestProcessor.serializer.deserializeResource(
@@ -3135,7 +3145,7 @@ module('JSONAPISource', function() {
         .withArgs('/solar-systems/sun/planets?sort=name')
         .returns(jsonapiResponse(200, { data }));
 
-      let transforms = await source.pull(q =>
+      let transforms = await source.pull((q) =>
         q.findRelatedRecords(solarSystem, 'planets').sort('name')
       );
 
@@ -3145,7 +3155,7 @@ module('JSONAPISource', function() {
         'log contains transform'
       );
       assert.deepEqual(
-        transforms[0].operations.map(o => o.op),
+        transforms[0].operations.map((o) => o.op),
         [
           'updateRecord',
           'updateRecord',
@@ -3161,7 +3171,7 @@ module('JSONAPISource', function() {
       let op3 = transforms[0].operations[2] as UpdateRecordOperation;
 
       assert.deepEqual(
-        [op1, op2, op3].map(o => o.record.attributes.name),
+        [op1, op2, op3].map((o) => o.record.attributes.name),
         ['Earth', 'Jupiter', 'Saturn']
       );
 
@@ -3173,7 +3183,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - records with sort by an attribute in descending order', async function(assert) {
+    test('#pull - records with sort by an attribute in descending order', async function (assert) {
       assert.expect(6);
 
       const solarSystem = source.requestProcessor.serializer.deserializeResource(
@@ -3202,7 +3212,7 @@ module('JSONAPISource', function() {
         .withArgs('/solar-systems/sun/planets?sort=-name')
         .returns(jsonapiResponse(200, { data }));
 
-      let transforms = await source.pull(q =>
+      let transforms = await source.pull((q) =>
         q.findRelatedRecords(solarSystem, 'planets').sort('-name')
       );
 
@@ -3212,7 +3222,7 @@ module('JSONAPISource', function() {
         'log contains transform'
       );
       assert.deepEqual(
-        transforms[0].operations.map(o => o.op),
+        transforms[0].operations.map((o) => o.op),
         [
           'updateRecord',
           'updateRecord',
@@ -3228,7 +3238,7 @@ module('JSONAPISource', function() {
       let op3 = transforms[0].operations[2] as UpdateRecordOperation;
 
       assert.deepEqual(
-        [op1, op2, op3].map(o => o.record.attributes.name),
+        [op1, op2, op3].map((o) => o.record.attributes.name),
         ['Saturn', 'Jupiter', 'Earth']
       );
 
@@ -3240,7 +3250,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - records with sort by multiple fields', async function(assert) {
+    test('#pull - records with sort by multiple fields', async function (assert) {
       assert.expect(6);
 
       const solarSystem = source.requestProcessor.serializer.deserializeResource(
@@ -3285,7 +3295,7 @@ module('JSONAPISource', function() {
         )
         .returns(jsonapiResponse(200, { data }));
 
-      let transforms = await source.pull(q =>
+      let transforms = await source.pull((q) =>
         q.findRelatedRecords(solarSystem, 'planets').sort('lengthOfDay', 'name')
       );
 
@@ -3295,7 +3305,7 @@ module('JSONAPISource', function() {
         'log contains transform'
       );
       assert.deepEqual(
-        transforms[0].operations.map(o => o.op),
+        transforms[0].operations.map((o) => o.op),
         [
           'updateRecord',
           'updateRecord',
@@ -3311,7 +3321,7 @@ module('JSONAPISource', function() {
       let op3 = transforms[0].operations[2] as UpdateRecordOperation;
 
       assert.deepEqual(
-        [op1, op2, op3].map(o => o.record.attributes.name),
+        [op1, op2, op3].map((o) => o.record.attributes.name),
         ['Jupiter', 'Saturn', 'Earth']
       );
 
@@ -3323,7 +3333,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - records with pagination', async function(assert) {
+    test('#pull - records with pagination', async function (assert) {
       assert.expect(6);
 
       const solarSystem = source.requestProcessor.serializer.deserializeResource(
@@ -3356,7 +3366,7 @@ module('JSONAPISource', function() {
         )
         .returns(jsonapiResponse(200, { data }));
 
-      let transforms = await source.pull(q =>
+      let transforms = await source.pull((q) =>
         q
           .findRelatedRecords(solarSystem, 'planets')
           .page({ offset: 1, limit: 10 })
@@ -3368,7 +3378,7 @@ module('JSONAPISource', function() {
         'log contains transform'
       );
       assert.deepEqual(
-        transforms[0].operations.map(o => o.op),
+        transforms[0].operations.map((o) => o.op),
         [
           'updateRecord',
           'updateRecord',
@@ -3384,7 +3394,7 @@ module('JSONAPISource', function() {
       let op3 = transforms[0].operations[2] as UpdateRecordOperation;
 
       assert.deepEqual(
-        [op1, op2, op3].map(o => o.record.attributes.name),
+        [op1, op2, op3].map((o) => o.record.attributes.name),
         ['Jupiter', 'Earth', 'Saturn']
       );
 
@@ -3396,7 +3406,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - records with include', async function(assert) {
+    test('#pull - records with include', async function (assert) {
       assert.expect(2);
 
       const options = {
@@ -3411,7 +3421,7 @@ module('JSONAPISource', function() {
         .withArgs('/planets?include=moons')
         .returns(jsonapiResponse(200, { data: [] }));
 
-      await source.pull(q => q.findRecords('planet'), options);
+      await source.pull((q) => q.findRecords('planet'), options);
 
       assert.equal(fetchStub.callCount, 1, 'fetch called once');
       assert.equal(
@@ -3421,7 +3431,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - records with include many relationships', async function(assert) {
+    test('#pull - records with include many relationships', async function (assert) {
       assert.expect(2);
 
       const options = {
@@ -3438,7 +3448,7 @@ module('JSONAPISource', function() {
         )
         .returns(jsonapiResponse(200, { data: [] }));
 
-      await source.pull(q => q.findRecords('planet'), options);
+      await source.pull((q) => q.findRecords('planet'), options);
 
       assert.equal(fetchStub.callCount, 1, 'fetch called once');
       assert.equal(
@@ -3448,7 +3458,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - relatedRecord', async function(assert) {
+    test('#pull - relatedRecord', async function (assert) {
       assert.expect(13);
 
       const planetRecord: Record = source.requestProcessor.serializer.deserialize(
@@ -3472,7 +3482,7 @@ module('JSONAPISource', function() {
         .withArgs('/planets/jupiter/solar-system')
         .returns(jsonapiResponse(200, { data }));
 
-      let transforms = await source.pull(q =>
+      let transforms = await source.pull((q) =>
         q.findRelatedRecord(planetRecord, 'solarSystem')
       );
 
@@ -3487,7 +3497,7 @@ module('JSONAPISource', function() {
       const ssId = keyMap.keyToId('solarSystem', 'remoteId', 'ours');
 
       assert.deepEqual(
-        operations.map(o => o.op),
+        operations.map((o) => o.op),
         ['updateRecord', 'replaceRelatedRecord']
       );
 
@@ -3511,7 +3521,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - relatedRecords', async function(assert) {
+    test('#pull - relatedRecords', async function (assert) {
       assert.expect(9);
 
       let planetRecord: Record = source.requestProcessor.serializer.deserialize(
@@ -3537,7 +3547,7 @@ module('JSONAPISource', function() {
         .withArgs('/planets/jupiter/moons')
         .returns(jsonapiResponse(200, { data }));
 
-      let transforms = await source.pull(q =>
+      let transforms = await source.pull((q) =>
         q.findRelatedRecords(planetRecord, 'moons')
       );
 
@@ -3547,7 +3557,7 @@ module('JSONAPISource', function() {
         'log contains transform'
       );
       assert.deepEqual(
-        transforms[0].operations.map(o => o.op),
+        transforms[0].operations.map((o) => o.op),
         ['updateRecord', 'replaceRelatedRecords']
       );
 
@@ -3558,7 +3568,7 @@ module('JSONAPISource', function() {
       assert.equal(op2.record.id, planetRecord.id);
       assert.equal(op2.relationship, 'moons');
       assert.deepEqual(
-        op2.relatedRecords.map(r => r.id),
+        op2.relatedRecords.map((r) => r.id),
         [op1.record.id]
       );
 
@@ -3570,7 +3580,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#pull - relatedRecords with include', async function(assert) {
+    test('#pull - relatedRecords with include', async function (assert) {
       assert.expect(2);
 
       const planetRecord = source.requestProcessor.serializer.deserialize({
@@ -3593,7 +3603,7 @@ module('JSONAPISource', function() {
         .returns(jsonapiResponse(200, { data: [] }));
 
       await source.pull(
-        q => q.findRelatedRecords(planetRecord, 'moons'),
+        (q) => q.findRelatedRecords(planetRecord, 'moons'),
         options
       );
 
@@ -3605,7 +3615,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - record', async function(assert) {
+    test('#query - record', async function (assert) {
       assert.expect(4);
 
       const data: Resource = {
@@ -3623,7 +3633,7 @@ module('JSONAPISource', function() {
         .withArgs('/planets/12345')
         .returns(jsonapiResponse(200, { data }));
 
-      let record = await source.query(q =>
+      let record = await source.query((q) =>
         q.findRecord({ type: 'planet', id: planet.id })
       );
 
@@ -3641,7 +3651,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - record (304 response)', async function(assert) {
+    test('#query - record (304 response)', async function (assert) {
       assert.expect(3);
 
       const planet = source.requestProcessor.serializer.deserializeResource({
@@ -3651,7 +3661,7 @@ module('JSONAPISource', function() {
 
       fetchStub.withArgs('/planets/12345').returns(jsonapiResponse(304));
 
-      let record = await source.query(q =>
+      let record = await source.query((q) =>
         q.findRecord({ type: 'planet', id: planet.id })
       );
 
@@ -3665,7 +3675,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - can query with multiple expressions', async function(assert) {
+    test('#query - can query with multiple expressions', async function (assert) {
       assert.expect(6);
 
       const data1: Resource = {
@@ -3697,7 +3707,7 @@ module('JSONAPISource', function() {
         .withArgs('/planets/1234')
         .returns(jsonapiResponse(200, { data: data2 }));
 
-      let records = await source.query(q => [
+      let records = await source.query((q) => [
         q.findRecord({ type: 'planet', id: planet1.id }),
         q.findRecord({ type: 'planet', id: planet2.id })
       ]);
@@ -3719,7 +3729,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - invokes preprocessResponseDocument when response has content', async function(assert) {
+    test('#query - invokes preprocessResponseDocument when response has content', async function (assert) {
       assert.expect(1);
 
       const data: Resource = {
@@ -3746,7 +3756,9 @@ module('JSONAPISource', function() {
         'preprocessResponseDocument'
       );
 
-      await source.query(q => q.findRecord({ type: 'planet', id: planet.id }));
+      await source.query((q) =>
+        q.findRecord({ type: 'planet', id: planet.id })
+      );
 
       assert.ok(
         preprocessResponseDocumentSpy.calledOnceWith(
@@ -3757,7 +3769,7 @@ module('JSONAPISource', function() {
       preprocessResponseDocumentSpy.restore();
     });
 
-    test('#query - request can timeout', async function(assert) {
+    test('#query - request can timeout', async function (assert) {
       assert.expect(2);
 
       const data: Resource = {
@@ -3780,7 +3792,7 @@ module('JSONAPISource', function() {
         .returns(jsonapiResponse(200, { data }, 20)); // 20ms delay
 
       try {
-        await source.query(q =>
+        await source.query((q) =>
           q.findRecord({ type: 'planet', id: planet.id })
         );
         assert.ok(false, 'should not be reached');
@@ -3790,7 +3802,7 @@ module('JSONAPISource', function() {
       }
     });
 
-    test('#query - allowed timeout can be specified per-request', async function(assert) {
+    test('#query - allowed timeout can be specified per-request', async function (assert) {
       assert.expect(2);
 
       const data: Resource = {
@@ -3821,7 +3833,7 @@ module('JSONAPISource', function() {
 
       try {
         await source.query(
-          q => q.findRecord({ type: 'planet', id: planet.id }),
+          (q) => q.findRecord({ type: 'planet', id: planet.id }),
           options
         );
         assert.ok(false, 'should not be reached');
@@ -3831,7 +3843,7 @@ module('JSONAPISource', function() {
       }
     });
 
-    test('#query - fetch can reject with a NetworkError', async function(assert) {
+    test('#query - fetch can reject with a NetworkError', async function (assert) {
       assert.expect(2);
 
       const planet = source.requestProcessor.serializer.deserializeResource({
@@ -3842,7 +3854,7 @@ module('JSONAPISource', function() {
       fetchStub.withArgs('/planets/12345').returns(Promise.reject(':('));
 
       try {
-        await source.query(q =>
+        await source.query((q) =>
           q.findRecord({ type: 'planet', id: planet.id })
         );
         assert.ok(false, 'should not be reached');
@@ -3852,7 +3864,7 @@ module('JSONAPISource', function() {
       }
     });
 
-    test('#query - record with include', async function(assert) {
+    test('#query - record with include', async function (assert) {
       assert.expect(2);
 
       const data: Resource = {
@@ -3880,7 +3892,7 @@ module('JSONAPISource', function() {
         .returns(jsonapiResponse(200, { data }));
 
       await source.query(
-        q => q.findRecord({ type: 'planet', id: planet.id }),
+        (q) => q.findRecord({ type: 'planet', id: planet.id }),
         options
       );
 
@@ -3892,7 +3904,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - options can be passed in at the root level or source-specific level', async function(assert) {
+    test('#query - options can be passed in at the root level or source-specific level', async function (assert) {
       assert.expect(1);
 
       const data: Resource = {
@@ -3911,15 +3923,18 @@ module('JSONAPISource', function() {
         .withArgs('/planets/12345?include=moons')
         .returns(jsonapiResponse(200, { data }));
 
-      await source.query(q => q.findRecord({ type: 'planet', id: planet.id }), {
-        label: 'Fetch planet with moons',
-        include: ['moons']
-      });
+      await source.query(
+        (q) => q.findRecord({ type: 'planet', id: planet.id }),
+        {
+          label: 'Fetch planet with moons',
+          include: ['moons']
+        }
+      );
 
       assert.equal(fetchStub.callCount, 1, 'fetch called once');
     });
 
-    test('#query - records', async function(assert) {
+    test('#query - records', async function (assert) {
       assert.expect(5);
 
       const data: Resource[] = [
@@ -3939,12 +3954,14 @@ module('JSONAPISource', function() {
 
       fetchStub.withArgs('/planets').returns(jsonapiResponse(200, { data }));
 
-      let records: Record[] = await source.query(q => q.findRecords('planet'));
+      let records: Record[] = await source.query((q) =>
+        q.findRecords('planet')
+      );
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
       assert.deepEqual(
-        records.map(o => o.attributes.name),
+        records.map((o) => o.attributes.name),
         ['Jupiter', 'Earth', 'Saturn']
       );
 
@@ -3956,12 +3973,12 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - records (304 response)', async function(assert) {
+    test('#query - records (304 response)', async function (assert) {
       assert.expect(3);
 
       fetchStub.withArgs('/planets').returns(jsonapiResponse(304));
 
-      let records = await source.query(q => q.findRecords('planet'));
+      let records = await source.query((q) => q.findRecords('planet'));
 
       assert.strictEqual(records, undefined);
 
@@ -3973,7 +3990,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - records with attribute filter', async function(assert) {
+    test('#query - records with attribute filter', async function (assert) {
       assert.expect(5);
 
       const data: Resource[] = [
@@ -3991,14 +4008,14 @@ module('JSONAPISource', function() {
         .withArgs(`/planets?${encodeURIComponent('filter[length-of-day]')}=24`)
         .returns(jsonapiResponse(200, { data }));
 
-      let records: Record[] = await source.query(q =>
+      let records: Record[] = await source.query((q) =>
         q.findRecords('planet').filter({ attribute: 'lengthOfDay', value: 24 })
       );
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 1, 'one objects in data returned');
       assert.deepEqual(
-        records.map(o => o.attributes.name),
+        records.map((o) => o.attributes.name),
         ['Earth']
       );
 
@@ -4010,7 +4027,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - records with relatedRecord filter (single value)', async function(assert) {
+    test('#query - records with relatedRecord filter (single value)', async function (assert) {
       assert.expect(5);
 
       const data: Resource[] = [
@@ -4028,7 +4045,7 @@ module('JSONAPISource', function() {
         .withArgs(`/moons?${encodeURIComponent('filter[planet]')}=earth`)
         .returns(jsonapiResponse(200, { data }));
 
-      let records: Record[] = await source.query(q =>
+      let records: Record[] = await source.query((q) =>
         q.findRecords('moon').filter({
           relation: 'planet',
           record: { id: 'earth', type: 'planets' }
@@ -4038,7 +4055,7 @@ module('JSONAPISource', function() {
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 1, 'one objects in data returned');
       assert.deepEqual(
-        records.map(o => o.attributes.name),
+        records.map((o) => o.attributes.name),
         ['Moon']
       );
 
@@ -4050,7 +4067,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - records with relatedRecord filter (multiple values)', async function(assert) {
+    test('#query - records with relatedRecord filter (multiple values)', async function (assert) {
       assert.expect(5);
 
       const data: Resource[] = [
@@ -4088,7 +4105,7 @@ module('JSONAPISource', function() {
         )
         .returns(jsonapiResponse(200, { data }));
 
-      let records: Record[] = await source.query(q =>
+      let records: Record[] = await source.query((q) =>
         q.findRecords('moon').filter({
           relation: 'planet',
           record: [
@@ -4101,7 +4118,7 @@ module('JSONAPISource', function() {
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
       assert.deepEqual(
-        records.map(o => o.attributes.name),
+        records.map((o) => o.attributes.name),
         ['Moon', 'Phobos', 'Deimos']
       );
 
@@ -4113,7 +4130,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - records with relatedRecords filter', async function(assert) {
+    test('#query - records with relatedRecords filter', async function (assert) {
       assert.expect(5);
 
       const data: Resource[] = [
@@ -4140,7 +4157,7 @@ module('JSONAPISource', function() {
         )
         .returns(jsonapiResponse(200, { data }));
 
-      let records: Record[] = await source.query(q =>
+      let records: Record[] = await source.query((q) =>
         q.findRecords('planet').filter({
           relation: 'moons',
           records: [
@@ -4154,7 +4171,7 @@ module('JSONAPISource', function() {
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 1, 'one objects in data returned');
       assert.deepEqual(
-        records.map(o => o.attributes.name),
+        records.map((o) => o.attributes.name),
         ['Mars']
       );
 
@@ -4166,7 +4183,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - records with sort by an attribute in ascending order', async function(assert) {
+    test('#query - records with sort by an attribute in ascending order', async function (assert) {
       assert.expect(5);
 
       const data: Resource[] = [
@@ -4188,14 +4205,14 @@ module('JSONAPISource', function() {
         .withArgs('/planets?sort=name')
         .returns(jsonapiResponse(200, { data }));
 
-      let records: Record[] = await source.query(q =>
+      let records: Record[] = await source.query((q) =>
         q.findRecords('planet').sort('name')
       );
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
       assert.deepEqual(
-        records.map(o => o.attributes.name),
+        records.map((o) => o.attributes.name),
         ['Earth', 'Jupiter', 'Saturn']
       );
 
@@ -4207,7 +4224,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - records with sort by an attribute in descending order', async function(assert) {
+    test('#query - records with sort by an attribute in descending order', async function (assert) {
       assert.expect(5);
 
       const data: Resource[] = [
@@ -4229,14 +4246,14 @@ module('JSONAPISource', function() {
         .withArgs('/planets?sort=-name')
         .returns(jsonapiResponse(200, { data }));
 
-      let records: Record[] = await source.query(q =>
+      let records: Record[] = await source.query((q) =>
         q.findRecords('planet').sort('-name')
       );
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
       assert.deepEqual(
-        records.map(o => o.attributes.name),
+        records.map((o) => o.attributes.name),
         ['Saturn', 'Jupiter', 'Earth']
       );
 
@@ -4248,7 +4265,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - records with sort by multiple fields', async function(assert) {
+    test('#query - records with sort by multiple fields', async function (assert) {
       assert.expect(5);
 
       const data: Resource[] = [
@@ -4282,14 +4299,14 @@ module('JSONAPISource', function() {
         .withArgs(`/planets?sort=${encodeURIComponent('length-of-day,name')}`)
         .returns(jsonapiResponse(200, { data }));
 
-      let records: Record[] = await source.query(q =>
+      let records: Record[] = await source.query((q) =>
         q.findRecords('planet').sort('lengthOfDay', 'name')
       );
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
       assert.deepEqual(
-        records.map(o => o.attributes.name),
+        records.map((o) => o.attributes.name),
         ['Jupiter', 'Saturn', 'Earth']
       );
 
@@ -4301,7 +4318,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - records with pagination', async function(assert) {
+    test('#query - records with pagination', async function (assert) {
       assert.expect(5);
 
       const data: Resource[] = [
@@ -4327,14 +4344,14 @@ module('JSONAPISource', function() {
         )
         .returns(jsonapiResponse(200, { data }));
 
-      let records: Record[] = await source.query(q =>
+      let records: Record[] = await source.query((q) =>
         q.findRecords('planet').page({ offset: 1, limit: 10 })
       );
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
       assert.deepEqual(
-        records.map(o => o.attributes.name),
+        records.map((o) => o.attributes.name),
         ['Jupiter', 'Earth', 'Saturn']
       );
 
@@ -4346,7 +4363,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - related records with attribute filter', async function(assert) {
+    test('#query - related records with attribute filter', async function (assert) {
       assert.expect(5);
 
       const solarSystem = source.requestProcessor.serializer.deserializeResource(
@@ -4383,7 +4400,7 @@ module('JSONAPISource', function() {
         )
         .returns(jsonapiResponse(200, { data }));
 
-      let records: Record[] = await source.query(q =>
+      let records: Record[] = await source.query((q) =>
         q
           .findRelatedRecords(solarSystem, 'planets')
           .filter({ attribute: 'lengthOfDay', value: 24 })
@@ -4392,7 +4409,7 @@ module('JSONAPISource', function() {
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 1, 'one objects in data returned');
       assert.deepEqual(
-        records.map(o => o.attributes.name),
+        records.map((o) => o.attributes.name),
         ['Earth']
       );
 
@@ -4404,7 +4421,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - related records with relatedRecord filter (single value)', async function(assert) {
+    test('#query - related records with relatedRecord filter (single value)', async function (assert) {
       assert.expect(5);
 
       const solarSystem = source.requestProcessor.serializer.deserializeResource(
@@ -4433,7 +4450,7 @@ module('JSONAPISource', function() {
         )
         .returns(jsonapiResponse(200, { data }));
 
-      let records: Record[] = await source.query(q =>
+      let records: Record[] = await source.query((q) =>
         q.findRelatedRecords(solarSystem, 'moons').filter({
           relation: 'planet',
           record: { id: 'earth', type: 'planets' }
@@ -4443,7 +4460,7 @@ module('JSONAPISource', function() {
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 1, 'one objects in data returned');
       assert.deepEqual(
-        records.map(o => o.attributes.name),
+        records.map((o) => o.attributes.name),
         ['Moon']
       );
 
@@ -4455,7 +4472,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - related records with relatedRecord filter (multiple values)', async function(assert) {
+    test('#query - related records with relatedRecord filter (multiple values)', async function (assert) {
       assert.expect(5);
 
       const solarSystem = source.requestProcessor.serializer.deserializeResource(
@@ -4500,7 +4517,7 @@ module('JSONAPISource', function() {
         )
         .returns(jsonapiResponse(200, { data }));
 
-      let records: Record[] = await source.query(q =>
+      let records: Record[] = await source.query((q) =>
         q.findRelatedRecords(solarSystem, 'moons').filter({
           relation: 'planet',
           record: [
@@ -4513,7 +4530,7 @@ module('JSONAPISource', function() {
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
       assert.deepEqual(
-        records.map(o => o.attributes.name),
+        records.map((o) => o.attributes.name),
         ['Moon', 'Phobos', 'Deimos']
       );
 
@@ -4525,7 +4542,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - related records with relatedRecords filter', async function(assert) {
+    test('#query - related records with relatedRecords filter', async function (assert) {
       assert.expect(5);
 
       const solarSystem = source.requestProcessor.serializer.deserializeResource(
@@ -4559,7 +4576,7 @@ module('JSONAPISource', function() {
         )
         .returns(jsonapiResponse(200, { data }));
 
-      let records: Record[] = await source.query(q =>
+      let records: Record[] = await source.query((q) =>
         q.findRelatedRecords(solarSystem, 'planets').filter({
           relation: 'moons',
           records: [
@@ -4573,7 +4590,7 @@ module('JSONAPISource', function() {
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 1, 'one objects in data returned');
       assert.deepEqual(
-        records.map(o => o.attributes.name),
+        records.map((o) => o.attributes.name),
         ['Mars']
       );
 
@@ -4585,7 +4602,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - related records with sort by an attribute in ascending order', async function(assert) {
+    test('#query - related records with sort by an attribute in ascending order', async function (assert) {
       assert.expect(5);
 
       const solarSystem = source.requestProcessor.serializer.deserializeResource(
@@ -4614,14 +4631,14 @@ module('JSONAPISource', function() {
         .withArgs('/solar-systems/sun/planets?sort=name')
         .returns(jsonapiResponse(200, { data }));
 
-      let records: Record[] = await source.query(q =>
+      let records: Record[] = await source.query((q) =>
         q.findRelatedRecords(solarSystem, 'planets').sort('name')
       );
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
       assert.deepEqual(
-        records.map(o => o.attributes.name),
+        records.map((o) => o.attributes.name),
         ['Earth', 'Jupiter', 'Saturn']
       );
 
@@ -4633,7 +4650,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - related records with sort by an attribute in descending order', async function(assert) {
+    test('#query - related records with sort by an attribute in descending order', async function (assert) {
       assert.expect(5);
 
       const solarSystem = source.requestProcessor.serializer.deserializeResource(
@@ -4662,14 +4679,14 @@ module('JSONAPISource', function() {
         .withArgs('/solar-systems/sun/planets?sort=-name')
         .returns(jsonapiResponse(200, { data }));
 
-      let records: Record[] = await source.query(q =>
+      let records: Record[] = await source.query((q) =>
         q.findRelatedRecords(solarSystem, 'planets').sort('-name')
       );
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
       assert.deepEqual(
-        records.map(o => o.attributes.name),
+        records.map((o) => o.attributes.name),
         ['Saturn', 'Jupiter', 'Earth']
       );
 
@@ -4681,7 +4698,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - related records with sort by multiple fields', async function(assert) {
+    test('#query - related records with sort by multiple fields', async function (assert) {
       assert.expect(5);
 
       const solarSystem = source.requestProcessor.serializer.deserializeResource(
@@ -4726,14 +4743,14 @@ module('JSONAPISource', function() {
         )
         .returns(jsonapiResponse(200, { data }));
 
-      let records: Record[] = await source.query(q =>
+      let records: Record[] = await source.query((q) =>
         q.findRelatedRecords(solarSystem, 'planets').sort('lengthOfDay', 'name')
       );
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
       assert.deepEqual(
-        records.map(o => o.attributes.name),
+        records.map((o) => o.attributes.name),
         ['Jupiter', 'Saturn', 'Earth']
       );
 
@@ -4745,7 +4762,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - related records with pagination', async function(assert) {
+    test('#query - related records with pagination', async function (assert) {
       assert.expect(5);
 
       const solarSystem = source.requestProcessor.serializer.deserializeResource(
@@ -4778,7 +4795,7 @@ module('JSONAPISource', function() {
         )
         .returns(jsonapiResponse(200, { data }));
 
-      let records: Record[] = await source.query(q =>
+      let records: Record[] = await source.query((q) =>
         q
           .findRelatedRecords(solarSystem, 'planets')
           .page({ offset: 1, limit: 10 })
@@ -4787,7 +4804,7 @@ module('JSONAPISource', function() {
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
       assert.deepEqual(
-        records.map(o => o.attributes.name),
+        records.map((o) => o.attributes.name),
         ['Jupiter', 'Earth', 'Saturn']
       );
 
@@ -4799,7 +4816,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - related record (304 response)', async function(assert) {
+    test('#query - related record (304 response)', async function (assert) {
       assert.expect(3);
 
       fetchStub
@@ -4811,7 +4828,7 @@ module('JSONAPISource', function() {
         id: 'earth'
       });
 
-      let records = await source.query(q =>
+      let records = await source.query((q) =>
         q.findRelatedRecord({ type: 'planet', id: earth.id }, 'solarSystem')
       );
 
@@ -4825,7 +4842,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - related records (304 response)', async function(assert) {
+    test('#query - related records (304 response)', async function (assert) {
       assert.expect(3);
 
       fetchStub
@@ -4839,7 +4856,7 @@ module('JSONAPISource', function() {
         }
       );
 
-      let records = await source.query(q =>
+      let records = await source.query((q) =>
         q.findRelatedRecords(
           { type: 'solarSystem', id: solarSystem.id },
           'planets'
@@ -4856,7 +4873,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - records with include', async function(assert) {
+    test('#query - records with include', async function (assert) {
       assert.expect(2);
 
       const options = {
@@ -4871,7 +4888,7 @@ module('JSONAPISource', function() {
         .withArgs('/planets?include=moons')
         .returns(jsonapiResponse(200, { data: [] }));
 
-      await source.query(q => q.findRecords('planet'), options);
+      await source.query((q) => q.findRecords('planet'), options);
 
       assert.equal(fetchStub.callCount, 1, 'fetch called once');
       assert.equal(
@@ -4881,7 +4898,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - records with include: verify only primary data array is returned', async function(assert) {
+    test('#query - records with include: verify only primary data array is returned', async function (assert) {
       assert.expect(6);
 
       const options = {
@@ -4906,7 +4923,7 @@ module('JSONAPISource', function() {
       );
 
       let records: Record[] = await source.query(
-        q => q.findRecords('planet'),
+        (q) => q.findRecords('planet'),
         options
       );
 
@@ -4920,11 +4937,11 @@ module('JSONAPISource', function() {
         'query result length equals primary data length'
       );
       assert.deepEqual(
-        records.map(planet => planet.type),
+        records.map((planet) => planet.type),
         ['planet', 'planet']
       );
       assert.deepEqual(
-        records.map(planet => planet.keys.remoteId),
+        records.map((planet) => planet.keys.remoteId),
         ['1', '2'],
         'returned IDs match primary data (including sorting)'
       );
@@ -4937,7 +4954,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - records with include many relationships', async function(assert) {
+    test('#query - records with include many relationships', async function (assert) {
       assert.expect(2);
 
       const options = {
@@ -4954,7 +4971,7 @@ module('JSONAPISource', function() {
         )
         .returns(jsonapiResponse(200, { data: [] }));
 
-      await source.query(q => q.findRecords('planet'), options);
+      await source.query((q) => q.findRecords('planet'), options);
 
       assert.equal(fetchStub.callCount, 1, 'fetch called once');
       assert.equal(
@@ -4964,7 +4981,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - records invokes preprocessResponseDocument when response has content', async function(assert) {
+    test('#query - records invokes preprocessResponseDocument when response has content', async function (assert) {
       assert.expect(1);
       const responseDoc: ResourceDocument = {
         meta: { interesting: 'info' },
@@ -4976,7 +4993,7 @@ module('JSONAPISource', function() {
         'preprocessResponseDocument'
       );
 
-      await source.query(q => q.findRecords('planet'), {});
+      await source.query((q) => q.findRecords('planet'), {});
 
       assert.ok(
         preprocessResponseDocumentSpy.calledOnceWith(
@@ -4987,7 +5004,7 @@ module('JSONAPISource', function() {
       preprocessResponseDocumentSpy.restore();
     });
 
-    test('#query - relatedRecords', async function(assert) {
+    test('#query - relatedRecords', async function (assert) {
       assert.expect(5);
 
       let planetRecord: Record = source.requestProcessor.serializer.deserialize(
@@ -5013,14 +5030,14 @@ module('JSONAPISource', function() {
         .withArgs('/planets/jupiter/moons')
         .returns(jsonapiResponse(200, { data }));
 
-      let records: Record[] = await source.query(q =>
+      let records: Record[] = await source.query((q) =>
         q.findRelatedRecords(planetRecord, 'moons')
       );
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 1, 'one objects in data returned');
       assert.deepEqual(
-        records.map(o => o.attributes.name),
+        records.map((o) => o.attributes.name),
         ['Io']
       );
 
@@ -5032,7 +5049,7 @@ module('JSONAPISource', function() {
       );
     });
 
-    test('#query - relatedRecords with include', async function(assert) {
+    test('#query - relatedRecords with include', async function (assert) {
       assert.expect(2);
 
       const planetRecord = source.requestProcessor.serializer.deserialize({
@@ -5055,7 +5072,7 @@ module('JSONAPISource', function() {
         .returns(jsonapiResponse(200, { data: [] }));
 
       await source.query(
-        q => q.findRelatedRecords(planetRecord, 'moons'),
+        (q) => q.findRelatedRecords(planetRecord, 'moons'),
         options
       );
 
@@ -5068,8 +5085,8 @@ module('JSONAPISource', function() {
     });
   });
 
-  module('with no secondary keys', function(hooks) {
-    hooks.beforeEach(function() {
+  module('with no secondary keys', function (hooks) {
+    hooks.beforeEach(function () {
       fetchStub = sinon.stub(self, 'fetch');
 
       let schema = new Schema({
@@ -5097,12 +5114,12 @@ module('JSONAPISource', function() {
       source = new JSONAPISource({ schema });
     });
 
-    hooks.afterEach(function() {
+    hooks.afterEach(function () {
       schema = source = null;
       fetchStub.restore();
     });
 
-    test('#push - can add records', async function(assert) {
+    test('#push - can add records', async function (assert) {
       assert.expect(5);
 
       let transformCount = 0;
@@ -5147,7 +5164,7 @@ module('JSONAPISource', function() {
         })
       );
 
-      await source.push(t => t.addRecord(planet));
+      await source.push((t) => t.addRecord(planet));
 
       assert.ok(true, 'transform resolves successfully');
 

--- a/packages/@orbit/jsonapi/test/jsonapi-url-builder-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-url-builder-test.ts
@@ -3,7 +3,7 @@ import { KeyMap, Schema } from '@orbit/data';
 import { JSONAPIURLBuilder } from '../src/index';
 import { JSONAPISerializer } from '../src/index';
 
-module('JSONAPIRequestProcessor', function(hooks) {
+module('JSONAPIRequestProcessor', function (hooks) {
   let keyMap: KeyMap;
   let urlBuilder: JSONAPIURLBuilder;
 
@@ -59,7 +59,7 @@ module('JSONAPIRequestProcessor', function(hooks) {
     });
     let serializer = new JSONAPISerializer({ schema, keyMap });
     urlBuilder = new JSONAPIURLBuilder({ serializer, keyMap });
-    urlBuilder.serializer.resourceKey = function() {
+    urlBuilder.serializer.resourceKey = function () {
       return 'remoteId';
     };
   });
@@ -68,11 +68,11 @@ module('JSONAPIRequestProcessor', function(hooks) {
     keyMap = urlBuilder = null;
   });
 
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     assert.ok(urlBuilder);
   });
 
-  test('#resourceURL - respects options to construct URLs', function(assert) {
+  test('#resourceURL - respects options to construct URLs', function (assert) {
     assert.expect(1);
     urlBuilder.host = 'http://127.0.0.1:8888';
     urlBuilder.namespace = 'api';
@@ -90,7 +90,7 @@ module('JSONAPIRequestProcessor', function(hooks) {
     );
   });
 
-  test("#resourcePath - returns resource's path without its host and namespace", function(assert) {
+  test("#resourcePath - returns resource's path without its host and namespace", function (assert) {
     assert.expect(1);
     urlBuilder.host = 'http://127.0.0.1:8888';
     urlBuilder.namespace = 'api';
@@ -108,7 +108,7 @@ module('JSONAPIRequestProcessor', function(hooks) {
     );
   });
 
-  test('#resourceRelationshipURL - constructs relationship URLs based upon base resourceURL', function(assert) {
+  test('#resourceRelationshipURL - constructs relationship URLs based upon base resourceURL', function (assert) {
     assert.expect(1);
     keyMap.pushRecord({
       type: 'planet',

--- a/packages/@orbit/jsonapi/test/lib/jsonapi-request-options-test.ts
+++ b/packages/@orbit/jsonapi/test/lib/jsonapi-request-options-test.ts
@@ -2,18 +2,18 @@ import { mergeJSONAPIRequestOptions } from '../../src/lib/jsonapi-request-option
 
 const { module, test } = QUnit;
 
-module('JSONAPIRequestOptions', function() {
-  module('mergeJSONAPIRequestOptions', function() {
+module('JSONAPIRequestOptions', function () {
+  module('mergeJSONAPIRequestOptions', function () {
     const OPTIONS = {
       filter: [{ foo: 'bar' }],
       include: ['baz.bay']
     };
 
-    test('merge empty options', function(assert) {
+    test('merge empty options', function (assert) {
       assert.deepEqual(mergeJSONAPIRequestOptions(OPTIONS, {}), OPTIONS);
     });
 
-    test('add sort', function(assert) {
+    test('add sort', function (assert) {
       assert.deepEqual(mergeJSONAPIRequestOptions(OPTIONS, { sort: ['qay'] }), {
         filter: [{ foo: 'bar' }],
         include: ['baz.bay'],
@@ -21,7 +21,7 @@ module('JSONAPIRequestOptions', function() {
       });
     });
 
-    test('merge includes', function(assert) {
+    test('merge includes', function (assert) {
       assert.deepEqual(
         mergeJSONAPIRequestOptions(OPTIONS, {
           include: ['baz.bay', 'snoop.dog']
@@ -33,7 +33,7 @@ module('JSONAPIRequestOptions', function() {
       );
     });
 
-    test('merge filters', function(assert) {
+    test('merge filters', function (assert) {
       assert.deepEqual(
         mergeJSONAPIRequestOptions(OPTIONS, {
           filter: [{ intelligence: 'low' }]
@@ -45,7 +45,7 @@ module('JSONAPIRequestOptions', function() {
       );
     });
 
-    test('override filter', function(assert) {
+    test('override filter', function (assert) {
       assert.deepEqual(
         mergeJSONAPIRequestOptions(OPTIONS, { filter: [{ foo: 'zaz' }] }),
         {
@@ -55,7 +55,7 @@ module('JSONAPIRequestOptions', function() {
       );
     });
 
-    test('add page', function(assert) {
+    test('add page', function (assert) {
       assert.deepEqual(
         mergeJSONAPIRequestOptions(OPTIONS, {
           page: {

--- a/packages/@orbit/jsonapi/test/lib/query-params-test.ts
+++ b/packages/@orbit/jsonapi/test/lib/query-params-test.ts
@@ -5,25 +5,25 @@ import {
 
 const { module, test } = QUnit;
 
-module('QueryParams', function() {
-  module('encodeQueryParams', function() {
-    test('empty', function(assert) {
+module('QueryParams', function () {
+  module('encodeQueryParams', function () {
+    test('empty', function (assert) {
       assert.strictEqual(encodeQueryParams({}), '');
     });
 
-    test('simple', function(assert) {
+    test('simple', function (assert) {
       assert.deepEqual(encodeQueryParams({ a: 'b' }), 'a=b');
     });
 
-    test('null value', function(assert) {
+    test('null value', function (assert) {
       assert.deepEqual(encodeQueryParams({ a: null }), 'a=null');
     });
 
-    test('multiple', function(assert) {
+    test('multiple', function (assert) {
       assert.deepEqual(encodeQueryParams({ a: 'b', b: 'c' }), 'a=b&b=c');
     });
 
-    test('multi-layered and encoded', function(assert) {
+    test('multi-layered and encoded', function (assert) {
       assert.deepEqual(
         encodeQueryParams({
           a: 'b',
@@ -50,22 +50,22 @@ module('QueryParams', function() {
     });
   });
 
-  module('appendQueryParams', function() {
-    test('empty', function(assert) {
+  module('appendQueryParams', function () {
+    test('empty', function (assert) {
       assert.strictEqual(
         appendQueryParams('http://example.com', {}),
         'http://example.com'
       );
     });
 
-    test('simple', function(assert) {
+    test('simple', function (assert) {
       assert.strictEqual(
         appendQueryParams('http://example.com', { a: 'b' }),
         'http://example.com?a=b'
       );
     });
 
-    test('appended to existing query params', function(assert) {
+    test('appended to existing query params', function (assert) {
       assert.strictEqual(
         appendQueryParams('http://example.com?c=d', { a: 'b' }),
         'http://example.com?c=d&a=b'

--- a/packages/@orbit/jsonapi/test/lib/query-requests-test.ts
+++ b/packages/@orbit/jsonapi/test/lib/query-requests-test.ts
@@ -10,7 +10,7 @@ import { jsonapiResponse } from '../support/jsonapi';
 declare const sinon: SinonStatic;
 const { module, test } = QUnit;
 
-module('QueryRequests', function(hooks) {
+module('QueryRequests', function (hooks) {
   let schema: Schema;
   let requestProcessor: JSONAPIRequestProcessor;
   let qb: QueryBuilder;
@@ -82,7 +82,7 @@ module('QueryRequests', function(hooks) {
     fetchStub.restore();
   });
 
-  test('meta and links', async function(assert) {
+  test('meta and links', async function (assert) {
     fetchStub.withArgs('/planets').returns(
       jsonapiResponse(200, {
         data: [

--- a/packages/@orbit/jsonapi/test/lib/transform-requests-test.ts
+++ b/packages/@orbit/jsonapi/test/lib/transform-requests-test.ts
@@ -10,8 +10,8 @@ import { jsonapiResponse } from '../support/jsonapi';
 declare const sinon: SinonStatic;
 const { module, test } = QUnit;
 
-module('TransformRequests', function(/* hooks */) {
-  module('getTransformRequests', function(hooks) {
+module('TransformRequests', function (/* hooks */) {
+  module('getTransformRequests', function (hooks) {
     let keyMap: KeyMap;
     let schema: Schema;
     let requestProcessor: JSONAPIRequestProcessor;
@@ -85,7 +85,7 @@ module('TransformRequests', function(/* hooks */) {
       fetchStub.restore();
     });
 
-    test('addRecord', function(assert) {
+    test('addRecord', function (assert) {
       const jupiter = {
         type: 'planet',
         id: 'jupiter',
@@ -102,7 +102,7 @@ module('TransformRequests', function(/* hooks */) {
       ]);
     });
 
-    test('removeRecord', function(assert) {
+    test('removeRecord', function (assert) {
       const jupiter = {
         type: 'planet',
         id: 'jupiter',
@@ -119,7 +119,7 @@ module('TransformRequests', function(/* hooks */) {
       ]);
     });
 
-    test('replaceAttribute => updateRecord', function(assert) {
+    test('replaceAttribute => updateRecord', function (assert) {
       const t = buildTransform(
         tb.replaceAttribute({ type: 'planet', id: 'jupiter' }, 'name', 'Earth')
       );
@@ -136,7 +136,7 @@ module('TransformRequests', function(/* hooks */) {
       ]);
     });
 
-    test('updateRecord', function(assert) {
+    test('updateRecord', function (assert) {
       const jupiter = {
         type: 'planet',
         id: 'jupiter',
@@ -153,7 +153,7 @@ module('TransformRequests', function(/* hooks */) {
       ]);
     });
 
-    test('addToRelatedRecords', function(assert) {
+    test('addToRelatedRecords', function (assert) {
       const jupiter = { type: 'planet', id: 'jupiter' };
       const io = { type: 'moon', id: 'io' };
 
@@ -169,7 +169,7 @@ module('TransformRequests', function(/* hooks */) {
       ]);
     });
 
-    test('removeFromRelatedRecords', function(assert) {
+    test('removeFromRelatedRecords', function (assert) {
       const jupiter = { type: 'planet', id: 'jupiter' };
       const io = { type: 'moon', id: 'io' };
 
@@ -187,7 +187,7 @@ module('TransformRequests', function(/* hooks */) {
       ]);
     });
 
-    test('replaceRelatedRecord => updateRecord', function(assert) {
+    test('replaceRelatedRecord => updateRecord', function (assert) {
       const jupiter = { type: 'planet', id: 'jupiter' };
       const io = { type: 'moon', id: 'io' };
 
@@ -209,7 +209,7 @@ module('TransformRequests', function(/* hooks */) {
       ]);
     });
 
-    test('replaceRelatedRecord (with null) => updateRecord', function(assert) {
+    test('replaceRelatedRecord (with null) => updateRecord', function (assert) {
       const io = { type: 'moon', id: 'io' };
 
       const t = buildTransform(tb.replaceRelatedRecord(io, 'planet', null));
@@ -230,7 +230,7 @@ module('TransformRequests', function(/* hooks */) {
       ]);
     });
 
-    test('replaceRelatedRecords => updateRecord', function(assert) {
+    test('replaceRelatedRecords => updateRecord', function (assert) {
       const jupiter = { type: 'planet', id: 'jupiter' };
       const io = { type: 'moon', id: 'io' };
       const europa = { type: 'moon', id: 'europa' };
@@ -258,7 +258,7 @@ module('TransformRequests', function(/* hooks */) {
       ]);
     });
 
-    test('addRecord + removeRecord => []', function(assert) {
+    test('addRecord + removeRecord => []', function (assert) {
       const t = buildTransform([
         tb.addRecord({
           type: 'planet',
@@ -271,7 +271,7 @@ module('TransformRequests', function(/* hooks */) {
       assert.deepEqual(getTransformRequests(requestProcessor, t), []);
     });
 
-    test('removeRecord + removeRecord => [removeRecord]', function(assert) {
+    test('removeRecord + removeRecord => [removeRecord]', function (assert) {
       const t = buildTransform([
         tb.removeRecord({ type: 'planet', id: 'jupiter' }),
         tb.removeRecord({ type: 'planet', id: 'jupiter' })
@@ -285,7 +285,7 @@ module('TransformRequests', function(/* hooks */) {
       ]);
     });
 
-    test('addRecord + replaceAttribute => [addRecord]', function(assert) {
+    test('addRecord + replaceAttribute => [addRecord]', function (assert) {
       const t = buildTransform([
         tb.addRecord({
           type: 'planet',
@@ -311,7 +311,7 @@ module('TransformRequests', function(/* hooks */) {
       ]);
     });
 
-    test('replaceAttribute + replaceAttribute => [updateRecord]', function(assert) {
+    test('replaceAttribute + replaceAttribute => [updateRecord]', function (assert) {
       const t = buildTransform([
         tb.replaceAttribute({ type: 'planet', id: 'jupiter' }, 'name', 'Earth'),
         tb.replaceAttribute(
@@ -333,7 +333,7 @@ module('TransformRequests', function(/* hooks */) {
       ]);
     });
 
-    test('addToRelatedRecords + addToRelatedRecords => [addToRelatedRecords]', function(assert) {
+    test('addToRelatedRecords + addToRelatedRecords => [addToRelatedRecords]', function (assert) {
       const jupiter = { type: 'planet', id: 'jupiter' };
       const io = { type: 'moon', id: 'io' };
       const europa = { type: 'moon', id: 'europa' };
@@ -353,7 +353,7 @@ module('TransformRequests', function(/* hooks */) {
       ]);
     });
 
-    test('meta and links', async function(assert) {
+    test('meta and links', async function (assert) {
       fetchStub.withArgs('/planets').returns(
         jsonapiResponse(201, {
           data: {

--- a/packages/@orbit/local-storage-bucket/.prettierrc.js
+++ b/packages/@orbit/local-storage-bucket/.prettierrc.js
@@ -1,3 +1,4 @@
 module.exports = {
-  singleQuote: true
+  singleQuote: true,
+  trailingComma: 'none'
 };

--- a/packages/@orbit/local-storage-bucket/package.json
+++ b/packages/@orbit/local-storage-bucket/package.json
@@ -30,11 +30,11 @@
   },
   "devDependencies": {
     "@glimmer/build": "^0.10.3",
-    "@typescript-eslint/eslint-plugin": "^2.23.0",
-    "@typescript-eslint/parser": "^2.23.0",
+    "@typescript-eslint/eslint-plugin": "^2.26.0",
+    "@typescript-eslint/parser": "^2.26.0",
     "eslint": "^6.8.0",
-    "eslint-config-prettier": "^6.10.0",
+    "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-prettier": "^3.1.2",
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.2"
   }
 }

--- a/packages/@orbit/local-storage-bucket/test/bucket-test.ts
+++ b/packages/@orbit/local-storage-bucket/test/bucket-test.ts
@@ -3,22 +3,22 @@ import LocalStorageBucket from '../src/bucket';
 
 const { module, test } = QUnit;
 
-module('LocalStorageBucket', function(hooks) {
+module('LocalStorageBucket', function (hooks) {
   let bucket: LocalStorageBucket;
 
   hooks.beforeEach(() => {
     bucket = new LocalStorageBucket();
   });
 
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     assert.ok(bucket);
   });
 
-  test('its prototype chain is correct', function(assert) {
+  test('its prototype chain is correct', function (assert) {
     assert.ok(bucket instanceof Bucket, 'instanceof Bucket');
   });
 
-  test('is assigned a default name, namespace, and delimiter', function(assert) {
+  test('is assigned a default name, namespace, and delimiter', function (assert) {
     assert.equal(
       bucket.name,
       'localStorage',
@@ -32,7 +32,7 @@ module('LocalStorageBucket', function(hooks) {
     assert.equal(bucket.delimiter, '/', '`delimiter` is `/` by default');
   });
 
-  test('#setItem sets a value, #getItem gets a value, #removeItem removes a value', async function(assert) {
+  test('#setItem sets a value, #getItem gets a value, #removeItem removes a value', async function (assert) {
     assert.expect(3);
 
     let planet = {
@@ -56,7 +56,7 @@ module('LocalStorageBucket', function(hooks) {
     assert.equal(item, null, 'bucket does not contain item');
   });
 
-  test('#clear clears all keys', async function(assert) {
+  test('#clear clears all keys', async function (assert) {
     assert.expect(2);
 
     let planet = {

--- a/packages/@orbit/local-storage/.prettierrc.js
+++ b/packages/@orbit/local-storage/.prettierrc.js
@@ -1,3 +1,4 @@
 module.exports = {
-  singleQuote: true
+  singleQuote: true,
+  trailingComma: 'none'
 };

--- a/packages/@orbit/local-storage/package.json
+++ b/packages/@orbit/local-storage/package.json
@@ -32,11 +32,11 @@
   },
   "devDependencies": {
     "@glimmer/build": "^0.10.3",
-    "@typescript-eslint/eslint-plugin": "^2.23.0",
-    "@typescript-eslint/parser": "^2.23.0",
+    "@typescript-eslint/eslint-plugin": "^2.26.0",
+    "@typescript-eslint/parser": "^2.26.0",
     "eslint": "^6.8.0",
-    "eslint-config-prettier": "^6.10.0",
+    "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-prettier": "^3.1.2",
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.2"
   }
 }

--- a/packages/@orbit/local-storage/src/local-storage-cache.ts
+++ b/packages/@orbit/local-storage/src/local-storage-cache.ts
@@ -181,7 +181,7 @@ export default class LocalStorageCache extends SyncRecordCache {
       if (item) {
         let rels: RecordRelationshipIdentity[] = item ? JSON.parse(item) : [];
         let newRels = rels.filter(
-          rel =>
+          (rel) =>
             !(
               equalRecordIdentities(rel.record, relationship.record) &&
               rel.relationship === relationship.relationship
@@ -199,10 +199,10 @@ export default class LocalStorageCache extends SyncRecordCache {
       }
     }
 
-    this._processors.forEach(processor => processor.reset());
+    this._processors.forEach((processor) => processor.reset());
   }
 
   upgrade() {
-    this._processors.forEach(processor => processor.upgrade());
+    this._processors.forEach((processor) => processor.upgrade());
   }
 }

--- a/packages/@orbit/local-storage/src/local-storage-source.ts
+++ b/packages/@orbit/local-storage/src/local-storage-source.ts
@@ -165,7 +165,7 @@ export default class LocalStorageSource extends Source
 
   _operationsFromQueryResult(result: QueryResultData): Operation[] {
     if (Array.isArray(result)) {
-      return result.map(r => {
+      return result.map((r) => {
         return {
           op: 'updateRecord',
           record: r

--- a/packages/@orbit/local-storage/test/local-storage-source-test.ts
+++ b/packages/@orbit/local-storage/test/local-storage-source-test.ts
@@ -16,7 +16,7 @@ import LocalStorageSource from '../src/local-storage-source';
 
 const { module, test } = QUnit;
 
-module('LocalStorageSource', function(hooks) {
+module('LocalStorageSource', function (hooks) {
   let schema: Schema, source: LocalStorageSource, keyMap: KeyMap;
 
   hooks.beforeEach(() => {
@@ -55,29 +55,29 @@ module('LocalStorageSource', function(hooks) {
     });
   });
 
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     assert.ok(source);
     assert.strictEqual(source.schema, schema, 'schema has been assigned');
     assert.strictEqual(source.keyMap, keyMap, 'keyMap has been assigned');
   });
 
-  test('its prototype chain is correct', function(assert) {
+  test('its prototype chain is correct', function (assert) {
     assert.ok(source instanceof Source, 'instanceof Source');
   });
 
-  test('is assigned a default namespace and delimiter', function(assert) {
+  test('is assigned a default namespace and delimiter', function (assert) {
     assert.equal(source.namespace, 'orbit', 'namespace is `orbit` by default');
     assert.equal(source.delimiter, '/', 'delimiter is `/` by default');
   });
 
-  test('#getKeyForRecord returns the local storage key that will be used for a record', function(assert) {
+  test('#getKeyForRecord returns the local storage key that will be used for a record', function (assert) {
     assert.equal(
       source.getKeyForRecord({ type: 'planet', id: 'jupiter' }),
       'orbit/planet/jupiter'
     );
   });
 
-  test('data persists across re-instantiating source', async function(assert) {
+  test('data persists across re-instantiating source', async function (assert) {
     assert.expect(2);
 
     let planet: Record = {
@@ -92,7 +92,7 @@ module('LocalStorageSource', function(hooks) {
       }
     };
 
-    await source.push(t => t.addRecord(planet));
+    await source.push((t) => t.addRecord(planet));
     assert.deepEqual(
       getRecordFromLocalStorage(source, planet),
       planet,
@@ -107,7 +107,7 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#sync - addRecord', async function(assert) {
+  test('#sync - addRecord', async function (assert) {
     assert.expect(3);
 
     let planet = {
@@ -142,7 +142,7 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#push - addRecord', async function(assert) {
+  test('#push - addRecord', async function (assert) {
     assert.expect(3);
 
     let planet = {
@@ -177,7 +177,7 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#push - addRecord - with beforePush listener that syncs transform', async function(assert) {
+  test('#push - addRecord - with beforePush listener that syncs transform', async function (assert) {
     assert.expect(4);
 
     let planet: Record = {
@@ -197,7 +197,7 @@ module('LocalStorageSource', function(hooks) {
       record: planet
     } as AddRecordOperation);
 
-    source.on('beforePush', async function(transform: Transform) {
+    source.on('beforePush', async function (transform: Transform) {
       await source.sync(transform);
     });
 
@@ -217,7 +217,7 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#push - updateRecord', async function(assert) {
+  test('#push - updateRecord', async function (assert) {
     assert.expect(2);
 
     let original: Record = {
@@ -269,8 +269,8 @@ module('LocalStorageSource', function(hooks) {
       }
     };
 
-    await source.push(t => t.addRecord(original));
-    await source.push(t => t.updateRecord(updates));
+    await source.push((t) => t.addRecord(original));
+    await source.push((t) => t.updateRecord(updates));
 
     assert.deepEqual(
       getRecordFromLocalStorage(source, expected),
@@ -284,7 +284,7 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#push - updateRecord - when record does not exist', async function(assert) {
+  test('#push - updateRecord - when record does not exist', async function (assert) {
     assert.expect(1);
 
     let revised: Record = {
@@ -297,7 +297,7 @@ module('LocalStorageSource', function(hooks) {
       }
     };
 
-    await source.push(t => t.updateRecord(revised));
+    await source.push((t) => t.updateRecord(revised));
 
     assert.deepEqual(
       getRecordFromLocalStorage(source, revised),
@@ -306,7 +306,7 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#push - removeRecord', async function(assert) {
+  test('#push - removeRecord', async function (assert) {
     assert.expect(1);
 
     let planet = {
@@ -318,8 +318,8 @@ module('LocalStorageSource', function(hooks) {
       }
     };
 
-    await source.push(t => t.addRecord(planet));
-    await source.push(t => t.removeRecord(planet));
+    await source.push((t) => t.addRecord(planet));
+    await source.push((t) => t.removeRecord(planet));
 
     assert.deepEqual(
       getRecordFromLocalStorage(source, planet),
@@ -328,7 +328,7 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#push - removeRecord when part of has many relationship', async function(assert) {
+  test('#push - removeRecord when part of has many relationship', async function (assert) {
     assert.expect(2);
 
     let moon1 = { type: 'moon', id: 'moon1' };
@@ -347,7 +347,7 @@ module('LocalStorageSource', function(hooks) {
       }
     };
 
-    await source.push(t => [
+    await source.push((t) => [
       t.addRecord(moon1),
       t.addRecord(moon2),
       t.addRecord(planet)
@@ -358,7 +358,7 @@ module('LocalStorageSource', function(hooks) {
       2,
       'record has 2 moons'
     );
-    await source.push(t => t.removeRecord(moon1));
+    await source.push((t) => t.removeRecord(moon1));
     assert.deepEqual(
       (await getRecordFromLocalStorage(source, planet)).relationships.moons.data
         .length,
@@ -367,7 +367,7 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#push - removeRecord - when record does not exist', async function(assert) {
+  test('#push - removeRecord - when record does not exist', async function (assert) {
     assert.expect(1);
 
     let planet = {
@@ -375,7 +375,7 @@ module('LocalStorageSource', function(hooks) {
       id: 'jupiter'
     };
 
-    await source.push(t => t.removeRecord(planet));
+    await source.push((t) => t.removeRecord(planet));
 
     assert.equal(
       getRecordFromLocalStorage(source, planet),
@@ -384,7 +384,7 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#push - replaceKey', async function(assert) {
+  test('#push - replaceKey', async function (assert) {
     assert.expect(2);
 
     let original: Record = {
@@ -408,8 +408,8 @@ module('LocalStorageSource', function(hooks) {
       }
     };
 
-    await source.push(t => t.addRecord(original));
-    await source.push(t => t.replaceKey(original, 'remoteId', '123'));
+    await source.push((t) => t.addRecord(original));
+    await source.push((t) => t.replaceKey(original, 'remoteId', '123'));
 
     assert.deepEqual(
       getRecordFromLocalStorage(source, revised),
@@ -423,7 +423,7 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#push - replaceKey - when base record does not exist', async function(assert) {
+  test('#push - replaceKey - when base record does not exist', async function (assert) {
     assert.expect(2);
 
     let revised: Record = {
@@ -434,7 +434,7 @@ module('LocalStorageSource', function(hooks) {
       }
     };
 
-    await source.push(t =>
+    await source.push((t) =>
       t.replaceKey({ type: 'planet', id: 'jupiter' }, 'remoteId', '123')
     );
 
@@ -450,7 +450,7 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#push - replaceAttribute', async function(assert) {
+  test('#push - replaceAttribute', async function (assert) {
     assert.expect(1);
 
     let original: Record = {
@@ -472,8 +472,8 @@ module('LocalStorageSource', function(hooks) {
       }
     };
 
-    await source.push(t => t.addRecord(original));
-    await source.push(t => t.replaceAttribute(original, 'order', 5));
+    await source.push((t) => t.addRecord(original));
+    await source.push((t) => t.replaceAttribute(original, 'order', 5));
 
     assert.deepEqual(
       getRecordFromLocalStorage(source, revised),
@@ -482,7 +482,7 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#push - replaceAttribute - when base record does not exist', async function(assert) {
+  test('#push - replaceAttribute - when base record does not exist', async function (assert) {
     assert.expect(1);
 
     let revised: Record = {
@@ -493,7 +493,7 @@ module('LocalStorageSource', function(hooks) {
       }
     };
 
-    await source.push(t =>
+    await source.push((t) =>
       t.replaceAttribute({ type: 'planet', id: 'jupiter' }, 'order', 5)
     );
 
@@ -504,7 +504,7 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#push - addToRelatedRecords', async function(assert) {
+  test('#push - addToRelatedRecords', async function (assert) {
     assert.expect(1);
 
     let original: Record = {
@@ -535,8 +535,8 @@ module('LocalStorageSource', function(hooks) {
       }
     };
 
-    await source.push(t => t.addRecord(original));
-    await source.push(t =>
+    await source.push((t) => t.addRecord(original));
+    await source.push((t) =>
       t.addToRelatedRecords(original, 'moons', { type: 'moon', id: 'moon1' })
     );
 
@@ -547,7 +547,7 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#push - addToRelatedRecords - when base record does not exist', async function(assert) {
+  test('#push - addToRelatedRecords - when base record does not exist', async function (assert) {
     assert.expect(1);
 
     let revised: Record = {
@@ -560,7 +560,7 @@ module('LocalStorageSource', function(hooks) {
       }
     };
 
-    await source.push(t =>
+    await source.push((t) =>
       t.addToRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons', {
         type: 'moon',
         id: 'moon1'
@@ -574,7 +574,7 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#push - removeFromRelatedRecords', async function(assert) {
+  test('#push - removeFromRelatedRecords', async function (assert) {
     assert.expect(1);
 
     let original: Record = {
@@ -608,8 +608,8 @@ module('LocalStorageSource', function(hooks) {
       }
     };
 
-    await source.push(t => t.addRecord(original));
-    await source.push(t =>
+    await source.push((t) => t.addRecord(original));
+    await source.push((t) =>
       t.removeFromRelatedRecords(original, 'moons', {
         type: 'moon',
         id: 'moon2'
@@ -623,7 +623,7 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#push - removeFromRelatedRecords - when base record does not exist', async function(assert) {
+  test('#push - removeFromRelatedRecords - when base record does not exist', async function (assert) {
     assert.expect(1);
 
     let revised: Record = {
@@ -636,7 +636,7 @@ module('LocalStorageSource', function(hooks) {
       }
     };
 
-    await source.push(t =>
+    await source.push((t) =>
       t.removeFromRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons', {
         type: 'moon',
         id: 'moon2'
@@ -650,7 +650,7 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#push - replaceRelatedRecords', async function(assert) {
+  test('#push - replaceRelatedRecords', async function (assert) {
     assert.expect(1);
 
     let original: Record = {
@@ -684,8 +684,8 @@ module('LocalStorageSource', function(hooks) {
       }
     };
 
-    await source.push(t => t.addRecord(original));
-    await source.push(t =>
+    await source.push((t) => t.addRecord(original));
+    await source.push((t) =>
       t.replaceRelatedRecords(original, 'moons', [
         { type: 'moon', id: 'moon2' },
         { type: 'moon', id: 'moon3' }
@@ -699,7 +699,7 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#push - replaceRelatedRecords - when base record does not exist', async function(assert) {
+  test('#push - replaceRelatedRecords - when base record does not exist', async function (assert) {
     assert.expect(1);
 
     let revised: Record = {
@@ -715,7 +715,7 @@ module('LocalStorageSource', function(hooks) {
       }
     };
 
-    await source.push(t =>
+    await source.push((t) =>
       t.replaceRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons', [
         { type: 'moon', id: 'moon2' },
         { type: 'moon', id: 'moon3' }
@@ -729,7 +729,7 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#push - replaceRelatedRecord - with record', async function(assert) {
+  test('#push - replaceRelatedRecord - with record', async function (assert) {
     assert.expect(1);
 
     let original: Record = {
@@ -760,8 +760,8 @@ module('LocalStorageSource', function(hooks) {
       }
     };
 
-    await source.push(t => t.addRecord(original));
-    await source.push(t =>
+    await source.push((t) => t.addRecord(original));
+    await source.push((t) =>
       t.replaceRelatedRecord(original, 'solarSystem', {
         type: 'solarSystem',
         id: 'ss1'
@@ -775,7 +775,7 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#push - replaceRelatedRecord - with record - when base record does not exist', async function(assert) {
+  test('#push - replaceRelatedRecord - with record - when base record does not exist', async function (assert) {
     assert.expect(1);
 
     let revised: Record = {
@@ -788,7 +788,7 @@ module('LocalStorageSource', function(hooks) {
       }
     };
 
-    await source.push(t =>
+    await source.push((t) =>
       t.replaceRelatedRecord({ type: 'planet', id: 'jupiter' }, 'solarSystem', {
         type: 'solarSystem',
         id: 'ss1'
@@ -801,7 +801,7 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#push - replaceRelatedRecord - with null', async function(assert) {
+  test('#push - replaceRelatedRecord - with null', async function (assert) {
     assert.expect(1);
 
     let original: Record = {
@@ -832,8 +832,8 @@ module('LocalStorageSource', function(hooks) {
       }
     };
 
-    await source.push(t => t.addRecord(original));
-    await source.push(t =>
+    await source.push((t) => t.addRecord(original));
+    await source.push((t) =>
       t.replaceRelatedRecord(original, 'solarSystem', null)
     );
     assert.deepEqual(
@@ -843,7 +843,7 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#push - replaceRelatedRecord - with null - when base record does not exist', async function(assert) {
+  test('#push - replaceRelatedRecord - with null - when base record does not exist', async function (assert) {
     assert.expect(1);
 
     let revised: Record = {
@@ -856,7 +856,7 @@ module('LocalStorageSource', function(hooks) {
       }
     };
 
-    await source.push(t =>
+    await source.push((t) =>
       t.replaceRelatedRecord(
         { type: 'planet', id: 'jupiter' },
         'solarSystem',
@@ -870,7 +870,7 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#reset - clears records for source', async function(assert) {
+  test('#reset - clears records for source', async function (assert) {
     assert.expect(2);
 
     let planet = {
@@ -878,7 +878,7 @@ module('LocalStorageSource', function(hooks) {
       id: 'jupiter'
     };
 
-    await source.push(t => t.addRecord(planet));
+    await source.push((t) => t.addRecord(planet));
 
     assert.deepEqual(
       getRecordFromLocalStorage(source, planet),
@@ -891,7 +891,7 @@ module('LocalStorageSource', function(hooks) {
     assert.ok(isLocalStorageEmpty(source), 'local storage is empty');
   });
 
-  test('#reset - ignores local-storage-bucket entries', async function(assert) {
+  test('#reset - ignores local-storage-bucket entries', async function (assert) {
     assert.expect(2);
 
     let planet = {
@@ -899,7 +899,7 @@ module('LocalStorageSource', function(hooks) {
       id: 'jupiter'
     };
 
-    await source.push(t => t.addRecord(planet));
+    await source.push((t) => t.addRecord(planet));
 
     Orbit.globals.localStorage.setItem('orbit-bucket/foo', '{}');
 
@@ -910,7 +910,7 @@ module('LocalStorageSource', function(hooks) {
     assert.equal(Orbit.globals.localStorage.getItem('orbit-bucket/foo'), '{}');
   });
 
-  test('#pull - all records', async function(assert) {
+  test('#pull - all records', async function (assert) {
     assert.expect(6);
 
     let earth = {
@@ -950,7 +950,7 @@ module('LocalStorageSource', function(hooks) {
 
     await source.reset();
 
-    await source.push(t => [
+    await source.push((t) => [
       t.addRecord(earth),
       t.addRecord(jupiter),
       t.addRecord(io)
@@ -959,7 +959,7 @@ module('LocalStorageSource', function(hooks) {
     // reset keyMap to verify that pulling records also adds keys
     keyMap.reset();
 
-    let transforms = await source.pull(q => q.findRecords());
+    let transforms = await source.pull((q) => q.findRecords());
 
     assert.equal(transforms.length, 1, 'one transform returned');
     assert.ok(
@@ -967,7 +967,7 @@ module('LocalStorageSource', function(hooks) {
       'log contains transform'
     );
     assert.deepEqual(
-      transforms[0].operations.map(o => o.op),
+      transforms[0].operations.map((o) => o.op),
       ['updateRecord', 'updateRecord', 'updateRecord'],
       'operations match expectations'
     );
@@ -988,7 +988,7 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#pull - records of one type', async function(assert) {
+  test('#pull - records of one type', async function (assert) {
     assert.expect(4);
 
     let earth = {
@@ -1019,13 +1019,13 @@ module('LocalStorageSource', function(hooks) {
 
     await source.reset();
 
-    await source.push(t => [
+    await source.push((t) => [
       t.addRecord(earth),
       t.addRecord(jupiter),
       t.addRecord(io)
     ]);
 
-    let transforms = await source.pull(q => q.findRecords('planet'));
+    let transforms = await source.pull((q) => q.findRecords('planet'));
 
     assert.equal(transforms.length, 1, 'one transform returned');
     assert.ok(
@@ -1037,13 +1037,13 @@ module('LocalStorageSource', function(hooks) {
       'log contains transform'
     );
     assert.deepEqual(
-      transforms[0].operations.map(o => o.op),
+      transforms[0].operations.map((o) => o.op),
       ['updateRecord', 'updateRecord'],
       'operations match expectations'
     );
   });
 
-  test('#pull - specific records', async function(assert) {
+  test('#pull - specific records', async function (assert) {
     assert.expect(4);
 
     let earth: Record = {
@@ -1072,13 +1072,13 @@ module('LocalStorageSource', function(hooks) {
       }
     };
 
-    await source.push(t => [
+    await source.push((t) => [
       t.addRecord(earth),
       t.addRecord(jupiter),
       t.addRecord(io)
     ]);
 
-    let transforms = await source.pull(q =>
+    let transforms = await source.pull((q) =>
       q.findRecords([earth, io, { type: 'moon', id: 'FAKE' }])
     );
 
@@ -1088,7 +1088,7 @@ module('LocalStorageSource', function(hooks) {
       'log contains transform'
     );
     assert.deepEqual(
-      transforms[0].operations.map(o => o.op),
+      transforms[0].operations.map((o) => o.op),
       ['updateRecord', 'updateRecord'],
       'operations match expectations'
     );
@@ -1099,7 +1099,7 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#pull - a specific record', async function(assert) {
+  test('#pull - a specific record', async function (assert) {
     assert.expect(4);
 
     let earth = {
@@ -1133,7 +1133,7 @@ module('LocalStorageSource', function(hooks) {
 
     await source.reset();
 
-    await source.push(t => [
+    await source.push((t) => [
       t.addRecord(earth),
       t.addRecord(jupiter),
       t.addRecord(io)
@@ -1142,7 +1142,7 @@ module('LocalStorageSource', function(hooks) {
     // reset keyMap to verify that pulling records also adds keys
     keyMap.reset();
 
-    let transforms = await source.pull(q => q.findRecord(jupiter));
+    let transforms = await source.pull((q) => q.findRecord(jupiter));
 
     assert.equal(transforms.length, 1, 'one transform returned');
     assert.ok(
@@ -1150,7 +1150,7 @@ module('LocalStorageSource', function(hooks) {
       'log contains transform'
     );
     assert.deepEqual(
-      transforms[0].operations.map(o => o.op),
+      transforms[0].operations.map((o) => o.op),
       ['updateRecord'],
       'operations match expectations'
     );
@@ -1161,14 +1161,14 @@ module('LocalStorageSource', function(hooks) {
     );
   });
 
-  test('#pull - ignores local-storage-bucket entries', async function(assert) {
+  test('#pull - ignores local-storage-bucket entries', async function (assert) {
     assert.expect(3);
 
     await source.reset();
 
     await Orbit.globals.localStorage.setItem('orbit-bucket/foo', '{}');
 
-    let transforms = await source.pull(q => q.findRecords());
+    let transforms = await source.pull((q) => q.findRecords());
 
     assert.equal(transforms.length, 1, 'one transform returned');
     assert.ok(

--- a/packages/@orbit/memory/.prettierrc.js
+++ b/packages/@orbit/memory/.prettierrc.js
@@ -1,3 +1,4 @@
 module.exports = {
-  singleQuote: true
+  singleQuote: true,
+  trailingComma: 'none'
 };

--- a/packages/@orbit/memory/package.json
+++ b/packages/@orbit/memory/package.json
@@ -34,11 +34,11 @@
   },
   "devDependencies": {
     "@glimmer/build": "^0.10.3",
-    "@typescript-eslint/eslint-plugin": "^2.23.0",
-    "@typescript-eslint/parser": "^2.23.0",
+    "@typescript-eslint/eslint-plugin": "^2.26.0",
+    "@typescript-eslint/parser": "^2.26.0",
     "eslint": "^6.8.0",
-    "eslint-config-prettier": "^6.10.0",
+    "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-prettier": "^3.1.2",
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.2"
   }
 }

--- a/packages/@orbit/memory/src/memory-cache.ts
+++ b/packages/@orbit/memory/src/memory-cache.ts
@@ -121,7 +121,7 @@ export default class MemoryCache extends SyncRecordCache {
   addInverseRelationshipsSync(
     relationships: RecordRelationshipIdentity[]
   ): void {
-    relationships.forEach(r => {
+    relationships.forEach((r) => {
       let rels = this._inverseRelationships[r.relatedRecord.type].get(
         r.relatedRecord.id
       );
@@ -137,13 +137,13 @@ export default class MemoryCache extends SyncRecordCache {
   removeInverseRelationshipsSync(
     relationships: RecordRelationshipIdentity[]
   ): void {
-    relationships.forEach(r => {
+    relationships.forEach((r) => {
       let rels = this._inverseRelationships[r.relatedRecord.type].get(
         r.relatedRecord.id
       );
       if (rels) {
         let newRels = rels.filter(
-          rel =>
+          (rel) =>
             !(
               equalRecordIdentities(rel.record, r.record) &&
               rel.relationship === r.relationship
@@ -170,7 +170,7 @@ export default class MemoryCache extends SyncRecordCache {
   reset(base?: MemoryCache): void {
     this._records = {};
 
-    Object.keys(this._schema.models).forEach(type => {
+    Object.keys(this._schema.models).forEach((type) => {
       let baseRecords = base && base._records[type];
 
       this._records[type] = new ImmutableMap<string, Record>(baseRecords);
@@ -178,7 +178,7 @@ export default class MemoryCache extends SyncRecordCache {
 
     this._resetInverseRelationships(base);
 
-    this._processors.forEach(processor => processor.reset(base));
+    this._processors.forEach((processor) => processor.reset(base));
 
     this.emit('reset');
   }
@@ -187,14 +187,14 @@ export default class MemoryCache extends SyncRecordCache {
    * Upgrade the cache based on the current state of the schema.
    */
   upgrade() {
-    Object.keys(this._schema.models).forEach(type => {
+    Object.keys(this._schema.models).forEach((type) => {
       if (!this._records[type]) {
         this._records[type] = new ImmutableMap<string, Record>();
       }
     });
 
     this._resetInverseRelationships();
-    this._processors.forEach(processor => processor.upgrade());
+    this._processors.forEach((processor) => processor.upgrade());
   }
 
   /////////////////////////////////////////////////////////////////////////////
@@ -206,7 +206,7 @@ export default class MemoryCache extends SyncRecordCache {
       string,
       RecordRelationshipIdentity[]
     >> = {};
-    Object.keys(this._schema.models).forEach(type => {
+    Object.keys(this._schema.models).forEach((type) => {
       let baseRelationships = base && base._inverseRelationships[type];
       inverseRelationships[type] = new ImmutableMap(baseRelationships);
     });

--- a/packages/@orbit/memory/src/memory-source.ts
+++ b/packages/@orbit/memory/src/memory-source.ts
@@ -229,7 +229,7 @@ export default class MemorySource extends Source
 
     let reducedTransform;
     let ops: RecordOperation[] = [];
-    transforms.forEach(t => {
+    transforms.forEach((t) => {
       Array.prototype.push.apply(ops, t.operations);
     });
 
@@ -269,7 +269,7 @@ export default class MemorySource extends Source
     if (baseTransforms.length > 0) {
       let localTransforms = this.allTransforms();
 
-      localTransforms.reverse().forEach(transform => {
+      localTransforms.reverse().forEach((transform) => {
         const inverseOperations = this._transformInverses[transform.id];
         if (inverseOperations) {
           this.cache.patch(inverseOperations);
@@ -277,8 +277,8 @@ export default class MemorySource extends Source
         this._clearTransformFromHistory(transform.id);
       });
 
-      baseTransforms.forEach(transform => this._applyTransform(transform));
-      localTransforms.forEach(transform => this._applyTransform(transform));
+      baseTransforms.forEach((transform) => this._applyTransform(transform));
+      localTransforms.forEach((transform) => this._applyTransform(transform));
       this._forkPoint = base.transformLog.head;
     }
   }
@@ -299,14 +299,16 @@ export default class MemorySource extends Source
    * @param transformId - The ID of the transform to start with.
    */
   transformsSince(transformId: string): Transform[] {
-    return this.transformLog.after(transformId).map(id => this._transforms[id]);
+    return this.transformLog
+      .after(transformId)
+      .map((id) => this._transforms[id]);
   }
 
   /**
    * Returns all tracked transforms.
    */
   allTransforms(): Transform[] {
-    return this.transformLog.entries.map(id => this._transforms[id]);
+    return this.transformLog.entries.map((id) => this._transforms[id]);
   }
 
   getTransform(transformId: string): Transform {
@@ -351,7 +353,7 @@ export default class MemorySource extends Source
     relativePosition: number,
     removed: string[]
   ): void {
-    removed.forEach(id => this._clearTransformFromHistory(id));
+    removed.forEach((id) => this._clearTransformFromHistory(id));
   }
 
   protected _logRolledback(
@@ -359,7 +361,7 @@ export default class MemorySource extends Source
     relativePosition: number,
     removed: string[]
   ): void {
-    removed.reverse().forEach(id => {
+    removed.reverse().forEach((id) => {
       const inverseOperations = this._transformInverses[id];
       if (inverseOperations) {
         this.cache.patch(inverseOperations);

--- a/packages/@orbit/memory/test/memory-cache-test.ts
+++ b/packages/@orbit/memory/test/memory-cache-test.ts
@@ -13,11 +13,11 @@ import { arrayMembershipMatches } from './support/matchers';
 
 const { module, test } = QUnit;
 
-module('MemoryCache', function(hooks) {
+module('MemoryCache', function (hooks) {
   let schema: Schema;
   let keyMap: KeyMap;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     schema = new Schema({
       models: {
         planet: {
@@ -42,23 +42,23 @@ module('MemoryCache', function(hooks) {
     keyMap = new KeyMap();
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     schema = null;
     keyMap = null;
   });
 
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     let cache = new MemoryCache({ schema });
 
     assert.ok(cache);
   });
 
-  test('it creates a `queryBuilder` if none is assigned', function(assert) {
+  test('it creates a `queryBuilder` if none is assigned', function (assert) {
     let cache = new MemoryCache({ schema });
     assert.ok(cache.queryBuilder, 'queryBuilder has been instantiated');
   });
 
-  test('creates a `transformBuilder` upon first access', function(assert) {
+  test('creates a `transformBuilder` upon first access', function (assert) {
     let cache = new MemoryCache({ schema });
     assert.ok(cache.transformBuilder, 'transformBuilder has been instantiated');
     assert.strictEqual(
@@ -68,7 +68,7 @@ module('MemoryCache', function(hooks) {
     );
   });
 
-  test('#patch sets data and #records retrieves it', function(assert) {
+  test('#patch sets data and #records retrieves it', function (assert) {
     assert.expect(4);
 
     let cache = new MemoryCache({ schema, keyMap });
@@ -88,7 +88,7 @@ module('MemoryCache', function(hooks) {
       assert.deepEqual(data, earth);
     });
 
-    cache.patch(t => t.addRecord(earth));
+    cache.patch((t) => t.addRecord(earth));
 
     assert.strictEqual(
       cache.getRecordSync({ type: 'planet', id: '1' }),
@@ -102,7 +102,7 @@ module('MemoryCache', function(hooks) {
     );
   });
 
-  test('#patch can replace records', function(assert) {
+  test('#patch can replace records', function (assert) {
     assert.expect(5);
 
     let cache = new MemoryCache({ schema, keyMap });
@@ -122,7 +122,7 @@ module('MemoryCache', function(hooks) {
       assert.deepEqual(data, earth);
     });
 
-    cache.patch(t => t.updateRecord(earth));
+    cache.patch((t) => t.updateRecord(earth));
 
     assert.deepEqual(
       cache.getRecordSync({ type: 'planet', id: '1' }),
@@ -141,7 +141,7 @@ module('MemoryCache', function(hooks) {
     );
   });
 
-  test('#patch can replace keys', function(assert) {
+  test('#patch can replace keys', function (assert) {
     assert.expect(4);
 
     let cache = new MemoryCache({ schema, keyMap });
@@ -162,7 +162,7 @@ module('MemoryCache', function(hooks) {
       });
     });
 
-    cache.patch(t => t.replaceKey(earth, 'remoteId', 'a'));
+    cache.patch((t) => t.replaceKey(earth, 'remoteId', 'a'));
 
     assert.deepEqual(
       cache.getRecordSync({ type: 'planet', id: '1' }),
@@ -176,12 +176,12 @@ module('MemoryCache', function(hooks) {
     );
   });
 
-  test('#reset clears the cache by default', function(assert) {
+  test('#reset clears the cache by default', function (assert) {
     assert.expect(3);
 
     let cache = new MemoryCache({ schema, keyMap });
 
-    cache.patch(t =>
+    cache.patch((t) =>
       t.addRecord({ type: 'planet', id: '1', attributes: { name: 'Earth' } })
     );
 
@@ -196,14 +196,14 @@ module('MemoryCache', function(hooks) {
     assert.equal(cache.getRecordsSync('planet').length, 0);
   });
 
-  test('#reset overrides the cache completely with data from another cache', function(assert) {
+  test('#reset overrides the cache completely with data from another cache', function (assert) {
     let cache1 = new MemoryCache({ schema, keyMap });
     let cache2 = new MemoryCache({ schema, keyMap });
 
-    cache1.patch(t =>
+    cache1.patch((t) =>
       t.addRecord({ type: 'planet', id: '1', attributes: { name: 'Earth' } })
     );
-    cache2.patch(t =>
+    cache2.patch((t) =>
       t.addRecord({ type: 'planet', id: '1', attributes: { name: 'Jupiter' } })
     );
 
@@ -215,7 +215,7 @@ module('MemoryCache', function(hooks) {
     );
   });
 
-  test('#upgrade upgrades the cache to include new models introduced in a schema', function(assert) {
+  test('#upgrade upgrades the cache to include new models introduced in a schema', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 
     let person = {
@@ -258,13 +258,13 @@ module('MemoryCache', function(hooks) {
     );
   });
 
-  test('#patch updates the cache and returns arrays of primary data and inverse ops', function(assert) {
+  test('#patch updates the cache and returns arrays of primary data and inverse ops', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 
     let p1 = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
     let p2 = { type: 'planet', id: '2' };
 
-    let result = cache.patch(t => [t.addRecord(p1), t.removeRecord(p2)]);
+    let result = cache.patch((t) => [t.addRecord(p1), t.removeRecord(p2)]);
 
     assert.deepEqual(
       result,
@@ -279,7 +279,7 @@ module('MemoryCache', function(hooks) {
     );
   });
 
-  test('#patch tracks refs and clears them from hasOne relationships when a referenced record is removed', function(assert) {
+  test('#patch tracks refs and clears them from hasOne relationships when a referenced record is removed', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -301,7 +301,7 @@ module('MemoryCache', function(hooks) {
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(io),
       t.addRecord(europa)
@@ -318,7 +318,7 @@ module('MemoryCache', function(hooks) {
       'Jupiter has been assigned to Europa'
     );
 
-    cache.patch(t => t.removeRecord(jupiter));
+    cache.patch((t) => t.removeRecord(jupiter));
 
     assert.equal(
       cache.getRecordSync({ type: 'planet', id: 'p1' }),
@@ -338,7 +338,7 @@ module('MemoryCache', function(hooks) {
     );
   });
 
-  test('#patch tracks refs and clears them from hasMany relationships when a referenced record is removed', function(assert) {
+  test('#patch tracks refs and clears them from hasMany relationships when a referenced record is removed', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 
     const io: Record = {
@@ -367,7 +367,7 @@ module('MemoryCache', function(hooks) {
       }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(io),
       t.addRecord(europa),
       t.addRecord(jupiter)
@@ -390,7 +390,7 @@ module('MemoryCache', function(hooks) {
       'Jupiter has been assigned to Io and Europa'
     );
 
-    cache.patch(t => t.removeRecord(io));
+    cache.patch((t) => t.removeRecord(io));
 
     assert.equal(
       cache.getRecordSync({ type: 'moon', id: 'm1' }),
@@ -398,7 +398,7 @@ module('MemoryCache', function(hooks) {
       'Io is GONE'
     );
 
-    cache.patch(t => t.removeRecord(europa));
+    cache.patch((t) => t.removeRecord(europa));
 
     assert.equal(
       cache.getRecordSync({ type: 'moon', id: 'm2' }),
@@ -413,10 +413,10 @@ module('MemoryCache', function(hooks) {
     );
   });
 
-  test("#patch adds link to hasMany if record doesn't exist", function(assert) {
+  test("#patch adds link to hasMany if record doesn't exist", function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 
-    cache.patch(t =>
+    cache.patch((t) =>
       t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
         type: 'moon',
         id: 'm1'
@@ -430,7 +430,7 @@ module('MemoryCache', function(hooks) {
     );
   });
 
-  test("#patch does not remove hasMany relationship if record doesn't exist", function(assert) {
+  test("#patch does not remove hasMany relationship if record doesn't exist", function (assert) {
     assert.expect(1);
 
     let cache = new MemoryCache({ schema, keyMap });
@@ -439,7 +439,7 @@ module('MemoryCache', function(hooks) {
       assert.ok(false, 'no operations were applied');
     });
 
-    cache.patch(t =>
+    cache.patch((t) =>
       t.removeFromRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
         type: 'moon',
         id: 'moon1'
@@ -453,7 +453,7 @@ module('MemoryCache', function(hooks) {
     );
   });
 
-  test("#patch adds hasOne if record doesn't exist", function(assert) {
+  test("#patch adds hasOne if record doesn't exist", function (assert) {
     assert.expect(2);
 
     let cache = new MemoryCache({ schema, keyMap });
@@ -472,7 +472,7 @@ module('MemoryCache', function(hooks) {
     );
 
     let order = 0;
-    cache.on('patch', op => {
+    cache.on('patch', (op) => {
       order++;
       if (order === 1) {
         assert.deepEqual(op, replacePlanet, 'applied replacePlanet operation');
@@ -486,7 +486,7 @@ module('MemoryCache', function(hooks) {
     cache.patch([replacePlanet]);
   });
 
-  test("#patch will add empty hasOne link if record doesn't exist", function(assert) {
+  test("#patch will add empty hasOne link if record doesn't exist", function (assert) {
     assert.expect(2);
 
     let cache = new MemoryCache({ schema, keyMap });
@@ -499,7 +499,7 @@ module('MemoryCache', function(hooks) {
     );
 
     let order = 0;
-    cache.on('patch', op => {
+    cache.on('patch', (op) => {
       order++;
       if (order === 1) {
         assert.deepEqual(op, clearPlanet, 'applied clearPlanet operation');
@@ -513,7 +513,7 @@ module('MemoryCache', function(hooks) {
     assert.ok(true, 'patch applied');
   });
 
-  test('#patch does not add link to hasMany if link already exists', function(assert) {
+  test('#patch does not add link to hasMany if link already exists', function (assert) {
     assert.expect(1);
 
     let cache = new MemoryCache({ schema, keyMap });
@@ -525,20 +525,20 @@ module('MemoryCache', function(hooks) {
       relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
     };
 
-    cache.patch(t => t.addRecord(jupiter));
+    cache.patch((t) => t.addRecord(jupiter));
 
     cache.on('patch', () => {
       assert.ok(false, 'no operations were applied');
     });
 
-    cache.patch(t =>
+    cache.patch((t) =>
       t.addToRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'm1' })
     );
 
     assert.ok(true, 'patch completed');
   });
 
-  test("#patch does not remove relationship from hasMany if relationship doesn't exist", function(assert) {
+  test("#patch does not remove relationship from hasMany if relationship doesn't exist", function (assert) {
     assert.expect(1);
 
     let cache = new MemoryCache({ schema, keyMap });
@@ -549,31 +549,31 @@ module('MemoryCache', function(hooks) {
       attributes: { name: 'Jupiter' }
     };
 
-    cache.patch(t => t.addRecord(jupiter));
+    cache.patch((t) => t.addRecord(jupiter));
 
     cache.on('patch', () => {
       assert.ok(false, 'no operations were applied');
     });
 
-    cache.patch(t =>
+    cache.patch((t) =>
       t.removeFromRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'm1' })
     );
 
     assert.ok(true, 'patch completed');
   });
 
-  test('#patch can add and remove to has-many relationship', function(assert) {
+  test('#patch can add and remove to has-many relationship', function (assert) {
     assert.expect(2);
 
     let cache = new MemoryCache({ schema, keyMap });
 
     const jupiter: Record = { id: 'jupiter', type: 'planet' };
-    cache.patch(t => t.addRecord(jupiter));
+    cache.patch((t) => t.addRecord(jupiter));
 
     const callisto = { id: 'callisto', type: 'moon' };
-    cache.patch(t => t.addRecord(callisto));
+    cache.patch((t) => t.addRecord(callisto));
 
-    cache.patch(t =>
+    cache.patch((t) =>
       t.addToRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'callisto' })
     );
 
@@ -582,7 +582,7 @@ module('MemoryCache', function(hooks) {
       'moon added'
     );
 
-    cache.patch(t =>
+    cache.patch((t) =>
       t.removeFromRelatedRecords(jupiter, 'moons', {
         type: 'moon',
         id: 'callisto'
@@ -595,18 +595,18 @@ module('MemoryCache', function(hooks) {
     );
   });
 
-  test('#patch can add and clear has-one relationship', function(assert) {
+  test('#patch can add and clear has-one relationship', function (assert) {
     assert.expect(2);
 
     let cache = new MemoryCache({ schema, keyMap });
 
     const jupiter: Record = { id: 'jupiter', type: 'planet' };
-    cache.patch(t => t.addRecord(jupiter));
+    cache.patch((t) => t.addRecord(jupiter));
 
     const callisto = { id: 'callisto', type: 'moon' };
-    cache.patch(t => t.addRecord(callisto));
+    cache.patch((t) => t.addRecord(callisto));
 
-    cache.patch(t =>
+    cache.patch((t) =>
       t.replaceRelatedRecord(callisto, 'planet', {
         type: 'planet',
         id: 'jupiter'
@@ -621,7 +621,7 @@ module('MemoryCache', function(hooks) {
       'relationship added'
     );
 
-    cache.patch(t => t.replaceRelatedRecord(callisto, 'planet', null));
+    cache.patch((t) => t.replaceRelatedRecord(callisto, 'planet', null));
 
     assert.notOk(
       equalRecordIdentities(
@@ -632,7 +632,7 @@ module('MemoryCache', function(hooks) {
     );
   });
 
-  test('does not replace hasOne if relationship already exists', function(assert) {
+  test('does not replace hasOne if relationship already exists', function (assert) {
     assert.expect(1);
 
     let cache = new MemoryCache({ schema, keyMap });
@@ -644,20 +644,20 @@ module('MemoryCache', function(hooks) {
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
 
-    cache.patch(t => t.addRecord(europa));
+    cache.patch((t) => t.addRecord(europa));
 
     cache.on('patch', () => {
       assert.ok(false, 'no operations were applied');
     });
 
-    cache.patch(t =>
+    cache.patch((t) =>
       t.replaceRelatedRecord(europa, 'planet', { type: 'planet', id: 'p1' })
     );
 
     assert.ok(true, 'patch completed');
   });
 
-  test("does not remove hasOne if relationship doesn't exist", function(assert) {
+  test("does not remove hasOne if relationship doesn't exist", function (assert) {
     assert.expect(1);
 
     let cache = new MemoryCache({ schema, keyMap });
@@ -669,18 +669,18 @@ module('MemoryCache', function(hooks) {
       relationships: { planet: { data: null } }
     };
 
-    cache.patch(t => t.addRecord(europa));
+    cache.patch((t) => t.addRecord(europa));
 
     cache.on('patch', () => {
       assert.ok(false, 'no operations were applied');
     });
 
-    cache.patch(t => t.replaceRelatedRecord(europa, 'planet', null));
+    cache.patch((t) => t.replaceRelatedRecord(europa, 'planet', null));
 
     assert.ok(true, 'patch completed');
   });
 
-  test('#patch removing model with a bi-directional hasOne', function(assert) {
+  test('#patch removing model with a bi-directional hasOne', function (assert) {
     assert.expect(5);
 
     const hasOneSchema = new Schema({
@@ -700,7 +700,7 @@ module('MemoryCache', function(hooks) {
 
     let cache = new MemoryCache({ schema: hasOneSchema, keyMap });
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord({
         id: '1',
         type: 'one',
@@ -732,7 +732,7 @@ module('MemoryCache', function(hooks) {
       'two links to one'
     );
 
-    cache.patch(t => t.removeRecord(two));
+    cache.patch((t) => t.removeRecord(two));
 
     assert.equal(
       cache.getRecordSync({ type: 'one', id: '1' }).relationships.two.data,
@@ -741,11 +741,11 @@ module('MemoryCache', function(hooks) {
     );
   });
 
-  test('#patch merges records when "replacing" and will not stomp on attributes and relationships that are not replaced', function(assert) {
+  test('#patch merges records when "replacing" and will not stomp on attributes and relationships that are not replaced', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord({
         type: 'planet',
         id: '1',
@@ -754,7 +754,7 @@ module('MemoryCache', function(hooks) {
       })
     ]);
 
-    let result = cache.patch(t => [
+    let result = cache.patch((t) => [
       t.updateRecord({
         type: 'planet',
         id: '1',
@@ -763,7 +763,7 @@ module('MemoryCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      cache.query(q => q.findRecord({ type: 'planet', id: '1' })),
+      cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
       {
         type: 'planet',
         id: '1',
@@ -803,11 +803,11 @@ module('MemoryCache', function(hooks) {
     );
   });
 
-  test('#patch can replace related records but only if they are different', function(assert) {
+  test('#patch can replace related records but only if they are different', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord({
         type: 'planet',
         id: '1',
@@ -816,7 +816,7 @@ module('MemoryCache', function(hooks) {
       })
     ]);
 
-    let result = cache.patch(t => [
+    let result = cache.patch((t) => [
       t.replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
         { type: 'moon', id: 'm1' }
       ])
@@ -831,14 +831,14 @@ module('MemoryCache', function(hooks) {
       'nothing has changed so there are no inverse ops'
     );
 
-    result = cache.patch(t => [
+    result = cache.patch((t) => [
       t.replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
         { type: 'moon', id: 'm2' }
       ])
     ]);
 
     assert.deepEqual(
-      cache.query(q => q.findRecord({ type: 'planet', id: '1' })),
+      cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
       {
         type: 'planet',
         id: '1',
@@ -876,7 +876,7 @@ module('MemoryCache', function(hooks) {
     );
   });
 
-  test('#patch merges records when "replacing" and _will_ replace specified attributes and relationships', function(assert) {
+  test('#patch merges records when "replacing" and _will_ replace specified attributes and relationships', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
@@ -927,7 +927,7 @@ module('MemoryCache', function(hooks) {
     });
 
     assert.deepEqual(
-      cache.query(q => q.findRecord({ type: 'planet', id: '1' })),
+      cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
       {
         type: 'planet',
         id: '1',
@@ -938,7 +938,7 @@ module('MemoryCache', function(hooks) {
     );
   });
 
-  test('#query can retrieve an individual record with `record`', function(assert) {
+  test('#query can retrieve an individual record with `record`', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 
     let jupiter = {
@@ -950,15 +950,15 @@ module('MemoryCache', function(hooks) {
         atmosphere: true
       }
     };
-    cache.patch(t => [t.addRecord(jupiter)]);
+    cache.patch((t) => [t.addRecord(jupiter)]);
 
     assert.deepEqual(
-      cache.query(q => q.findRecord({ type: 'planet', id: 'jupiter' })),
+      cache.query((q) => q.findRecord({ type: 'planet', id: 'jupiter' })),
       jupiter
     );
   });
 
-  test('#query can perform a simple attribute filter by value equality', function(assert) {
+  test('#query can perform a simple attribute filter by value equality', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
@@ -999,7 +999,7 @@ module('MemoryCache', function(hooks) {
       }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -1008,14 +1008,14 @@ module('MemoryCache', function(hooks) {
 
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q.findRecords('planet').filter({ attribute: 'name', value: 'Jupiter' })
       ),
       [jupiter]
     );
   });
 
-  test('#query can perform a simple attribute filter by value comparison (gt, lt, gte & lte)', function(assert) {
+  test('#query can perform a simple attribute filter by value comparison (gt, lt, gte & lte)', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
@@ -1060,7 +1060,7 @@ module('MemoryCache', function(hooks) {
       }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -1068,7 +1068,7 @@ module('MemoryCache', function(hooks) {
     ]);
     arrayMembershipMatches(
       assert,
-      cache.query(q => {
+      cache.query((q) => {
         let tmp = q.findRecords('planet');
         return tmp.filter({ attribute: 'sequence', value: 2, op: 'gt' });
       }),
@@ -1076,7 +1076,7 @@ module('MemoryCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q => {
+      cache.query((q) => {
         let tmp = q.findRecords('planet');
         return tmp.filter({ attribute: 'sequence', value: 2, op: 'gte' });
       }),
@@ -1084,7 +1084,7 @@ module('MemoryCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q => {
+      cache.query((q) => {
         let tmp = q.findRecords('planet');
         return tmp.filter({ attribute: 'sequence', value: 2, op: 'lt' });
       }),
@@ -1092,7 +1092,7 @@ module('MemoryCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q => {
+      cache.query((q) => {
         let tmp = q.findRecords('planet');
         return tmp.filter({ attribute: 'sequence', value: 2, op: 'lte' });
       }),
@@ -1100,7 +1100,7 @@ module('MemoryCache', function(hooks) {
     );
   });
 
-  test('#query can perform relatedRecords filters with operators `equal`, `all`, `some` and `none`', function(assert) {
+  test('#query can perform relatedRecords filters with operators `equal`, `all`, `some` and `none`', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
@@ -1205,7 +1205,7 @@ module('MemoryCache', function(hooks) {
       relationships: {}
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(mars),
@@ -1220,7 +1220,7 @@ module('MemoryCache', function(hooks) {
     ]);
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [theMoon], op: 'equal' })
@@ -1229,7 +1229,7 @@ module('MemoryCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [phobos], op: 'equal' })
@@ -1238,7 +1238,7 @@ module('MemoryCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [phobos], op: 'all' })
@@ -1247,7 +1247,7 @@ module('MemoryCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [phobos, callisto], op: 'all' })
@@ -1256,7 +1256,7 @@ module('MemoryCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q.findRecords('planet').filter({
           relation: 'moons',
           records: [phobos, callisto],
@@ -1267,7 +1267,7 @@ module('MemoryCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [titan], op: 'some' })
@@ -1276,7 +1276,7 @@ module('MemoryCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [ganymede], op: 'none' })
@@ -1285,7 +1285,7 @@ module('MemoryCache', function(hooks) {
     );
   });
 
-  test('#query can perform relatedRecord filters', function(assert) {
+  test('#query can perform relatedRecord filters', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
@@ -1390,7 +1390,7 @@ module('MemoryCache', function(hooks) {
       relationships: {}
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(mars),
@@ -1405,28 +1405,28 @@ module('MemoryCache', function(hooks) {
     ]);
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q.findRecords('moon').filter({ relation: 'planet', record: earth })
       ),
       [theMoon]
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q.findRecords('moon').filter({ relation: 'planet', record: jupiter })
       ),
       [europa, ganymede, callisto]
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q.findRecords('moon').filter({ relation: 'planet', record: mercury })
       ),
       []
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRecords('moon')
           .filter({ relation: 'planet', record: [earth, mars] })
@@ -1435,7 +1435,7 @@ module('MemoryCache', function(hooks) {
     );
   });
 
-  test('#query can perform a complex attribute filter by value', function(assert) {
+  test('#query can perform a complex attribute filter by value', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 
     let jupiter = {
@@ -1475,7 +1475,7 @@ module('MemoryCache', function(hooks) {
       }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -1484,7 +1484,7 @@ module('MemoryCache', function(hooks) {
 
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRecords('planet')
           .filter(
@@ -1496,7 +1496,7 @@ module('MemoryCache', function(hooks) {
     );
   });
 
-  test('#query can perform a filter on attributes, even when a particular record has none', function(assert) {
+  test('#query can perform a filter on attributes, even when a particular record has none', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 
     let jupiter = { type: 'planet', id: 'jupiter' };
@@ -1528,7 +1528,7 @@ module('MemoryCache', function(hooks) {
       }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -1537,7 +1537,7 @@ module('MemoryCache', function(hooks) {
 
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRecords('planet')
           .filter(
@@ -1549,7 +1549,7 @@ module('MemoryCache', function(hooks) {
     );
   });
 
-  test('#query can sort by an attribute', function(assert) {
+  test('#query can sort by an attribute', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 
     let jupiter = {
@@ -1589,7 +1589,7 @@ module('MemoryCache', function(hooks) {
       }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -1597,12 +1597,12 @@ module('MemoryCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      cache.query(q => q.findRecords('planet').sort('name')),
+      cache.query((q) => q.findRecords('planet').sort('name')),
       [earth, jupiter, mercury, venus]
     );
   });
 
-  test('#query can sort by an attribute, even when a particular record has none', function(assert) {
+  test('#query can sort by an attribute, even when a particular record has none', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 
     let jupiter = { type: 'planet', id: 'jupiter' };
@@ -1634,7 +1634,7 @@ module('MemoryCache', function(hooks) {
       }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -1642,12 +1642,12 @@ module('MemoryCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      cache.query(q => q.findRecords('planet').sort('name')),
+      cache.query((q) => q.findRecords('planet').sort('name')),
       [earth, mercury, venus, jupiter]
     );
   });
 
-  test('#query can filter and sort by attributes', function(assert) {
+  test('#query can filter and sort by attributes', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 
     let jupiter = {
@@ -1687,7 +1687,7 @@ module('MemoryCache', function(hooks) {
       }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -1695,7 +1695,7 @@ module('MemoryCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRecords('planet')
           .filter(
@@ -1708,7 +1708,7 @@ module('MemoryCache', function(hooks) {
     );
   });
 
-  test('#query can sort by an attribute in descending order', function(assert) {
+  test('#query can sort by an attribute in descending order', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 
     let jupiter = {
@@ -1748,7 +1748,7 @@ module('MemoryCache', function(hooks) {
       }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -1756,12 +1756,12 @@ module('MemoryCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      cache.query(q => q.findRecords('planet').sort('-name')),
+      cache.query((q) => q.findRecords('planet').sort('-name')),
       [venus, mercury, jupiter, earth]
     );
   });
 
-  test('#query can sort by according to multiple criteria', function(assert) {
+  test('#query can sort by according to multiple criteria', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 
     let jupiter = {
@@ -1801,7 +1801,7 @@ module('MemoryCache', function(hooks) {
       }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -1809,12 +1809,14 @@ module('MemoryCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      cache.query(q => q.findRecords('planet').sort('classification', 'name')),
+      cache.query((q) =>
+        q.findRecords('planet').sort('classification', 'name')
+      ),
       [jupiter, earth, mercury, venus]
     );
   });
 
-  test('#query - findRecord - finds record', function(assert) {
+  test('#query - findRecord - finds record', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -1824,24 +1826,24 @@ module('MemoryCache', function(hooks) {
       relationships: { moons: { data: [{ type: 'moon', id: 'callisto' }] } }
     };
 
-    cache.patch(t => [t.addRecord(jupiter)]);
+    cache.patch((t) => [t.addRecord(jupiter)]);
 
     assert.deepEqual(
-      cache.query(q => q.findRecord({ type: 'planet', id: 'jupiter' })),
+      cache.query((q) => q.findRecord({ type: 'planet', id: 'jupiter' })),
       jupiter
     );
   });
 
-  test("#query - findRecord - throws RecordNotFoundException if record doesn't exist", function(assert) {
+  test("#query - findRecord - throws RecordNotFoundException if record doesn't exist", function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 
     assert.throws(
-      () => cache.query(q => q.findRecord({ type: 'planet', id: 'jupiter' })),
+      () => cache.query((q) => q.findRecord({ type: 'planet', id: 'jupiter' })),
       RecordNotFoundException
     );
   });
 
-  test('#query - findRecords - records by type', function(assert) {
+  test('#query - findRecords - records by type', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -1858,15 +1860,15 @@ module('MemoryCache', function(hooks) {
       relationships: { planet: { data: [{ type: 'planet', id: 'jupiter' }] } }
     };
 
-    cache.patch(t => [t.addRecord(jupiter), t.addRecord(callisto)]);
+    cache.patch((t) => [t.addRecord(jupiter), t.addRecord(callisto)]);
 
     assert.deepEqual(
-      cache.query(q => q.findRecords('planet')),
+      cache.query((q) => q.findRecords('planet')),
       [jupiter]
     );
   });
 
-  test('#query - findRecords - records by identity', async function(assert) {
+  test('#query - findRecords - records by identity', async function (assert) {
     assert.expect(1);
 
     let cache = new MemoryCache({ schema, keyMap });
@@ -1897,19 +1899,19 @@ module('MemoryCache', function(hooks) {
       }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(earth),
       t.addRecord(jupiter),
       t.addRecord(io)
     ]);
 
-    let records = await cache.query(q =>
+    let records = await cache.query((q) =>
       q.findRecords([earth, io, { type: 'moon', id: 'FAKE' }])
     );
     assert.deepEqual(records, [earth, io], 'query results are expected');
   });
 
-  test('#query - page - can paginate records by offset and limit', function(assert) {
+  test('#query - page - can paginate records by offset and limit', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -1936,7 +1938,7 @@ module('MemoryCache', function(hooks) {
       attributes: { name: 'Mars' }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -1944,32 +1946,26 @@ module('MemoryCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      cache.query(q => q.findRecords('planet').sort('name')),
+      cache.query((q) => q.findRecords('planet').sort('name')),
       [earth, jupiter, mars, venus]
     );
 
     assert.deepEqual(
-      cache.query(q =>
-        q
-          .findRecords('planet')
-          .sort('name')
-          .page({ limit: 3 })
+      cache.query((q) =>
+        q.findRecords('planet').sort('name').page({ limit: 3 })
       ),
       [earth, jupiter, mars]
     );
 
     assert.deepEqual(
-      cache.query(q =>
-        q
-          .findRecords('planet')
-          .sort('name')
-          .page({ offset: 1, limit: 2 })
+      cache.query((q) =>
+        q.findRecords('planet').sort('name').page({ offset: 1, limit: 2 })
       ),
       [jupiter, mars]
     );
   });
 
-  test('#query - findRelatedRecords', function(assert) {
+  test('#query - findRelatedRecords', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -1986,17 +1982,17 @@ module('MemoryCache', function(hooks) {
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
 
-    cache.patch(t => [t.addRecord(jupiter), t.addRecord(callisto)]);
+    cache.patch((t) => [t.addRecord(jupiter), t.addRecord(callisto)]);
 
     assert.deepEqual(
-      cache.query(q =>
+      cache.query((q) =>
         q.findRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons')
       ),
       [callisto]
     );
   });
 
-  test('#query - findRelatedRecord', function(assert) {
+  test('#query - findRelatedRecord', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -2013,10 +2009,10 @@ module('MemoryCache', function(hooks) {
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
 
-    cache.patch(t => [t.addRecord(jupiter), t.addRecord(callisto)]);
+    cache.patch((t) => [t.addRecord(jupiter), t.addRecord(callisto)]);
 
     assert.deepEqual(
-      cache.query(q =>
+      cache.query((q) =>
         q.findRelatedRecord({ type: 'moon', id: 'callisto' }, 'planet')
       ),
       jupiter

--- a/packages/@orbit/memory/test/memory-source-test.ts
+++ b/packages/@orbit/memory/test/memory-source-test.ts
@@ -19,7 +19,7 @@ import MemorySource from '../src/index';
 
 const { module, test } = QUnit;
 
-module('MemorySource', function(hooks) {
+module('MemorySource', function (hooks) {
   const schemaDefinition: SchemaSettings = {
     models: {
       star: {
@@ -56,18 +56,18 @@ module('MemorySource', function(hooks) {
   let source: MemorySource;
   let keyMap: KeyMap;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     keyMap = new KeyMap();
     source = new MemorySource({ schema, keyMap });
   });
 
-  test('its prototype chain is correct', function(assert) {
+  test('its prototype chain is correct', function (assert) {
     assert.ok(source instanceof Source, 'instanceof Source');
     assert.ok(source instanceof MemorySource, 'instanceof MemorySource');
     assert.equal(source.name, 'memory', 'should have default name');
   });
 
-  test("internal cache's settings can be specified with `cacheSettings`", function(assert) {
+  test("internal cache's settings can be specified with `cacheSettings`", function (assert) {
     let source = new MemorySource({
       schema,
       keyMap,
@@ -85,7 +85,7 @@ module('MemorySource', function(hooks) {
     assert.equal(cache._processors.length, 2, 'cache has 2 processors');
   });
 
-  test('automatically shares its `transformBuilder` and `queryBuilder` with its cache', function(assert) {
+  test('automatically shares its `transformBuilder` and `queryBuilder` with its cache', function (assert) {
     assert.strictEqual(
       source.cache.transformBuilder,
       source.transformBuilder,
@@ -98,7 +98,7 @@ module('MemorySource', function(hooks) {
     );
   });
 
-  test("#update - transforms the source's cache", async function(assert) {
+  test("#update - transforms the source's cache", async function (assert) {
     assert.expect(4);
 
     const jupiter: Record = {
@@ -113,7 +113,7 @@ module('MemorySource', function(hooks) {
       'cache should start empty'
     );
 
-    let record = await source.update(t => t.addRecord(jupiter));
+    let record = await source.update((t) => t.addRecord(jupiter));
 
     assert.equal(
       source.cache.getRecordsSync('planet').length,
@@ -128,7 +128,7 @@ module('MemorySource', function(hooks) {
     assert.strictEqual(record, jupiter, 'result should be returned');
   });
 
-  test('#update - can perform multiple operations and return the results', async function(assert) {
+  test('#update - can perform multiple operations and return the results', async function (assert) {
     assert.expect(3);
 
     const jupiter: Record = {
@@ -149,7 +149,7 @@ module('MemorySource', function(hooks) {
       'cache should start empty'
     );
 
-    let records = await source.update(t => [
+    let records = await source.update((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth)
     ]);
@@ -166,7 +166,7 @@ module('MemorySource', function(hooks) {
     );
   });
 
-  test('#update - accepts hints that can return a single record', async function(assert) {
+  test('#update - accepts hints that can return a single record', async function (assert) {
     assert.expect(2);
 
     let jupiter = {
@@ -181,7 +181,7 @@ module('MemorySource', function(hooks) {
       attributes: { name: 'Earth' }
     };
 
-    source.cache.patch(t => t.addRecord(earth));
+    source.cache.patch((t) => t.addRecord(earth));
 
     source.on('beforeUpdate', (transform: Transform, hints: any) => {
       if (transform.options.customizeResults) {
@@ -189,7 +189,7 @@ module('MemorySource', function(hooks) {
       }
     });
 
-    let planet = await source.update(t => t.addRecord(jupiter), {
+    let planet = await source.update((t) => t.addRecord(jupiter), {
       customizeResults: true
     });
 
@@ -202,7 +202,7 @@ module('MemorySource', function(hooks) {
     assert.deepEqual(planet, earth, 'added planet matches hinted record');
   });
 
-  test('#update - accepts hints that can return a collection of records', async function(assert) {
+  test('#update - accepts hints that can return a collection of records', async function (assert) {
     assert.expect(2);
 
     let jupiter = {
@@ -233,7 +233,7 @@ module('MemorySource', function(hooks) {
     });
 
     let planets = await source.update(
-      t => [t.addRecord(jupiter), t.addRecord(earth), t.addRecord(uranus)],
+      (t) => [t.addRecord(jupiter), t.addRecord(earth), t.addRecord(uranus)],
       {
         customizeResults: true
       }
@@ -252,7 +252,7 @@ module('MemorySource', function(hooks) {
     );
   });
 
-  test('#update - accepts hints that can return an array of varied results', async function(assert) {
+  test('#update - accepts hints that can return an array of varied results', async function (assert) {
     assert.expect(2);
 
     let jupiter = {
@@ -286,7 +286,7 @@ module('MemorySource', function(hooks) {
     });
 
     let planets = await source.update(
-      t => [t.addRecord(jupiter), t.addRecord(earth), t.addRecord(uranus)],
+      (t) => [t.addRecord(jupiter), t.addRecord(earth), t.addRecord(uranus)],
       {
         customizeResults: true
       }
@@ -305,7 +305,7 @@ module('MemorySource', function(hooks) {
     );
   });
 
-  test("#query - queries the source's cache", async function(assert) {
+  test("#query - queries the source's cache", async function (assert) {
     assert.expect(2);
 
     let jupiter = {
@@ -314,7 +314,7 @@ module('MemorySource', function(hooks) {
       attributes: { name: 'Jupiter', classification: 'gas giant' }
     };
 
-    source.cache.patch(t => t.addRecord(jupiter));
+    source.cache.patch((t) => t.addRecord(jupiter));
 
     assert.equal(
       source.cache.getRecordsSync('planet').length,
@@ -322,14 +322,14 @@ module('MemorySource', function(hooks) {
       'cache should contain one planet'
     );
 
-    let planet = await source.query(q =>
+    let planet = await source.query((q) =>
       q.findRecord({ type: 'planet', id: 'jupiter' })
     );
 
     assert.deepEqual(planet, jupiter, 'found planet matches original');
   });
 
-  test('#query - findRecord accepts hints that can influence results', async function(assert) {
+  test('#query - findRecord accepts hints that can influence results', async function (assert) {
     assert.expect(2);
 
     let jupiter2 = {
@@ -344,7 +344,7 @@ module('MemorySource', function(hooks) {
       }
     });
 
-    source.cache.patch(t => t.addRecord(jupiter2));
+    source.cache.patch((t) => t.addRecord(jupiter2));
 
     assert.equal(
       source.cache.getRecordsSync('planet').length,
@@ -352,14 +352,14 @@ module('MemorySource', function(hooks) {
       'cache should contain one planet'
     );
 
-    let planet = await source.query(q =>
+    let planet = await source.query((q) =>
       q.findRecord({ type: 'planet', id: 'jupiter' })
     );
 
     assert.deepEqual(planet, jupiter2, 'found planet matches hinted record');
   });
 
-  test('#query - findRecords accepts hints that can influence results', async function(assert) {
+  test('#query - findRecords accepts hints that can influence results', async function (assert) {
     assert.expect(2);
 
     let jupiter = {
@@ -392,7 +392,7 @@ module('MemorySource', function(hooks) {
       }
     });
 
-    source.cache.patch(t => [
+    source.cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(uranus)
@@ -404,7 +404,7 @@ module('MemorySource', function(hooks) {
       'cache should contain three planets'
     );
 
-    let distantPlanets = await source.query(q => q.findRecords('planet'), {
+    let distantPlanets = await source.query((q) => q.findRecords('planet'), {
       sources: {
         remote: {
           customFilter: 'distantPlanets' // custom remote-only filter
@@ -419,7 +419,7 @@ module('MemorySource', function(hooks) {
     );
   });
 
-  test('#query - catches errors', async function(assert) {
+  test('#query - catches errors', async function (assert) {
     assert.expect(2);
 
     source.cache.reset();
@@ -431,13 +431,15 @@ module('MemorySource', function(hooks) {
     );
 
     try {
-      await source.query(q => q.findRecord({ type: 'planet', id: 'jupiter' }));
+      await source.query((q) =>
+        q.findRecord({ type: 'planet', id: 'jupiter' })
+      );
     } catch (e) {
       assert.equal(e.message, 'Record not found: planet:jupiter');
     }
   });
 
-  test('#query - can query with multiple expressions', async function(assert) {
+  test('#query - can query with multiple expressions', async function (assert) {
     const jupiter: Record = {
       type: 'planet',
       id: 'jupiter',
@@ -452,10 +454,10 @@ module('MemorySource', function(hooks) {
         name: 'Earth'
       }
     };
-    await source.update(t => [t.addRecord(jupiter), t.addRecord(earth)]);
+    await source.update((t) => [t.addRecord(jupiter), t.addRecord(earth)]);
 
     assert.deepEqual(
-      await source.query(q => [
+      await source.query((q) => [
         q.findRecord({ type: 'planet', id: 'jupiter' }),
         q.findRecord({ type: 'planet', id: 'earth' })
       ]),
@@ -463,7 +465,7 @@ module('MemorySource', function(hooks) {
     );
   });
 
-  test('#sync - appends transform to log', async function(assert) {
+  test('#sync - appends transform to log', async function (assert) {
     const recordA = {
       id: 'jupiter',
       type: 'planet',
@@ -482,7 +484,7 @@ module('MemorySource', function(hooks) {
     );
   });
 
-  test('#getTransform - returns a particular transform given an id', async function(assert) {
+  test('#getTransform - returns a particular transform given an id', async function (assert) {
     const recordA = {
       id: 'jupiter',
       type: 'planet',
@@ -501,7 +503,7 @@ module('MemorySource', function(hooks) {
     );
   });
 
-  test('#getInverseOperations - returns the inverse operations for a particular transform', async function(assert) {
+  test('#getInverseOperations - returns the inverse operations for a particular transform', async function (assert) {
     const recordA = {
       id: 'jupiter',
       type: 'planet',
@@ -518,7 +520,7 @@ module('MemorySource', function(hooks) {
     ]);
   });
 
-  test('#transformsSince - returns all transforms since a specified transformId', async function(assert) {
+  test('#transformsSince - returns all transforms since a specified transformId', async function (assert) {
     const recordA = {
       id: 'jupiter',
       type: 'planet',
@@ -551,7 +553,7 @@ module('MemorySource', function(hooks) {
     );
   });
 
-  test('#allTransforms - returns all tracked transforms', async function(assert) {
+  test('#allTransforms - returns all tracked transforms', async function (assert) {
     const recordA = {
       id: 'jupiter',
       type: 'planet',
@@ -584,7 +586,7 @@ module('MemorySource', function(hooks) {
     );
   });
 
-  test('transformLog.truncate - clears transforms from log as well as tracked transforms before a specified transform', async function(assert) {
+  test('transformLog.truncate - clears transforms from log as well as tracked transforms before a specified transform', async function (assert) {
     const recordA = {
       id: 'jupiter',
       type: 'planet',
@@ -619,7 +621,7 @@ module('MemorySource', function(hooks) {
     );
   });
 
-  test('transformLog.clear - clears all transforms from log as well as tracked transforms', async function(assert) {
+  test('transformLog.clear - clears all transforms from log as well as tracked transforms', async function (assert) {
     const recordA = {
       id: 'jupiter',
       type: 'planet',
@@ -654,14 +656,14 @@ module('MemorySource', function(hooks) {
     );
   });
 
-  test('#fork - creates a new source that starts with the same schema, keyMap, and cache contents as the base source', async function(assert) {
+  test('#fork - creates a new source that starts with the same schema, keyMap, and cache contents as the base source', async function (assert) {
     const jupiter: Record = {
       type: 'planet',
       id: 'jupiter-id',
       attributes: { name: 'Jupiter', classification: 'gas giant' }
     };
 
-    await source.update(t => t.addRecord(jupiter));
+    await source.update((t) => t.addRecord(jupiter));
 
     assert.deepEqual(
       source.cache.getRecordSync({ type: 'planet', id: 'jupiter-id' }),
@@ -700,7 +702,7 @@ module('MemorySource', function(hooks) {
     );
   });
 
-  test('#merge - merges transforms from a forked source back into a base source', async function(assert) {
+  test('#merge - merges transforms from a forked source back into a base source', async function (assert) {
     const jupiter: Record = {
       type: 'planet',
       id: 'jupiter-id',
@@ -709,7 +711,7 @@ module('MemorySource', function(hooks) {
 
     let fork = source.fork();
 
-    await fork.update(t => t.addRecord(jupiter));
+    await fork.update((t) => t.addRecord(jupiter));
 
     assert.deepEqual(
       fork.cache.getRecordSync({ type: 'planet', id: 'jupiter-id' }),
@@ -726,7 +728,7 @@ module('MemorySource', function(hooks) {
     );
   });
 
-  test('#merge - can accept options that will be assigned to the resulting transform', async function(assert) {
+  test('#merge - can accept options that will be assigned to the resulting transform', async function (assert) {
     assert.expect(3);
 
     const jupiter: Record = {
@@ -737,11 +739,11 @@ module('MemorySource', function(hooks) {
 
     let fork = source.fork();
 
-    source.on('update', transform => {
+    source.on('update', (transform) => {
       assert.equal(transform.options.label, 'Create Jupiter');
     });
 
-    await fork.update(t => t.addRecord(jupiter));
+    await fork.update((t) => t.addRecord(jupiter));
 
     assert.deepEqual(
       fork.cache.getRecordSync({ type: 'planet', id: 'jupiter-id' }),
@@ -758,7 +760,7 @@ module('MemorySource', function(hooks) {
     );
   });
 
-  test('#rebase - works with empty sources', function(assert) {
+  test('#rebase - works with empty sources', function (assert) {
     assert.expect(1);
 
     let child = source.fork();
@@ -767,7 +769,7 @@ module('MemorySource', function(hooks) {
     assert.ok(true, 'no exception has been thrown');
   });
 
-  test('#rebase - record ends up in child source', async function(assert) {
+  test('#rebase - record ends up in child source', async function (assert) {
     assert.expect(3);
 
     const jupiter: Record = {
@@ -778,7 +780,7 @@ module('MemorySource', function(hooks) {
 
     let child = source.fork();
 
-    await source.update(t => t.addRecord(jupiter));
+    await source.update((t) => t.addRecord(jupiter));
 
     assert.deepEqual(
       source.cache.getRecordSync({ type: 'planet', id: 'jupiter-id' }),
@@ -800,7 +802,7 @@ module('MemorySource', function(hooks) {
     );
   });
 
-  test('#rebase - maintains only unique transforms in fork', async function(assert) {
+  test('#rebase - maintains only unique transforms in fork', async function (assert) {
     const recordA = {
       id: 'jupiter',
       type: 'planet',
@@ -857,7 +859,7 @@ module('MemorySource', function(hooks) {
     assert.deepEqual(fork.cache.getRecordsSync('planet').length, 5);
   });
 
-  test('#rebase - rebase orders conflicting transforms in expected way', async function(assert) {
+  test('#rebase - rebase orders conflicting transforms in expected way', async function (assert) {
     assert.expect(6);
 
     const jupiter: Record = {
@@ -870,7 +872,7 @@ module('MemorySource', function(hooks) {
     let child: MemorySource;
 
     // 1. fill source with some data
-    await source.update(t => t.addRecord(jupiter));
+    await source.update((t) => t.addRecord(jupiter));
 
     // 2. create a child source
     assert.deepEqual(
@@ -886,8 +888,8 @@ module('MemorySource', function(hooks) {
     );
 
     // 3. update the child and the parent source (in any order)
-    await child.update(t => t.replaceAttribute(id, 'name', 'The Gas Giant'));
-    await source.update(t => t.replaceAttribute(id, 'name', 'Gassy Giant'));
+    await child.update((t) => t.replaceAttribute(id, 'name', 'The Gas Giant'));
+    await source.update((t) => t.replaceAttribute(id, 'name', 'Gassy Giant'));
 
     // 4. make sure updates were successful
     assert.equal(
@@ -906,7 +908,7 @@ module('MemorySource', function(hooks) {
     assert.equal(source.cache.getRecordSync(id).attributes.name, 'Gassy Giant');
   });
 
-  test('#rebase - calling rebase multiple times', async function(assert) {
+  test('#rebase - calling rebase multiple times', async function (assert) {
     assert.expect(22);
 
     const jupiter: Record = {
@@ -919,7 +921,7 @@ module('MemorySource', function(hooks) {
     let child: MemorySource;
 
     // 1. fill source with some data
-    await source.update(t => t.addRecord(jupiter));
+    await source.update((t) => t.addRecord(jupiter));
     // 2. create a child source
     assert.deepEqual(
       source.cache.getRecordSync(id),
@@ -934,8 +936,8 @@ module('MemorySource', function(hooks) {
     );
 
     // 3. update the child and the parent source (in any order)
-    await child.update(t => t.replaceAttribute(id, 'name', 'The Gas Giant'));
-    await source.update(t => t.replaceAttribute(id, 'name', 'Gassy Giant'));
+    await child.update((t) => t.replaceAttribute(id, 'name', 'The Gas Giant'));
+    await source.update((t) => t.replaceAttribute(id, 'name', 'Gassy Giant'));
     // 4. make sure updates were successful
     assert.equal(
       child.cache.getRecordSync(id).attributes.name,
@@ -956,7 +958,7 @@ module('MemorySource', function(hooks) {
       source.cache.getRecordSync(id).attributes.classification,
       'gas giant'
     );
-    await source.update(t =>
+    await source.update((t) =>
       t.updateRecord({
         ...id,
         attributes: {
@@ -1000,7 +1002,7 @@ module('MemorySource', function(hooks) {
     );
 
     // 9. update the parent source a third time
-    await source.update(t =>
+    await source.update((t) =>
       t.replaceAttribute(id, 'classification', 'gas giant III')
     );
     // 10. make sure updates were successful
@@ -1043,7 +1045,7 @@ module('MemorySource', function(hooks) {
     );
   });
 
-  test('#rollback - rolls back transform log and replays transform inverses against the cache', async function(assert) {
+  test('#rollback - rolls back transform log and replays transform inverses against the cache', async function (assert) {
     const recordA = {
       id: 'jupiter',
       type: 'planet',
@@ -1107,7 +1109,7 @@ module('MemorySource', function(hooks) {
     );
   });
 
-  test('#upgrade upgrades the cache to include new models introduced in a schema', async function(assert) {
+  test('#upgrade upgrades the cache to include new models introduced in a schema', async function (assert) {
     let person = {
       type: 'person',
       id: '1',
@@ -1128,7 +1130,7 @@ module('MemorySource', function(hooks) {
 
     schema.upgrade({ models });
 
-    await source.update(t => t.addRecord(person));
+    await source.update((t) => t.addRecord(person));
 
     assert.deepEqual(
       source.cache.getRecordSync({ type: 'person', id: '1' }),

--- a/packages/@orbit/record-cache/.prettierrc.js
+++ b/packages/@orbit/record-cache/.prettierrc.js
@@ -1,3 +1,4 @@
 module.exports = {
-  singleQuote: true
+  singleQuote: true,
+  trailingComma: 'none'
 };

--- a/packages/@orbit/record-cache/package.json
+++ b/packages/@orbit/record-cache/package.json
@@ -32,11 +32,11 @@
   },
   "devDependencies": {
     "@glimmer/build": "^0.10.3",
-    "@typescript-eslint/eslint-plugin": "^2.23.0",
-    "@typescript-eslint/parser": "^2.23.0",
+    "@typescript-eslint/eslint-plugin": "^2.26.0",
+    "@typescript-eslint/parser": "^2.26.0",
     "eslint": "^6.8.0",
-    "eslint-config-prettier": "^6.10.0",
+    "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-prettier": "^3.1.2",
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.2"
   }
 }

--- a/packages/@orbit/record-cache/src/async-record-cache.ts
+++ b/packages/@orbit/record-cache/src/async-record-cache.ts
@@ -101,7 +101,7 @@ export abstract class AsyncRecordCache implements Evented, AsyncRecordAccessor {
           AsyncSchemaConsistencyProcessor,
           AsyncCacheIntegrityProcessor
         ];
-    this._processors = processors.map(Processor => {
+    this._processors = processors.map((Processor) => {
       let processor = new Processor(this);
       assert(
         'Each processor must extend AsyncOperationProcessor',

--- a/packages/@orbit/record-cache/src/live-query/live-query.ts
+++ b/packages/@orbit/record-cache/src/live-query/live-query.ts
@@ -139,7 +139,7 @@ export abstract class LiveQuery {
       expression.relationship
     );
 
-    if (Array.isArray(type) && type.find(type => type === change.type)) {
+    if (Array.isArray(type) && type.find((type) => type === change.type)) {
       return true;
     } else if (type === change.type) {
       return true;
@@ -156,7 +156,7 @@ const isNode =
   typeof process === 'object' && typeof process.nextTick === 'function';
 let resolvedPromise: Promise<void>;
 const nextTick = isNode
-  ? function(fn: () => void) {
+  ? function (fn: () => void) {
       if (!resolvedPromise) {
         resolvedPromise = Promise.resolve();
       }

--- a/packages/@orbit/record-cache/src/operation-processors/async-schema-validation-processor.ts
+++ b/packages/@orbit/record-cache/src/operation-processors/async-schema-validation-processor.ts
@@ -108,7 +108,7 @@ export default class AsyncSchemaValidationProcessor extends AsyncOperationProces
   ) {
     this._validateRecordIdentity(record);
 
-    relatedRecords.forEach(relatedRecord => {
+    relatedRecords.forEach((relatedRecord) => {
       this._validateRecordIdentity(relatedRecord);
       this._validateRelationship(record, relationship, relatedRecord);
     });

--- a/packages/@orbit/record-cache/src/operation-processors/sync-schema-validation-processor.ts
+++ b/packages/@orbit/record-cache/src/operation-processors/sync-schema-validation-processor.ts
@@ -108,7 +108,7 @@ export default class SyncSchemaValidationProcessor extends SyncOperationProcesso
   ) {
     this._validateRecordIdentity(record);
 
-    relatedRecords.forEach(relatedRecord => {
+    relatedRecords.forEach((relatedRecord) => {
       this._validateRecordIdentity(relatedRecord);
       this._validateRelationship(record, relationship, relatedRecord);
     });

--- a/packages/@orbit/record-cache/src/operation-processors/utils/cache-integrity-utils.ts
+++ b/packages/@orbit/record-cache/src/operation-processors/utils/cache-integrity-utils.ts
@@ -40,7 +40,7 @@ export function getInverseRelationships(
     if (relationshipDef.inverse) {
       const recordIdentity = cloneRecordIdentity(record);
 
-      return relatedRecords.map(relatedRecord => {
+      return relatedRecords.map((relatedRecord) => {
         return {
           record: recordIdentity,
           relationship,
@@ -59,7 +59,7 @@ export function getAllInverseRelationships(
   const recordIdentity = cloneRecordIdentity(record);
   const inverseRelationships: RecordRelationshipIdentity[] = [];
 
-  schema.eachRelationship(record.type, relationship => {
+  schema.eachRelationship(record.type, (relationship) => {
     const relationshipData = deepGet(record, [
       'relationships',
       relationship,

--- a/packages/@orbit/record-cache/src/operation-processors/utils/schema-consistency-utils.ts
+++ b/packages/@orbit/record-cache/src/operation-processors/utils/schema-consistency-utils.ts
@@ -269,7 +269,7 @@ function addRelatedRecordsOps(
 ): RecordOperation[] {
   if (relatedRecords.length > 0 && relationshipDef.inverse) {
     const inverse = relationshipDef.inverse;
-    return relatedRecords.map(relatedRecord =>
+    return relatedRecords.map((relatedRecord) =>
       addRelationshipOp(schema, relatedRecord, inverse, record)
     );
   }
@@ -287,7 +287,7 @@ export function removeRelatedRecordsOps(
       return removeDependentRecords(relatedRecords);
     } else if (relationshipDef.inverse) {
       const inverse = relationshipDef.inverse;
-      return relatedRecords.map(relatedRecord =>
+      return relatedRecords.map((relatedRecord) =>
         removeRelationshipOp(schema, relatedRecord, inverse, record)
       );
     }
@@ -345,7 +345,7 @@ function removeDependentRecords(
   relatedRecords: RecordIdentity[]
 ): RecordOperation[] {
   return relatedRecords.map(
-    record =>
+    (record) =>
       ({
         op: 'removeRecord',
         record

--- a/packages/@orbit/record-cache/src/operators/async-inverse-patch-operators.ts
+++ b/packages/@orbit/record-cache/src/operators/async-inverse-patch-operators.ts
@@ -62,9 +62,9 @@ export const AsyncInversePatchOperators: Dict<AsyncInversePatchOperator> = {
       let result = { type, id };
       let changed = false;
 
-      ['attributes', 'keys'].forEach(grouping => {
+      ['attributes', 'keys'].forEach((grouping) => {
         if ((replacement as any)[grouping]) {
-          Object.keys((replacement as any)[grouping]).forEach(field => {
+          Object.keys((replacement as any)[grouping]).forEach((field) => {
             let value = (replacement as any)[grouping][field];
             let currentValue = deepGet(current, [grouping, field]);
             if (!eq(value, currentValue)) {
@@ -80,7 +80,7 @@ export const AsyncInversePatchOperators: Dict<AsyncInversePatchOperator> = {
       });
 
       if (replacement.relationships) {
-        Object.keys(replacement.relationships).forEach(field => {
+        Object.keys(replacement.relationships).forEach((field) => {
           let data = deepGet(replacement, ['relationships', field, 'data']);
           if (data !== undefined) {
             let currentData = deepGet(current, [

--- a/packages/@orbit/record-cache/src/operators/async-patch-operators.ts
+++ b/packages/@orbit/record-cache/src/operators/async-patch-operators.ts
@@ -149,7 +149,7 @@ export const AsyncPatchOperators: Dict<AsyncPatchOperator> = {
       ]);
       if (relatedRecords) {
         relatedRecords = relatedRecords.filter(
-          r => !equalRecordIdentities(r, relatedRecord)
+          (r) => !equalRecordIdentities(r, relatedRecord)
         );
 
         if (

--- a/packages/@orbit/record-cache/src/operators/async-query-operators.ts
+++ b/packages/@orbit/record-cache/src/operators/async-query-operators.ts
@@ -102,7 +102,7 @@ export const AsyncQueryOperators: Dict<AsyncQueryOperator> = {
 };
 
 function filterRecords(records: Record[], filters: any[]) {
-  return records.filter(record => {
+  return records.filter((record) => {
     for (let i = 0, l = filters.length; i < l; i++) {
       if (!applyFilter(record, filters[i])) {
         return false;
@@ -150,21 +150,21 @@ function applyFilter(record: Record, filter: any): boolean {
       case 'equal':
         return (
           actual.length === expected.length &&
-          expected.every(e =>
-            actual.some(a => a.id === e.id && a.type === e.type)
+          expected.every((e) =>
+            actual.some((a) => a.id === e.id && a.type === e.type)
           )
         );
       case 'all':
-        return expected.every(e =>
-          actual.some(a => a.id === e.id && a.type === e.type)
+        return expected.every((e) =>
+          actual.some((a) => a.id === e.id && a.type === e.type)
         );
       case 'some':
-        return expected.some(e =>
-          actual.some(a => a.id === e.id && a.type === e.type)
+        return expected.some((e) =>
+          actual.some((a) => a.id === e.id && a.type === e.type)
         );
       case 'none':
-        return !expected.some(e =>
-          actual.some(a => a.id === e.id && a.type === e.type)
+        return !expected.some((e) =>
+          actual.some((a) => a.id === e.id && a.type === e.type)
         );
       default:
         throw new QueryExpressionParseError(
@@ -185,7 +185,7 @@ function applyFilter(record: Record, filter: any): boolean {
         } else {
           if (Array.isArray(expected)) {
             return expected.some(
-              e => actual.type === e.type && actual.id === e.id
+              (e) => actual.type === e.type && actual.id === e.id
             );
           } else if (expected) {
             return actual.type === expected.type && actual.id === expected.id;
@@ -206,10 +206,10 @@ function applyFilter(record: Record, filter: any): boolean {
 function sortRecords(records: Record[], sortSpecifiers: SortSpecifier[]) {
   const comparisonValues = new Map();
 
-  records.forEach(record => {
+  records.forEach((record) => {
     comparisonValues.set(
       record,
-      sortSpecifiers.map(sortSpecifier => {
+      sortSpecifiers.map((sortSpecifier) => {
         if (sortSpecifier.kind === 'attribute') {
           return deepGet(record, [
             'attributes',
@@ -225,7 +225,7 @@ function sortRecords(records: Record[], sortSpecifiers: SortSpecifier[]) {
     );
   });
 
-  const comparisonOrders = sortSpecifiers.map(sortExpression =>
+  const comparisonOrders = sortSpecifiers.map((sortExpression) =>
     sortExpression.order === 'descending' ? -1 : 1
   );
 

--- a/packages/@orbit/record-cache/src/operators/sync-inverse-patch-operators.ts
+++ b/packages/@orbit/record-cache/src/operators/sync-inverse-patch-operators.ts
@@ -59,9 +59,9 @@ export const SyncInversePatchOperators: Dict<SyncInversePatchOperator> = {
       let result = { type, id };
       let changed = false;
 
-      ['attributes', 'keys'].forEach(grouping => {
+      ['attributes', 'keys'].forEach((grouping) => {
         if ((replacement as any)[grouping]) {
-          Object.keys((replacement as any)[grouping]).forEach(field => {
+          Object.keys((replacement as any)[grouping]).forEach((field) => {
             let value = (replacement as any)[grouping][field];
             let currentValue = deepGet(current, [grouping, field]);
             if (!eq(value, currentValue)) {
@@ -77,7 +77,7 @@ export const SyncInversePatchOperators: Dict<SyncInversePatchOperator> = {
       });
 
       if (replacement.relationships) {
-        Object.keys(replacement.relationships).forEach(field => {
+        Object.keys(replacement.relationships).forEach((field) => {
           let data = deepGet(replacement, ['relationships', field, 'data']);
           if (data !== undefined) {
             let currentData = deepGet(current, [

--- a/packages/@orbit/record-cache/src/operators/sync-patch-operators.ts
+++ b/packages/@orbit/record-cache/src/operators/sync-patch-operators.ts
@@ -149,7 +149,7 @@ export const SyncPatchOperators: Dict<SyncPatchOperator> = {
       ]);
       if (relatedRecords) {
         relatedRecords = relatedRecords.filter(
-          r => !equalRecordIdentities(r, relatedRecord)
+          (r) => !equalRecordIdentities(r, relatedRecord)
         );
 
         if (

--- a/packages/@orbit/record-cache/src/operators/sync-query-operators.ts
+++ b/packages/@orbit/record-cache/src/operators/sync-query-operators.ts
@@ -91,7 +91,7 @@ export const SyncQueryOperators: Dict<SyncQueryOperator> = {
 };
 
 function filterRecords(records: Record[], filters: any[]) {
-  return records.filter(record => {
+  return records.filter((record) => {
     for (let i = 0, l = filters.length; i < l; i++) {
       if (!applyFilter(record, filters[i])) {
         return false;
@@ -139,21 +139,21 @@ function applyFilter(record: Record, filter: any): boolean {
       case 'equal':
         return (
           actual.length === expected.length &&
-          expected.every(e =>
-            actual.some(a => a.id === e.id && a.type === e.type)
+          expected.every((e) =>
+            actual.some((a) => a.id === e.id && a.type === e.type)
           )
         );
       case 'all':
-        return expected.every(e =>
-          actual.some(a => a.id === e.id && a.type === e.type)
+        return expected.every((e) =>
+          actual.some((a) => a.id === e.id && a.type === e.type)
         );
       case 'some':
-        return expected.some(e =>
-          actual.some(a => a.id === e.id && a.type === e.type)
+        return expected.some((e) =>
+          actual.some((a) => a.id === e.id && a.type === e.type)
         );
       case 'none':
-        return !expected.some(e =>
-          actual.some(a => a.id === e.id && a.type === e.type)
+        return !expected.some((e) =>
+          actual.some((a) => a.id === e.id && a.type === e.type)
         );
       default:
         throw new QueryExpressionParseError(
@@ -174,7 +174,7 @@ function applyFilter(record: Record, filter: any): boolean {
         } else {
           if (Array.isArray(expected)) {
             return expected.some(
-              e => actual.type === e.type && actual.id === e.id
+              (e) => actual.type === e.type && actual.id === e.id
             );
           } else if (expected) {
             return actual.type === expected.type && actual.id === expected.id;
@@ -195,10 +195,10 @@ function applyFilter(record: Record, filter: any): boolean {
 function sortRecords(records: Record[], sortSpecifiers: SortSpecifier[]) {
   const comparisonValues = new Map();
 
-  records.forEach(record => {
+  records.forEach((record) => {
     comparisonValues.set(
       record,
-      sortSpecifiers.map(sortSpecifier => {
+      sortSpecifiers.map((sortSpecifier) => {
         if (sortSpecifier.kind === 'attribute') {
           return deepGet(record, [
             'attributes',
@@ -214,7 +214,7 @@ function sortRecords(records: Record[], sortSpecifiers: SortSpecifier[]) {
     );
   });
 
-  const comparisonOrders = sortSpecifiers.map(sortExpression =>
+  const comparisonOrders = sortSpecifiers.map((sortExpression) =>
     sortExpression.order === 'descending' ? -1 : 1
   );
 

--- a/packages/@orbit/record-cache/src/sync-record-cache.ts
+++ b/packages/@orbit/record-cache/src/sync-record-cache.ts
@@ -101,7 +101,7 @@ export abstract class SyncRecordCache implements Evented, SyncRecordAccessor {
           SyncSchemaConsistencyProcessor,
           SyncCacheIntegrityProcessor
         ];
-    this._processors = processors.map(Processor => {
+    this._processors = processors.map((Processor) => {
       let processor = new Processor(this);
       assert(
         'Each processor must extend SyncOperationProcessor',
@@ -292,7 +292,7 @@ export abstract class SyncRecordCache implements Evented, SyncRecordAccessor {
     result: PatchResult,
     primary = false
   ) {
-    ops.forEach(op => this._applyPatchOperation(op, result, primary));
+    ops.forEach((op) => this._applyPatchOperation(op, result, primary));
   }
 
   protected _applyPatchOperation(
@@ -310,7 +310,7 @@ export abstract class SyncRecordCache implements Evented, SyncRecordAccessor {
       };
     }
 
-    this._processors.forEach(processor => processor.validate(operation));
+    this._processors.forEach((processor) => processor.validate(operation));
 
     const inversePatchOperator = this.getInversePatchOperator(operation.op);
     const inverseOp: RecordOperation | undefined = inversePatchOperator(
@@ -323,12 +323,12 @@ export abstract class SyncRecordCache implements Evented, SyncRecordAccessor {
 
       // Query and perform related `before` operations
       this._processors
-        .map(processor => processor.before(operation))
-        .forEach(ops => this._applyPatchOperations(ops, result));
+        .map((processor) => processor.before(operation))
+        .forEach((ops) => this._applyPatchOperations(ops, result));
 
       // Query related `after` operations before performing
       // the requested operation. These will be applied on success.
-      let preparedOps = this._processors.map(processor =>
+      let preparedOps = this._processors.map((processor) =>
         processor.after(operation)
       );
 
@@ -340,18 +340,18 @@ export abstract class SyncRecordCache implements Evented, SyncRecordAccessor {
       }
 
       // Query and perform related `immediate` operations
-      this._processors.forEach(processor => processor.immediate(operation));
+      this._processors.forEach((processor) => processor.immediate(operation));
 
       // Emit event
       this.emit('patch', operation, data);
 
       // Perform prepared operations after performing the requested operation
-      preparedOps.forEach(ops => this._applyPatchOperations(ops, result));
+      preparedOps.forEach((ops) => this._applyPatchOperations(ops, result));
 
       // Query and perform related `finally` operations
       this._processors
-        .map(processor => processor.finally(operation))
-        .forEach(ops => this._applyPatchOperations(ops, result));
+        .map((processor) => processor.finally(operation))
+        .forEach((ops) => this._applyPatchOperations(ops, result));
     } else if (primary) {
       result.data.push(null);
     }

--- a/packages/@orbit/record-cache/test/async-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/async-record-cache-test.ts
@@ -13,10 +13,10 @@ import { arrayMembershipMatches } from './support/matchers';
 
 const { module, test } = QUnit;
 
-module('AsyncRecordCache', function(hooks) {
+module('AsyncRecordCache', function (hooks) {
   let schema: Schema, keyMap: KeyMap;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     schema = new Schema({
       models: {
         star: {
@@ -55,12 +55,12 @@ module('AsyncRecordCache', function(hooks) {
     keyMap = new KeyMap();
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     schema = null;
     keyMap = null;
   });
 
-  test('it exists', async function(assert) {
+  test('it exists', async function (assert) {
     const cache = new Cache({ schema });
 
     assert.ok(cache);
@@ -71,12 +71,12 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('it requires a schema', function(assert) {
+  test('it requires a schema', function (assert) {
     assert.expect(1);
     assert.throws(() => new Cache({ schema: null }));
   });
 
-  test('can be assigned processors', async function(assert) {
+  test('can be assigned processors', async function (assert) {
     let cache = new Cache({
       schema,
       processors: [AsyncSchemaValidationProcessor]
@@ -90,7 +90,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch sets data and #records retrieves it', async function(assert) {
+  test('#patch sets data and #records retrieves it', async function (assert) {
     assert.expect(4);
 
     const cache = new Cache({ schema, keyMap });
@@ -110,7 +110,7 @@ module('AsyncRecordCache', function(hooks) {
       assert.deepEqual(data, earth);
     });
 
-    await cache.patch(t => t.addRecord(earth));
+    await cache.patch((t) => t.addRecord(earth));
 
     assert.strictEqual(
       await cache.getRecordAsync({ type: 'planet', id: '1' }),
@@ -124,7 +124,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch can replace records', async function(assert) {
+  test('#patch can replace records', async function (assert) {
     assert.expect(5);
 
     const cache = new Cache({ schema, keyMap });
@@ -144,7 +144,7 @@ module('AsyncRecordCache', function(hooks) {
       assert.deepEqual(data, earth);
     });
 
-    await cache.patch(t => t.updateRecord(earth));
+    await cache.patch((t) => t.updateRecord(earth));
 
     assert.deepEqual(
       await cache.getRecordAsync({ type: 'planet', id: '1' }),
@@ -163,7 +163,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch can replace keys', async function(assert) {
+  test('#patch can replace keys', async function (assert) {
     assert.expect(4);
 
     const cache = new Cache({ schema, keyMap });
@@ -184,7 +184,7 @@ module('AsyncRecordCache', function(hooks) {
       });
     });
 
-    await cache.patch(t => t.replaceKey(earth, 'remoteId', 'a'));
+    await cache.patch((t) => t.replaceKey(earth, 'remoteId', 'a'));
 
     assert.deepEqual(
       await cache.getRecordAsync({ type: 'planet', id: '1' }),
@@ -198,13 +198,16 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch updates the cache and returns arrays of primary data and inverse ops', async function(assert) {
+  test('#patch updates the cache and returns arrays of primary data and inverse ops', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     let p1 = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
     let p2 = { type: 'planet', id: '2' };
 
-    let result = await cache.patch(t => [t.addRecord(p1), t.removeRecord(p2)]);
+    let result = await cache.patch((t) => [
+      t.addRecord(p1),
+      t.removeRecord(p2)
+    ]);
 
     assert.deepEqual(
       result,
@@ -219,7 +222,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch updates inverse hasOne relationship when a record with relationships unspecified is added - record added after', async function(assert) {
+  test('#patch updates inverse hasOne relationship when a record with relationships unspecified is added - record added after', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -230,7 +233,7 @@ module('AsyncRecordCache', function(hooks) {
     };
     const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' } };
 
-    await cache.patch(t => [t.updateRecord(jupiter), t.updateRecord(io)]);
+    await cache.patch((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
 
     assert.deepEqual(
       (await cache.getRecordAsync({ type: 'planet', id: 'p1' })).relationships
@@ -246,7 +249,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch updates inverse hasOne relationship when a record with relationships unspecified is added - record added before', async function(assert) {
+  test('#patch updates inverse hasOne relationship when a record with relationships unspecified is added - record added before', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -257,7 +260,7 @@ module('AsyncRecordCache', function(hooks) {
     };
     const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' } };
 
-    await cache.patch(t => [t.updateRecord(io), t.updateRecord(jupiter)]);
+    await cache.patch((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
 
     assert.deepEqual(
       (await cache.getRecordAsync({ type: 'planet', id: 'p1' })).relationships
@@ -273,7 +276,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch updates inverse hasMany relationship when a record with relationships unspecified is added - record added after', async function(assert) {
+  test('#patch updates inverse hasMany relationship when a record with relationships unspecified is added - record added after', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const io: Record = {
@@ -288,7 +291,7 @@ module('AsyncRecordCache', function(hooks) {
       attributes: { name: 'Jupiter' }
     };
 
-    await cache.patch(t => [t.updateRecord(io), t.updateRecord(jupiter)]);
+    await cache.patch((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
 
     assert.deepEqual(
       (await cache.getRecordAsync({ type: 'planet', id: 'p1' })).relationships
@@ -304,7 +307,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch updates inverse hasMany relationship when a record with relationships unspecified is added - record added before', async function(assert) {
+  test('#patch updates inverse hasMany relationship when a record with relationships unspecified is added - record added before', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const io: Record = {
@@ -319,7 +322,7 @@ module('AsyncRecordCache', function(hooks) {
       attributes: { name: 'Jupiter' }
     };
 
-    await cache.patch(t => [t.updateRecord(jupiter), t.updateRecord(io)]);
+    await cache.patch((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
 
     assert.deepEqual(
       (await cache.getRecordAsync({ type: 'planet', id: 'p1' })).relationships
@@ -335,7 +338,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch updates inverse hasOne relationship when a record with an empty relationship is added', async function(assert) {
+  test('#patch updates inverse hasOne relationship when a record with an empty relationship is added', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const io: Record = {
@@ -351,7 +354,7 @@ module('AsyncRecordCache', function(hooks) {
       relationships: { moons: { data: [] } }
     };
 
-    await cache.patch(t => [t.updateRecord(io), t.updateRecord(jupiter)]);
+    await cache.patch((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
 
     assert.deepEqual(
       (await cache.getRecordAsync({ type: 'planet', id: 'p1' })).relationships
@@ -367,7 +370,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch updates inverse hasMany relationship when a record with an empty relationship is added', async function(assert) {
+  test('#patch updates inverse hasMany relationship when a record with an empty relationship is added', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -383,7 +386,7 @@ module('AsyncRecordCache', function(hooks) {
       relationships: { planet: { data: null } }
     };
 
-    await cache.patch(t => [t.updateRecord(jupiter), t.updateRecord(io)]);
+    await cache.patch((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
 
     assert.deepEqual(
       (await cache.getRecordAsync({ type: 'planet', id: 'p1' })).relationships
@@ -399,7 +402,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch updates inverse hasMany polymorphic relationship', async function(assert) {
+  test('#patch updates inverse hasMany polymorphic relationship', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const sun: Record = {
@@ -422,7 +425,7 @@ module('AsyncRecordCache', function(hooks) {
     };
     const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' } };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.updateRecord(sun),
       t.updateRecord(jupiter),
       t.updateRecord(io)
@@ -451,7 +454,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch updates inverse hasOne polymorphic relationship', async function(assert) {
+  test('#patch updates inverse hasOne polymorphic relationship', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -468,7 +471,7 @@ module('AsyncRecordCache', function(hooks) {
     };
     const sun: Record = { type: 'star', id: 's1', attributes: { name: 'Sun' } };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.updateRecord(jupiter),
       t.updateRecord(io),
       t.updateRecord(sun)
@@ -497,7 +500,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch tracks refs and clears them from hasOne relationships when a referenced record is removed', async function(assert) {
+  test('#patch tracks refs and clears them from hasOne relationships when a referenced record is removed', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -519,7 +522,7 @@ module('AsyncRecordCache', function(hooks) {
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(io),
       t.addRecord(europa)
@@ -538,7 +541,7 @@ module('AsyncRecordCache', function(hooks) {
       'Jupiter has been assigned to Europa'
     );
 
-    await cache.patch(t => t.removeRecord(jupiter));
+    await cache.patch((t) => t.removeRecord(jupiter));
 
     assert.equal(
       await cache.getRecordAsync({ type: 'planet', id: 'p1' }),
@@ -560,7 +563,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch tracks refs and clears them from hasMany relationships when a referenced record is removed', async function(assert) {
+  test('#patch tracks refs and clears them from hasMany relationships when a referenced record is removed', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const io: Record = {
@@ -589,7 +592,7 @@ module('AsyncRecordCache', function(hooks) {
       }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(io),
       t.addRecord(europa),
       t.addRecord(jupiter)
@@ -612,7 +615,7 @@ module('AsyncRecordCache', function(hooks) {
       'Jupiter has been assigned to Io and Europa'
     );
 
-    await cache.patch(t => t.removeRecord(io));
+    await cache.patch((t) => t.removeRecord(io));
 
     assert.equal(
       await cache.getRecordAsync({ type: 'moon', id: 'm1' }),
@@ -626,7 +629,7 @@ module('AsyncRecordCache', function(hooks) {
       'Io have been cleared from Jupiter'
     );
 
-    await cache.patch(t => t.removeRecord(europa));
+    await cache.patch((t) => t.removeRecord(europa));
 
     assert.equal(
       await cache.getRecordAsync({ type: 'moon', id: 'm2' }),
@@ -641,17 +644,17 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test("#patch adds link to hasMany if record doesn't exist", async function(assert) {
+  test("#patch adds link to hasMany if record doesn't exist", async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
-    await cache.patch(t =>
+    await cache.patch((t) =>
       t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
         type: 'moon',
         id: 'm1'
       })
     );
 
-    await cache.patch(t =>
+    await cache.patch((t) =>
       t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
         type: 'moon',
         id: 'm1'
@@ -666,7 +669,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test("#patch does not remove hasMany relationship if record doesn't exist", async function(assert) {
+  test("#patch does not remove hasMany relationship if record doesn't exist", async function (assert) {
     assert.expect(1);
 
     const cache = new Cache({ schema, keyMap });
@@ -675,7 +678,7 @@ module('AsyncRecordCache', function(hooks) {
       assert.ok(false, 'no operations were applied');
     });
 
-    await cache.patch(t =>
+    await cache.patch((t) =>
       t.removeFromRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
         type: 'moon',
         id: 'moon1'
@@ -689,7 +692,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test("#patch adds hasOne if record doesn't exist", async function(assert) {
+  test("#patch adds hasOne if record doesn't exist", async function (assert) {
     assert.expect(2);
 
     const cache = new Cache({ schema, keyMap });
@@ -708,7 +711,7 @@ module('AsyncRecordCache', function(hooks) {
     );
 
     let order = 0;
-    cache.on('patch', op => {
+    cache.on('patch', (op) => {
       order++;
       if (order === 1) {
         assert.deepEqual(op, replacePlanet, 'applied replacePlanet operation');
@@ -722,7 +725,7 @@ module('AsyncRecordCache', function(hooks) {
     await cache.patch([replacePlanet]);
   });
 
-  test("#patch will add empty hasOne link if record doesn't exist", async function(assert) {
+  test("#patch will add empty hasOne link if record doesn't exist", async function (assert) {
     assert.expect(2);
 
     const cache = new Cache({ schema, keyMap });
@@ -735,7 +738,7 @@ module('AsyncRecordCache', function(hooks) {
     );
 
     let order = 0;
-    cache.on('patch', op => {
+    cache.on('patch', (op) => {
       order++;
       if (order === 1) {
         assert.deepEqual(op, clearPlanet, 'applied clearPlanet operation');
@@ -749,7 +752,7 @@ module('AsyncRecordCache', function(hooks) {
     assert.ok(true, 'patch applied');
   });
 
-  test('#patch does not add link to hasMany if link already exists', async function(assert) {
+  test('#patch does not add link to hasMany if link already exists', async function (assert) {
     assert.expect(1);
 
     const cache = new Cache({ schema, keyMap });
@@ -761,20 +764,20 @@ module('AsyncRecordCache', function(hooks) {
       relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
     };
 
-    await cache.patch(t => t.addRecord(jupiter));
+    await cache.patch((t) => t.addRecord(jupiter));
 
     cache.on('patch', () => {
       assert.ok(false, 'no operations were applied');
     });
 
-    await cache.patch(t =>
+    await cache.patch((t) =>
       t.addToRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'm1' })
     );
 
     assert.ok(true, 'patch completed');
   });
 
-  test("#patch does not remove relationship from hasMany if relationship doesn't exist", async function(assert) {
+  test("#patch does not remove relationship from hasMany if relationship doesn't exist", async function (assert) {
     assert.expect(1);
 
     const cache = new Cache({ schema, keyMap });
@@ -785,31 +788,31 @@ module('AsyncRecordCache', function(hooks) {
       attributes: { name: 'Jupiter' }
     };
 
-    await cache.patch(t => t.addRecord(jupiter));
+    await cache.patch((t) => t.addRecord(jupiter));
 
     cache.on('patch', () => {
       assert.ok(false, 'no operations were applied');
     });
 
-    await cache.patch(t =>
+    await cache.patch((t) =>
       t.removeFromRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'm1' })
     );
 
     assert.ok(true, 'patch completed');
   });
 
-  test('#patch can add and remove to has-many relationship', async function(assert) {
+  test('#patch can add and remove to has-many relationship', async function (assert) {
     assert.expect(2);
 
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = { id: 'jupiter', type: 'planet' };
-    await cache.patch(t => t.addRecord(jupiter));
+    await cache.patch((t) => t.addRecord(jupiter));
 
     const callisto = { id: 'callisto', type: 'moon' };
-    await cache.patch(t => t.addRecord(callisto));
+    await cache.patch((t) => t.addRecord(callisto));
 
-    await cache.patch(t =>
+    await cache.patch((t) =>
       t.addToRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'callisto' })
     );
 
@@ -821,7 +824,7 @@ module('AsyncRecordCache', function(hooks) {
       'moon added'
     );
 
-    await cache.patch(t =>
+    await cache.patch((t) =>
       t.removeFromRelatedRecords(jupiter, 'moons', {
         type: 'moon',
         id: 'callisto'
@@ -837,18 +840,18 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch can add and clear has-one relationship', async function(assert) {
+  test('#patch can add and clear has-one relationship', async function (assert) {
     assert.expect(2);
 
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = { id: 'jupiter', type: 'planet' };
-    await cache.patch(t => t.addRecord(jupiter));
+    await cache.patch((t) => t.addRecord(jupiter));
 
     const callisto = { id: 'callisto', type: 'moon' };
-    await cache.patch(t => t.addRecord(callisto));
+    await cache.patch((t) => t.addRecord(callisto));
 
-    await cache.patch(t =>
+    await cache.patch((t) =>
       t.replaceRelatedRecord(callisto, 'planet', {
         type: 'planet',
         id: 'jupiter'
@@ -863,7 +866,7 @@ module('AsyncRecordCache', function(hooks) {
       'relationship added'
     );
 
-    await cache.patch(t => t.replaceRelatedRecord(callisto, 'planet', null));
+    await cache.patch((t) => t.replaceRelatedRecord(callisto, 'planet', null));
 
     assert.notOk(
       equalRecordIdentities(
@@ -874,7 +877,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('does not replace hasOne if relationship already exists', async function(assert) {
+  test('does not replace hasOne if relationship already exists', async function (assert) {
     assert.expect(1);
 
     const cache = new Cache({ schema, keyMap });
@@ -886,20 +889,20 @@ module('AsyncRecordCache', function(hooks) {
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
 
-    await cache.patch(t => t.addRecord(europa));
+    await cache.patch((t) => t.addRecord(europa));
 
     cache.on('patch', () => {
       assert.ok(false, 'no operations were applied');
     });
 
-    await cache.patch(t =>
+    await cache.patch((t) =>
       t.replaceRelatedRecord(europa, 'planet', { type: 'planet', id: 'p1' })
     );
 
     assert.ok(true, 'patch completed');
   });
 
-  test("does not remove hasOne if relationship doesn't exist", async function(assert) {
+  test("does not remove hasOne if relationship doesn't exist", async function (assert) {
     assert.expect(1);
 
     const cache = new Cache({ schema, keyMap });
@@ -911,18 +914,18 @@ module('AsyncRecordCache', function(hooks) {
       relationships: { planet: { data: null } }
     };
 
-    await cache.patch(t => t.addRecord(europa));
+    await cache.patch((t) => t.addRecord(europa));
 
     cache.on('patch', () => {
       assert.ok(false, 'no operations were applied');
     });
 
-    await cache.patch(t => t.replaceRelatedRecord(europa, 'planet', null));
+    await cache.patch((t) => t.replaceRelatedRecord(europa, 'planet', null));
 
     assert.ok(true, 'patch completed');
   });
 
-  test('#patch removing model with a bi-directional hasOne', async function(assert) {
+  test('#patch removing model with a bi-directional hasOne', async function (assert) {
     assert.expect(5);
 
     const hasOneSchema = new Schema({
@@ -942,7 +945,7 @@ module('AsyncRecordCache', function(hooks) {
 
     const cache = new Cache({ schema: hasOneSchema, keyMap });
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord({
         id: '1',
         type: 'one',
@@ -974,7 +977,7 @@ module('AsyncRecordCache', function(hooks) {
       'two links to one'
     );
 
-    await cache.patch(t => t.removeRecord(two));
+    await cache.patch((t) => t.removeRecord(two));
 
     assert.equal(
       (await cache.getRecordAsync({ type: 'one', id: '1' })).relationships.two
@@ -984,7 +987,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch removes dependent records in a hasOne relationship', async function(assert) {
+  test('#patch removes dependent records in a hasOne relationship', async function (assert) {
     const dependentSchema = new Schema({
       models: {
         planet: {
@@ -1020,7 +1023,7 @@ module('AsyncRecordCache', function(hooks) {
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(io),
       t.addRecord(europa),
@@ -1028,7 +1031,7 @@ module('AsyncRecordCache', function(hooks) {
       t.addToRelatedRecords(jupiter, 'moons', europa)
     ]);
 
-    await cache.patch(t => t.removeRecord(io));
+    await cache.patch((t) => t.removeRecord(io));
 
     assert.equal(
       (await cache.getRecordsAsync('moon')).length,
@@ -1042,7 +1045,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch removes dependent records in a hasMany relationship', async function(assert) {
+  test('#patch removes dependent records in a hasMany relationship', async function (assert) {
     const dependentSchema = new Schema({
       models: {
         planet: {
@@ -1078,7 +1081,7 @@ module('AsyncRecordCache', function(hooks) {
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.updateRecord(jupiter),
       t.updateRecord(io),
       t.updateRecord(europa),
@@ -1086,7 +1089,7 @@ module('AsyncRecordCache', function(hooks) {
       t.addToRelatedRecords(jupiter, 'moons', europa)
     ]);
 
-    await cache.patch(t => t.removeRecord(jupiter));
+    await cache.patch((t) => t.removeRecord(jupiter));
 
     assert.equal(
       (await cache.getRecordsAsync('planet')).length,
@@ -1100,7 +1103,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch does not remove non-dependent records', async function(assert) {
+  test('#patch does not remove non-dependent records', async function (assert) {
     const dependentSchema = new Schema({
       models: {
         planet: {
@@ -1136,7 +1139,7 @@ module('AsyncRecordCache', function(hooks) {
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(io),
       t.addRecord(europa)
@@ -1144,7 +1147,7 @@ module('AsyncRecordCache', function(hooks) {
 
     // Since there are no dependent relationships, no other records will be
     // removed
-    await cache.patch(t => t.removeRecord(io));
+    await cache.patch((t) => t.removeRecord(io));
 
     assert.equal(
       (await cache.getRecordsAsync('moon')).length,
@@ -1158,11 +1161,11 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch merges records when "replacing" and will not stomp on attributes and relationships that are not replaced', async function(assert) {
+  test('#patch merges records when "replacing" and will not stomp on attributes and relationships that are not replaced', async function (assert) {
     const cache = new Cache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord({
         type: 'planet',
         id: '1',
@@ -1171,7 +1174,7 @@ module('AsyncRecordCache', function(hooks) {
       })
     ]);
 
-    let result = await cache.patch(t => [
+    let result = await cache.patch((t) => [
       t.updateRecord({
         type: 'planet',
         id: '1',
@@ -1180,7 +1183,7 @@ module('AsyncRecordCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      await cache.query(q => q.findRecord({ type: 'planet', id: '1' })),
+      await cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
       {
         type: 'planet',
         id: '1',
@@ -1220,11 +1223,11 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch can replace related records but only if they are different', async function(assert) {
+  test('#patch can replace related records but only if they are different', async function (assert) {
     const cache = new Cache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord({
         type: 'planet',
         id: '1',
@@ -1233,7 +1236,7 @@ module('AsyncRecordCache', function(hooks) {
       })
     ]);
 
-    let result = await cache.patch(t => [
+    let result = await cache.patch((t) => [
       t.replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
         { type: 'moon', id: 'm1' }
       ])
@@ -1248,14 +1251,14 @@ module('AsyncRecordCache', function(hooks) {
       'nothing has changed so there are no inverse ops'
     );
 
-    result = await cache.patch(t => [
+    result = await cache.patch((t) => [
       t.replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
         { type: 'moon', id: 'm2' }
       ])
     ]);
 
     assert.deepEqual(
-      await cache.query(q => q.findRecord({ type: 'planet', id: '1' })),
+      await cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
       {
         type: 'planet',
         id: '1',
@@ -1293,7 +1296,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch merges records when updating and _will_ replace only specified attributes and relationships', async function(assert) {
+  test('#patch merges records when updating and _will_ replace only specified attributes and relationships', async function (assert) {
     const cache = new Cache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
@@ -1344,7 +1347,7 @@ module('AsyncRecordCache', function(hooks) {
     });
 
     assert.deepEqual(
-      await cache.query(q => q.findRecord({ type: 'planet', id: '1' })),
+      await cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
       {
         type: 'planet',
         id: '1',
@@ -1355,11 +1358,11 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch can update existing record with empty relationship', async function(assert) {
+  test('#patch can update existing record with empty relationship', async function (assert) {
     const cache = new Cache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
-    let result = await cache.patch(t => [
+    let result = await cache.patch((t) => [
       t.addRecord({ id: '1', type: 'planet' })
     ]);
 
@@ -1373,7 +1376,7 @@ module('AsyncRecordCache', function(hooks) {
       ]
     });
 
-    result = await cache.patch(t => [
+    result = await cache.patch((t) => [
       t.updateRecord({
         id: '1',
         type: 'planet',
@@ -1413,11 +1416,11 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch will not overwrite an existing relationship with a missing relationship', async function(assert) {
+  test('#patch will not overwrite an existing relationship with a missing relationship', async function (assert) {
     const cache = new Cache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
-    let result = await cache.patch(t => [
+    let result = await cache.patch((t) => [
       t.addRecord({
         id: '1',
         type: 'planet',
@@ -1460,7 +1463,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query can retrieve an individual record', async function(assert) {
+  test('#query can retrieve an individual record', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -1472,15 +1475,15 @@ module('AsyncRecordCache', function(hooks) {
         atmosphere: true
       }
     };
-    await cache.patch(t => [t.addRecord(jupiter)]);
+    await cache.patch((t) => [t.addRecord(jupiter)]);
 
     assert.deepEqual(
-      await cache.query(q => q.findRecord({ type: 'planet', id: 'jupiter' })),
+      await cache.query((q) => q.findRecord({ type: 'planet', id: 'jupiter' })),
       jupiter
     );
   });
 
-  test('#query can retrieve multiple expressions', async function(assert) {
+  test('#query can retrieve multiple expressions', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -1501,10 +1504,10 @@ module('AsyncRecordCache', function(hooks) {
         atmosphere: true
       }
     };
-    await cache.patch(t => [t.addRecord(jupiter), t.addRecord(earth)]);
+    await cache.patch((t) => [t.addRecord(jupiter), t.addRecord(earth)]);
 
     assert.deepEqual(
-      await cache.query(q => [
+      await cache.query((q) => [
         q.findRecord({ type: 'planet', id: 'jupiter' }),
         q.findRecord({ type: 'planet', id: 'earth' })
       ]),
@@ -1512,7 +1515,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query can find records by type', async function(assert) {
+  test('#query can find records by type', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -1552,7 +1555,7 @@ module('AsyncRecordCache', function(hooks) {
       }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -1561,12 +1564,12 @@ module('AsyncRecordCache', function(hooks) {
 
     arrayMembershipMatches(
       assert,
-      await cache.query(q => q.findRecords('planet')),
+      await cache.query((q) => q.findRecords('planet')),
       [jupiter, earth, venus, mercury]
     );
   });
 
-  test('#query can find records by identities', async function(assert) {
+  test('#query can find records by identities', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -1606,7 +1609,7 @@ module('AsyncRecordCache', function(hooks) {
       }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -1615,7 +1618,7 @@ module('AsyncRecordCache', function(hooks) {
 
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q.findRecords([
           { type: 'planet', id: 'jupiter' },
           { type: 'planet', id: 'venus' },
@@ -1626,7 +1629,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query can perform a simple attribute filter by value equality', async function(assert) {
+  test('#query can perform a simple attribute filter by value equality', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -1666,7 +1669,7 @@ module('AsyncRecordCache', function(hooks) {
       }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -1675,14 +1678,14 @@ module('AsyncRecordCache', function(hooks) {
 
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q.findRecords('planet').filter({ attribute: 'name', value: 'Jupiter' })
       ),
       [jupiter]
     );
   });
 
-  test('#query can perform a simple attribute filter by value comparison (gt, lt, gte & lte)', async function(assert) {
+  test('#query can perform a simple attribute filter by value comparison (gt, lt, gte & lte)', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -1726,7 +1729,7 @@ module('AsyncRecordCache', function(hooks) {
       }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -1734,7 +1737,7 @@ module('AsyncRecordCache', function(hooks) {
     ]);
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRecords('planet')
           .filter({ attribute: 'sequence', value: 2, op: 'gt' })
@@ -1743,7 +1746,7 @@ module('AsyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      await cache.query(q => {
+      await cache.query((q) => {
         let tmp = q.findRecords('planet');
         return tmp.filter({ attribute: 'sequence', value: 2, op: 'gte' });
       }),
@@ -1751,7 +1754,7 @@ module('AsyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      await cache.query(q => {
+      await cache.query((q) => {
         let tmp = q.findRecords('planet');
         return tmp.filter({ attribute: 'sequence', value: 2, op: 'lt' });
       }),
@@ -1759,7 +1762,7 @@ module('AsyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      await cache.query(q => {
+      await cache.query((q) => {
         let tmp = q.findRecords('planet');
         return tmp.filter({ attribute: 'sequence', value: 2, op: 'lte' });
       }),
@@ -1767,7 +1770,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query can perform relatedRecords filters with operators `equal`, `all`, `some` and `none`', async function(assert) {
+  test('#query can perform relatedRecords filters with operators `equal`, `all`, `some` and `none`', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -1871,7 +1874,7 @@ module('AsyncRecordCache', function(hooks) {
       relationships: {}
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(mars),
@@ -1886,7 +1889,7 @@ module('AsyncRecordCache', function(hooks) {
     ]);
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [theMoon], op: 'equal' })
@@ -1895,7 +1898,7 @@ module('AsyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [phobos], op: 'equal' })
@@ -1904,7 +1907,7 @@ module('AsyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [phobos], op: 'all' })
@@ -1913,7 +1916,7 @@ module('AsyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [phobos, callisto], op: 'all' })
@@ -1922,7 +1925,7 @@ module('AsyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q.findRecords('planet').filter({
           relation: 'moons',
           records: [phobos, callisto],
@@ -1933,7 +1936,7 @@ module('AsyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [titan], op: 'some' })
@@ -1942,7 +1945,7 @@ module('AsyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [ganymede], op: 'none' })
@@ -1951,7 +1954,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query can perform relatedRecord filters', async function(assert) {
+  test('#query can perform relatedRecord filters', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -2055,7 +2058,7 @@ module('AsyncRecordCache', function(hooks) {
       relationships: { planet: { data: null } }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(mars),
@@ -2070,35 +2073,35 @@ module('AsyncRecordCache', function(hooks) {
     ]);
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q.findRecords('moon').filter({ relation: 'planet', record: null })
       ),
       [titan]
     );
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q.findRecords('moon').filter({ relation: 'planet', record: earth })
       ),
       [theMoon]
     );
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q.findRecords('moon').filter({ relation: 'planet', record: jupiter })
       ),
       [europa, ganymede, callisto]
     );
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q.findRecords('moon').filter({ relation: 'planet', record: mercury })
       ),
       []
     );
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRecords('moon')
           .filter({ relation: 'planet', record: [earth, mars] })
@@ -2107,7 +2110,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query can perform a complex attribute filter by value', async function(assert) {
+  test('#query can perform a complex attribute filter by value', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -2147,7 +2150,7 @@ module('AsyncRecordCache', function(hooks) {
       }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -2156,7 +2159,7 @@ module('AsyncRecordCache', function(hooks) {
 
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRecords('planet')
           .filter(
@@ -2168,7 +2171,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query can perform a filter on attributes, even when a particular record has none', async function(assert) {
+  test('#query can perform a filter on attributes, even when a particular record has none', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = { type: 'planet', id: 'jupiter' };
@@ -2200,7 +2203,7 @@ module('AsyncRecordCache', function(hooks) {
       }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -2209,7 +2212,7 @@ module('AsyncRecordCache', function(hooks) {
 
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRecords('planet')
           .filter(
@@ -2221,7 +2224,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query can sort by an attribute', async function(assert) {
+  test('#query can sort by an attribute', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -2261,7 +2264,7 @@ module('AsyncRecordCache', function(hooks) {
       }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -2269,12 +2272,12 @@ module('AsyncRecordCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      await cache.query(q => q.findRecords('planet').sort('name')),
+      await cache.query((q) => q.findRecords('planet').sort('name')),
       [earth, jupiter, mercury, venus]
     );
   });
 
-  test('#query can sort by an attribute, even when a particular record has none', async function(assert) {
+  test('#query can sort by an attribute, even when a particular record has none', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = { type: 'planet', id: 'jupiter' };
@@ -2306,7 +2309,7 @@ module('AsyncRecordCache', function(hooks) {
       }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -2314,12 +2317,12 @@ module('AsyncRecordCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      await cache.query(q => q.findRecords('planet').sort('name')),
+      await cache.query((q) => q.findRecords('planet').sort('name')),
       [earth, mercury, venus, jupiter]
     );
   });
 
-  test('#query can filter and sort by attributes', async function(assert) {
+  test('#query can filter and sort by attributes', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -2359,7 +2362,7 @@ module('AsyncRecordCache', function(hooks) {
       }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -2367,7 +2370,7 @@ module('AsyncRecordCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRecords('planet')
           .filter(
@@ -2380,7 +2383,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query can sort by an attribute in descending order', async function(assert) {
+  test('#query can sort by an attribute in descending order', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -2420,7 +2423,7 @@ module('AsyncRecordCache', function(hooks) {
       }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -2428,12 +2431,12 @@ module('AsyncRecordCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      await cache.query(q => q.findRecords('planet').sort('-name')),
+      await cache.query((q) => q.findRecords('planet').sort('-name')),
       [venus, mercury, jupiter, earth]
     );
   });
 
-  test('#query can sort by according to multiple criteria', async function(assert) {
+  test('#query can sort by according to multiple criteria', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -2473,7 +2476,7 @@ module('AsyncRecordCache', function(hooks) {
       }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -2481,14 +2484,14 @@ module('AsyncRecordCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      await cache.query(q =>
+      await cache.query((q) =>
         q.findRecords('planet').sort('classification', 'name')
       ),
       [jupiter, earth, mercury, venus]
     );
   });
 
-  test('#query - findRecord - finds record', async function(assert) {
+  test('#query - findRecord - finds record', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -2498,25 +2501,25 @@ module('AsyncRecordCache', function(hooks) {
       relationships: { moons: { data: [{ type: 'moon', id: 'callisto' }] } }
     };
 
-    await cache.patch(t => [t.addRecord(jupiter)]);
+    await cache.patch((t) => [t.addRecord(jupiter)]);
 
     assert.deepEqual(
-      await cache.query(q => q.findRecord({ type: 'planet', id: 'jupiter' })),
+      await cache.query((q) => q.findRecord({ type: 'planet', id: 'jupiter' })),
       jupiter
     );
   });
 
-  test("#query - findRecord - throws RecordNotFoundException if record doesn't exist", async function(assert) {
+  test("#query - findRecord - throws RecordNotFoundException if record doesn't exist", async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     try {
-      await cache.query(q => q.findRecord({ type: 'planet', id: 'jupiter' }));
+      await cache.query((q) => q.findRecord({ type: 'planet', id: 'jupiter' }));
     } catch (e) {
       assert.ok(e instanceof RecordNotFoundException);
     }
   });
 
-  test('#query - findRecords - finds matching records', async function(assert) {
+  test('#query - findRecords - finds matching records', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -2533,14 +2536,14 @@ module('AsyncRecordCache', function(hooks) {
       relationships: { planet: { data: [{ type: 'planet', id: 'jupiter' }] } }
     };
 
-    await cache.patch(t => [t.addRecord(jupiter), t.addRecord(callisto)]);
+    await cache.patch((t) => [t.addRecord(jupiter), t.addRecord(callisto)]);
 
-    assert.deepEqual(await cache.query(q => q.findRecords('planet')), [
+    assert.deepEqual(await cache.query((q) => q.findRecords('planet')), [
       jupiter
     ]);
   });
 
-  test('#query - page - can paginate records by offset and limit', async function(assert) {
+  test('#query - page - can paginate records by offset and limit', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -2567,7 +2570,7 @@ module('AsyncRecordCache', function(hooks) {
       attributes: { name: 'Mars' }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -2575,32 +2578,26 @@ module('AsyncRecordCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      await cache.query(q => q.findRecords('planet').sort('name')),
+      await cache.query((q) => q.findRecords('planet').sort('name')),
       [earth, jupiter, mars, venus]
     );
 
     assert.deepEqual(
-      await cache.query(q =>
-        q
-          .findRecords('planet')
-          .sort('name')
-          .page({ limit: 3 })
+      await cache.query((q) =>
+        q.findRecords('planet').sort('name').page({ limit: 3 })
       ),
       [earth, jupiter, mars]
     );
 
     assert.deepEqual(
-      await cache.query(q =>
-        q
-          .findRecords('planet')
-          .sort('name')
-          .page({ offset: 1, limit: 2 })
+      await cache.query((q) =>
+        q.findRecords('planet').sort('name').page({ offset: 1, limit: 2 })
       ),
       [jupiter, mars]
     );
   });
 
-  test('#query - findRelatedRecords', async function(assert) {
+  test('#query - findRelatedRecords', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -2617,17 +2614,17 @@ module('AsyncRecordCache', function(hooks) {
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
 
-    await cache.patch(t => [t.addRecord(jupiter), t.addRecord(callisto)]);
+    await cache.patch((t) => [t.addRecord(jupiter), t.addRecord(callisto)]);
 
     assert.deepEqual(
-      await cache.query(q =>
+      await cache.query((q) =>
         q.findRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons')
       ),
       [callisto]
     );
   });
 
-  test('#query - findRelatedRecords - returns empty array if there are no related records', async function(assert) {
+  test('#query - findRelatedRecords - returns empty array if there are no related records', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -2636,21 +2633,21 @@ module('AsyncRecordCache', function(hooks) {
       attributes: { name: 'Jupiter' }
     };
 
-    await cache.patch(t => [t.addRecord(jupiter)]);
+    await cache.patch((t) => [t.addRecord(jupiter)]);
 
     assert.deepEqual(
-      await cache.query(q =>
+      await cache.query((q) =>
         q.findRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons')
       ),
       []
     );
   });
 
-  test("#query - findRelatedRecords - throws RecordNotFoundException if primary record doesn't exist", async function(assert) {
+  test("#query - findRelatedRecords - throws RecordNotFoundException if primary record doesn't exist", async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     try {
-      await cache.query(q =>
+      await cache.query((q) =>
         q.findRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons')
       );
     } catch (e) {
@@ -2658,7 +2655,7 @@ module('AsyncRecordCache', function(hooks) {
     }
   });
 
-  test('#query - findRelatedRecord', async function(assert) {
+  test('#query - findRelatedRecord', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -2675,17 +2672,17 @@ module('AsyncRecordCache', function(hooks) {
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
 
-    await cache.patch(t => [t.addRecord(jupiter), t.addRecord(callisto)]);
+    await cache.patch((t) => [t.addRecord(jupiter), t.addRecord(callisto)]);
 
     assert.deepEqual(
-      await cache.query(q =>
+      await cache.query((q) =>
         q.findRelatedRecord({ type: 'moon', id: 'callisto' }, 'planet')
       ),
       jupiter
     );
   });
 
-  test('#query - findRelatedRecord - return null if no related record is found', async function(assert) {
+  test('#query - findRelatedRecord - return null if no related record is found', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const callisto: Record = {
@@ -2694,21 +2691,21 @@ module('AsyncRecordCache', function(hooks) {
       attributes: { name: 'Callisto' }
     };
 
-    await cache.patch(t => [t.addRecord(callisto)]);
+    await cache.patch((t) => [t.addRecord(callisto)]);
 
     assert.deepEqual(
-      await cache.query(q =>
+      await cache.query((q) =>
         q.findRelatedRecord({ type: 'moon', id: 'callisto' }, 'planet')
       ),
       null
     );
   });
 
-  test("#query - findRelatedRecord - throws RecordNotFoundException if primary record doesn't exist", async function(assert) {
+  test("#query - findRelatedRecord - throws RecordNotFoundException if primary record doesn't exist", async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     try {
-      await cache.query(q =>
+      await cache.query((q) =>
         q.findRelatedRecord({ type: 'moon', id: 'callisto' }, 'planet')
       );
     } catch (e) {
@@ -2716,7 +2713,7 @@ module('AsyncRecordCache', function(hooks) {
     }
   });
 
-  test('#query - findRelatedRecords can perform a simple attribute filter by value equality', async function(assert) {
+  test('#query - findRelatedRecords can perform a simple attribute filter by value equality', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const sun: Record = {
@@ -2775,7 +2772,7 @@ module('AsyncRecordCache', function(hooks) {
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(sun),
       t.addRecord(jupiter),
       t.addRecord(earth),
@@ -2785,7 +2782,7 @@ module('AsyncRecordCache', function(hooks) {
 
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ attribute: 'name', value: 'Jupiter' })
@@ -2794,7 +2791,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query - findRelatedRecords - can perform a simple attribute filter by value comparison (gt, lt, gte & lte)', async function(assert) {
+  test('#query - findRelatedRecords - can perform a simple attribute filter by value comparison (gt, lt, gte & lte)', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const sun: Record = {
@@ -2857,7 +2854,7 @@ module('AsyncRecordCache', function(hooks) {
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(sun),
       t.addRecord(jupiter),
       t.addRecord(earth),
@@ -2866,7 +2863,7 @@ module('AsyncRecordCache', function(hooks) {
     ]);
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ attribute: 'sequence', value: 2, op: 'gt' })
@@ -2875,7 +2872,7 @@ module('AsyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ attribute: 'sequence', value: 2, op: 'gte' })
@@ -2884,7 +2881,7 @@ module('AsyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ attribute: 'sequence', value: 2, op: 'lt' })
@@ -2893,7 +2890,7 @@ module('AsyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ attribute: 'sequence', value: 2, op: 'lte' })
@@ -2902,7 +2899,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query - findRelatedRecords - can perform relatedRecords filters with operators `equal`, `all`, `some` and `none`', async function(assert) {
+  test('#query - findRelatedRecords - can perform relatedRecords filters with operators `equal`, `all`, `some` and `none`', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const sun: Record = {
@@ -3027,7 +3024,7 @@ module('AsyncRecordCache', function(hooks) {
       relationships: {}
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(sun),
       t.addRecord(jupiter),
       t.addRecord(earth),
@@ -3043,7 +3040,7 @@ module('AsyncRecordCache', function(hooks) {
     ]);
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'moons', records: [theMoon], op: 'equal' })
@@ -3052,7 +3049,7 @@ module('AsyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'moons', records: [phobos], op: 'equal' })
@@ -3061,7 +3058,7 @@ module('AsyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'moons', records: [phobos], op: 'all' })
@@ -3070,7 +3067,7 @@ module('AsyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'moons', records: [phobos, callisto], op: 'all' })
@@ -3079,7 +3076,7 @@ module('AsyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q.findRelatedRecords(sun, 'celestialObjects').filter({
           relation: 'moons',
           records: [phobos, callisto],
@@ -3090,7 +3087,7 @@ module('AsyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'moons', records: [titan], op: 'some' })
@@ -3099,7 +3096,7 @@ module('AsyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'moons', records: [ganymede], op: 'none' })
@@ -3108,7 +3105,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query - findRelatedRecords - can perform relatedRecord filters', async function(assert) {
+  test('#query - findRelatedRecords - can perform relatedRecord filters', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const sun: Record = {
@@ -3260,7 +3257,7 @@ module('AsyncRecordCache', function(hooks) {
       }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(sun),
       t.addRecord(jupiter),
       t.addRecord(earth),
@@ -3276,7 +3273,7 @@ module('AsyncRecordCache', function(hooks) {
     ]);
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'planet', record: null })
@@ -3285,7 +3282,7 @@ module('AsyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRelatedRecords(earth, 'moons')
           .filter({ relation: 'planet', record: earth })
@@ -3294,7 +3291,7 @@ module('AsyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRelatedRecords(jupiter, 'moons')
           .filter({ relation: 'planet', record: jupiter })
@@ -3303,7 +3300,7 @@ module('AsyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRelatedRecords(mercury, 'moons')
           .filter({ relation: 'planet', record: mercury })
@@ -3312,7 +3309,7 @@ module('AsyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'planet', record: [earth, mars] })
@@ -3321,7 +3318,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query - findRelatedRecords - can perform a complex attribute filter by value', async function(assert) {
+  test('#query - findRelatedRecords - can perform a complex attribute filter by value', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const sun: Record = {
@@ -3380,7 +3377,7 @@ module('AsyncRecordCache', function(hooks) {
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(sun),
       t.addRecord(jupiter),
       t.addRecord(earth),
@@ -3390,7 +3387,7 @@ module('AsyncRecordCache', function(hooks) {
 
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter(
@@ -3402,7 +3399,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query - findRelatedRecords - can perform a filter on attributes, even when a particular record has none', async function(assert) {
+  test('#query - findRelatedRecords - can perform a filter on attributes, even when a particular record has none', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const sun: Record = {
@@ -3456,7 +3453,7 @@ module('AsyncRecordCache', function(hooks) {
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(sun),
       t.addRecord(jupiter),
       t.addRecord(earth),
@@ -3466,7 +3463,7 @@ module('AsyncRecordCache', function(hooks) {
 
     arrayMembershipMatches(
       assert,
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter(
@@ -3478,7 +3475,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query - findRelatedRecords - can sort by an attribute', async function(assert) {
+  test('#query - findRelatedRecords - can sort by an attribute', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const sun: Record = {
@@ -3537,7 +3534,7 @@ module('AsyncRecordCache', function(hooks) {
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(sun),
       t.addRecord(jupiter),
       t.addRecord(earth),
@@ -3546,14 +3543,14 @@ module('AsyncRecordCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      await cache.query(q =>
+      await cache.query((q) =>
         q.findRelatedRecords(sun, 'celestialObjects').sort('name')
       ),
       [earth, jupiter, mercury, venus]
     );
   });
 
-  test('#query - findRelatedRecords - can sort by an attribute, even when a particular record has none', async function(assert) {
+  test('#query - findRelatedRecords - can sort by an attribute, even when a particular record has none', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const sun: Record = {
@@ -3603,7 +3600,7 @@ module('AsyncRecordCache', function(hooks) {
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(sun),
       t.addRecord(jupiter),
       t.addRecord(earth),
@@ -3612,14 +3609,14 @@ module('AsyncRecordCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      await cache.query(q =>
+      await cache.query((q) =>
         q.findRelatedRecords(sun, 'celestialObjects').sort('name')
       ),
       [earth, mercury, venus, jupiter]
     );
   });
 
-  test('#query - findRelatedRecords - can filter and sort by attributes', async function(assert) {
+  test('#query - findRelatedRecords - can filter and sort by attributes', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const sun: Record = {
@@ -3678,7 +3675,7 @@ module('AsyncRecordCache', function(hooks) {
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(sun),
       t.addRecord(jupiter),
       t.addRecord(earth),
@@ -3687,7 +3684,7 @@ module('AsyncRecordCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter(
@@ -3700,7 +3697,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query - findRelatedRecords - can sort by an attribute in descending order', async function(assert) {
+  test('#query - findRelatedRecords - can sort by an attribute in descending order', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const sun: Record = {
@@ -3759,7 +3756,7 @@ module('AsyncRecordCache', function(hooks) {
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(sun),
       t.addRecord(jupiter),
       t.addRecord(earth),
@@ -3768,14 +3765,14 @@ module('AsyncRecordCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      await cache.query(q =>
+      await cache.query((q) =>
         q.findRelatedRecords(sun, 'celestialObjects').sort('-name')
       ),
       [venus, mercury, jupiter, earth]
     );
   });
 
-  test('#query - findRelatedRecords - can sort by according to multiple criteria', async function(assert) {
+  test('#query - findRelatedRecords - can sort by according to multiple criteria', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const sun: Record = {
@@ -3834,7 +3831,7 @@ module('AsyncRecordCache', function(hooks) {
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(sun),
       t.addRecord(jupiter),
       t.addRecord(earth),
@@ -3843,7 +3840,7 @@ module('AsyncRecordCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .sort('classification', 'name')
@@ -3852,7 +3849,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query - findRelatedRecords - page - can paginate records by offset and limit', async function(assert) {
+  test('#query - findRelatedRecords - page - can paginate records by offset and limit', async function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const sun: Record = {
@@ -3898,7 +3895,7 @@ module('AsyncRecordCache', function(hooks) {
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
 
-    await cache.patch(t => [
+    await cache.patch((t) => [
       t.addRecord(sun),
       t.addRecord(jupiter),
       t.addRecord(earth),
@@ -3907,14 +3904,14 @@ module('AsyncRecordCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      await cache.query(q =>
+      await cache.query((q) =>
         q.findRelatedRecords(sun, 'celestialObjects').sort('name')
       ),
       [earth, jupiter, mars, venus]
     );
 
     assert.deepEqual(
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .sort('name')
@@ -3924,7 +3921,7 @@ module('AsyncRecordCache', function(hooks) {
     );
 
     assert.deepEqual(
-      await cache.query(q =>
+      await cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .sort('name')
@@ -3934,7 +3931,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#liveQuery', async function(assert) {
+  test('#liveQuery', async function (assert) {
     let cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -3960,14 +3957,14 @@ module('AsyncRecordCache', function(hooks) {
       relationships: { moons: { data: [{ type: 'moon', id: 'callisto' }] } }
     };
 
-    const livePlanet = cache.liveQuery(q =>
+    const livePlanet = cache.liveQuery((q) =>
       q.findRecord({ type: 'planet', id: 'jupiter' })
     );
-    const livePlanets = cache.liveQuery(q => q.findRecords('planet'));
-    const livePlanetMoons = cache.liveQuery(q =>
+    const livePlanets = cache.liveQuery((q) => q.findRecords('planet'));
+    const livePlanetMoons = cache.liveQuery((q) =>
       q.findRelatedRecords(jupiter, 'moons')
     );
-    const liveMoonPlanet = cache.liveQuery(q =>
+    const liveMoonPlanet = cache.liveQuery((q) =>
       q.findRelatedRecord(callisto, 'planet')
     );
 
@@ -3980,7 +3977,7 @@ module('AsyncRecordCache', function(hooks) {
       let defer: Deferred = {};
       defer.promise = new Promise((resolve, reject) => {
         defer.resolve = resolve;
-        defer.reject = message => reject(new Error(message));
+        defer.reject = (message) => reject(new Error(message));
       });
       return defer;
     }
@@ -4006,10 +4003,10 @@ module('AsyncRecordCache', function(hooks) {
     }
 
     let n = 0;
-    let livePlanetUnsubscribe = livePlanet.subscribe(update => {
+    let livePlanetUnsubscribe = livePlanet.subscribe((update) => {
       update
         .query()
-        .then(result => {
+        .then((result) => {
           n++;
           if (n === 1) {
             assert.deepEqual(result, jupiter, 'findRecord jupiter');
@@ -4026,7 +4023,7 @@ module('AsyncRecordCache', function(hooks) {
           }
           next();
         })
-        .catch(error => {
+        .catch((error) => {
           n++;
           if (n === 4) {
             assert.ok(
@@ -4041,10 +4038,10 @@ module('AsyncRecordCache', function(hooks) {
     });
 
     let i = 0;
-    let livePlanetsUnsubscribe = livePlanets.subscribe(update => {
+    let livePlanetsUnsubscribe = livePlanets.subscribe((update) => {
       update
         .query()
-        .then(result => {
+        .then((result) => {
           i++;
           if (i === 1) {
             assert.deepEqual(result, [jupiter], 'findRecords [jupiter]');
@@ -4069,10 +4066,10 @@ module('AsyncRecordCache', function(hooks) {
     });
 
     let j = 0;
-    let livePlanetMoonsUnsubscribe = livePlanetMoons.subscribe(update => {
+    let livePlanetMoonsUnsubscribe = livePlanetMoons.subscribe((update) => {
       update
         .query()
-        .then(result => {
+        .then((result) => {
           j++;
           if (j === 1) {
             assert.deepEqual(
@@ -4085,7 +4082,7 @@ module('AsyncRecordCache', function(hooks) {
           }
           next();
         })
-        .catch(error => {
+        .catch((error) => {
           j++;
           if (j === 2) {
             assert.ok(
@@ -4100,10 +4097,10 @@ module('AsyncRecordCache', function(hooks) {
     });
 
     let k = 0;
-    let liveMoonPlanetUnsubscribe = liveMoonPlanet.subscribe(update => {
+    let liveMoonPlanetUnsubscribe = liveMoonPlanet.subscribe((update) => {
       update
         .query()
-        .then(result => {
+        .then((result) => {
           k++;
           if (k === 1) {
             assert.deepEqual(
@@ -4134,16 +4131,16 @@ module('AsyncRecordCache', function(hooks) {
       jupiterRemoved.reject('reject jupiterRemoved');
     }, 500);
 
-    await cache.patch(t => t.addRecord(jupiter));
+    await cache.patch((t) => t.addRecord(jupiter));
     await jupiterAdded.promise;
 
-    await cache.patch(t => t.updateRecord(jupiter2));
+    await cache.patch((t) => t.updateRecord(jupiter2));
     await jupiterUpdated.promise;
 
-    await cache.patch(t => t.addRecord(callisto));
+    await cache.patch((t) => t.addRecord(callisto));
     await callistoAdded.promise;
 
-    await cache.patch(t => t.removeRecord(jupiter));
+    await cache.patch((t) => t.removeRecord(jupiter));
     await jupiterRemoved.promise;
 
     assert.expect(16);
@@ -4157,7 +4154,7 @@ module('AsyncRecordCache', function(hooks) {
     livePlanetMoonsUnsubscribe();
     liveMoonPlanetUnsubscribe();
 
-    await cache.patch(t =>
+    await cache.patch((t) =>
       t.addRecord({
         type: 'planet',
         id: 'mercury',
@@ -4168,7 +4165,7 @@ module('AsyncRecordCache', function(hooks) {
     );
   });
 
-  test('#liveQuery findRecords (debounce)', async function(assert) {
+  test('#liveQuery findRecords (debounce)', async function (assert) {
     let cache = new Cache({ schema, keyMap });
 
     const planets: Record[] = [
@@ -4189,24 +4186,24 @@ module('AsyncRecordCache', function(hooks) {
       }
     ];
 
-    const livePlanets = cache.liveQuery(q => q.findRecords('planet'));
+    const livePlanets = cache.liveQuery((q) => q.findRecords('planet'));
 
     let i = 0;
     cache.on('patch', () => i++);
 
     const done = assert.async();
-    livePlanets.subscribe(async update => {
+    livePlanets.subscribe(async (update) => {
       const result = await update.query();
       assert.deepEqual(result, planets);
       assert.equal(i, 3);
       done();
     });
 
-    cache.patch(t => planets.map(planet => t.addRecord(planet)));
+    cache.patch((t) => planets.map((planet) => t.addRecord(planet)));
     assert.expect(2);
   });
 
-  test('#liveQuery findRecords (no debounce)', async function(assert) {
+  test('#liveQuery findRecords (no debounce)', async function (assert) {
     let cache = new Cache({ schema, keyMap, debounceLiveQueries: false });
 
     const planets: Record[] = [
@@ -4227,13 +4224,13 @@ module('AsyncRecordCache', function(hooks) {
       }
     ];
 
-    const livePlanets = cache.liveQuery(q => q.findRecords('planet'));
+    const livePlanets = cache.liveQuery((q) => q.findRecords('planet'));
 
     let i = 0;
     cache.on('patch', () => i++);
 
     const done = assert.async();
-    livePlanets.subscribe(async update => {
+    livePlanets.subscribe(async (update) => {
       const result = (await update.query()) as Record[];
       assert.equal(result.length, i);
 
@@ -4242,7 +4239,7 @@ module('AsyncRecordCache', function(hooks) {
       }
     });
 
-    cache.patch(t => planets.map(planet => t.addRecord(planet)));
+    cache.patch((t) => planets.map((planet) => t.addRecord(planet)));
     assert.expect(3);
   });
 });

--- a/packages/@orbit/record-cache/test/operation-processors/cache-integrity-processor-test.ts
+++ b/packages/@orbit/record-cache/test/operation-processors/cache-integrity-processor-test.ts
@@ -14,7 +14,7 @@ import Cache from '../support/example-sync-record-cache';
 
 const { module, test } = QUnit;
 
-module('CacheIntegrityProcessor', function(hooks) {
+module('CacheIntegrityProcessor', function (hooks) {
   let schema: Schema;
   let cache: Cache;
   let processor: SyncCacheIntegrityProcessor;
@@ -63,7 +63,7 @@ module('CacheIntegrityProcessor', function(hooks) {
   const earthId = { type: 'planet', id: 'earth' };
   const humanId = { type: 'inhabitant', id: 'human' };
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     let keyMap = new KeyMap();
     schema = new Schema(schemaDefinition);
     cache = new Cache({
@@ -74,13 +74,13 @@ module('CacheIntegrityProcessor', function(hooks) {
     processor = cache.processors[0] as SyncCacheIntegrityProcessor;
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     schema = null;
     cache = null;
     processor = null;
   });
 
-  test('reset empty cache', function(assert) {
+  test('reset empty cache', function (assert) {
     const saturn = {
       type: 'planet',
       id: 'saturn',
@@ -109,7 +109,7 @@ module('CacheIntegrityProcessor', function(hooks) {
       relationships: { planet: { data: jupiterId } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(saturn),
       t.addRecord(jupiter),
       t.addRecord(titan),
@@ -149,7 +149,7 @@ module('CacheIntegrityProcessor', function(hooks) {
     ]);
   });
 
-  test('add to hasOne => hasMany', function(assert) {
+  test('add to hasOne => hasMany', function (assert) {
     const saturn = {
       type: 'planet',
       id: 'saturn',
@@ -178,7 +178,7 @@ module('CacheIntegrityProcessor', function(hooks) {
       relationships: { planet: { data: jupiterId } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(saturn),
       t.addRecord(jupiter),
       t.addRecord(titan),
@@ -262,7 +262,7 @@ module('CacheIntegrityProcessor', function(hooks) {
     ]);
   });
 
-  test('replace hasOne => hasMany', function(assert) {
+  test('replace hasOne => hasMany', function (assert) {
     const saturn = {
       type: 'planet',
       id: 'saturn',
@@ -291,7 +291,7 @@ module('CacheIntegrityProcessor', function(hooks) {
       relationships: { planet: { data: jupiterId } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(saturn),
       t.addRecord(jupiter),
       t.addRecord(titan),
@@ -375,7 +375,7 @@ module('CacheIntegrityProcessor', function(hooks) {
     ]);
   });
 
-  test('replace hasMany => hasOne with empty array', function(assert) {
+  test('replace hasMany => hasOne with empty array', function (assert) {
     const saturn = {
       type: 'planet',
       id: 'saturn',
@@ -390,7 +390,7 @@ module('CacheIntegrityProcessor', function(hooks) {
       relationships: { planet: { data: saturnId } }
     };
 
-    cache.patch(t => [t.addRecord(saturn), t.addRecord(titan)]);
+    cache.patch((t) => [t.addRecord(saturn), t.addRecord(titan)]);
 
     assert.deepEqual(cache.getInverseRelationshipsSync(titan), [
       {
@@ -432,7 +432,7 @@ module('CacheIntegrityProcessor', function(hooks) {
     ]);
   });
 
-  test('replace hasMany => hasOne with populated array', function(assert) {
+  test('replace hasMany => hasOne with populated array', function (assert) {
     const saturn = {
       type: 'planet',
       id: 'saturn',
@@ -453,7 +453,7 @@ module('CacheIntegrityProcessor', function(hooks) {
       relationships: { planet: { data: saturnId } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(saturn),
       t.addRecord(jupiter),
       t.addRecord(titan)
@@ -505,7 +505,7 @@ module('CacheIntegrityProcessor', function(hooks) {
     ]);
   });
 
-  test('replace hasMany => hasOne with populated array, when already populated', function(assert) {
+  test('replace hasMany => hasOne with populated array, when already populated', function (assert) {
     const saturn = {
       type: 'planet',
       id: 'saturn',
@@ -534,7 +534,7 @@ module('CacheIntegrityProcessor', function(hooks) {
       relationships: { planet: { data: jupiterId } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(saturn),
       t.addRecord(jupiter),
       t.addRecord(titan),
@@ -618,7 +618,7 @@ module('CacheIntegrityProcessor', function(hooks) {
     ]);
   });
 
-  test('replace hasMany => hasMany', function(assert) {
+  test('replace hasMany => hasMany', function (assert) {
     const human = {
       type: 'inhabitant',
       id: 'human',
@@ -630,7 +630,7 @@ module('CacheIntegrityProcessor', function(hooks) {
       relationships: { inhabitants: { data: [humanId] } }
     };
 
-    cache.patch(t => [t.addRecord(human), t.addRecord(earth)]);
+    cache.patch((t) => [t.addRecord(human), t.addRecord(earth)]);
 
     assert.deepEqual(cache.getInverseRelationshipsSync(earth), [
       {
@@ -670,7 +670,7 @@ module('CacheIntegrityProcessor', function(hooks) {
     assert.deepEqual(cache.getInverseRelationshipsSync(human), []);
   });
 
-  test('remove hasOne => hasMany', function(assert) {
+  test('remove hasOne => hasMany', function (assert) {
     const saturn = {
       type: 'planet',
       id: 'saturn',
@@ -699,7 +699,7 @@ module('CacheIntegrityProcessor', function(hooks) {
       relationships: { planet: { data: jupiterId } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(saturn),
       t.addRecord(jupiter),
       t.addRecord(titan),
@@ -778,7 +778,7 @@ module('CacheIntegrityProcessor', function(hooks) {
     ]);
   });
 
-  test('add to hasOne => hasOne', function(assert) {
+  test('add to hasOne => hasOne', function (assert) {
     const saturn = {
       type: 'planet',
       id: 'saturn',
@@ -799,7 +799,7 @@ module('CacheIntegrityProcessor', function(hooks) {
       attributes: { name: 'Earth' }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(saturn),
       t.addRecord(jupiter),
       t.addRecord(earth)
@@ -856,7 +856,7 @@ module('CacheIntegrityProcessor', function(hooks) {
     ]);
   });
 
-  test('replace hasOne => hasOne with existing value', function(assert) {
+  test('replace hasOne => hasOne with existing value', function (assert) {
     const saturn = {
       type: 'planet',
       id: 'saturn',
@@ -877,7 +877,7 @@ module('CacheIntegrityProcessor', function(hooks) {
       attributes: { name: 'Earth' }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(saturn),
       t.addRecord(jupiter),
       t.addRecord(earth)
@@ -934,11 +934,11 @@ module('CacheIntegrityProcessor', function(hooks) {
     ]);
   });
 
-  test('add to hasMany => hasMany', function(assert) {
+  test('add to hasMany => hasMany', function (assert) {
     const earth = earthId;
     const human = humanId;
 
-    cache.patch(t => [t.addRecord(earth), t.addRecord(human)]);
+    cache.patch((t) => [t.addRecord(earth), t.addRecord(human)]);
 
     assert.deepEqual(cache.getInverseRelationshipsSync(earth), []);
     assert.deepEqual(cache.getInverseRelationshipsSync(human), []);
@@ -965,7 +965,7 @@ module('CacheIntegrityProcessor', function(hooks) {
     ]);
   });
 
-  test('remove from hasMany => hasMany', function(assert) {
+  test('remove from hasMany => hasMany', function (assert) {
     const earth = {
       type: 'planet',
       id: 'earth',
@@ -977,7 +977,7 @@ module('CacheIntegrityProcessor', function(hooks) {
       relationships: { planets: { data: [earthId] } }
     };
 
-    cache.patch(t => [t.addRecord(earth), t.addRecord(human)]);
+    cache.patch((t) => [t.addRecord(earth), t.addRecord(human)]);
 
     assert.deepEqual(cache.getInverseRelationshipsSync(earth), [
       {
@@ -1019,7 +1019,7 @@ module('CacheIntegrityProcessor', function(hooks) {
     ]);
   });
 
-  test('remove record with hasMany relationships - verify processor', function(assert) {
+  test('remove record with hasMany relationships - verify processor', function (assert) {
     const earth = {
       type: 'planet',
       id: 'earth',
@@ -1031,7 +1031,7 @@ module('CacheIntegrityProcessor', function(hooks) {
       relationships: { planets: { data: [earthId] } }
     };
 
-    cache.patch(t => [t.addRecord(earth), t.addRecord(human)]);
+    cache.patch((t) => [t.addRecord(earth), t.addRecord(human)]);
 
     assert.deepEqual(cache.getInverseRelationshipsSync(earth), [
       {
@@ -1068,7 +1068,7 @@ module('CacheIntegrityProcessor', function(hooks) {
     ]);
   });
 
-  test('remove record with hasMany relationships - verify inverse relationships are cleared', function(assert) {
+  test('remove record with hasMany relationships - verify inverse relationships are cleared', function (assert) {
     const earth = {
       type: 'planet',
       id: 'earth',
@@ -1080,7 +1080,7 @@ module('CacheIntegrityProcessor', function(hooks) {
       relationships: { planets: { data: [earthId] } }
     };
 
-    cache.patch(t => [t.addRecord(earth), t.addRecord(human)]);
+    cache.patch((t) => [t.addRecord(earth), t.addRecord(human)]);
 
     assert.deepEqual(cache.getInverseRelationshipsSync(earth), [
       {
@@ -1098,17 +1098,17 @@ module('CacheIntegrityProcessor', function(hooks) {
       }
     ]);
 
-    cache.patch(t => t.removeRecord(humanId));
+    cache.patch((t) => t.removeRecord(humanId));
 
     assert.deepEqual(cache.getInverseRelationshipsSync(earth), []);
     assert.deepEqual(cache.getInverseRelationshipsSync(human), []);
   });
 
-  test('updateRecord', function(assert) {
+  test('updateRecord', function (assert) {
     const earth = earthId;
     const human = humanId;
 
-    cache.patch(t => [t.addRecord(earth), t.addRecord(human)]);
+    cache.patch((t) => [t.addRecord(earth), t.addRecord(human)]);
 
     assert.deepEqual(cache.getInverseRelationshipsSync(earth), []);
     assert.deepEqual(cache.getInverseRelationshipsSync(human), []);

--- a/packages/@orbit/record-cache/test/operation-processors/schema-consistency-processor-test.ts
+++ b/packages/@orbit/record-cache/test/operation-processors/schema-consistency-processor-test.ts
@@ -19,7 +19,7 @@ import Cache from '../support/example-sync-record-cache';
 
 const { module, test } = QUnit;
 
-module('SchemaConsistencyProcessor', function(hooks) {
+module('SchemaConsistencyProcessor', function (hooks) {
   let schema: Schema;
   let cache: Cache;
   let processor: SyncSchemaConsistencyProcessor;
@@ -61,7 +61,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
     }
   };
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     let keyMap = new KeyMap();
     schema = new Schema(schemaDefinition);
     cache = new Cache({
@@ -72,13 +72,13 @@ module('SchemaConsistencyProcessor', function(hooks) {
     processor = cache.processors[1] as SyncSchemaConsistencyProcessor;
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     schema = null;
     cache = null;
     processor = null;
   });
 
-  test('add to hasOne => hasMany', function(assert) {
+  test('add to hasOne => hasMany', function (assert) {
     const saturn = {
       type: 'planet',
       id: 'saturn',
@@ -107,7 +107,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(saturn),
       t.addRecord(jupiter),
       t.addRecord(titan),
@@ -135,7 +135,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
     assert.deepEqual(processor.finally(addPlanetOp), []);
   });
 
-  test('replace hasOne => hasMany', function(assert) {
+  test('replace hasOne => hasMany', function (assert) {
     const saturn = {
       type: 'planet',
       id: 'saturn',
@@ -164,7 +164,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(saturn),
       t.addRecord(jupiter),
       t.addRecord(titan),
@@ -198,7 +198,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
     assert.deepEqual(processor.finally(replacePlanetOp), []);
   });
 
-  test('replace hasMany => hasOne with empty array', function(assert) {
+  test('replace hasMany => hasOne with empty array', function (assert) {
     const saturn = {
       type: 'planet',
       id: 'saturn',
@@ -213,7 +213,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       relationships: { planet: { data: { type: 'planet', id: 'saturn' } } }
     };
 
-    cache.patch(t => [t.addRecord(saturn), t.addRecord(titan)]);
+    cache.patch((t) => [t.addRecord(saturn), t.addRecord(titan)]);
 
     const clearMoonsOp: ReplaceRelatedRecordsOperation = {
       op: 'replaceRelatedRecords',
@@ -236,7 +236,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
     assert.deepEqual(processor.finally(clearMoonsOp), []);
   });
 
-  test('replace hasMany => hasOne with populated array', function(assert) {
+  test('replace hasMany => hasOne with populated array', function (assert) {
     const saturn = {
       type: 'planet',
       id: 'saturn',
@@ -257,7 +257,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       attributes: { name: 'Jupiter' }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(saturn),
       t.addRecord(jupiter),
       t.addRecord(titan)
@@ -284,7 +284,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
     assert.deepEqual(processor.finally(replaceMoonsOp), []);
   });
 
-  test('replace hasMany => hasOne with populated array, when already populated', function(assert) {
+  test('replace hasMany => hasOne with populated array, when already populated', function (assert) {
     const saturn = {
       type: 'planet',
       id: 'saturn',
@@ -313,7 +313,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(saturn),
       t.addRecord(jupiter),
       t.addRecord(titan),
@@ -347,7 +347,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
     assert.deepEqual(processor.finally(replaceMoonsOp), []);
   });
 
-  test('replace hasMany => hasMany, clearing records', function(assert) {
+  test('replace hasMany => hasMany, clearing records', function (assert) {
     const human = {
       type: 'inhabitant',
       id: 'human',
@@ -361,7 +361,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       }
     };
 
-    cache.patch(t => [t.addRecord(earth), t.addRecord(human)]);
+    cache.patch((t) => [t.addRecord(earth), t.addRecord(human)]);
 
     const clearInhabitantsOp: ReplaceRelatedRecordsOperation = {
       op: 'replaceRelatedRecords',
@@ -382,7 +382,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
     assert.deepEqual(processor.finally(clearInhabitantsOp), []);
   });
 
-  test('replace hasMany => hasMany, replacing some records', function(assert) {
+  test('replace hasMany => hasMany, replacing some records', function (assert) {
     const human = {
       type: 'inhabitant',
       id: 'human',
@@ -398,7 +398,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(earth),
       t.addRecord(human),
       t.addRecord(cat),
@@ -430,7 +430,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
     assert.deepEqual(processor.finally(clearInhabitantsOp), []);
   });
 
-  test('remove hasOne => hasMany', function(assert) {
+  test('remove hasOne => hasMany', function (assert) {
     const saturn = {
       type: 'planet',
       id: 'saturn',
@@ -459,7 +459,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(saturn),
       t.addRecord(jupiter),
       t.addRecord(titan),
@@ -487,7 +487,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
     assert.deepEqual(processor.finally(removePlanetOp), []);
   });
 
-  test('add to hasOne => hasOne', function(assert) {
+  test('add to hasOne => hasOne', function (assert) {
     const saturn = {
       type: 'planet',
       id: 'saturn',
@@ -508,7 +508,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       attributes: { name: 'Earth' }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(saturn),
       t.addRecord(jupiter),
       t.addRecord(earth)
@@ -535,7 +535,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
     assert.deepEqual(processor.finally(changePlanetOp), []);
   });
 
-  test('replace hasOne => hasOne with existing value', function(assert) {
+  test('replace hasOne => hasOne with existing value', function (assert) {
     const saturn = {
       type: 'planet',
       id: 'saturn',
@@ -556,7 +556,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       attributes: { name: 'Earth' }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(saturn),
       t.addRecord(jupiter),
       t.addRecord(earth)
@@ -583,7 +583,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
     assert.deepEqual(processor.finally(changePlanetOp), []);
   });
 
-  test('replace hasOne => hasOne with current existing value', function(assert) {
+  test('replace hasOne => hasOne with current existing value', function (assert) {
     const saturn = {
       type: 'planet',
       id: 'saturn',
@@ -604,7 +604,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       attributes: { name: 'Earth' }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(saturn),
       t.addRecord(jupiter),
       t.addRecord(earth)
@@ -624,11 +624,11 @@ module('SchemaConsistencyProcessor', function(hooks) {
     assert.deepEqual(processor.finally(changePlanetOp), []);
   });
 
-  test('add to hasMany => hasMany', function(assert) {
+  test('add to hasMany => hasMany', function (assert) {
     const earth = { type: 'planet', id: 'earth' };
     const human = { type: 'inhabitant', id: 'human' };
 
-    cache.patch(t => [t.addRecord(earth), t.addRecord(human)]);
+    cache.patch((t) => [t.addRecord(earth), t.addRecord(human)]);
 
     const addPlanetOp: AddToRelatedRecordsOperation = {
       op: 'addToRelatedRecords',
@@ -651,7 +651,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
     assert.deepEqual(processor.finally(addPlanetOp), []);
   });
 
-  test('remove from hasMany => hasMany', function(assert) {
+  test('remove from hasMany => hasMany', function (assert) {
     const earth = {
       type: 'planet',
       id: 'earth',
@@ -665,7 +665,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       relationships: { planets: { data: [{ type: 'planet', id: 'earth' }] } }
     };
 
-    cache.patch(t => [t.addRecord(earth), t.addRecord(human)]);
+    cache.patch((t) => [t.addRecord(earth), t.addRecord(human)]);
 
     const removePlanetOp: RemoveFromRelatedRecordsOperation = {
       op: 'removeFromRelatedRecords',
@@ -688,7 +688,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
     assert.deepEqual(processor.finally(removePlanetOp), []);
   });
 
-  test('updateRecord', function(assert) {
+  test('updateRecord', function (assert) {
     const human = {
       type: 'inhabitant',
       id: 'human',
@@ -741,7 +741,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(earth),
       t.addRecord(jupiter),
       t.addRecord(saturn),
@@ -792,7 +792,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
     assert.deepEqual(processor.finally(clearInhabitantsOp), []);
   });
 
-  test('remove record with hasMany relationships - verify processor', function(assert) {
+  test('remove record with hasMany relationships - verify processor', function (assert) {
     const earth = {
       type: 'planet',
       id: 'earth',
@@ -806,7 +806,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       relationships: { planets: { data: [{ type: 'planet', id: 'earth' }] } }
     };
 
-    cache.patch(t => [t.addRecord(earth), t.addRecord(human)]);
+    cache.patch((t) => [t.addRecord(earth), t.addRecord(human)]);
 
     assert.deepEqual(
       cache.getInverseRelationshipsSync(earth),
@@ -863,7 +863,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
     );
   });
 
-  test('remove record with hasMany relationships - verify inverse relationships are cleared', function(assert) {
+  test('remove record with hasMany relationships - verify inverse relationships are cleared', function (assert) {
     const earth = {
       type: 'planet',
       id: 'earth',
@@ -877,7 +877,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       relationships: { planets: { data: [{ type: 'planet', id: 'earth' }] } }
     };
 
-    cache.patch(t => [t.addRecord(earth), t.addRecord(human)]);
+    cache.patch((t) => [t.addRecord(earth), t.addRecord(human)]);
 
     assert.deepEqual(
       cache.getInverseRelationshipsSync(earth),
@@ -903,13 +903,13 @@ module('SchemaConsistencyProcessor', function(hooks) {
       'earth contains human as an inhabitant'
     );
 
-    cache.patch(t => t.removeRecord(human));
+    cache.patch((t) => t.removeRecord(human));
 
     assert.deepEqual(cache.getInverseRelationshipsSync(earth), []);
     assert.deepEqual(cache.getInverseRelationshipsSync(human), []);
   });
 
-  test('remove record with dependent hasMany relationships - verify inverse relationships are removed', function(assert) {
+  test('remove record with dependent hasMany relationships - verify inverse relationships are removed', function (assert) {
     const earth = {
       type: 'planet',
       id: 'earth',
@@ -923,7 +923,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       relationships: { planets: { data: [{ type: 'planet', id: 'earth' }] } }
     };
 
-    cache.patch(t => [t.addRecord(earth), t.addRecord(human)]);
+    cache.patch((t) => [t.addRecord(earth), t.addRecord(human)]);
 
     assert.deepEqual(
       cache.getInverseRelationshipsSync(earth),
@@ -980,7 +980,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
     );
   });
 
-  test('remove record with dependent hasMany relationships - verify dependent relationships deleted', function(assert) {
+  test('remove record with dependent hasMany relationships - verify dependent relationships deleted', function (assert) {
     const schema = new Schema({
       models: {
         planet: {
@@ -1031,7 +1031,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(io),
       t.addRecord(europa)
@@ -1070,7 +1070,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
     );
   });
 
-  test('remove record with dependent hasOne relationships - verify dependent relationships deleted', function(assert) {
+  test('remove record with dependent hasOne relationships - verify dependent relationships deleted', function (assert) {
     const schema = new Schema({
       models: {
         planet: {
@@ -1121,7 +1121,7 @@ module('SchemaConsistencyProcessor', function(hooks) {
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(io),
       t.addRecord(europa)

--- a/packages/@orbit/record-cache/test/operation-processors/schema-validation-processor-test.ts
+++ b/packages/@orbit/record-cache/test/operation-processors/schema-validation-processor-test.ts
@@ -11,7 +11,7 @@ import { SyncSchemaValidationProcessor } from '../../src/index';
 
 const { module, test } = QUnit;
 
-module('SchemaValidationProcessor', function(hooks) {
+module('SchemaValidationProcessor', function (hooks) {
   let schema: Schema;
   let cache: Cache;
 
@@ -58,7 +58,7 @@ module('SchemaValidationProcessor', function(hooks) {
   const unknown = { type: 'unknown', id: '?' };
   const unknownError = new ModelNotFound('unknown');
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     let keyMap = new KeyMap();
     schema = new Schema(schemaDefinition);
     cache = new Cache({
@@ -68,56 +68,56 @@ module('SchemaValidationProcessor', function(hooks) {
     });
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     schema = null;
     cache = null;
   });
 
-  test('addRecord with an unknown model type', assert => {
+  test('addRecord with an unknown model type', (assert) => {
     assert.throws(() => {
-      cache.patch(t => t.addRecord(unknown));
+      cache.patch((t) => t.addRecord(unknown));
     }, unknownError);
   });
 
-  test('updateRecord with an unknown model type', assert => {
+  test('updateRecord with an unknown model type', (assert) => {
     assert.throws(() => {
-      cache.patch(t => t.updateRecord(unknown));
+      cache.patch((t) => t.updateRecord(unknown));
     }, unknownError);
   });
 
-  test('removeRecord with an unknown model type', assert => {
+  test('removeRecord with an unknown model type', (assert) => {
     assert.throws(() => {
-      cache.patch(t => t.removeRecord(unknown));
+      cache.patch((t) => t.removeRecord(unknown));
     }, unknownError);
   });
 
-  test('replaceKey with an unknown model type', assert => {
+  test('replaceKey with an unknown model type', (assert) => {
     assert.throws(() => {
-      cache.patch(t => t.replaceKey(unknown, 'key', 'value'));
+      cache.patch((t) => t.replaceKey(unknown, 'key', 'value'));
     }, unknownError);
   });
 
-  test('replaceAttribute with an unknown model type', assert => {
+  test('replaceAttribute with an unknown model type', (assert) => {
     assert.throws(() => {
-      cache.patch(t => t.replaceAttribute(unknown, 'attribute', 'value'));
+      cache.patch((t) => t.replaceAttribute(unknown, 'attribute', 'value'));
     }, unknownError);
   });
 
-  test('addToRelatedRecords with an unknown model type', assert => {
+  test('addToRelatedRecords with an unknown model type', (assert) => {
     assert.throws(() => {
-      cache.patch(t => t.addToRelatedRecords(unknown, 'children', node));
+      cache.patch((t) => t.addToRelatedRecords(unknown, 'children', node));
     }, unknownError);
   });
 
-  test('addToRelatedRecords with an unknown related model type', assert => {
+  test('addToRelatedRecords with an unknown related model type', (assert) => {
     assert.throws(() => {
-      cache.patch(t => t.addToRelatedRecords(node, 'children', unknown));
+      cache.patch((t) => t.addToRelatedRecords(node, 'children', unknown));
     }, unknownError);
   });
 
-  test('addToRelatedRecords with a relationship not defined in the schema', assert => {
+  test('addToRelatedRecords with a relationship not defined in the schema', (assert) => {
     assert.throws(() => {
-      cache.patch(t =>
+      cache.patch((t) =>
         t.addToRelatedRecords({ type: 'node', id: '1' }, 'sibling', {
           type: 'node',
           id: '2'
@@ -126,9 +126,9 @@ module('SchemaValidationProcessor', function(hooks) {
     }, new RelationshipNotFound('sibling', 'node'));
   });
 
-  test('addToRelatedRecord with a related record with an invalid type for a non-polymorphic relationship', assert => {
+  test('addToRelatedRecord with a related record with an invalid type for a non-polymorphic relationship', (assert) => {
     assert.throws(() => {
-      cache.patch(t =>
+      cache.patch((t) =>
         t.addToRelatedRecords({ type: 'node', id: '1' }, 'children', {
           type: 'person',
           id: '1'
@@ -137,9 +137,9 @@ module('SchemaValidationProcessor', function(hooks) {
     }, new IncorrectRelatedRecordType('person', 'children', 'node'));
   });
 
-  test('addToRelatedRecords with a related record with an invalid type for a polymorphic relationship', assert => {
+  test('addToRelatedRecords with a related record with an invalid type for a polymorphic relationship', (assert) => {
     assert.throws(() => {
-      cache.patch(t =>
+      cache.patch((t) =>
         t.addToRelatedRecords({ type: 'person', id: '1' }, 'pets', {
           type: 'person',
           id: '2'
@@ -148,33 +148,33 @@ module('SchemaValidationProcessor', function(hooks) {
     }, new IncorrectRelatedRecordType('person', 'pets', 'person'));
   });
 
-  test('removeFromRelatedRecords with an unknown model type', assert => {
+  test('removeFromRelatedRecords with an unknown model type', (assert) => {
     assert.throws(() => {
-      cache.patch(t => t.removeFromRelatedRecords(unknown, 'children', node));
+      cache.patch((t) => t.removeFromRelatedRecords(unknown, 'children', node));
     }, unknownError);
   });
 
-  test('removeFromRelatedRecords with an unknown related model type', assert => {
+  test('removeFromRelatedRecords with an unknown related model type', (assert) => {
     assert.throws(() => {
-      cache.patch(t => t.removeFromRelatedRecords(node, 'children', unknown));
+      cache.patch((t) => t.removeFromRelatedRecords(node, 'children', unknown));
     }, unknownError);
   });
 
-  test('replaceRelatedRecords with an unknown model type', assert => {
+  test('replaceRelatedRecords with an unknown model type', (assert) => {
     assert.throws(() => {
-      cache.patch(t => t.replaceRelatedRecords(unknown, 'children', [node]));
+      cache.patch((t) => t.replaceRelatedRecords(unknown, 'children', [node]));
     }, unknownError);
   });
 
-  test('replaceRelatedRecords with an unknown related model type', assert => {
+  test('replaceRelatedRecords with an unknown related model type', (assert) => {
     assert.throws(() => {
-      cache.patch(t => t.replaceRelatedRecords(node, 'children', [unknown]));
+      cache.patch((t) => t.replaceRelatedRecords(node, 'children', [unknown]));
     }, unknownError);
   });
 
-  test('replaceRelatedRecords with a relationship not defined in the schema', assert => {
+  test('replaceRelatedRecords with a relationship not defined in the schema', (assert) => {
     assert.throws(() => {
-      cache.patch(t =>
+      cache.patch((t) =>
         t.replaceRelatedRecords({ type: 'node', id: '1' }, 'siblings', [
           { type: 'node', id: '2' }
         ])
@@ -182,9 +182,9 @@ module('SchemaValidationProcessor', function(hooks) {
     }, new RelationshipNotFound('siblings', 'node'));
   });
 
-  test('replaceRelatedRecords with a related record with an invalid type for a non-polymorphic relationship', assert => {
+  test('replaceRelatedRecords with a related record with an invalid type for a non-polymorphic relationship', (assert) => {
     assert.throws(() => {
-      cache.patch(t =>
+      cache.patch((t) =>
         t.replaceRelatedRecords({ type: 'node', id: '1' }, 'children', [
           { type: 'person', id: '1' }
         ])
@@ -192,9 +192,9 @@ module('SchemaValidationProcessor', function(hooks) {
     }, new IncorrectRelatedRecordType('person', 'children', 'node'));
   });
 
-  test('replaceRelatedRecords with a related record with an invalid type for a polymorphic relationship', assert => {
+  test('replaceRelatedRecords with a related record with an invalid type for a polymorphic relationship', (assert) => {
     assert.throws(() => {
-      cache.patch(t =>
+      cache.patch((t) =>
         t.replaceRelatedRecords({ type: 'person', id: '1' }, 'pets', [
           { type: 'person', id: '2' }
         ])
@@ -202,26 +202,26 @@ module('SchemaValidationProcessor', function(hooks) {
     }, new IncorrectRelatedRecordType('person', 'pets', 'person'));
   });
 
-  test('replaceRelatedRecord with an unknown model type', assert => {
+  test('replaceRelatedRecord with an unknown model type', (assert) => {
     assert.throws(() => {
-      cache.patch(t => t.replaceRelatedRecord(unknown, 'parent', node));
+      cache.patch((t) => t.replaceRelatedRecord(unknown, 'parent', node));
     }, unknownError);
   });
 
-  test('replaceRelatedRecord with an unknown related model type', assert => {
+  test('replaceRelatedRecord with an unknown related model type', (assert) => {
     assert.throws(() => {
-      cache.patch(t => t.replaceRelatedRecord(node, 'parent', unknown));
+      cache.patch((t) => t.replaceRelatedRecord(node, 'parent', unknown));
     }, unknownError);
   });
 
-  test('replaceRelatedRecord with a null related model', assert => {
-    cache.patch(t => t.replaceRelatedRecord(node, 'parent', null));
+  test('replaceRelatedRecord with a null related model', (assert) => {
+    cache.patch((t) => t.replaceRelatedRecord(node, 'parent', null));
     assert.ok(true, 'no error is thrown');
   });
 
-  test('replaceRelatedRecord with a relationship not defined in the schema', assert => {
+  test('replaceRelatedRecord with a relationship not defined in the schema', (assert) => {
     assert.throws(() => {
-      cache.patch(t =>
+      cache.patch((t) =>
         t.replaceRelatedRecord({ type: 'node', id: '1' }, 'mother', {
           type: 'node',
           id: '1'
@@ -230,9 +230,9 @@ module('SchemaValidationProcessor', function(hooks) {
     }, new RelationshipNotFound('mother', 'node'));
   });
 
-  test('replaceRelatedRecord with a related record with an invalid type for a non-polymorphic relationship', assert => {
+  test('replaceRelatedRecord with a related record with an invalid type for a non-polymorphic relationship', (assert) => {
     assert.throws(() => {
-      cache.patch(t =>
+      cache.patch((t) =>
         t.replaceRelatedRecord({ type: 'node', id: '1' }, 'parent', {
           type: 'person',
           id: '1'
@@ -241,9 +241,9 @@ module('SchemaValidationProcessor', function(hooks) {
     }, new IncorrectRelatedRecordType('person', 'parent', 'node'));
   });
 
-  test('replaceRelatedRecord with a related record with an invalid type for a polymorphic relationship', assert => {
+  test('replaceRelatedRecord with a related record with an invalid type for a polymorphic relationship', (assert) => {
     assert.throws(() => {
-      cache.patch(t =>
+      cache.patch((t) =>
         t.replaceRelatedRecord({ type: 'person', id: '1' }, 'favoritePet', {
           type: 'person',
           id: '2'

--- a/packages/@orbit/record-cache/test/support/example-async-record-cache.ts
+++ b/packages/@orbit/record-cache/test/support/example-async-record-cache.ts
@@ -20,7 +20,7 @@ export default class ExampleAsyncRecordCache extends AsyncRecordCache {
     this._records = {};
     this._inverseRelationships = {};
 
-    Object.keys(this._schema.models).forEach(type => {
+    Object.keys(this._schema.models).forEach((type) => {
       this._records[type] = {};
       this._inverseRelationships[type] = {};
     });

--- a/packages/@orbit/record-cache/test/support/example-sync-record-cache.ts
+++ b/packages/@orbit/record-cache/test/support/example-sync-record-cache.ts
@@ -20,7 +20,7 @@ export default class ExampleSyncRecordCache extends SyncRecordCache {
     this._records = {};
     this._inverseRelationships = {};
 
-    Object.keys(this._schema.models).forEach(type => {
+    Object.keys(this._schema.models).forEach((type) => {
       this._records[type] = {};
       this._inverseRelationships[type] = {};
     });

--- a/packages/@orbit/record-cache/test/sync-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/sync-record-cache-test.ts
@@ -13,10 +13,10 @@ import { arrayMembershipMatches } from './support/matchers';
 
 const { module, test } = QUnit;
 
-module('SyncRecordCache', function(hooks) {
+module('SyncRecordCache', function (hooks) {
   let schema: Schema, keyMap: KeyMap;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     schema = new Schema({
       models: {
         star: {
@@ -55,12 +55,12 @@ module('SyncRecordCache', function(hooks) {
     keyMap = new KeyMap();
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     schema = null;
     keyMap = null;
   });
 
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     const cache = new Cache({ schema });
 
     assert.ok(cache);
@@ -71,12 +71,12 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('it requires a schema', function(assert) {
+  test('it requires a schema', function (assert) {
     assert.expect(1);
     assert.throws(() => new Cache({ schema: null }));
   });
 
-  test('can be assigned processors', function(assert) {
+  test('can be assigned processors', function (assert) {
     let cache = new Cache({
       schema,
       processors: [SyncSchemaValidationProcessor]
@@ -90,7 +90,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch sets data and #records retrieves it', function(assert) {
+  test('#patch sets data and #records retrieves it', function (assert) {
     assert.expect(4);
 
     const cache = new Cache({ schema, keyMap });
@@ -110,7 +110,7 @@ module('SyncRecordCache', function(hooks) {
       assert.deepEqual(data, earth);
     });
 
-    cache.patch(t => t.addRecord(earth));
+    cache.patch((t) => t.addRecord(earth));
 
     assert.strictEqual(
       cache.getRecordSync({ type: 'planet', id: '1' }),
@@ -124,7 +124,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch can replace records', function(assert) {
+  test('#patch can replace records', function (assert) {
     assert.expect(5);
 
     const cache = new Cache({ schema, keyMap });
@@ -144,7 +144,7 @@ module('SyncRecordCache', function(hooks) {
       assert.deepEqual(data, earth);
     });
 
-    cache.patch(t => t.updateRecord(earth));
+    cache.patch((t) => t.updateRecord(earth));
 
     assert.deepEqual(
       cache.getRecordSync({ type: 'planet', id: '1' }),
@@ -163,7 +163,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch can replace keys', function(assert) {
+  test('#patch can replace keys', function (assert) {
     assert.expect(4);
 
     const cache = new Cache({ schema, keyMap });
@@ -184,7 +184,7 @@ module('SyncRecordCache', function(hooks) {
       });
     });
 
-    cache.patch(t => t.replaceKey(earth, 'remoteId', 'a'));
+    cache.patch((t) => t.replaceKey(earth, 'remoteId', 'a'));
 
     assert.deepEqual(
       cache.getRecordSync({ type: 'planet', id: '1' }),
@@ -198,13 +198,13 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch updates the cache and returns arrays of primary data and inverse ops', function(assert) {
+  test('#patch updates the cache and returns arrays of primary data and inverse ops', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     let p1 = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
     let p2 = { type: 'planet', id: '2' };
 
-    let result = cache.patch(t => [t.addRecord(p1), t.removeRecord(p2)]);
+    let result = cache.patch((t) => [t.addRecord(p1), t.removeRecord(p2)]);
 
     assert.deepEqual(
       result,
@@ -219,7 +219,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch updates inverse hasOne relationship when a record with relationships unspecified is added - record added after', function(assert) {
+  test('#patch updates inverse hasOne relationship when a record with relationships unspecified is added - record added after', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -230,7 +230,7 @@ module('SyncRecordCache', function(hooks) {
     };
     const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' } };
 
-    cache.patch(t => [t.updateRecord(jupiter), t.updateRecord(io)]);
+    cache.patch((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
 
     assert.deepEqual(
       cache.getRecordSync({ type: 'planet', id: 'p1' }).relationships.moons
@@ -245,7 +245,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch updates inverse hasOne relationship when a record with relationships unspecified is added - record added before', function(assert) {
+  test('#patch updates inverse hasOne relationship when a record with relationships unspecified is added - record added before', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -256,7 +256,7 @@ module('SyncRecordCache', function(hooks) {
     };
     const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' } };
 
-    cache.patch(t => [t.updateRecord(io), t.updateRecord(jupiter)]);
+    cache.patch((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
 
     assert.deepEqual(
       cache.getRecordSync({ type: 'planet', id: 'p1' }).relationships.moons
@@ -271,7 +271,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch updates inverse hasMany relationship when a record with relationships unspecified is added - record added after', function(assert) {
+  test('#patch updates inverse hasMany relationship when a record with relationships unspecified is added - record added after', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const io: Record = {
@@ -286,7 +286,7 @@ module('SyncRecordCache', function(hooks) {
       attributes: { name: 'Jupiter' }
     };
 
-    cache.patch(t => [t.updateRecord(io), t.updateRecord(jupiter)]);
+    cache.patch((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
 
     assert.deepEqual(
       cache.getRecordSync({ type: 'planet', id: 'p1' }).relationships.moons
@@ -301,7 +301,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch updates inverse hasMany relationship when a record with relationships unspecified is added - record added before', function(assert) {
+  test('#patch updates inverse hasMany relationship when a record with relationships unspecified is added - record added before', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const io: Record = {
@@ -316,7 +316,7 @@ module('SyncRecordCache', function(hooks) {
       attributes: { name: 'Jupiter' }
     };
 
-    cache.patch(t => [t.updateRecord(jupiter), t.updateRecord(io)]);
+    cache.patch((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
 
     assert.deepEqual(
       cache.getRecordSync({ type: 'planet', id: 'p1' }).relationships.moons
@@ -331,7 +331,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch updates inverse hasOne relationship when a record with an empty relationship is added', function(assert) {
+  test('#patch updates inverse hasOne relationship when a record with an empty relationship is added', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const io: Record = {
@@ -347,7 +347,7 @@ module('SyncRecordCache', function(hooks) {
       relationships: { moons: { data: [] } }
     };
 
-    cache.patch(t => [t.updateRecord(io), t.updateRecord(jupiter)]);
+    cache.patch((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
 
     assert.deepEqual(
       cache.getRecordSync({ type: 'planet', id: 'p1' }).relationships.moons
@@ -362,7 +362,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch updates inverse hasMany relationship when a record with an empty relationship is added', function(assert) {
+  test('#patch updates inverse hasMany relationship when a record with an empty relationship is added', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -378,7 +378,7 @@ module('SyncRecordCache', function(hooks) {
       relationships: { planet: { data: null } }
     };
 
-    cache.patch(t => [t.updateRecord(jupiter), t.updateRecord(io)]);
+    cache.patch((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
 
     assert.deepEqual(
       cache.getRecordSync({ type: 'planet', id: 'p1' }).relationships.moons
@@ -393,7 +393,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch updates inverse hasMany polymorphic relationship', function(assert) {
+  test('#patch updates inverse hasMany polymorphic relationship', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const sun: Record = {
@@ -416,7 +416,7 @@ module('SyncRecordCache', function(hooks) {
     };
     const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' } };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.updateRecord(sun),
       t.updateRecord(jupiter),
       t.updateRecord(io)
@@ -443,7 +443,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch updates inverse hasOne polymorphic relationship', function(assert) {
+  test('#patch updates inverse hasOne polymorphic relationship', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -460,7 +460,7 @@ module('SyncRecordCache', function(hooks) {
     };
     const sun: Record = { type: 'star', id: 's1', attributes: { name: 'Sun' } };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.updateRecord(jupiter),
       t.updateRecord(io),
       t.updateRecord(sun)
@@ -487,7 +487,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch tracks refs and clears them from hasOne relationships when a referenced record is removed', function(assert) {
+  test('#patch tracks refs and clears them from hasOne relationships when a referenced record is removed', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -509,7 +509,7 @@ module('SyncRecordCache', function(hooks) {
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(io),
       t.addRecord(europa)
@@ -526,7 +526,7 @@ module('SyncRecordCache', function(hooks) {
       'Jupiter has been assigned to Europa'
     );
 
-    cache.patch(t => t.removeRecord(jupiter));
+    cache.patch((t) => t.removeRecord(jupiter));
 
     assert.equal(
       cache.getRecordSync({ type: 'planet', id: 'p1' }),
@@ -546,7 +546,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch tracks refs and clears them from hasMany relationships when a referenced record is removed', function(assert) {
+  test('#patch tracks refs and clears them from hasMany relationships when a referenced record is removed', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const io: Record = {
@@ -575,7 +575,7 @@ module('SyncRecordCache', function(hooks) {
       }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(io),
       t.addRecord(europa),
       t.addRecord(jupiter)
@@ -598,7 +598,7 @@ module('SyncRecordCache', function(hooks) {
       'Jupiter has been assigned to Io and Europa'
     );
 
-    cache.patch(t => t.removeRecord(io));
+    cache.patch((t) => t.removeRecord(io));
 
     assert.equal(
       cache.getRecordSync({ type: 'moon', id: 'm1' }),
@@ -606,7 +606,7 @@ module('SyncRecordCache', function(hooks) {
       'Io is GONE'
     );
 
-    cache.patch(t => t.removeRecord(europa));
+    cache.patch((t) => t.removeRecord(europa));
 
     assert.equal(
       cache.getRecordSync({ type: 'moon', id: 'm2' }),
@@ -621,17 +621,17 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test("#patch adds link to hasMany if record doesn't exist", function(assert) {
+  test("#patch adds link to hasMany if record doesn't exist", function (assert) {
     const cache = new Cache({ schema, keyMap });
 
-    cache.patch(t =>
+    cache.patch((t) =>
       t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
         type: 'moon',
         id: 'm1'
       })
     );
 
-    cache.patch(t =>
+    cache.patch((t) =>
       t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
         type: 'moon',
         id: 'm1'
@@ -646,7 +646,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test("#patch does not remove hasMany relationship if record doesn't exist", function(assert) {
+  test("#patch does not remove hasMany relationship if record doesn't exist", function (assert) {
     assert.expect(1);
 
     const cache = new Cache({ schema, keyMap });
@@ -655,7 +655,7 @@ module('SyncRecordCache', function(hooks) {
       assert.ok(false, 'no operations were applied');
     });
 
-    cache.patch(t =>
+    cache.patch((t) =>
       t.removeFromRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
         type: 'moon',
         id: 'moon1'
@@ -669,7 +669,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test("#patch adds hasOne if record doesn't exist", function(assert) {
+  test("#patch adds hasOne if record doesn't exist", function (assert) {
     assert.expect(2);
 
     const cache = new Cache({ schema, keyMap });
@@ -688,7 +688,7 @@ module('SyncRecordCache', function(hooks) {
     );
 
     let order = 0;
-    cache.on('patch', op => {
+    cache.on('patch', (op) => {
       order++;
       if (order === 1) {
         assert.deepEqual(op, replacePlanet, 'applied replacePlanet operation');
@@ -702,7 +702,7 @@ module('SyncRecordCache', function(hooks) {
     cache.patch([replacePlanet]);
   });
 
-  test("#patch will add empty hasOne link if record doesn't exist", function(assert) {
+  test("#patch will add empty hasOne link if record doesn't exist", function (assert) {
     assert.expect(2);
 
     const cache = new Cache({ schema, keyMap });
@@ -715,7 +715,7 @@ module('SyncRecordCache', function(hooks) {
     );
 
     let order = 0;
-    cache.on('patch', op => {
+    cache.on('patch', (op) => {
       order++;
       if (order === 1) {
         assert.deepEqual(op, clearPlanet, 'applied clearPlanet operation');
@@ -729,7 +729,7 @@ module('SyncRecordCache', function(hooks) {
     assert.ok(true, 'patch applied');
   });
 
-  test('#patch does not add link to hasMany if link already exists', function(assert) {
+  test('#patch does not add link to hasMany if link already exists', function (assert) {
     assert.expect(1);
 
     const cache = new Cache({ schema, keyMap });
@@ -741,20 +741,20 @@ module('SyncRecordCache', function(hooks) {
       relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
     };
 
-    cache.patch(t => t.addRecord(jupiter));
+    cache.patch((t) => t.addRecord(jupiter));
 
     cache.on('patch', () => {
       assert.ok(false, 'no operations were applied');
     });
 
-    cache.patch(t =>
+    cache.patch((t) =>
       t.addToRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'm1' })
     );
 
     assert.ok(true, 'patch completed');
   });
 
-  test("#patch does not remove relationship from hasMany if relationship doesn't exist", function(assert) {
+  test("#patch does not remove relationship from hasMany if relationship doesn't exist", function (assert) {
     assert.expect(1);
 
     const cache = new Cache({ schema, keyMap });
@@ -765,31 +765,31 @@ module('SyncRecordCache', function(hooks) {
       attributes: { name: 'Jupiter' }
     };
 
-    cache.patch(t => t.addRecord(jupiter));
+    cache.patch((t) => t.addRecord(jupiter));
 
     cache.on('patch', () => {
       assert.ok(false, 'no operations were applied');
     });
 
-    cache.patch(t =>
+    cache.patch((t) =>
       t.removeFromRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'm1' })
     );
 
     assert.ok(true, 'patch completed');
   });
 
-  test('#patch can add and remove to has-many relationship', function(assert) {
+  test('#patch can add and remove to has-many relationship', function (assert) {
     assert.expect(2);
 
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = { id: 'jupiter', type: 'planet' };
-    cache.patch(t => t.addRecord(jupiter));
+    cache.patch((t) => t.addRecord(jupiter));
 
     const callisto: Record = { id: 'callisto', type: 'moon' };
-    cache.patch(t => t.addRecord(callisto));
+    cache.patch((t) => t.addRecord(callisto));
 
-    cache.patch(t =>
+    cache.patch((t) =>
       t.addToRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'callisto' })
     );
 
@@ -798,7 +798,7 @@ module('SyncRecordCache', function(hooks) {
       'moon added'
     );
 
-    cache.patch(t =>
+    cache.patch((t) =>
       t.removeFromRelatedRecords(jupiter, 'moons', {
         type: 'moon',
         id: 'callisto'
@@ -811,18 +811,18 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch can add and clear has-one relationship', function(assert) {
+  test('#patch can add and clear has-one relationship', function (assert) {
     assert.expect(2);
 
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = { id: 'jupiter', type: 'planet' };
-    cache.patch(t => t.addRecord(jupiter));
+    cache.patch((t) => t.addRecord(jupiter));
 
     const callisto: Record = { id: 'callisto', type: 'moon' };
-    cache.patch(t => t.addRecord(callisto));
+    cache.patch((t) => t.addRecord(callisto));
 
-    cache.patch(t =>
+    cache.patch((t) =>
       t.replaceRelatedRecord(callisto, 'planet', {
         type: 'planet',
         id: 'jupiter'
@@ -837,7 +837,7 @@ module('SyncRecordCache', function(hooks) {
       'relationship added'
     );
 
-    cache.patch(t => t.replaceRelatedRecord(callisto, 'planet', null));
+    cache.patch((t) => t.replaceRelatedRecord(callisto, 'planet', null));
 
     assert.notOk(
       equalRecordIdentities(
@@ -848,7 +848,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('does not replace hasOne if relationship already exists', function(assert) {
+  test('does not replace hasOne if relationship already exists', function (assert) {
     assert.expect(1);
 
     const cache = new Cache({ schema, keyMap });
@@ -860,20 +860,20 @@ module('SyncRecordCache', function(hooks) {
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
 
-    cache.patch(t => t.addRecord(europa));
+    cache.patch((t) => t.addRecord(europa));
 
     cache.on('patch', () => {
       assert.ok(false, 'no operations were applied');
     });
 
-    cache.patch(t =>
+    cache.patch((t) =>
       t.replaceRelatedRecord(europa, 'planet', { type: 'planet', id: 'p1' })
     );
 
     assert.ok(true, 'patch completed');
   });
 
-  test("does not remove hasOne if relationship doesn't exist", function(assert) {
+  test("does not remove hasOne if relationship doesn't exist", function (assert) {
     assert.expect(1);
 
     const cache = new Cache({ schema, keyMap });
@@ -885,18 +885,18 @@ module('SyncRecordCache', function(hooks) {
       relationships: { planet: { data: null } }
     };
 
-    cache.patch(t => t.addRecord(europa));
+    cache.patch((t) => t.addRecord(europa));
 
     cache.on('patch', () => {
       assert.ok(false, 'no operations were applied');
     });
 
-    cache.patch(t => t.replaceRelatedRecord(europa, 'planet', null));
+    cache.patch((t) => t.replaceRelatedRecord(europa, 'planet', null));
 
     assert.ok(true, 'patch completed');
   });
 
-  test('#patch removing model with a bi-directional hasOne', function(assert) {
+  test('#patch removing model with a bi-directional hasOne', function (assert) {
     assert.expect(5);
 
     const hasOneSchema = new Schema({
@@ -916,7 +916,7 @@ module('SyncRecordCache', function(hooks) {
 
     const cache = new Cache({ schema: hasOneSchema, keyMap });
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord({
         id: '1',
         type: 'one',
@@ -948,7 +948,7 @@ module('SyncRecordCache', function(hooks) {
       'two links to one'
     );
 
-    cache.patch(t => t.removeRecord(two));
+    cache.patch((t) => t.removeRecord(two));
 
     assert.equal(
       cache.getRecordSync({ type: 'one', id: '1' }).relationships.two.data,
@@ -957,7 +957,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch removes dependent records in a hasOne relationship', function(assert) {
+  test('#patch removes dependent records in a hasOne relationship', function (assert) {
     const dependentSchema = new Schema({
       models: {
         planet: {
@@ -993,7 +993,7 @@ module('SyncRecordCache', function(hooks) {
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(io),
       t.addRecord(europa),
@@ -1001,7 +1001,7 @@ module('SyncRecordCache', function(hooks) {
       t.addToRelatedRecords(jupiter, 'moons', europa)
     ]);
 
-    cache.patch(t => t.removeRecord(io));
+    cache.patch((t) => t.removeRecord(io));
 
     assert.equal(
       cache.getRecordsSync('moon').length,
@@ -1015,7 +1015,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch removes dependent records in a hasMany relationship', function(assert) {
+  test('#patch removes dependent records in a hasMany relationship', function (assert) {
     const dependentSchema = new Schema({
       models: {
         planet: {
@@ -1051,7 +1051,7 @@ module('SyncRecordCache', function(hooks) {
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.updateRecord(jupiter),
       t.updateRecord(io),
       t.updateRecord(europa),
@@ -1059,7 +1059,7 @@ module('SyncRecordCache', function(hooks) {
       t.addToRelatedRecords(jupiter, 'moons', europa)
     ]);
 
-    cache.patch(t => t.removeRecord(jupiter));
+    cache.patch((t) => t.removeRecord(jupiter));
 
     assert.equal(
       cache.getRecordsSync('planet').length,
@@ -1073,7 +1073,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch does not remove non-dependent records', function(assert) {
+  test('#patch does not remove non-dependent records', function (assert) {
     const dependentSchema = new Schema({
       models: {
         planet: {
@@ -1109,7 +1109,7 @@ module('SyncRecordCache', function(hooks) {
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(io),
       t.addRecord(europa),
@@ -1119,7 +1119,7 @@ module('SyncRecordCache', function(hooks) {
 
     // Since there are no dependent relationships, no other records will be
     // removed
-    cache.patch(t => t.removeRecord(io));
+    cache.patch((t) => t.removeRecord(io));
 
     assert.equal(
       cache.getRecordsSync('moon').length,
@@ -1133,11 +1133,11 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch merges records when "replacing" and will not stomp on attributes and relationships that are not replaced', function(assert) {
+  test('#patch merges records when "replacing" and will not stomp on attributes and relationships that are not replaced', function (assert) {
     const cache = new Cache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord({
         type: 'planet',
         id: '1',
@@ -1146,7 +1146,7 @@ module('SyncRecordCache', function(hooks) {
       })
     ]);
 
-    let result = cache.patch(t => [
+    let result = cache.patch((t) => [
       t.updateRecord({
         type: 'planet',
         id: '1',
@@ -1155,7 +1155,7 @@ module('SyncRecordCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      cache.query(q => q.findRecord({ type: 'planet', id: '1' })),
+      cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
       {
         type: 'planet',
         id: '1',
@@ -1195,11 +1195,11 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch can replace related records but only if they are different', function(assert) {
+  test('#patch can replace related records but only if they are different', function (assert) {
     const cache = new Cache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord({
         type: 'planet',
         id: '1',
@@ -1208,7 +1208,7 @@ module('SyncRecordCache', function(hooks) {
       })
     ]);
 
-    let result = cache.patch(t => [
+    let result = cache.patch((t) => [
       t.replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
         { type: 'moon', id: 'm1' }
       ])
@@ -1223,14 +1223,14 @@ module('SyncRecordCache', function(hooks) {
       'nothing has changed so there are no inverse ops'
     );
 
-    result = cache.patch(t => [
+    result = cache.patch((t) => [
       t.replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
         { type: 'moon', id: 'm2' }
       ])
     ]);
 
     assert.deepEqual(
-      cache.query(q => q.findRecord({ type: 'planet', id: '1' })),
+      cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
       {
         type: 'planet',
         id: '1',
@@ -1268,7 +1268,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch merges records when "replacing" and _will_ replace specified attributes and relationships', function(assert) {
+  test('#patch merges records when "replacing" and _will_ replace specified attributes and relationships', function (assert) {
     const cache = new Cache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
@@ -1319,7 +1319,7 @@ module('SyncRecordCache', function(hooks) {
     });
 
     assert.deepEqual(
-      cache.query(q => q.findRecord({ type: 'planet', id: '1' })),
+      cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
       {
         type: 'planet',
         id: '1',
@@ -1330,11 +1330,11 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch can update existing record with empty relationship', function(assert) {
+  test('#patch can update existing record with empty relationship', function (assert) {
     const cache = new Cache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
-    let result = cache.patch(t => [t.addRecord({ id: '1', type: 'planet' })]);
+    let result = cache.patch((t) => [t.addRecord({ id: '1', type: 'planet' })]);
 
     assert.deepEqual(result, {
       data: [{ id: '1', type: 'planet' }],
@@ -1346,7 +1346,7 @@ module('SyncRecordCache', function(hooks) {
       ]
     });
 
-    result = cache.patch(t => [
+    result = cache.patch((t) => [
       t.updateRecord({
         id: '1',
         type: 'planet',
@@ -1386,11 +1386,11 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#patch will not overwrite an existing relationship with a missing relationship', function(assert) {
+  test('#patch will not overwrite an existing relationship with a missing relationship', function (assert) {
     const cache = new Cache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
-    let result = cache.patch(t => [
+    let result = cache.patch((t) => [
       t.addRecord({
         id: '1',
         type: 'planet',
@@ -1433,7 +1433,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query can retrieve an individual record', function(assert) {
+  test('#query can retrieve an individual record', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -1445,15 +1445,15 @@ module('SyncRecordCache', function(hooks) {
         atmosphere: true
       }
     };
-    cache.patch(t => [t.addRecord(jupiter)]);
+    cache.patch((t) => [t.addRecord(jupiter)]);
 
     assert.deepEqual(
-      cache.query(q => q.findRecord({ type: 'planet', id: 'jupiter' })),
+      cache.query((q) => q.findRecord({ type: 'planet', id: 'jupiter' })),
       jupiter
     );
   });
 
-  test('#query can retrieve multiple expressions', function(assert) {
+  test('#query can retrieve multiple expressions', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -1474,10 +1474,10 @@ module('SyncRecordCache', function(hooks) {
         atmosphere: true
       }
     };
-    cache.patch(t => [t.addRecord(jupiter), t.addRecord(earth)]);
+    cache.patch((t) => [t.addRecord(jupiter), t.addRecord(earth)]);
 
     assert.deepEqual(
-      cache.query(q => [
+      cache.query((q) => [
         q.findRecord({ type: 'planet', id: 'jupiter' }),
         q.findRecord({ type: 'planet', id: 'earth' })
       ]),
@@ -1485,7 +1485,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query can find records by type', function(assert) {
+  test('#query can find records by type', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -1525,7 +1525,7 @@ module('SyncRecordCache', function(hooks) {
       }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -1534,12 +1534,12 @@ module('SyncRecordCache', function(hooks) {
 
     arrayMembershipMatches(
       assert,
-      cache.query(q => q.findRecords('planet')),
+      cache.query((q) => q.findRecords('planet')),
       [jupiter, earth, venus, mercury]
     );
   });
 
-  test('#query can find records by identities', function(assert) {
+  test('#query can find records by identities', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -1579,7 +1579,7 @@ module('SyncRecordCache', function(hooks) {
       }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -1588,7 +1588,7 @@ module('SyncRecordCache', function(hooks) {
 
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q.findRecords([
           { type: 'planet', id: 'jupiter' },
           { type: 'planet', id: 'venus' },
@@ -1599,7 +1599,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query can perform a simple attribute filter by value equality', function(assert) {
+  test('#query can perform a simple attribute filter by value equality', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -1639,7 +1639,7 @@ module('SyncRecordCache', function(hooks) {
       }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -1648,14 +1648,14 @@ module('SyncRecordCache', function(hooks) {
 
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q.findRecords('planet').filter({ attribute: 'name', value: 'Jupiter' })
       ),
       [jupiter]
     );
   });
 
-  test('#query can perform a simple attribute filter by value comparison (gt, lt, gte & lte)', function(assert) {
+  test('#query can perform a simple attribute filter by value comparison (gt, lt, gte & lte)', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -1699,7 +1699,7 @@ module('SyncRecordCache', function(hooks) {
       }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -1707,7 +1707,7 @@ module('SyncRecordCache', function(hooks) {
     ]);
     arrayMembershipMatches(
       assert,
-      cache.query(q => {
+      cache.query((q) => {
         let tmp = q.findRecords('planet');
         return tmp.filter({ attribute: 'sequence', value: 2, op: 'gt' });
       }),
@@ -1715,7 +1715,7 @@ module('SyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q => {
+      cache.query((q) => {
         let tmp = q.findRecords('planet');
         return tmp.filter({ attribute: 'sequence', value: 2, op: 'gte' });
       }),
@@ -1723,7 +1723,7 @@ module('SyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q => {
+      cache.query((q) => {
         let tmp = q.findRecords('planet');
         return tmp.filter({ attribute: 'sequence', value: 2, op: 'lt' });
       }),
@@ -1731,7 +1731,7 @@ module('SyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q => {
+      cache.query((q) => {
         let tmp = q.findRecords('planet');
         return tmp.filter({ attribute: 'sequence', value: 2, op: 'lte' });
       }),
@@ -1739,7 +1739,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query can perform relatedRecords filters with operators `equal`, `all`, `some` and `none`', function(assert) {
+  test('#query can perform relatedRecords filters with operators `equal`, `all`, `some` and `none`', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -1843,7 +1843,7 @@ module('SyncRecordCache', function(hooks) {
       relationships: {}
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(mars),
@@ -1858,7 +1858,7 @@ module('SyncRecordCache', function(hooks) {
     ]);
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [theMoon], op: 'equal' })
@@ -1867,7 +1867,7 @@ module('SyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [phobos], op: 'equal' })
@@ -1876,7 +1876,7 @@ module('SyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [phobos], op: 'all' })
@@ -1885,7 +1885,7 @@ module('SyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [phobos, callisto], op: 'all' })
@@ -1894,7 +1894,7 @@ module('SyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q.findRecords('planet').filter({
           relation: 'moons',
           records: [phobos, callisto],
@@ -1905,7 +1905,7 @@ module('SyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [titan], op: 'some' })
@@ -1914,7 +1914,7 @@ module('SyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [ganymede], op: 'none' })
@@ -1923,7 +1923,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query can perform relatedRecord filters', function(assert) {
+  test('#query can perform relatedRecord filters', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -2027,7 +2027,7 @@ module('SyncRecordCache', function(hooks) {
       relationships: { planet: { data: null } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(mars),
@@ -2042,35 +2042,35 @@ module('SyncRecordCache', function(hooks) {
     ]);
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q.findRecords('moon').filter({ relation: 'planet', record: null })
       ),
       [titan]
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q.findRecords('moon').filter({ relation: 'planet', record: earth })
       ),
       [theMoon]
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q.findRecords('moon').filter({ relation: 'planet', record: jupiter })
       ),
       [europa, ganymede, callisto]
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q.findRecords('moon').filter({ relation: 'planet', record: mercury })
       ),
       []
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRecords('moon')
           .filter({ relation: 'planet', record: [earth, mars] })
@@ -2079,7 +2079,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query can perform a complex attribute filter by value', function(assert) {
+  test('#query can perform a complex attribute filter by value', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -2119,7 +2119,7 @@ module('SyncRecordCache', function(hooks) {
       }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -2128,7 +2128,7 @@ module('SyncRecordCache', function(hooks) {
 
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRecords('planet')
           .filter(
@@ -2140,7 +2140,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query can perform a filter on attributes, even when a particular record has none', function(assert) {
+  test('#query can perform a filter on attributes, even when a particular record has none', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = { type: 'planet', id: 'jupiter' };
@@ -2172,7 +2172,7 @@ module('SyncRecordCache', function(hooks) {
       }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -2181,7 +2181,7 @@ module('SyncRecordCache', function(hooks) {
 
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRecords('planet')
           .filter(
@@ -2193,7 +2193,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query can sort by an attribute', function(assert) {
+  test('#query can sort by an attribute', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -2233,7 +2233,7 @@ module('SyncRecordCache', function(hooks) {
       }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -2241,12 +2241,12 @@ module('SyncRecordCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      cache.query(q => q.findRecords('planet').sort('name')),
+      cache.query((q) => q.findRecords('planet').sort('name')),
       [earth, jupiter, mercury, venus]
     );
   });
 
-  test('#query can sort by an attribute, even when a particular record has none', function(assert) {
+  test('#query can sort by an attribute, even when a particular record has none', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = { type: 'planet', id: 'jupiter' };
@@ -2278,7 +2278,7 @@ module('SyncRecordCache', function(hooks) {
       }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -2286,12 +2286,12 @@ module('SyncRecordCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      cache.query(q => q.findRecords('planet').sort('name')),
+      cache.query((q) => q.findRecords('planet').sort('name')),
       [earth, mercury, venus, jupiter]
     );
   });
 
-  test('#query can filter and sort by attributes', function(assert) {
+  test('#query can filter and sort by attributes', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -2331,7 +2331,7 @@ module('SyncRecordCache', function(hooks) {
       }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -2339,7 +2339,7 @@ module('SyncRecordCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRecords('planet')
           .filter(
@@ -2352,7 +2352,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query can sort by an attribute in descending order', function(assert) {
+  test('#query can sort by an attribute in descending order', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -2392,7 +2392,7 @@ module('SyncRecordCache', function(hooks) {
       }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -2400,12 +2400,12 @@ module('SyncRecordCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      cache.query(q => q.findRecords('planet').sort('-name')),
+      cache.query((q) => q.findRecords('planet').sort('-name')),
       [venus, mercury, jupiter, earth]
     );
   });
 
-  test('#query can sort by according to multiple criteria', function(assert) {
+  test('#query can sort by according to multiple criteria', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -2445,7 +2445,7 @@ module('SyncRecordCache', function(hooks) {
       }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -2453,12 +2453,14 @@ module('SyncRecordCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      cache.query(q => q.findRecords('planet').sort('classification', 'name')),
+      cache.query((q) =>
+        q.findRecords('planet').sort('classification', 'name')
+      ),
       [jupiter, earth, mercury, venus]
     );
   });
 
-  test('#query - findRecord - finds record', function(assert) {
+  test('#query - findRecord - finds record', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -2468,24 +2470,24 @@ module('SyncRecordCache', function(hooks) {
       relationships: { moons: { data: [{ type: 'moon', id: 'callisto' }] } }
     };
 
-    cache.patch(t => [t.addRecord(jupiter)]);
+    cache.patch((t) => [t.addRecord(jupiter)]);
 
     assert.deepEqual(
-      cache.query(q => q.findRecord({ type: 'planet', id: 'jupiter' })),
+      cache.query((q) => q.findRecord({ type: 'planet', id: 'jupiter' })),
       jupiter
     );
   });
 
-  test("#query - findRecord - throws RecordNotFoundException if record doesn't exist", function(assert) {
+  test("#query - findRecord - throws RecordNotFoundException if record doesn't exist", function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     assert.throws(
-      () => cache.query(q => q.findRecord({ type: 'planet', id: 'jupiter' })),
+      () => cache.query((q) => q.findRecord({ type: 'planet', id: 'jupiter' })),
       RecordNotFoundException
     );
   });
 
-  test('#query - findRecords - finds matching records', function(assert) {
+  test('#query - findRecords - finds matching records', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -2502,15 +2504,15 @@ module('SyncRecordCache', function(hooks) {
       relationships: { planet: { data: [{ type: 'planet', id: 'jupiter' }] } }
     };
 
-    cache.patch(t => [t.addRecord(jupiter), t.addRecord(callisto)]);
+    cache.patch((t) => [t.addRecord(jupiter), t.addRecord(callisto)]);
 
     assert.deepEqual(
-      cache.query(q => q.findRecords('planet')),
+      cache.query((q) => q.findRecords('planet')),
       [jupiter]
     );
   });
 
-  test('#query - page - can paginate records by offset and limit', function(assert) {
+  test('#query - page - can paginate records by offset and limit', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -2537,7 +2539,7 @@ module('SyncRecordCache', function(hooks) {
       attributes: { name: 'Mars' }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(venus),
@@ -2545,32 +2547,26 @@ module('SyncRecordCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      cache.query(q => q.findRecords('planet').sort('name')),
+      cache.query((q) => q.findRecords('planet').sort('name')),
       [earth, jupiter, mars, venus]
     );
 
     assert.deepEqual(
-      cache.query(q =>
-        q
-          .findRecords('planet')
-          .sort('name')
-          .page({ limit: 3 })
+      cache.query((q) =>
+        q.findRecords('planet').sort('name').page({ limit: 3 })
       ),
       [earth, jupiter, mars]
     );
 
     assert.deepEqual(
-      cache.query(q =>
-        q
-          .findRecords('planet')
-          .sort('name')
-          .page({ offset: 1, limit: 2 })
+      cache.query((q) =>
+        q.findRecords('planet').sort('name').page({ offset: 1, limit: 2 })
       ),
       [jupiter, mars]
     );
   });
 
-  test('#query - findRelatedRecords', function(assert) {
+  test('#query - findRelatedRecords', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -2587,17 +2583,17 @@ module('SyncRecordCache', function(hooks) {
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
 
-    cache.patch(t => [t.addRecord(jupiter), t.addRecord(callisto)]);
+    cache.patch((t) => [t.addRecord(jupiter), t.addRecord(callisto)]);
 
     assert.deepEqual(
-      cache.query(q =>
+      cache.query((q) =>
         q.findRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons')
       ),
       [callisto]
     );
   });
 
-  test('#query - findRelatedRecords - returns empty array if there are no related records', function(assert) {
+  test('#query - findRelatedRecords - returns empty array if there are no related records', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -2606,29 +2602,29 @@ module('SyncRecordCache', function(hooks) {
       attributes: { name: 'Jupiter' }
     };
 
-    cache.patch(t => [t.addRecord(jupiter)]);
+    cache.patch((t) => [t.addRecord(jupiter)]);
 
     assert.deepEqual(
-      cache.query(q =>
+      cache.query((q) =>
         q.findRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons')
       ),
       []
     );
   });
 
-  test("#query - findRelatedRecords - throws RecordNotFoundException if primary record doesn't exist", function(assert) {
+  test("#query - findRelatedRecords - throws RecordNotFoundException if primary record doesn't exist", function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     assert.throws(
       () =>
-        cache.query(q =>
+        cache.query((q) =>
           q.findRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons')
         ),
       RecordNotFoundException
     );
   });
 
-  test('#query - findRelatedRecord', function(assert) {
+  test('#query - findRelatedRecord', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -2645,17 +2641,17 @@ module('SyncRecordCache', function(hooks) {
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
 
-    cache.patch(t => [t.addRecord(jupiter), t.addRecord(callisto)]);
+    cache.patch((t) => [t.addRecord(jupiter), t.addRecord(callisto)]);
 
     assert.deepEqual(
-      cache.query(q =>
+      cache.query((q) =>
         q.findRelatedRecord({ type: 'moon', id: 'callisto' }, 'planet')
       ),
       jupiter
     );
   });
 
-  test('#query - findRelatedRecord - return null if no related record is found', function(assert) {
+  test('#query - findRelatedRecord - return null if no related record is found', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const callisto: Record = {
@@ -2664,29 +2660,29 @@ module('SyncRecordCache', function(hooks) {
       attributes: { name: 'Callisto' }
     };
 
-    cache.patch(t => [t.addRecord(callisto)]);
+    cache.patch((t) => [t.addRecord(callisto)]);
 
     assert.deepEqual(
-      cache.query(q =>
+      cache.query((q) =>
         q.findRelatedRecord({ type: 'moon', id: 'callisto' }, 'planet')
       ),
       null
     );
   });
 
-  test("#query - findRelatedRecord - throws RecordNotFoundException if primary record doesn't exist", function(assert) {
+  test("#query - findRelatedRecord - throws RecordNotFoundException if primary record doesn't exist", function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     assert.throws(
       () =>
-        cache.query(q =>
+        cache.query((q) =>
           q.findRelatedRecord({ type: 'moon', id: 'callisto' }, 'planet')
         ),
       RecordNotFoundException
     );
   });
 
-  test('#query - findRelatedRecords can perform a simple attribute filter by value equality', function(assert) {
+  test('#query - findRelatedRecords can perform a simple attribute filter by value equality', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const sun: Record = {
@@ -2745,7 +2741,7 @@ module('SyncRecordCache', function(hooks) {
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(sun),
       t.addRecord(jupiter),
       t.addRecord(earth),
@@ -2755,7 +2751,7 @@ module('SyncRecordCache', function(hooks) {
 
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ attribute: 'name', value: 'Jupiter' })
@@ -2764,7 +2760,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query - findRelatedRecords - can perform a simple attribute filter by value comparison (gt, lt, gte & lte)', function(assert) {
+  test('#query - findRelatedRecords - can perform a simple attribute filter by value comparison (gt, lt, gte & lte)', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const sun: Record = {
@@ -2827,7 +2823,7 @@ module('SyncRecordCache', function(hooks) {
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(sun),
       t.addRecord(jupiter),
       t.addRecord(earth),
@@ -2836,7 +2832,7 @@ module('SyncRecordCache', function(hooks) {
     ]);
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ attribute: 'sequence', value: 2, op: 'gt' })
@@ -2845,7 +2841,7 @@ module('SyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ attribute: 'sequence', value: 2, op: 'gte' })
@@ -2854,7 +2850,7 @@ module('SyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ attribute: 'sequence', value: 2, op: 'lt' })
@@ -2863,7 +2859,7 @@ module('SyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ attribute: 'sequence', value: 2, op: 'lte' })
@@ -2872,7 +2868,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query - findRelatedRecords - can perform relatedRecords filters with operators `equal`, `all`, `some` and `none`', function(assert) {
+  test('#query - findRelatedRecords - can perform relatedRecords filters with operators `equal`, `all`, `some` and `none`', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const sun: Record = {
@@ -2997,7 +2993,7 @@ module('SyncRecordCache', function(hooks) {
       relationships: {}
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(sun),
       t.addRecord(jupiter),
       t.addRecord(earth),
@@ -3013,7 +3009,7 @@ module('SyncRecordCache', function(hooks) {
     ]);
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'moons', records: [theMoon], op: 'equal' })
@@ -3022,7 +3018,7 @@ module('SyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'moons', records: [phobos], op: 'equal' })
@@ -3031,7 +3027,7 @@ module('SyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'moons', records: [phobos], op: 'all' })
@@ -3040,7 +3036,7 @@ module('SyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'moons', records: [phobos, callisto], op: 'all' })
@@ -3049,7 +3045,7 @@ module('SyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q.findRelatedRecords(sun, 'celestialObjects').filter({
           relation: 'moons',
           records: [phobos, callisto],
@@ -3060,7 +3056,7 @@ module('SyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'moons', records: [titan], op: 'some' })
@@ -3069,7 +3065,7 @@ module('SyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'moons', records: [ganymede], op: 'none' })
@@ -3078,7 +3074,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query - findRelatedRecords - can perform relatedRecord filters', function(assert) {
+  test('#query - findRelatedRecords - can perform relatedRecord filters', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const sun: Record = {
@@ -3230,7 +3226,7 @@ module('SyncRecordCache', function(hooks) {
       }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(sun),
       t.addRecord(jupiter),
       t.addRecord(earth),
@@ -3246,7 +3242,7 @@ module('SyncRecordCache', function(hooks) {
     ]);
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'planet', record: null })
@@ -3255,7 +3251,7 @@ module('SyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRelatedRecords(earth, 'moons')
           .filter({ relation: 'planet', record: earth })
@@ -3264,7 +3260,7 @@ module('SyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRelatedRecords(jupiter, 'moons')
           .filter({ relation: 'planet', record: jupiter })
@@ -3273,7 +3269,7 @@ module('SyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRelatedRecords(mercury, 'moons')
           .filter({ relation: 'planet', record: mercury })
@@ -3282,7 +3278,7 @@ module('SyncRecordCache', function(hooks) {
     );
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'planet', record: [earth, mars] })
@@ -3291,7 +3287,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query - findRelatedRecords - can perform a complex attribute filter by value', function(assert) {
+  test('#query - findRelatedRecords - can perform a complex attribute filter by value', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const sun: Record = {
@@ -3350,7 +3346,7 @@ module('SyncRecordCache', function(hooks) {
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(sun),
       t.addRecord(jupiter),
       t.addRecord(earth),
@@ -3360,7 +3356,7 @@ module('SyncRecordCache', function(hooks) {
 
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter(
@@ -3372,7 +3368,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query - findRelatedRecords - can perform a filter on attributes, even when a particular record has none', function(assert) {
+  test('#query - findRelatedRecords - can perform a filter on attributes, even when a particular record has none', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const sun: Record = {
@@ -3426,7 +3422,7 @@ module('SyncRecordCache', function(hooks) {
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(sun),
       t.addRecord(jupiter),
       t.addRecord(earth),
@@ -3436,7 +3432,7 @@ module('SyncRecordCache', function(hooks) {
 
     arrayMembershipMatches(
       assert,
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter(
@@ -3448,7 +3444,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query - findRelatedRecords - can sort by an attribute', function(assert) {
+  test('#query - findRelatedRecords - can sort by an attribute', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const sun: Record = {
@@ -3507,7 +3503,7 @@ module('SyncRecordCache', function(hooks) {
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(sun),
       t.addRecord(jupiter),
       t.addRecord(earth),
@@ -3516,14 +3512,14 @@ module('SyncRecordCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      cache.query(q =>
+      cache.query((q) =>
         q.findRelatedRecords(sun, 'celestialObjects').sort('name')
       ),
       [earth, jupiter, mercury, venus]
     );
   });
 
-  test('#query - findRelatedRecords - can sort by an attribute, even when a particular record has none', function(assert) {
+  test('#query - findRelatedRecords - can sort by an attribute, even when a particular record has none', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const sun: Record = {
@@ -3573,7 +3569,7 @@ module('SyncRecordCache', function(hooks) {
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(sun),
       t.addRecord(jupiter),
       t.addRecord(earth),
@@ -3582,14 +3578,14 @@ module('SyncRecordCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      cache.query(q =>
+      cache.query((q) =>
         q.findRelatedRecords(sun, 'celestialObjects').sort('name')
       ),
       [earth, mercury, venus, jupiter]
     );
   });
 
-  test('#query - findRelatedRecords - can filter and sort by attributes', function(assert) {
+  test('#query - findRelatedRecords - can filter and sort by attributes', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const sun: Record = {
@@ -3648,7 +3644,7 @@ module('SyncRecordCache', function(hooks) {
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(sun),
       t.addRecord(jupiter),
       t.addRecord(earth),
@@ -3657,7 +3653,7 @@ module('SyncRecordCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter(
@@ -3670,7 +3666,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query - findRelatedRecords - can sort by an attribute in descending order', function(assert) {
+  test('#query - findRelatedRecords - can sort by an attribute in descending order', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const sun: Record = {
@@ -3729,7 +3725,7 @@ module('SyncRecordCache', function(hooks) {
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(sun),
       t.addRecord(jupiter),
       t.addRecord(earth),
@@ -3738,14 +3734,14 @@ module('SyncRecordCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      cache.query(q =>
+      cache.query((q) =>
         q.findRelatedRecords(sun, 'celestialObjects').sort('-name')
       ),
       [venus, mercury, jupiter, earth]
     );
   });
 
-  test('#query - findRelatedRecords - can sort by according to multiple criteria', function(assert) {
+  test('#query - findRelatedRecords - can sort by according to multiple criteria', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const sun: Record = {
@@ -3804,7 +3800,7 @@ module('SyncRecordCache', function(hooks) {
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(sun),
       t.addRecord(jupiter),
       t.addRecord(earth),
@@ -3813,7 +3809,7 @@ module('SyncRecordCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .sort('classification', 'name')
@@ -3822,7 +3818,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#query - findRelatedRecords - page - can paginate records by offset and limit', function(assert) {
+  test('#query - findRelatedRecords - page - can paginate records by offset and limit', function (assert) {
     const cache = new Cache({ schema, keyMap });
 
     const sun: Record = {
@@ -3868,7 +3864,7 @@ module('SyncRecordCache', function(hooks) {
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
 
-    cache.patch(t => [
+    cache.patch((t) => [
       t.addRecord(sun),
       t.addRecord(jupiter),
       t.addRecord(earth),
@@ -3877,14 +3873,14 @@ module('SyncRecordCache', function(hooks) {
     ]);
 
     assert.deepEqual(
-      cache.query(q =>
+      cache.query((q) =>
         q.findRelatedRecords(sun, 'celestialObjects').sort('name')
       ),
       [earth, jupiter, mars, venus]
     );
 
     assert.deepEqual(
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .sort('name')
@@ -3894,7 +3890,7 @@ module('SyncRecordCache', function(hooks) {
     );
 
     assert.deepEqual(
-      cache.query(q =>
+      cache.query((q) =>
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .sort('name')
@@ -3904,7 +3900,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#liveQuery', async function(assert) {
+  test('#liveQuery', async function (assert) {
     let cache = new Cache({ schema, keyMap });
 
     const jupiter: Record = {
@@ -3930,14 +3926,14 @@ module('SyncRecordCache', function(hooks) {
       relationships: { moons: { data: [{ type: 'moon', id: 'callisto' }] } }
     };
 
-    const livePlanet = cache.liveQuery(q =>
+    const livePlanet = cache.liveQuery((q) =>
       q.findRecord({ type: 'planet', id: 'jupiter' })
     );
-    const livePlanets = cache.liveQuery(q => q.findRecords('planet'));
-    const livePlanetMoons = cache.liveQuery(q =>
+    const livePlanets = cache.liveQuery((q) => q.findRecords('planet'));
+    const livePlanetMoons = cache.liveQuery((q) =>
       q.findRelatedRecords(jupiter, 'moons')
     );
-    const liveMoonPlanet = cache.liveQuery(q =>
+    const liveMoonPlanet = cache.liveQuery((q) =>
       q.findRelatedRecord(callisto, 'planet')
     );
 
@@ -3950,7 +3946,7 @@ module('SyncRecordCache', function(hooks) {
       let defer: Deferred = {};
       defer.promise = new Promise((resolve, reject) => {
         defer.resolve = resolve;
-        defer.reject = message => reject(new Error(message));
+        defer.reject = (message) => reject(new Error(message));
       });
       return defer;
     }
@@ -3976,7 +3972,7 @@ module('SyncRecordCache', function(hooks) {
     }
 
     let n = 0;
-    let livePlanetUnsubscribe = livePlanet.subscribe(update => {
+    let livePlanetUnsubscribe = livePlanet.subscribe((update) => {
       n++;
       try {
         const result = update.query();
@@ -4008,7 +4004,7 @@ module('SyncRecordCache', function(hooks) {
     });
 
     let i = 0;
-    let livePlanetsUnsubscribe = livePlanets.subscribe(update => {
+    let livePlanetsUnsubscribe = livePlanets.subscribe((update) => {
       i++;
       try {
         const result = update.query();
@@ -4035,7 +4031,7 @@ module('SyncRecordCache', function(hooks) {
     });
 
     let j = 0;
-    let livePlanetMoonsUnsubscribe = livePlanetMoons.subscribe(update => {
+    let livePlanetMoonsUnsubscribe = livePlanetMoons.subscribe((update) => {
       j++;
       try {
         const result = update.query();
@@ -4063,7 +4059,7 @@ module('SyncRecordCache', function(hooks) {
     });
 
     let k = 0;
-    let liveMoonPlanetUnsubscribe = liveMoonPlanet.subscribe(update => {
+    let liveMoonPlanetUnsubscribe = liveMoonPlanet.subscribe((update) => {
       k++;
       try {
         const result = update.query();
@@ -4096,16 +4092,16 @@ module('SyncRecordCache', function(hooks) {
       jupiterRemoved.reject('reject jupiterRemoved');
     }, 500);
 
-    cache.patch(t => t.addRecord(jupiter));
+    cache.patch((t) => t.addRecord(jupiter));
     await jupiterAdded.promise;
 
-    cache.patch(t => t.updateRecord(jupiter2));
+    cache.patch((t) => t.updateRecord(jupiter2));
     await jupiterUpdated.promise;
 
-    cache.patch(t => t.addRecord(callisto));
+    cache.patch((t) => t.addRecord(callisto));
     await callistoAdded.promise;
 
-    cache.patch(t => t.removeRecord(jupiter));
+    cache.patch((t) => t.removeRecord(jupiter));
     await jupiterRemoved.promise;
 
     assert.expect(16);
@@ -4119,7 +4115,7 @@ module('SyncRecordCache', function(hooks) {
     livePlanetMoonsUnsubscribe();
     liveMoonPlanetUnsubscribe();
 
-    cache.patch(t =>
+    cache.patch((t) =>
       t.addRecord({
         type: 'planet',
         id: 'mercury',
@@ -4130,7 +4126,7 @@ module('SyncRecordCache', function(hooks) {
     );
   });
 
-  test('#liveQuery findRecords (debounce)', async function(assert) {
+  test('#liveQuery findRecords (debounce)', async function (assert) {
     let cache = new Cache({ schema, keyMap });
 
     const planets: Record[] = [
@@ -4151,24 +4147,24 @@ module('SyncRecordCache', function(hooks) {
       }
     ];
 
-    const livePlanets = cache.liveQuery(q => q.findRecords('planet'));
+    const livePlanets = cache.liveQuery((q) => q.findRecords('planet'));
 
     let i = 0;
     cache.on('patch', () => i++);
 
     const done = assert.async();
-    livePlanets.subscribe(update => {
+    livePlanets.subscribe((update) => {
       const result = update.query();
       assert.deepEqual(result, planets);
       assert.equal(i, 3);
       done();
     });
 
-    cache.patch(t => planets.map(planet => t.addRecord(planet)));
+    cache.patch((t) => planets.map((planet) => t.addRecord(planet)));
     assert.expect(2);
   });
 
-  test('#liveQuery findRecords (no debounce)', async function(assert) {
+  test('#liveQuery findRecords (no debounce)', async function (assert) {
     let cache = new Cache({ schema, keyMap, debounceLiveQueries: false });
 
     const planets: Record[] = [
@@ -4189,13 +4185,13 @@ module('SyncRecordCache', function(hooks) {
       }
     ];
 
-    const livePlanets = cache.liveQuery(q => q.findRecords('planet'));
+    const livePlanets = cache.liveQuery((q) => q.findRecords('planet'));
 
     let i = 0;
     cache.on('patch', () => i++);
 
     const done = assert.async();
-    livePlanets.subscribe(update => {
+    livePlanets.subscribe((update) => {
       const result = update.query() as Record[];
       assert.equal(result.length, i);
 
@@ -4204,7 +4200,7 @@ module('SyncRecordCache', function(hooks) {
       }
     });
 
-    cache.patch(t => planets.map(planet => t.addRecord(planet)));
+    cache.patch((t) => planets.map((planet) => t.addRecord(planet)));
     assert.expect(3);
   });
 });

--- a/packages/@orbit/serializers/.prettierrc.js
+++ b/packages/@orbit/serializers/.prettierrc.js
@@ -1,3 +1,4 @@
 module.exports = {
-  singleQuote: true
+  singleQuote: true,
+  trailingComma: 'none'
 };

--- a/packages/@orbit/serializers/package.json
+++ b/packages/@orbit/serializers/package.json
@@ -27,11 +27,11 @@
   },
   "devDependencies": {
     "@glimmer/build": "^0.10.3",
-    "@typescript-eslint/eslint-plugin": "^2.23.0",
-    "@typescript-eslint/parser": "^2.23.0",
+    "@typescript-eslint/eslint-plugin": "^2.26.0",
+    "@typescript-eslint/parser": "^2.26.0",
     "eslint": "^6.8.0",
-    "eslint-config-prettier": "^6.10.0",
+    "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-prettier": "^3.1.2",
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.2"
   }
 }

--- a/packages/@orbit/serializers/test/boolean-serializer-test.ts
+++ b/packages/@orbit/serializers/test/boolean-serializer-test.ts
@@ -2,19 +2,19 @@ import { BooleanSerializer } from '../src/index';
 
 const { module, test } = QUnit;
 
-module('BooleanSerializer', function(hooks) {
+module('BooleanSerializer', function (hooks) {
   let serializer: BooleanSerializer;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     serializer = new BooleanSerializer();
   });
 
-  test('#serialize returns arg untouched', function(assert) {
+  test('#serialize returns arg untouched', function (assert) {
     assert.strictEqual(serializer.serialize(true), true);
     assert.strictEqual(serializer.serialize(false), false);
   });
 
-  test('#deserialize returns arg untouched', function(assert) {
+  test('#deserialize returns arg untouched', function (assert) {
     assert.strictEqual(serializer.deserialize(true), true);
     assert.strictEqual(serializer.deserialize(false), false);
   });

--- a/packages/@orbit/serializers/test/date-serializer-test.ts
+++ b/packages/@orbit/serializers/test/date-serializer-test.ts
@@ -2,18 +2,18 @@ import { DateSerializer } from '../src/index';
 
 const { module, test } = QUnit;
 
-module('DateSerializer', function(hooks) {
+module('DateSerializer', function (hooks) {
   let serializer: DateSerializer;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     serializer = new DateSerializer();
   });
 
-  test('#serialize returns a date in YYYY-MM-DD form', function(assert) {
+  test('#serialize returns a date in YYYY-MM-DD form', function (assert) {
     assert.equal(serializer.serialize(new Date(2017, 11, 31)), '2017-12-31');
   });
 
-  test('#deserialize returns a Date', function(assert) {
+  test('#deserialize returns a Date', function (assert) {
     assert.equal(
       serializer.deserialize('2017-12-31').toISOString(),
       new Date(2017, 11, 31).toISOString()

--- a/packages/@orbit/serializers/test/date-time-serializer-test.ts
+++ b/packages/@orbit/serializers/test/date-time-serializer-test.ts
@@ -2,21 +2,21 @@ import { DateTimeSerializer } from '../src/index';
 
 const { module, test } = QUnit;
 
-module('DateTimeSerializer', function(hooks) {
+module('DateTimeSerializer', function (hooks) {
   let serializer: DateTimeSerializer;
 
   let dateString = '2015-01-01T10:00:00.000Z';
   let date = new Date(dateString);
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     serializer = new DateTimeSerializer();
   });
 
-  test('#serialize returns a date-time in ISO format', function(assert) {
+  test('#serialize returns a date-time in ISO format', function (assert) {
     assert.equal(serializer.serialize(date), dateString);
   });
 
-  test('#deserialize returns a Date, with a time set', function(assert) {
+  test('#deserialize returns a Date, with a time set', function (assert) {
     assert.equal(
       serializer.deserialize(dateString).toISOString(),
       date.toISOString()

--- a/packages/@orbit/serializers/test/number-serializer-test.ts
+++ b/packages/@orbit/serializers/test/number-serializer-test.ts
@@ -2,19 +2,19 @@ import { NumberSerializer } from '../src/index';
 
 const { module, test } = QUnit;
 
-module('NumberSerializer', function(hooks) {
+module('NumberSerializer', function (hooks) {
   let serializer: NumberSerializer;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     serializer = new NumberSerializer();
   });
 
-  test('#serialize returns arg untouched', function(assert) {
+  test('#serialize returns arg untouched', function (assert) {
     assert.strictEqual(serializer.serialize(1), 1);
     assert.strictEqual(serializer.serialize(2.4), 2.4);
   });
 
-  test('#deserialize returns arg untouched', function(assert) {
+  test('#deserialize returns arg untouched', function (assert) {
     assert.strictEqual(serializer.deserialize(1), 1);
     assert.strictEqual(serializer.deserialize(2.4), 2.4);
   });

--- a/packages/@orbit/serializers/test/string-serializer-test.ts
+++ b/packages/@orbit/serializers/test/string-serializer-test.ts
@@ -2,18 +2,18 @@ import { StringSerializer } from '../src/index';
 
 const { module, test } = QUnit;
 
-module('StringSerializer', function(hooks) {
+module('StringSerializer', function (hooks) {
   let serializer: StringSerializer;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     serializer = new StringSerializer();
   });
 
-  test('#serialize returns arg untouched', function(assert) {
+  test('#serialize returns arg untouched', function (assert) {
     assert.equal(serializer.serialize('abc'), 'abc');
   });
 
-  test('#deserialize returns arg untouched', function(assert) {
+  test('#deserialize returns arg untouched', function (assert) {
     assert.equal(serializer.deserialize('abc'), 'abc');
   });
 });

--- a/packages/@orbit/store/.prettierrc.js
+++ b/packages/@orbit/store/.prettierrc.js
@@ -1,3 +1,4 @@
 module.exports = {
-  singleQuote: true
+  singleQuote: true,
+  trailingComma: 'none'
 };

--- a/packages/@orbit/store/package.json
+++ b/packages/@orbit/store/package.json
@@ -35,11 +35,11 @@
   },
   "devDependencies": {
     "@glimmer/build": "^0.10.3",
-    "@typescript-eslint/eslint-plugin": "^2.23.0",
-    "@typescript-eslint/parser": "^2.23.0",
+    "@typescript-eslint/eslint-plugin": "^2.26.0",
+    "@typescript-eslint/parser": "^2.26.0",
     "eslint": "^6.8.0",
-    "eslint-config-prettier": "^6.10.0",
+    "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-prettier": "^3.1.2",
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.2"
   }
 }

--- a/packages/@orbit/store/test/cache-test.ts
+++ b/packages/@orbit/store/test/cache-test.ts
@@ -3,11 +3,11 @@ import { Cache } from '../src/index';
 
 const { module, test } = QUnit;
 
-module('Cache', function(hooks) {
+module('Cache', function (hooks) {
   let schema: Schema;
   let cache: Cache;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     schema = new Schema({
       models: {
         planet: {}
@@ -16,12 +16,12 @@ module('Cache', function(hooks) {
     cache = new Cache({ schema });
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     schema = null;
     cache = null;
   });
 
-  test('it exists', function(assert) {
+  test('it exists', function (assert) {
     assert.ok(cache instanceof Cache, 'instanceof Cache');
   });
 });

--- a/packages/@orbit/store/test/store-test.ts
+++ b/packages/@orbit/store/test/store-test.ts
@@ -3,11 +3,11 @@ import Store from '../src/index';
 
 const { module, test } = QUnit;
 
-module('Store', function(hooks) {
+module('Store', function (hooks) {
   let schema;
   let store;
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     schema = new Schema({
       models: {
         planet: {}
@@ -16,12 +16,12 @@ module('Store', function(hooks) {
     store = new Store({ schema });
   });
 
-  hooks.afterEach(function() {
+  hooks.afterEach(function () {
     schema = null;
     store = null;
   });
 
-  test('its prototype chain is correct', function(assert) {
+  test('its prototype chain is correct', function (assert) {
     assert.ok(store instanceof Source, 'instanceof Source');
     assert.ok(store instanceof Store, 'instanceof Store');
     assert.equal(store.name, 'store', 'should have default name');

--- a/packages/@orbit/utils/.prettierrc.js
+++ b/packages/@orbit/utils/.prettierrc.js
@@ -1,3 +1,4 @@
 module.exports = {
-  singleQuote: true
+  singleQuote: true,
+  trailingComma: 'none'
 };

--- a/packages/@orbit/utils/package.json
+++ b/packages/@orbit/utils/package.json
@@ -27,11 +27,11 @@
   },
   "devDependencies": {
     "@glimmer/build": "^0.10.3",
-    "@typescript-eslint/eslint-plugin": "^2.23.0",
-    "@typescript-eslint/parser": "^2.23.0",
+    "@typescript-eslint/eslint-plugin": "^2.26.0",
+    "@typescript-eslint/parser": "^2.26.0",
     "eslint": "^6.8.0",
-    "eslint-config-prettier": "^6.10.0",
+    "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-prettier": "^3.1.2",
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.2"
   }
 }

--- a/packages/@orbit/utils/src/objects.ts
+++ b/packages/@orbit/utils/src/objects.ts
@@ -64,9 +64,9 @@ export function expose(destination: any, source: any): void {
     properties = Object.keys(source);
   }
 
-  properties.forEach(p => {
+  properties.forEach((p) => {
     if (typeof source[p] === 'function') {
-      destination[p] = function() {
+      destination[p] = function () {
         return source[p].apply(source, arguments);
       };
     } else {
@@ -84,7 +84,7 @@ export function expose(destination: any, source: any): void {
  * @returns {any}
  */
 export function extend(destination: any, ...sources: any[]): any {
-  sources.forEach(source => {
+  sources.forEach((source) => {
     for (let p in source) {
       if (source.hasOwnProperty(p)) {
         destination[p] = source[p];
@@ -156,8 +156,8 @@ export function isNone(obj: any): boolean {
  * @returns {*}
  */
 export function merge(object: any, ...sources: any[]): any {
-  sources.forEach(source => {
-    Object.keys(source).forEach(field => {
+  sources.forEach((source) => {
+    Object.keys(source).forEach((field) => {
       if (source.hasOwnProperty(field)) {
         let value = source[field];
         if (value !== undefined) {
@@ -182,8 +182,8 @@ export function merge(object: any, ...sources: any[]): any {
  * @returns {*}
  */
 export function deepMerge(object: any, ...sources: any[]): any {
-  sources.forEach(source => {
-    Object.keys(source).forEach(field => {
+  sources.forEach((source) => {
+    Object.keys(source).forEach((field) => {
       if (source.hasOwnProperty(field)) {
         let a = object[field];
         let b = source[field];
@@ -274,6 +274,6 @@ export function objectValues(obj: any): any[] {
   if (Object.values) {
     return Object.values(obj);
   } else {
-    return Object.keys(obj).map(k => obj[k]);
+    return Object.keys(obj).map((k) => obj[k]);
   }
 }

--- a/packages/@orbit/utils/src/strings.ts
+++ b/packages/@orbit/utils/src/strings.ts
@@ -19,10 +19,10 @@ export function capitalize(str: string): string {
  */
 export function camelize(str: string): string {
   return str
-    .replace(/(\-|\_|\.|\s)+(.)?/g, function(match, separator, chr) {
+    .replace(/(\-|\_|\.|\s)+(.)?/g, function (match, separator, chr) {
       return chr ? chr.toUpperCase() : '';
     })
-    .replace(/(^|\/)([A-Z])/g, function(match) {
+    .replace(/(^|\/)([A-Z])/g, function (match) {
       return match.toLowerCase();
     });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1268,7 +1268,7 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
-"@types/minimatch@*", "@types/minimatch@3.0.3", "@types/minimatch@^3.0.3":
+"@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
@@ -1283,50 +1283,57 @@
   resolved "https://registry.yarnpkg.com/@types/qunit/-/qunit-2.9.0.tgz#0b3fcbe2b92f067856adac82ba3afbc66d8835ac"
   integrity sha512-Hx34HZmTJKRay+x3sFdEK62I8Z8YSWYg+rAlNr4M+AbwvNUJYxTTmWEH4a8B9ZN+Fl61awFrw+oRicWLFVugvQ==
 
-"@types/sinon@7.5.2":
-  version "7.5.2"
-  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-7.5.2.tgz#5e2f1d120f07b9cda07e5dedd4f3bf8888fccdb9"
-  integrity sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg==
+"@types/sinon@9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-9.0.0.tgz#5b70a360f55645dd64f205defd2a31b749a59799"
+  integrity sha512-v2TkYHkts4VXshMkcmot/H+ERZ2SevKa10saGaJPGCJ8vh3lKrC4u663zYEeRZxep+VbG6YRDtQ6gVqw9dYzPA==
+  dependencies:
+    "@types/sinonjs__fake-timers" "*"
+
+"@types/sinonjs__fake-timers@*":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz#681df970358c82836b42f989188d133e218c458e"
+  integrity sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==
 
 "@types/symlink-or-copy@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/symlink-or-copy/-/symlink-or-copy-1.2.0.tgz#4151a81b4052c80bc2becbae09f3a9ec010a9c7a"
   integrity sha512-Lja2xYuuf2B3knEsga8ShbOdsfNOtzT73GyJmZyY7eGl2+ajOqrs8yM5ze0fsSoYwvA6bw7/Qr7OZ7PEEmYwWg==
 
-"@typescript-eslint/eslint-plugin@^2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.23.0.tgz#aa7133bfb7b685379d9eafe4ae9e08b9037e129d"
-  integrity sha512-8iA4FvRsz8qTjR0L/nK9RcRUN3QtIHQiOm69FzV7WS3SE+7P7DyGGwh3k4UNR2JBbk+Ej2Io+jLAaqKibNhmtw==
+"@typescript-eslint/eslint-plugin@^2.26.0":
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.26.0.tgz#04c96560c8981421e5a9caad8394192363cc423f"
+  integrity sha512-4yUnLv40bzfzsXcTAtZyTjbiGUXMrcIJcIMioI22tSOyAxpdXiZ4r7YQUU8Jj6XXrLz9d5aMHPQf5JFR7h27Nw==
   dependencies:
-    "@typescript-eslint/experimental-utils" "2.23.0"
-    eslint-utils "^1.4.3"
+    "@typescript-eslint/experimental-utils" "2.26.0"
     functional-red-black-tree "^1.0.1"
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.23.0.tgz#5d2261c8038ec1698ca4435a8da479c661dc9242"
-  integrity sha512-OswxY59RcXH3NNPmq+4Kis2CYZPurRU6mG5xPcn24CjFyfdVli5mySwZz/g/xDbJXgDsYqNGq7enV0IziWGXVQ==
+"@typescript-eslint/experimental-utils@2.26.0":
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.26.0.tgz#063390c404d9980767d76274df386c0aa675d91d"
+  integrity sha512-RELVoH5EYd+JlGprEyojUv9HeKcZqF7nZUGSblyAw1FwOGNnmQIU8kxJ69fttQvEwCsX5D6ECJT8GTozxrDKVQ==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.23.0"
+    "@typescript-eslint/typescript-estree" "2.26.0"
     eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@^2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.23.0.tgz#f3d4e2928ff647fe77fc2fcef1a3534fee6a3212"
-  integrity sha512-k61pn/Nepk43qa1oLMiyqApC6x5eP5ddPz6VUYXCAuXxbmRLqkPYzkFRKl42ltxzB2luvejlVncrEpflgQoSUg==
+"@typescript-eslint/parser@^2.26.0":
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.26.0.tgz#385463615818b33acb72a25b39c03579df93d76f"
+  integrity sha512-+Xj5fucDtdKEVGSh9353wcnseMRkPpEAOY96EEenN7kJVrLqy/EVwtIh3mxcUz8lsFXW1mT5nN5vvEam/a5HiQ==
   dependencies:
     "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "2.23.0"
-    "@typescript-eslint/typescript-estree" "2.23.0"
+    "@typescript-eslint/experimental-utils" "2.26.0"
+    "@typescript-eslint/typescript-estree" "2.26.0"
     eslint-visitor-keys "^1.1.0"
 
-"@typescript-eslint/typescript-estree@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.23.0.tgz#d355960fab96bd550855488dcc34b9a4acac8d36"
-  integrity sha512-pmf7IlmvXdlEXvE/JWNNJpEvwBV59wtJqA8MLAxMKLXNKVRC3HZBXR/SlZLPWTCcwOSg9IM7GeRSV3SIerGVqw==
+"@typescript-eslint/typescript-estree@2.26.0":
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.26.0.tgz#d8132cf1ee8a72234f996519a47d8a9118b57d56"
+  integrity sha512-3x4SyZCLB4zsKsjuhxDLeVJN6W29VwBnYpCsZ7vIdPel9ZqLfIZJgJXO47MNUkurGpQuIBALdPQKtsSnWpE1Yg==
   dependencies:
     debug "^4.1.1"
     eslint-visitor-keys "^1.1.0"
@@ -1709,7 +1716,7 @@ babel-runtime@^6.22.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
-backbone@^1.1.2, backbone@^1.4.0:
+backbone@^1.1.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/backbone/-/backbone-1.4.0.tgz#54db4de9df7c3811c3f032f34749a4cd27f3bd12"
   integrity sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==
@@ -3107,10 +3114,10 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-eslint-config-prettier@^6.10.0:
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz#7b15e303bf9c956875c948f6b21500e48ded6a7f"
-  integrity sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==
+eslint-config-prettier@^6.10.1:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz#129ef9ec575d5ddc0e269667bf09defcd898642a"
+  integrity sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==
   dependencies:
     get-stdin "^6.0.0"
 
@@ -3133,6 +3140,13 @@ eslint-utils@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
   integrity sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
+eslint-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.0.0.tgz#7be1cc70f27a72a76cd14aa698bcabed6890e1cd"
+  integrity sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
@@ -3985,14 +3999,14 @@ handlebars@^4.1.0:
   optionalDependencies:
     uglify-js "^3.1.4"
 
-handlebars@^4.7.2:
-  version "4.7.3"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.3.tgz#8ece2797826886cf8082d1726ff21d2a022550ee"
-  integrity sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==
+handlebars@^4.7.3:
+  version "4.7.5"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.5.tgz#3105d3f54038976bd54e5ae0c711c70d4ed040f8"
+  integrity sha512-PiM2ZRLZ0X+CIRSX66u7tkQi3rzrlSHAuioMBI1XP8DsfDaXEA+sD7Iyyoz4QACFuhX5z+IimN+n3BFWvvgWrQ==
   dependencies:
     neo-async "^2.6.0"
-    optimist "^0.6.1"
     source-map "^0.6.1"
+    yargs "^14.2.3"
   optionalDependencies:
     uglify-js "^3.1.4"
 
@@ -4113,7 +4127,7 @@ heimdalljs@^0.2.0, heimdalljs@^0.2.1, heimdalljs@^0.2.3, heimdalljs@^0.2.5, heim
   dependencies:
     rsvp "~3.2.1"
 
-highlight.js@^9.17.1:
+highlight.js@^9.18.1:
   version "9.18.1"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.1.tgz#ed21aa001fe6252bb10a3d76d47573c6539fe13c"
   integrity sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==
@@ -4660,11 +4674,6 @@ istextorbinary@2.1.0:
     editions "^1.1.1"
     textextensions "1 || 2"
 
-jquery@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
-  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
-
 js-reporters@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/js-reporters/-/js-reporters-1.2.1.tgz#f88c608e324a3373a95bcc45ad305e5c979c459b"
@@ -5124,7 +5133,7 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marked@^0.8.0:
+marked@0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.8.0.tgz#ec5c0c9b93878dc52dd54be8d0e524097bd81a99"
   integrity sha512-MyUe+T/Pw4TZufHkzAfDj6HarCBWia2y27/bhuYkTaiUnfDYFnCP3KUN+9oM7Wi6JA2rymtVYbQu3spE0GCmxQ==
@@ -6083,10 +6092,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.2.tgz#1ba8f3eb92231e769b7fcd7cb73ae1b6b74ade08"
+  integrity sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==
 
 printf@^0.5.1:
   version "0.5.2"
@@ -7678,42 +7687,32 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typedoc-default-themes@^0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.7.2.tgz#1e9896f920b58e6da0bba9d7e643738d02405a5a"
-  integrity sha512-fiFKlFO6VTqjcno8w6WpTsbCgXmfPHVjnLfYkmByZE7moaz+E2DSpAT+oHtDHv7E0BM5kAhPrHJELP2J2Y2T9A==
+typedoc-default-themes@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.9.0.tgz#170132ddcdfb10823a0b006b0e084ebd4acb540c"
+  integrity sha512-ExfIAg3EjZvWnnDsv2wQcZ9I8Lnln643LsfV05BrRGcIMSYPuavils96j4yGXiBYUzldIYw3xmZ7rsdqWfDunQ==
   dependencies:
-    backbone "^1.4.0"
-    jquery "^3.4.1"
     lunr "^2.3.8"
-    underscore "^1.9.1"
 
 typedoc-plugin-lerna-packages@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/typedoc-plugin-lerna-packages/-/typedoc-plugin-lerna-packages-0.3.0.tgz#c0b13fa6cf5b9a495e4f7cb7d8fa8844d8967412"
   integrity sha512-Ek6yaJczfSIxfUkHNx7yL+JoJ86KifHecrmbFxtkSlYxGwDrQTqlTQncChslJO2EmQyOn9PUQVyBDnYyrOBB2w==
 
-typedoc@^0.16.11:
-  version "0.16.11"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.16.11.tgz#95f862c6eba78533edc9af7096d2295b718eddc1"
-  integrity sha512-YEa5i0/n0yYmLJISJ5+po6seYfJQJ5lQYcHCPF9ffTF92DB/TAZO/QrazX5skPHNPtmlIht5FdTXCM2kC7jQFQ==
+typedoc@^0.17.3:
+  version "0.17.3"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.17.3.tgz#cd5b598f851a41a90d82b7651da35e62cf4fa0e4"
+  integrity sha512-sCKyLeXMUYHyul0kd/jSGSGY+o7lfLvbNlnp8kAamQSLPp/f4EOOR50JGjwfYEQkEeETWMXILdU4UUXS42MmSQ==
   dependencies:
-    "@types/minimatch" "3.0.3"
     fs-extra "^8.1.0"
-    handlebars "^4.7.2"
-    highlight.js "^9.17.1"
+    handlebars "^4.7.3"
+    highlight.js "^9.18.1"
     lodash "^4.17.15"
-    marked "^0.8.0"
+    marked "0.8.0"
     minimatch "^3.0.0"
     progress "^2.0.3"
     shelljs "^0.8.3"
-    typedoc-default-themes "^0.7.2"
-    typescript "3.7.x"
-
-typescript@3.7.x:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+    typedoc-default-themes "^0.9.0"
 
 typescript@~3.2.1:
   version "3.2.4"
@@ -7755,11 +7754,6 @@ underscore@>=1.8.3:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
   integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
-
-underscore@^1.9.1:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.2.tgz#0c8d6f536d6f378a5af264a72f7bec50feb7cf2f"
-  integrity sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ==
 
 union-value@^1.0.0:
   version "1.0.0"
@@ -8103,6 +8097,14 @@ yargs-parser@^15.0.0:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^15.0.1:
+  version "15.0.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.1.tgz#54786af40b820dcb2fb8025b11b4d659d76323b3"
+  integrity sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs@^14.2.2:
   version "14.2.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.2.2.tgz#2769564379009ff8597cdd38fba09da9b493c4b5"
@@ -8119,6 +8121,23 @@ yargs@^14.2.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^15.0.0"
+
+yargs@^14.2.3:
+  version "14.2.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.2.3.tgz#1a1c3edced1afb2a2fea33604bc6d1d8d688a414"
+  integrity sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==
+  dependencies:
+    cliui "^5.0.0"
+    decamelize "^1.2.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^15.0.1"
 
 yeast@0.1.2:
   version "0.1.2"


### PR DESCRIPTION
The main two changes are:

* Change default value for arrowParens to always
* Always add a space after the function keyword

We could configure `arrowParens` back to `avoid` but I am quite convinced by the new default

I left out:
* Change default value for trailingComma to es5

I am relatively convinced by https://medium.com/@nikgraf/why-you-should-enforce-dangling-commas-for-multiline-statements-d034c98e36f8 but if we decide to do it we can do it later.

The main benefit of upgrading to prettier 2 is that it means that we are ready for TypeScript 3.8 and private fields !