### PR TITLE
[jsonapi] Support `url` request option

### DIFF
--- a/packages/@orbit/jsonapi/src/lib/jsonapi-request-options.ts
+++ b/packages/@orbit/jsonapi/src/lib/jsonapi-request-options.ts
@@ -14,6 +14,7 @@ export interface JSONAPIRequestOptions {
   page?: any;
   include?: any;
   settings?: FetchSettings;
+  url?: string;
 }
 
 export function buildFetchSettings(

--- a/packages/@orbit/jsonapi/src/lib/query-requests.ts
+++ b/packages/@orbit/jsonapi/src/lib/query-requests.ts
@@ -181,12 +181,13 @@ export const QueryRequestProcessors: Dict<QueryRequestProcessor> = {
     request: FindRecordRequest
   ): Promise<QueryProcessorResponse> {
     const { record } = request;
+    const options = request.options || {};
+    const settings = requestProcessor.buildFetchSettings(options);
+    const url =
+      options.url ||
+      requestProcessor.urlBuilder.resourceURL(record.type, record.id);
 
-    const settings = requestProcessor.buildFetchSettings(request.options);
-    const document = await requestProcessor.fetch(
-      requestProcessor.urlBuilder.resourceURL(record.type, record.id),
-      settings
-    );
+    const document = await requestProcessor.fetch(url, settings);
     requestProcessor.preprocessResponseDocument(document, request);
 
     if (document) {
@@ -209,12 +210,11 @@ export const QueryRequestProcessors: Dict<QueryRequestProcessor> = {
     request: FindRecordsRequest
   ): Promise<QueryProcessorResponse> {
     const { type } = request;
+    const options = request.options || {};
+    const settings = requestProcessor.buildFetchSettings(options);
+    const url = options.url || requestProcessor.urlBuilder.resourceURL(type);
 
-    const settings = requestProcessor.buildFetchSettings(request.options);
-    const document = await requestProcessor.fetch(
-      requestProcessor.urlBuilder.resourceURL(type),
-      settings
-    );
+    const document = await requestProcessor.fetch(url, settings);
     requestProcessor.preprocessResponseDocument(document, request);
 
     if (document) {
@@ -237,16 +237,17 @@ export const QueryRequestProcessors: Dict<QueryRequestProcessor> = {
     request: FindRelatedRecordRequest
   ): Promise<QueryProcessorResponse> {
     const { record, relationship } = request;
-
-    const settings = requestProcessor.buildFetchSettings(request.options);
-    const document = await requestProcessor.fetch(
+    const options = request.options || {};
+    const settings = requestProcessor.buildFetchSettings(options);
+    const url =
+      options.url ||
       requestProcessor.urlBuilder.relatedResourceURL(
         record.type,
         record.id,
         relationship
-      ),
-      settings
-    );
+      );
+
+    const document = await requestProcessor.fetch(url, settings);
     requestProcessor.preprocessResponseDocument(document, request);
 
     if (document) {
@@ -276,21 +277,18 @@ export const QueryRequestProcessors: Dict<QueryRequestProcessor> = {
     request: FindRelatedRecordsRequest
   ): Promise<QueryProcessorResponse> {
     const { record, relationship } = request;
-    const isFiltered = !!(
-      request.options.filter ||
-      request.options.sort ||
-      request.options.page
-    );
-
-    const settings = requestProcessor.buildFetchSettings(request.options);
-    const document = await requestProcessor.fetch(
+    const options = request.options || {};
+    const isFiltered = !!(options.filter || options.sort || options.page);
+    const settings = requestProcessor.buildFetchSettings(options);
+    const url =
+      options.url ||
       requestProcessor.urlBuilder.relatedResourceURL(
         record.type,
         record.id,
         relationship
-      ),
-      settings
-    );
+      );
+
+    const document = await requestProcessor.fetch(url, settings);
     requestProcessor.preprocessResponseDocument(document, request);
 
     if (document) {

--- a/packages/@orbit/jsonapi/src/lib/transform-requests.ts
+++ b/packages/@orbit/jsonapi/src/lib/transform-requests.ts
@@ -100,21 +100,21 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     requestProcessor: JSONAPIRequestProcessor,
     request: AddRecordRequest
   ): Promise<RequestProcessorResponse> {
-    const record = request.record;
+    const { record } = request;
+    const options = request.options || {};
     const requestDoc: ResourceDocument = requestProcessor.serializer.serialize({
       data: record
     });
-    const settings = requestProcessor.buildFetchSettings(request.options, {
+    const settings = requestProcessor.buildFetchSettings(options, {
       method: 'POST',
       json: requestDoc
     });
+    const url =
+      options.url || requestProcessor.urlBuilder.resourceURL(record.type);
 
-    let raw: ResourceDocument = await requestProcessor.fetch(
-      requestProcessor.urlBuilder.resourceURL(record.type),
-      settings
-    );
+    const raw: ResourceDocument = await requestProcessor.fetch(url, settings);
     requestProcessor.preprocessResponseDocument(raw, request);
-    let deserialized = requestProcessor.serializer.deserialize(raw, {
+    const deserialized = requestProcessor.serializer.deserialize(raw, {
       primaryRecord: record
     });
     return handleChanges(record, deserialized);
@@ -124,16 +124,16 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     requestProcessor: JSONAPIRequestProcessor,
     request: RemoveRecordRequest
   ): Promise<RequestProcessorResponse> {
-    const { record, options } = request;
+    const { record } = request;
+    const options = request.options || {};
     const { type, id } = record;
     const settings = requestProcessor.buildFetchSettings(options, {
       method: 'DELETE'
     });
+    const url =
+      options.url || requestProcessor.urlBuilder.resourceURL(type, id);
 
-    await requestProcessor.fetch(
-      requestProcessor.urlBuilder.resourceURL(type, id),
-      settings
-    );
+    await requestProcessor.fetch(url, settings);
     return { transforms: [], primaryData: record };
   },
 
@@ -141,7 +141,8 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     requestProcessor: JSONAPIRequestProcessor,
     request: UpdateRecordRequest
   ): Promise<RequestProcessorResponse> {
-    const { record, options } = request;
+    const { record } = request;
+    const options = request.options || {};
     const { type, id } = record;
     const requestDoc: ResourceDocument = requestProcessor.serializer.serialize({
       data: record
@@ -150,14 +151,13 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
       method: 'PATCH',
       json: requestDoc
     });
+    const url =
+      options.url || requestProcessor.urlBuilder.resourceURL(type, id);
 
-    let raw: ResourceDocument = await requestProcessor.fetch(
-      requestProcessor.urlBuilder.resourceURL(type, id),
-      settings
-    );
+    const raw: ResourceDocument = await requestProcessor.fetch(url, settings);
     if (raw) {
       requestProcessor.preprocessResponseDocument(raw, request);
-      let deserialized = requestProcessor.serializer.deserialize(raw, {
+      const deserialized = requestProcessor.serializer.deserialize(raw, {
         primaryRecord: record
       });
       return handleChanges(record, deserialized);
@@ -170,7 +170,8 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     requestProcessor: JSONAPIRequestProcessor,
     request: AddToRelatedRecordsRequest
   ): Promise<RequestProcessorResponse> {
-    const { relationship, record, options } = request;
+    const { relationship, record } = request;
+    const options = request.options || {};
     const { type, id } = record;
     const json = {
       data: request.relatedRecords.map((r) =>
@@ -181,15 +182,15 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
       method: 'POST',
       json
     });
-
-    await requestProcessor.fetch(
+    const url =
+      options.url ||
       requestProcessor.urlBuilder.resourceRelationshipURL(
         type,
         id,
         relationship
-      ),
-      settings
-    );
+      );
+
+    await requestProcessor.fetch(url, settings);
     return { transforms: [], primaryData: record };
   },
 
@@ -197,7 +198,8 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     requestProcessor: JSONAPIRequestProcessor,
     request: RemoveFromRelatedRecordsRequest
   ): Promise<RequestProcessorResponse> {
-    const { relationship, record, options } = request;
+    const { relationship, record } = request;
+    const options = request.options || {};
     const { type, id } = record;
     const json = {
       data: request.relatedRecords.map((r) =>
@@ -208,15 +210,15 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
       method: 'DELETE',
       json
     });
-
-    await requestProcessor.fetch(
+    const url =
+      options.url ||
       requestProcessor.urlBuilder.resourceRelationshipURL(
         type,
         id,
         relationship
-      ),
-      settings
-    );
+      );
+
+    await requestProcessor.fetch(url, settings);
     return { transforms: [], primaryData: record };
   },
 
@@ -224,7 +226,8 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     requestProcessor: JSONAPIRequestProcessor,
     request: ReplaceRelatedRecordRequest
   ): Promise<RequestProcessorResponse> {
-    const { relationship, relatedRecord, record, options } = request;
+    const { relationship, relatedRecord, record } = request;
+    const options = request.options || {};
     const { type, id } = record;
     const json = {
       data: relatedRecord
@@ -235,15 +238,15 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
       method: 'PATCH',
       json
     });
-
-    await requestProcessor.fetch(
+    const url =
+      options.url ||
       requestProcessor.urlBuilder.resourceRelationshipURL(
         type,
         id,
         relationship
-      ),
-      settings
-    );
+      );
+
+    await requestProcessor.fetch(url, settings);
     return { transforms: [], primaryData: record };
   },
 
@@ -251,7 +254,8 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
     requestProcessor: JSONAPIRequestProcessor,
     request: ReplaceRelatedRecordsRequest
   ): Promise<RequestProcessorResponse> {
-    const { relationship, relatedRecords, record, options } = request;
+    const { relationship, relatedRecords, record } = request;
+    const options = request.options || {};
     const { type, id } = record;
     const json = {
       data: relatedRecords.map((r) =>
@@ -262,15 +266,15 @@ export const TransformRequestProcessors: Dict<TransformRequestProcessor> = {
       method: 'PATCH',
       json
     });
-
-    await requestProcessor.fetch(
+    const url =
+      options.url ||
       requestProcessor.urlBuilder.resourceRelationshipURL(
         type,
         id,
         relationship
-      ),
-      settings
-    );
+      );
+
+    await requestProcessor.fetch(url, settings);
     return { transforms: [], primaryData: record };
   }
 };

--- a/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
@@ -5118,7 +5118,7 @@ module('JSONAPISource', function () {
       fetchStub.restore();
     });
 
-    test('#push - can add records', async function (assert) {
+    test('#push - addRecord', async function (assert) {
       assert.expect(5);
 
       let transformCount = 0;
@@ -5187,6 +5187,224 @@ module('JSONAPISource', function () {
         },
         'fetch called with expected data'
       );
+    });
+
+    test('#push - addRecord - url option can be passed', async function (assert) {
+      assert.expect(1);
+
+      const planetResource = {
+        id: '12345',
+        type: 'planets',
+        attributes: { name: 'Jupiter' }
+      };
+
+      const planet = source.requestProcessor.serializer.deserializeResource(
+        planetResource
+      );
+
+      fetchStub.withArgs('/custom/path/here').returns(
+        jsonapiResponse(201, {
+          data: planetResource
+        })
+      );
+
+      await source.push((t) => t.addRecord(planet), {
+        url: '/custom/path/here'
+      });
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+    });
+
+    test('#push - updateRecord - url option can be passed', async function (assert) {
+      assert.expect(1);
+
+      fetchStub.withArgs('/custom/path/here').returns(jsonapiResponse(200));
+
+      await source.push((t) => t.updateRecord({ type: 'planet', id: '123' }), {
+        url: '/custom/path/here'
+      });
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+    });
+
+    test('#push - removeRecord - url option can be passed', async function (assert) {
+      assert.expect(1);
+
+      fetchStub.withArgs('/custom/path/here').returns(jsonapiResponse(200));
+
+      await source.push((t) => t.removeRecord({ type: 'planet', id: '123' }), {
+        url: '/custom/path/here'
+      });
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+    });
+
+    test('#push - addToRelatedRecords - url option can be passed', async function (assert) {
+      assert.expect(1);
+
+      fetchStub.withArgs('/custom/path/here').returns(jsonapiResponse(200));
+
+      await source.push(
+        (t) =>
+          t.addToRelatedRecords({ type: 'planet', id: '123' }, 'moons', {
+            type: 'moon',
+            id: 'io'
+          }),
+        {
+          url: '/custom/path/here'
+        }
+      );
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+    });
+
+    test('#push - removeFromRelatedRecords - url option can be passed', async function (assert) {
+      assert.expect(1);
+
+      fetchStub.withArgs('/custom/path/here').returns(jsonapiResponse(200));
+
+      await source.push(
+        (t) =>
+          t.removeFromRelatedRecords({ type: 'planet', id: '123' }, 'moons', {
+            type: 'moon',
+            id: 'io'
+          }),
+        {
+          url: '/custom/path/here'
+        }
+      );
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+    });
+
+    test('#push - replaceRelatedRecords - url option can be passed', async function (assert) {
+      assert.expect(1);
+
+      fetchStub.withArgs('/custom/path/here').returns(jsonapiResponse(200));
+
+      await source.push(
+        (t) =>
+          t.replaceRelatedRecords({ type: 'planet', id: '123' }, 'moons', [
+            {
+              type: 'moon',
+              id: 'io'
+            }
+          ]),
+        {
+          url: '/custom/path/here'
+        }
+      );
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+    });
+
+    test('#push - replaceRelatedRecord - url option can be passed', async function (assert) {
+      assert.expect(1);
+
+      fetchStub.withArgs('/custom/path/here').returns(jsonapiResponse(200));
+
+      await source.push(
+        (t) =>
+          t.replaceRelatedRecord({ type: 'planet', id: '123' }, 'sun', {
+            type: 'star',
+            id: '1'
+          }),
+        {
+          url: '/custom/path/here'
+        }
+      );
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+    });
+
+    test('#query - findRecord - url option can be passed', async function (assert) {
+      assert.expect(1);
+
+      const planetResource = {
+        id: '12345',
+        type: 'planets',
+        attributes: { name: 'Jupiter' }
+      };
+
+      const planet = source.requestProcessor.serializer.deserializeResource(
+        planetResource
+      );
+
+      fetchStub.withArgs('/custom/path/here').returns(
+        jsonapiResponse(200, {
+          data: planetResource
+        })
+      );
+
+      await source.query((q) => q.findRecord(planet), {
+        url: '/custom/path/here'
+      });
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+    });
+
+    test('#query - findRecords - url option can be passed', async function (assert) {
+      assert.expect(1);
+
+      const planetResource = {
+        id: '12345',
+        type: 'planets',
+        attributes: { name: 'Jupiter' }
+      };
+
+      fetchStub.withArgs('/custom/path/here').returns(
+        jsonapiResponse(200, {
+          data: [planetResource]
+        })
+      );
+
+      await source.query((q) => q.findRecords('planet'), {
+        url: '/custom/path/here'
+      });
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+    });
+
+    test('#query - findRelatedRecord - url option can be passed', async function (assert) {
+      assert.expect(1);
+
+      const planet = {
+        id: '12345',
+        type: 'planet'
+      };
+
+      fetchStub.withArgs('/custom/path/here').returns(
+        jsonapiResponse(200, {
+          data: null
+        })
+      );
+
+      await source.query((q) => q.findRelatedRecord(planet, 'star'), {
+        url: '/custom/path/here'
+      });
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
+    });
+
+    test('#query - findRelatedRecords - url option can be passed', async function (assert) {
+      assert.expect(1);
+
+      const planet = {
+        id: '12345',
+        type: 'planet'
+      };
+
+      fetchStub.withArgs('/custom/path/here').returns(
+        jsonapiResponse(200, {
+          data: []
+        })
+      );
+
+      await source.query((q) => q.findRelatedRecords(planet, 'moons'), {
+        url: '/custom/path/here'
+      });
+
+      assert.equal(fetchStub.callCount, 1, 'fetch called once');
     });
   });
 });


### PR DESCRIPTION
Allow the `url` of a request to be overridden for all queries and transforms.

Any `url` that's passed will form a base URL that may be further amended with query params if additional options are passed that would normally include query params. Note that the `url` itself may also include query params.