### PR TITLE
Introduce NoopSerializer, DasherizedStringSerializer, and UnderscoredStringSerializer

### DIFF
--- a/packages/@orbit/serializers/package.json
+++ b/packages/@orbit/serializers/package.json
@@ -27,6 +27,10 @@
     "start": "node ../build dev && snowpack dev",
     "test": "node ../build ci && snowpack build && testem ci"
   },
+  "dependencies": {
+    "@orbit/core": "^0.17.0-beta.3",
+    "@orbit/utils": "^0.17.0-beta.3"
+  },
   "devDependencies": {
     "@orbit/build": "^0.17.0-beta.3"
   }

--- a/packages/@orbit/serializers/src/boolean-serializer.ts
+++ b/packages/@orbit/serializers/src/boolean-serializer.ts
@@ -1,6 +1,16 @@
 import { Serializer } from './serializer';
+import Orbit from '@orbit/core';
 
+const { deprecate } = Orbit;
+
+/**
+ * @deprecated until v0.18
+ */
 export class BooleanSerializer implements Serializer<boolean, boolean> {
+  constructor() {
+    deprecate('BooleanSerializer is deprecated. Use NoopSerializer instead.');
+  }
+
   serialize(arg: boolean): boolean {
     return arg;
   }

--- a/packages/@orbit/serializers/src/dasherized-string-serializer.ts
+++ b/packages/@orbit/serializers/src/dasherized-string-serializer.ts
@@ -1,0 +1,12 @@
+import { Serializer } from './serializer';
+import { dasherize, camelize } from '@orbit/utils';
+
+export class DasherizedStringSerializer implements Serializer<string, string> {
+  serialize(arg: string): string {
+    return dasherize(arg);
+  }
+
+  deserialize(arg: string): string {
+    return camelize(arg);
+  }
+}

--- a/packages/@orbit/serializers/src/index.ts
+++ b/packages/@orbit/serializers/src/index.ts
@@ -2,5 +2,6 @@ export * from './serializer';
 export * from './boolean-serializer';
 export * from './date-serializer';
 export * from './date-time-serializer';
+export * from './noop-serializer';
 export * from './number-serializer';
 export * from './string-serializer';

--- a/packages/@orbit/serializers/src/noop-serializer.ts
+++ b/packages/@orbit/serializers/src/noop-serializer.ts
@@ -1,0 +1,11 @@
+import { Serializer } from './serializer';
+
+export class NoopSerializer implements Serializer<unknown, unknown> {
+  serialize(arg: unknown): unknown {
+    return arg;
+  }
+
+  deserialize(arg: unknown): unknown {
+    return arg;
+  }
+}

--- a/packages/@orbit/serializers/src/number-serializer.ts
+++ b/packages/@orbit/serializers/src/number-serializer.ts
@@ -1,6 +1,16 @@
 import { Serializer } from './serializer';
+import Orbit from '@orbit/core';
 
+const { deprecate } = Orbit;
+
+/**
+ * @deprecated until v0.18
+ */
 export class NumberSerializer implements Serializer<number, number> {
+  constructor() {
+    deprecate('NumberSerializer is deprecated. Use NoopSerializer instead.');
+  }
+
   serialize(arg: number): number {
     return arg;
   }

--- a/packages/@orbit/serializers/src/string-serializer.ts
+++ b/packages/@orbit/serializers/src/string-serializer.ts
@@ -1,6 +1,16 @@
 import { Serializer } from './serializer';
+import Orbit from '@orbit/core';
 
+const { deprecate } = Orbit;
+
+/**
+ * @deprecated until v0.18
+ */
 export class StringSerializer implements Serializer<string, string> {
+  constructor() {
+    deprecate('StringSerializer is deprecated. Use NoopSerializer instead.');
+  }
+
   serialize(arg: string): string {
     return arg;
   }

--- a/packages/@orbit/serializers/src/underscored-string-serializer.ts
+++ b/packages/@orbit/serializers/src/underscored-string-serializer.ts
@@ -1,0 +1,12 @@
+import { Serializer } from './serializer';
+import { underscore, camelize } from '@orbit/utils';
+
+export class UnderscoredStringSerializer implements Serializer<string, string> {
+  serialize(arg: string): string {
+    return underscore(arg);
+  }
+
+  deserialize(arg: string): string {
+    return camelize(arg);
+  }
+}

--- a/packages/@orbit/serializers/test/dasherized-string-serializer-test.ts
+++ b/packages/@orbit/serializers/test/dasherized-string-serializer-test.ts
@@ -1,0 +1,62 @@
+import { DasherizedStringSerializer } from '../src/dasherized-string-serializer';
+
+const { module, test } = QUnit;
+
+module('DasherizedStringSerializer', function (hooks) {
+  let serializer: DasherizedStringSerializer;
+
+  hooks.beforeEach(function () {
+    serializer = new DasherizedStringSerializer();
+  });
+
+  test('#serialize dasherizes strings', function (assert) {
+    assert.equal(
+      serializer.serialize('lowercase'),
+      'lowercase',
+      'leaves lowercase words alone'
+    );
+    assert.equal(
+      serializer.serialize('MixedCase'),
+      'mixed-case',
+      'lowercases and dasherizes MixedCase words'
+    );
+    assert.equal(
+      serializer.serialize('one_two'),
+      'one-two',
+      'dasherizes underscored words'
+    );
+    assert.equal(
+      serializer.serialize('one two three'),
+      'one-two-three',
+      'converts space separated words'
+    );
+  });
+
+  test('#deserialize camelizes strings', function (assert) {
+    assert.equal(
+      serializer.deserialize('lowercase'),
+      'lowercase',
+      'leaves lowercase words alone'
+    );
+    assert.equal(
+      serializer.deserialize('MixedCase'),
+      'mixedCase',
+      'lowercases the first letter in MixedCase words'
+    );
+    assert.equal(
+      serializer.deserialize('one-two'),
+      'oneTwo',
+      'converts dasherized words'
+    );
+    assert.equal(
+      serializer.deserialize('one_two_three'),
+      'oneTwoThree',
+      'converts underscored words'
+    );
+    assert.equal(
+      serializer.deserialize('one two three'),
+      'oneTwoThree',
+      'converts space separated words'
+    );
+  });
+});

--- a/packages/@orbit/serializers/test/noop-serializer-test.ts
+++ b/packages/@orbit/serializers/test/noop-serializer-test.ts
@@ -1,0 +1,23 @@
+import { NoopSerializer } from '../src/noop-serializer';
+
+const { module, test } = QUnit;
+
+module('NoopSerializer', function (hooks) {
+  let serializer: NoopSerializer;
+
+  hooks.beforeEach(function () {
+    serializer = new NoopSerializer();
+  });
+
+  test('#serialize returns arg untouched', function (assert) {
+    assert.equal(serializer.serialize('abc'), 'abc');
+    assert.equal(serializer.serialize(123), 123);
+    assert.equal(serializer.serialize(true), true);
+  });
+
+  test('#deserialize returns arg untouched', function (assert) {
+    assert.equal(serializer.deserialize('abc'), 'abc');
+    assert.equal(serializer.deserialize(123), 123);
+    assert.equal(serializer.deserialize(true), true);
+  });
+});

--- a/packages/@orbit/serializers/test/underscored-string-serializer-test.ts
+++ b/packages/@orbit/serializers/test/underscored-string-serializer-test.ts
@@ -1,0 +1,67 @@
+import { UnderscoredStringSerializer } from '../src/underscored-string-serializer';
+
+const { module, test } = QUnit;
+
+module('UnderscoredStringSerializer', function (hooks) {
+  let serializer: UnderscoredStringSerializer;
+
+  hooks.beforeEach(function () {
+    serializer = new UnderscoredStringSerializer();
+  });
+
+  test('#serialize underscores strings', function (assert) {
+    assert.equal(
+      serializer.serialize('lowercase'),
+      'lowercase',
+      'leaves lowercase words alone'
+    );
+    assert.equal(
+      serializer.serialize('MixedCase'),
+      'mixed_case',
+      'lowercases the first letter in MixedCase words'
+    );
+    assert.equal(
+      serializer.serialize('oneTwo'),
+      'one_two',
+      'converts lowerCamelCase words'
+    );
+    assert.equal(
+      serializer.serialize('one_two_three'),
+      'one_two_three',
+      'leaves underscore-separated words alone'
+    );
+    assert.equal(
+      serializer.serialize('one two three'),
+      'one_two_three',
+      'underscores space-separated words'
+    );
+  });
+
+  test('#deserialize camelizes strings', function (assert) {
+    assert.equal(
+      serializer.deserialize('lowercase'),
+      'lowercase',
+      'leaves lowercase words alone'
+    );
+    assert.equal(
+      serializer.deserialize('MixedCase'),
+      'mixedCase',
+      'lowercases the first letter in MixedCase words'
+    );
+    assert.equal(
+      serializer.deserialize('one-two'),
+      'oneTwo',
+      'converts dasherized words'
+    );
+    assert.equal(
+      serializer.deserialize('one_two_three'),
+      'oneTwoThree',
+      'converts underscored words'
+    );
+    assert.equal(
+      serializer.deserialize('one two three'),
+      'oneTwoThree',
+      'converts space separated words'
+    );
+  });
+});


### PR DESCRIPTION
Introduces three new serializers in `@orbit/serializers`:
* `NoopSerializer` - a serializer that does nothing to arguments on serialization / deserialization
* `DasherizedStringSerializer` - serializes strings to `dasherized-case` and deserializes them to `camelCase`.
* `UnderscoredStringSerializer` - serializes strings to `lower_underscored_case` and deserializes them to `camelCase`.

The `NoopSerializer` now takes the place of other serializers that served the same role. The following have been deprecated and will be removed in v0.18:
* `StringSerializer`
* `BooleanSerializer`
* `NumberSerializer`

The motivation for this work is to allow much more control over serialization in `@orbit/jsonapi` and other packages that need to serialize data.