### PR TITLE
cache settings as part of source settings should be partial

### DIFF
--- a/packages/@orbit/indexeddb/src/indexeddb-source.ts
+++ b/packages/@orbit/indexeddb/src/indexeddb-source.ts
@@ -26,7 +26,7 @@ const { assert } = Orbit;
 
 export interface IndexedDBSourceSettings extends SourceSettings {
   namespace?: string;
-  cacheSettings?: IndexedDBCacheSettings;
+  cacheSettings?: Partial<IndexedDBCacheSettings>;
 }
 
 /**
@@ -69,9 +69,8 @@ export default class IndexedDBSource extends Source
 
     super(settings);
 
-    let cacheSettings: IndexedDBCacheSettings = settings.cacheSettings || {
-      schema: settings.schema
-    };
+    let cacheSettings: Partial<IndexedDBCacheSettings> =
+      settings.cacheSettings || {};
     cacheSettings.schema = settings.schema;
     cacheSettings.keyMap = settings.keyMap;
     cacheSettings.queryBuilder =
@@ -80,7 +79,7 @@ export default class IndexedDBSource extends Source
       cacheSettings.transformBuilder || this.transformBuilder;
     cacheSettings.namespace = cacheSettings.namespace || settings.namespace;
 
-    this._cache = new IndexedDBCache(cacheSettings);
+    this._cache = new IndexedDBCache(cacheSettings as IndexedDBCacheSettings);
     if (autoActivate) {
       this.activate();
     }

--- a/packages/@orbit/local-storage/src/local-storage-source.ts
+++ b/packages/@orbit/local-storage/src/local-storage-source.ts
@@ -31,7 +31,7 @@ const { assert } = Orbit;
 export interface LocalStorageSourceSettings extends SourceSettings {
   delimiter?: string;
   namespace?: string;
-  cacheSettings?: LocalStorageCacheSettings;
+  cacheSettings?: Partial<LocalStorageCacheSettings>;
 }
 
 /**
@@ -75,9 +75,8 @@ export default class LocalStorageSource extends Source
 
     super(settings);
 
-    let cacheSettings: LocalStorageCacheSettings = settings.cacheSettings || {
-      schema: settings.schema
-    };
+    let cacheSettings: Partial<LocalStorageCacheSettings> =
+      settings.cacheSettings || {};
     cacheSettings.schema = settings.schema;
     cacheSettings.keyMap = settings.keyMap;
     cacheSettings.queryBuilder =
@@ -87,7 +86,9 @@ export default class LocalStorageSource extends Source
     cacheSettings.namespace = cacheSettings.namespace || settings.namespace;
     cacheSettings.delimiter = cacheSettings.delimiter || settings.delimiter;
 
-    this._cache = new LocalStorageCache(cacheSettings);
+    this._cache = new LocalStorageCache(
+      cacheSettings as LocalStorageCacheSettings
+    );
   }
 
   get namespace(): string {

--- a/packages/@orbit/memory/src/memory-source.ts
+++ b/packages/@orbit/memory/src/memory-source.ts
@@ -27,7 +27,7 @@ const { assert } = Orbit;
 
 export interface MemorySourceSettings extends SourceSettings {
   base?: MemorySource;
-  cacheSettings?: MemoryCacheSettings;
+  cacheSettings?: Partial<MemoryCacheSettings>;
 }
 
 export interface MemorySourceMergeOptions {
@@ -84,9 +84,8 @@ export default class MemorySource extends Source
     this.transformLog.on('truncate', this._logTruncated.bind(this));
     this.transformLog.on('rollback', this._logRolledback.bind(this));
 
-    let cacheSettings: MemoryCacheSettings = settings.cacheSettings || {
-      schema
-    };
+    let cacheSettings: Partial<MemoryCacheSettings> =
+      settings.cacheSettings || {};
     cacheSettings.schema = schema;
     cacheSettings.keyMap = keyMap;
     cacheSettings.queryBuilder =
@@ -98,7 +97,7 @@ export default class MemorySource extends Source
       this._forkPoint = this._base.transformLog.head;
       cacheSettings.base = this._base.cache;
     }
-    this._cache = new MemoryCache(cacheSettings);
+    this._cache = new MemoryCache(cacheSettings as MemoryCacheSettings);
   }
 
   get cache(): MemoryCache {


### PR DESCRIPTION
This is needed as otherwise it is impossible to pass cache settings to a source in TS. The only non-optional setting on a cache settings type is `schema` and it is set by the source before creating a cache instance.