### PR TITLE
Fix cache integrity processors' handling of relationships without explicit inverses.

### DIFF
--- a/packages/@orbit/record-cache/src/operation-processors/utils/cache-integrity-utils.ts
+++ b/packages/@orbit/record-cache/src/operation-processors/utils/cache-integrity-utils.ts
@@ -15,15 +15,13 @@ export function getInverseRelationship(
   relatedRecord?: RecordIdentity | null
 ): RecordRelationshipIdentity | null {
   if (relatedRecord) {
-    const relationshipDef = schema.getRelationship(record.type, relationship);
+    const recordIdentity = cloneRecordIdentity(record);
 
-    if (relationshipDef.inverse) {
-      return {
-        record,
-        relationship,
-        relatedRecord
-      };
-    }
+    return {
+      record: recordIdentity,
+      relationship,
+      relatedRecord
+    };
   }
   return null;
 }
@@ -35,19 +33,15 @@ export function getInverseRelationships(
   relatedRecords?: RecordIdentity[]
 ): RecordRelationshipIdentity[] {
   if (relatedRecords && relatedRecords.length > 0) {
-    const relationshipDef = schema.getRelationship(record.type, relationship);
+    const recordIdentity = cloneRecordIdentity(record);
 
-    if (relationshipDef.inverse) {
-      const recordIdentity = cloneRecordIdentity(record);
-
-      return relatedRecords.map((relatedRecord) => {
-        return {
-          record: recordIdentity,
-          relationship,
-          relatedRecord
-        };
-      });
-    }
+    return relatedRecords.map((relatedRecord) => {
+      return {
+        record: recordIdentity,
+        relationship,
+        relatedRecord
+      };
+    });
   }
   return [];
 }

--- a/packages/@orbit/record-cache/test/async-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/async-record-cache-test.ts
@@ -48,6 +48,23 @@ module('AsyncRecordCache', function (hooks) {
             planet: { kind: 'hasOne', type: 'planet', inverse: 'moons' },
             star: { kind: 'hasOne', type: 'star', inverse: 'celestialObjects' }
           }
+        },
+        binaryStar: {
+          attributes: {
+            name: { type: 'string' }
+          },
+          relationships: {
+            starOne: { kind: 'hasOne', type: 'star' }, // no inverse
+            starTwo: { kind: 'hasOne', type: 'star' } // no inverse
+          }
+        },
+        planetarySystem: {
+          attributes: {
+            name: { type: 'string' }
+          },
+          relationships: {
+            star: { kind: 'hasOne', type: ['star', 'binaryStar'] } // no inverse
+          }
         }
       }
     });
@@ -1459,6 +1476,74 @@ module('AsyncRecordCache', function (hooks) {
       planet.relationships.moons.data,
       [{ type: 'moon', id: 'm1' }],
       'planet has a moons relationship'
+    );
+  });
+
+  test('#patch allows replaceRelatedRecord to be called on a relationship with no inverse and to be followed up by removing the replaced record', async function (assert) {
+    assert.expect(2);
+
+    const cache = new Cache({ schema, keyMap });
+
+    const star1 = {
+      id: 'star1',
+      type: 'star',
+      attributes: { name: 'sun1' }
+    };
+
+    const star2 = {
+      id: 'star2',
+      type: 'star',
+      attributes: { name: 'sun2' }
+    };
+
+    const home = {
+      id: 'home',
+      type: 'planetarySystem',
+      attributes: { name: 'Home' },
+      relationships: {
+        star: {
+          data: { id: 'star1', type: 'star' }
+        }
+      }
+    };
+
+    await cache.patch((t) => [
+      t.addRecord(star1),
+      t.addRecord(star2),
+      t.addRecord(home)
+    ]);
+
+    let latestHome = await cache.getRecordAsync({
+      id: 'home',
+      type: 'planetarySystem'
+    });
+    assert.deepEqual(
+      (latestHome.relationships.star.data as Record).id,
+      star1.id,
+      'The original related record is in place.'
+    );
+
+    await cache.patch((t) => [
+      t.replaceRelatedRecord(
+        {
+          id: 'home',
+          type: 'planetarySystem'
+        },
+        'star',
+        star2
+      ),
+      t.removeRecord(star1)
+    ]);
+
+    latestHome = await cache.getRecordAsync({
+      id: 'home',
+      type: 'planetarySystem'
+    });
+
+    assert.deepEqual(
+      (latestHome.relationships.star.data as Record).id,
+      star2.id,
+      'The related record was replaced.'
     );
   });
 

--- a/packages/@orbit/record-cache/test/sync-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/sync-record-cache-test.ts
@@ -48,6 +48,23 @@ module('SyncRecordCache', function (hooks) {
             planet: { kind: 'hasOne', type: 'planet', inverse: 'moons' },
             star: { kind: 'hasOne', type: 'star', inverse: 'celestialObjects' }
           }
+        },
+        binaryStar: {
+          attributes: {
+            name: { type: 'string' }
+          },
+          relationships: {
+            starOne: { kind: 'hasOne', type: 'star' }, // no inverse
+            starTwo: { kind: 'hasOne', type: 'star' } // no inverse
+          }
+        },
+        planetarySystem: {
+          attributes: {
+            name: { type: 'string' }
+          },
+          relationships: {
+            star: { kind: 'hasOne', type: ['star', 'binaryStar'] } // no inverse
+          }
         }
       }
     });
@@ -1429,6 +1446,74 @@ module('SyncRecordCache', function (hooks) {
       planet.relationships.moons.data,
       [{ type: 'moon', id: 'm1' }],
       'planet has a moons relationship'
+    );
+  });
+
+  test('#patch allows replaceRelatedRecord to be called on a relationship with no inverse and to be followed up by removing the replaced record', function (assert) {
+    assert.expect(2);
+
+    const cache = new Cache({ schema, keyMap });
+
+    const star1 = {
+      id: 'star1',
+      type: 'star',
+      attributes: { name: 'sun1' }
+    };
+
+    const star2 = {
+      id: 'star2',
+      type: 'star',
+      attributes: { name: 'sun2' }
+    };
+
+    const home = {
+      id: 'home',
+      type: 'planetarySystem',
+      attributes: { name: 'Home' },
+      relationships: {
+        star: {
+          data: { id: 'star1', type: 'star' }
+        }
+      }
+    };
+
+    cache.patch((t) => [
+      t.addRecord(star1),
+      t.addRecord(star2),
+      t.addRecord(home)
+    ]);
+
+    let latestHome = cache.getRecordSync({
+      id: 'home',
+      type: 'planetarySystem'
+    });
+    assert.deepEqual(
+      (latestHome.relationships.star.data as Record).id,
+      star1.id,
+      'The original related record is in place.'
+    );
+
+    cache.patch((t) => [
+      t.replaceRelatedRecord(
+        {
+          id: 'home',
+          type: 'planetarySystem'
+        },
+        'star',
+        star2
+      ),
+      t.removeRecord(star1)
+    ]);
+
+    latestHome = cache.getRecordSync({
+      id: 'home',
+      type: 'planetarySystem'
+    });
+
+    assert.deepEqual(
+      (latestHome.relationships.star.data as Record).id,
+      star2.id,
+      'The related record was replaced.'
     );
   });
 


### PR DESCRIPTION
This resolves an issue uncovered by @derekwsgray in #760 in which cache integrity processors were mishandling relationship bookkeeping when an explicit `inverse` was not defined in the schema.

This removes the schema relationship check such that inverse relationships will always be tracked.

Part of the confusion is the somewhat overloaded term "inverse relationship". This should probably be clarified prior to v0.17 and this fix should be backported to v0.16.

Fixes #760