### PR TITLE
Backport PR 762 to v0.16

### DIFF
--- a/packages/@orbit/record-cache/src/operation-processors/utils/cache-integrity-utils.ts
+++ b/packages/@orbit/record-cache/src/operation-processors/utils/cache-integrity-utils.ts
@@ -15,15 +15,13 @@ export function getInverseRelationship(
   relatedRecord?: RecordIdentity | null
 ): RecordRelationshipIdentity | null {
   if (relatedRecord) {
-    const relationshipDef = schema.getRelationship(record.type, relationship);
+    const recordIdentity = cloneRecordIdentity(record);
 
-    if (relationshipDef.inverse) {
-      return {
-        record,
-        relationship,
-        relatedRecord
-      };
-    }
+    return {
+      record: recordIdentity,
+      relationship,
+      relatedRecord
+    };
   }
   return null;
 }
@@ -35,19 +33,15 @@ export function getInverseRelationships(
   relatedRecords?: RecordIdentity[]
 ): RecordRelationshipIdentity[] {
   if (relatedRecords && relatedRecords.length > 0) {
-    const relationshipDef = schema.getRelationship(record.type, relationship);
+    const recordIdentity = cloneRecordIdentity(record);
 
-    if (relationshipDef.inverse) {
-      const recordIdentity = cloneRecordIdentity(record);
-
-      return relatedRecords.map(relatedRecord => {
-        return {
-          record: recordIdentity,
-          relationship,
-          relatedRecord
-        };
-      });
-    }
+    return relatedRecords.map(relatedRecord => {
+      return {
+        record: recordIdentity,
+        relationship,
+        relatedRecord
+      };
+    });
   }
   return [];
 }

--- a/packages/@orbit/record-cache/test/sync-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/sync-record-cache-test.ts
@@ -48,6 +48,23 @@ module('SyncRecordCache', function(hooks) {
             planet: { type: 'hasOne', model: 'planet', inverse: 'moons' },
             star: { type: 'hasOne', model: 'star', inverse: 'celestialObjects' }
           }
+        },
+        binaryStar: {
+          attributes: {
+            name: { type: 'string' }
+          },
+          relationships: {
+            starOne: { kind: 'hasOne', type: 'star' }, // no inverse
+            starTwo: { kind: 'hasOne', type: 'star' } // no inverse
+          }
+        },
+        planetarySystem: {
+          attributes: {
+            name: { type: 'string' }
+          },
+          relationships: {
+            star: { kind: 'hasOne', type: ['star', 'binaryStar'] } // no inverse
+          }
         }
       }
     });
@@ -1415,6 +1432,74 @@ module('SyncRecordCache', function(hooks) {
       planet.relationships.moons.data,
       [{ type: 'moon', id: 'm1' }],
       'planet has a moons relationship'
+    );
+  });
+
+  test('#patch allows replaceRelatedRecord to be called on a relationship with no inverse and to be followed up by removing the replaced record', function(assert) {
+    assert.expect(2);
+
+    const cache = new Cache({ schema, keyMap });
+
+    const star1 = {
+      id: 'star1',
+      type: 'star',
+      attributes: { name: 'sun1' }
+    };
+
+    const star2 = {
+      id: 'star2',
+      type: 'star',
+      attributes: { name: 'sun2' }
+    };
+
+    const home = {
+      id: 'home',
+      type: 'planetarySystem',
+      attributes: { name: 'Home' },
+      relationships: {
+        star: {
+          data: { id: 'star1', type: 'star' }
+        }
+      }
+    };
+
+    cache.patch(t => [
+      t.addRecord(star1),
+      t.addRecord(star2),
+      t.addRecord(home)
+    ]);
+
+    let latestHome = cache.getRecordSync({
+      id: 'home',
+      type: 'planetarySystem'
+    });
+    assert.deepEqual(
+      (latestHome.relationships.star.data as Record).id,
+      star1.id,
+      'The original related record is in place.'
+    );
+
+    cache.patch(t => [
+      t.replaceRelatedRecord(
+        {
+          id: 'home',
+          type: 'planetarySystem'
+        },
+        'star',
+        star2
+      ),
+      t.removeRecord(star1)
+    ]);
+
+    latestHome = cache.getRecordSync({
+      id: 'home',
+      type: 'planetarySystem'
+    });
+
+    assert.deepEqual(
+      (latestHome.relationships.star.data as Record).id,
+      star2.id,
+      'The related record was replaced.'
     );
   });
 


### PR DESCRIPTION
Fix cache integrity processors' handling of relationships without explicit inverses

Inverses of relationships must still be maintained even when no explicit inverse is included in a relationship definition.