### PR TITLE
Refactor internal modules to remove default module exports

### DIFF
--- a/packages/@orbit/coordinator/src/coordinator.ts
+++ b/packages/@orbit/coordinator/src/coordinator.ts
@@ -1,4 +1,5 @@
-import Orbit, { Source } from '@orbit/data';
+import { Orbit } from '@orbit/core';
+import { Source } from '@orbit/data';
 import { Dict, objectValues } from '@orbit/utils';
 import { Strategy } from './strategy';
 
@@ -25,7 +26,7 @@ export interface ActivationOptions {
  * The Coordinator class manages a set of sources to which it applies a set of
  * coordination strategies.
  */
-export default class Coordinator {
+export class Coordinator {
   protected _sources: Dict<Source>;
   protected _strategies: Dict<Strategy>;
   protected _activated: Promise<any>;

--- a/packages/@orbit/coordinator/src/index.ts
+++ b/packages/@orbit/coordinator/src/index.ts
@@ -1,9 +1,5 @@
-export {
-  default,
-  CoordinatorOptions,
-  ActivationOptions,
-  LogLevel
-} from './coordinator';
+export { Coordinator as default } from './coordinator';
+export * from './coordinator';
 export * from './strategy';
 export * from './strategies/log-truncation-strategy';
 export * from './strategies/event-logging-strategy';

--- a/packages/@orbit/coordinator/src/strategies/connection-strategy.ts
+++ b/packages/@orbit/coordinator/src/strategies/connection-strategy.ts
@@ -1,6 +1,6 @@
-import Coordinator, { ActivationOptions } from '../coordinator';
+import { Coordinator, ActivationOptions } from '../coordinator';
 import { Strategy, StrategyOptions } from '../strategy';
-import Orbit, { Listener } from '@orbit/core';
+import { Orbit, Listener } from '@orbit/core';
 import { Source } from '@orbit/data';
 
 const { assert } = Orbit;

--- a/packages/@orbit/coordinator/src/strategies/event-logging-strategy.ts
+++ b/packages/@orbit/coordinator/src/strategies/event-logging-strategy.ts
@@ -1,4 +1,4 @@
-import Coordinator, { ActivationOptions, LogLevel } from '../coordinator';
+import { Coordinator, ActivationOptions, LogLevel } from '../coordinator';
 import { Strategy, StrategyOptions } from '../strategy';
 import { Listener } from '@orbit/core';
 import {

--- a/packages/@orbit/coordinator/src/strategies/log-truncation-strategy.ts
+++ b/packages/@orbit/coordinator/src/strategies/log-truncation-strategy.ts
@@ -1,4 +1,4 @@
-import Coordinator, { ActivationOptions } from '../coordinator';
+import { Coordinator, ActivationOptions } from '../coordinator';
 import { Strategy, StrategyOptions } from '../strategy';
 import { Source, Transform } from '@orbit/data';
 import { Dict } from '@orbit/utils';

--- a/packages/@orbit/coordinator/src/strategies/sync-strategy.ts
+++ b/packages/@orbit/coordinator/src/strategies/sync-strategy.ts
@@ -1,9 +1,9 @@
+import { Orbit } from '@orbit/core';
 import { StrategyOptions } from '../strategy';
 import {
   ConnectionStrategy,
   ConnectionStrategyOptions
 } from './connection-strategy';
-import Orbit from '@orbit/core';
 
 const { assert } = Orbit;
 

--- a/packages/@orbit/coordinator/src/strategy.ts
+++ b/packages/@orbit/coordinator/src/strategy.ts
@@ -1,5 +1,6 @@
-import Coordinator, { ActivationOptions, LogLevel } from './coordinator';
-import Orbit, { Source } from '@orbit/data';
+import { Orbit } from '@orbit/core';
+import { Source } from '@orbit/data';
+import { Coordinator, ActivationOptions, LogLevel } from './coordinator';
 
 const { assert } = Orbit;
 

--- a/packages/@orbit/coordinator/test/coordinator-test.ts
+++ b/packages/@orbit/coordinator/test/coordinator-test.ts
@@ -1,6 +1,5 @@
-import Coordinator, { ActivationOptions } from '../src/coordinator';
+import { Coordinator, ActivationOptions } from '../src/coordinator';
 import { Strategy } from '../src/strategy';
-
 import { Source } from '@orbit/data';
 
 const { module, test } = QUnit;

--- a/packages/@orbit/coordinator/test/strategies/connection-strategy-test.ts
+++ b/packages/@orbit/coordinator/test/strategies/connection-strategy-test.ts
@@ -1,4 +1,4 @@
-import Coordinator from '../../src/coordinator';
+import { Coordinator } from '../../src/coordinator';
 import { ConnectionStrategy } from '../../src/strategies/connection-strategy';
 import {
   Source,

--- a/packages/@orbit/coordinator/test/strategies/event-logging-strategy-test.ts
+++ b/packages/@orbit/coordinator/test/strategies/event-logging-strategy-test.ts
@@ -1,4 +1,4 @@
-import Coordinator from '../../src/coordinator';
+import { Coordinator } from '../../src/coordinator';
 import { EventLoggingStrategy } from '../../src/strategies/event-logging-strategy';
 import { Source } from '@orbit/data';
 

--- a/packages/@orbit/coordinator/test/strategies/log-truncation-strategy-test.ts
+++ b/packages/@orbit/coordinator/test/strategies/log-truncation-strategy-test.ts
@@ -1,4 +1,4 @@
-import Coordinator from '../../src/coordinator';
+import { Coordinator } from '../../src/coordinator';
 import { LogTruncationStrategy } from '../../src/strategies/log-truncation-strategy';
 import { Source, TransformBuilder, buildTransform } from '@orbit/data';
 

--- a/packages/@orbit/coordinator/test/strategies/request-strategy-test.ts
+++ b/packages/@orbit/coordinator/test/strategies/request-strategy-test.ts
@@ -1,4 +1,4 @@
-import Coordinator from '../../src/coordinator';
+import { Coordinator } from '../../src/coordinator';
 import { RequestStrategy } from '../../src/strategies/request-strategy';
 import {
   Source,

--- a/packages/@orbit/coordinator/test/strategies/sync-strategy-test.ts
+++ b/packages/@orbit/coordinator/test/strategies/sync-strategy-test.ts
@@ -1,4 +1,4 @@
-import Coordinator from '../../src/coordinator';
+import { Coordinator } from '../../src/coordinator';
 import { SyncStrategy } from '../../src/strategies/sync-strategy';
 import {
   Source,

--- a/packages/@orbit/coordinator/test/strategy-test.ts
+++ b/packages/@orbit/coordinator/test/strategy-test.ts
@@ -1,4 +1,4 @@
-import Coordinator, { ActivationOptions, LogLevel } from '../src/coordinator';
+import { Coordinator, ActivationOptions, LogLevel } from '../src/coordinator';
 import { Strategy, StrategyOptions } from '../src/strategy';
 import { Source } from '@orbit/data';
 

--- a/packages/@orbit/core/src/bucket.ts
+++ b/packages/@orbit/core/src/bucket.ts
@@ -1,4 +1,4 @@
-import evented, { Evented } from './evented';
+import { evented, Evented } from './evented';
 import { Listener } from './notifier';
 
 /**

--- a/packages/@orbit/core/src/evented.ts
+++ b/packages/@orbit/core/src/evented.ts
@@ -1,6 +1,6 @@
-import Notifier, { Listener } from './notifier';
+import { Notifier, Listener } from './notifier';
 
-export const EVENTED = '__evented__';
+const EVENTED = '__evented__';
 
 /**
  * Has a class been decorated as `@evented`?
@@ -69,7 +69,7 @@ export interface Evented {
  * source.off('greeting', listener2);
  * ```
  */
-export default function evented(Klass: any): void {
+export function evented(Klass: any): void {
   let proto = Klass.prototype;
 
   if (isEvented(proto)) {

--- a/packages/@orbit/core/src/index.ts
+++ b/packages/@orbit/core/src/index.ts
@@ -1,15 +1,10 @@
-export { default, OrbitGlobal } from './main';
-export { default as TaskQueue, TaskQueueSettings } from './task-queue';
+export { Orbit as default } from './main';
+export * from './main';
+export * from './task-queue';
 export * from './task';
-export { default as TaskProcessor } from './task-processor';
-export { Bucket, BucketSettings } from './bucket';
-export {
-  default as evented,
-  Evented,
-  isEvented,
-  settleInSeries,
-  fulfillInSeries
-} from './evented';
+export * from './task-processor';
+export * from './bucket';
+export * from './evented';
 export * from './exception';
-export { default as Notifier, Listener } from './notifier';
-export { default as Log, LogOptions } from './log';
+export * from './notifier';
+export * from './log';

--- a/packages/@orbit/core/src/log.ts
+++ b/packages/@orbit/core/src/log.ts
@@ -1,5 +1,5 @@
-import Orbit from './main';
-import evented, { Evented } from './evented';
+import { Orbit } from './main';
+import { evented, Evented } from './evented';
 import { Listener } from './notifier';
 import { Bucket } from './bucket';
 import { NotLoggedException, OutOfRangeException } from './exception';
@@ -20,7 +20,7 @@ export interface LogOptions {
  * Logs can automatically be persisted by assigning them a bucket.
  */
 @evented
-export default class Log implements Evented {
+export class Log implements Evented {
   private _name: string;
   private _bucket: Bucket;
   private _data: string[];

--- a/packages/@orbit/core/src/main.ts
+++ b/packages/@orbit/core/src/main.ts
@@ -26,11 +26,9 @@ const globals =
   (typeof global == 'object' && global) ||
   {};
 
-const Orbit: OrbitGlobal = {
+export const Orbit: OrbitGlobal = {
   globals,
   assert,
   deprecate,
   uuid
 };
-
-export default Orbit;

--- a/packages/@orbit/core/src/notifier.ts
+++ b/packages/@orbit/core/src/notifier.ts
@@ -20,7 +20,7 @@ export type Listener = (...args: any[]) => any;
  *
  * Calls to `emit` will send along all of their arguments.
  */
-export default class Notifier {
+export class Notifier {
   public listeners: Listener[];
 
   constructor() {

--- a/packages/@orbit/core/src/task-processor.ts
+++ b/packages/@orbit/core/src/task-processor.ts
@@ -11,7 +11,7 @@ import { Task, Performer } from './task';
  * A task can be re-tried by first calling `reset()` on the processor. This
  * will clear the processor's state and allow `process()` to be invoked again.
  */
-export default class TaskProcessor {
+export class TaskProcessor {
   target: Performer;
   task: Task;
 

--- a/packages/@orbit/core/src/task-queue.ts
+++ b/packages/@orbit/core/src/task-queue.ts
@@ -1,8 +1,8 @@
-import Orbit from './main';
+import { Orbit } from './main';
 import { Task, Performer } from './task';
-import TaskProcessor from './task-processor';
+import { TaskProcessor } from './task-processor';
 import { Bucket } from './bucket';
-import evented, { Evented, settleInSeries } from './evented';
+import { evented, Evented, settleInSeries } from './evented';
 import { Listener } from './notifier';
 
 const { assert } = Orbit;
@@ -52,7 +52,7 @@ export interface TaskQueueSettings {
  * processing.
  */
 @evented
-export default class TaskQueue implements Evented {
+export class TaskQueue implements Evented {
   public autoProcess: boolean;
 
   private _name: string;

--- a/packages/@orbit/core/test/evented-test.ts
+++ b/packages/@orbit/core/test/evented-test.ts
@@ -1,5 +1,5 @@
 import {
-  default as evented,
+  evented,
   isEvented,
   fulfillInSeries,
   settleInSeries,

--- a/packages/@orbit/core/test/log-test.ts
+++ b/packages/@orbit/core/test/log-test.ts
@@ -1,6 +1,6 @@
-import Log from '../src/log';
+import { Log } from '../src/log';
 import { NotLoggedException, OutOfRangeException } from '../src/exception';
-import FakeBucket from './support/fake-bucket';
+import { FakeBucket } from './support/fake-bucket';
 import { Bucket } from '../src/bucket';
 
 const { module, test } = QUnit;

--- a/packages/@orbit/core/test/notifier-test.ts
+++ b/packages/@orbit/core/test/notifier-test.ts
@@ -1,4 +1,4 @@
-import Notifier from '../src/notifier';
+import { Notifier } from '../src/notifier';
 
 const { module, test } = QUnit;
 

--- a/packages/@orbit/core/test/support/fake-bucket.ts
+++ b/packages/@orbit/core/test/support/fake-bucket.ts
@@ -6,7 +6,7 @@ import { Dict } from '@orbit/utils';
  * object. Not practical, since Buckets are intended to persist values from
  * memory, but useful for testing.
  */
-export default class FakeBucket extends Bucket {
+export class FakeBucket extends Bucket {
   data: Dict<any>;
 
   constructor(settings = {}) {

--- a/packages/@orbit/core/test/task-processor-test.ts
+++ b/packages/@orbit/core/test/task-processor-test.ts
@@ -1,6 +1,6 @@
-import Orbit from '../src/main';
+import { Orbit } from '../src/main';
 import { Task, Performer } from '../src/task';
-import TaskProcessor from '../src/task-processor';
+import { TaskProcessor } from '../src/task-processor';
 
 const { module, test } = QUnit;
 

--- a/packages/@orbit/core/test/task-queue-test.ts
+++ b/packages/@orbit/core/test/task-queue-test.ts
@@ -1,7 +1,7 @@
 import { Bucket } from '../src/bucket';
 import { Task, Performer } from '../src/task';
-import { default as TaskQueue } from '../src/task-queue';
-import FakeBucket from './support/fake-bucket';
+import { TaskQueue } from '../src/task-queue';
+import { FakeBucket } from './support/fake-bucket';
 
 const { module, test } = QUnit;
 

--- a/packages/@orbit/data/src/index.ts
+++ b/packages/@orbit/data/src/index.ts
@@ -1,48 +1,21 @@
-export { default } from './main';
+export { default } from '@orbit/core';
 export * from './exception';
-export { default as KeyMap } from './key-map';
+export * from './key-map';
 export * from './operation';
 export * from './options';
-export { default as QueryBuilder } from './query-builder';
+export * from './query-builder';
 export * from './query-expression';
 export * from './query-term';
 export * from './query';
 export * from './record';
 export * from './request';
-export {
-  default as Schema,
-  AttributeDefinition,
-  RelationshipDefinition,
-  KeyDefinition,
-  ModelDefinition,
-  SchemaSettings
-} from './schema';
+export * from './schema';
 export * from './source';
 export * from './transform';
-export { default as TransformBuilder } from './transform-builder';
-export {
-  default as pullable,
-  Pullable,
-  isPullable
-} from './source-interfaces/pullable';
-export {
-  default as pushable,
-  Pushable,
-  isPushable
-} from './source-interfaces/pushable';
-export {
-  default as queryable,
-  Queryable,
-  isQueryable
-} from './source-interfaces/queryable';
+export * from './transform-builder';
+export * from './source-interfaces/pullable';
+export * from './source-interfaces/pushable';
+export * from './source-interfaces/queryable';
 export * from './source-interfaces/resettable';
-export {
-  default as syncable,
-  Syncable,
-  isSyncable
-} from './source-interfaces/syncable';
-export {
-  default as updatable,
-  Updatable,
-  isUpdatable
-} from './source-interfaces/updatable';
+export * from './source-interfaces/syncable';
+export * from './source-interfaces/updatable';

--- a/packages/@orbit/data/src/key-map.ts
+++ b/packages/@orbit/data/src/key-map.ts
@@ -4,7 +4,7 @@ import { Record } from './record';
 /**
  * Maintains a map between records' ids and keys.
  */
-export default class KeyMap {
+export class KeyMap {
   private _idsToKeys: Dict<Dict<string>>;
   private _keysToIds: Dict<Dict<string>>;
 

--- a/packages/@orbit/data/src/main.ts
+++ b/packages/@orbit/data/src/main.ts
@@ -1,1 +1,0 @@
-export { default } from '@orbit/core';

--- a/packages/@orbit/data/src/query-builder.ts
+++ b/packages/@orbit/data/src/query-builder.ts
@@ -6,7 +6,7 @@ import {
   FindRelatedRecordsTerm
 } from './query-term';
 
-export default class QueryBuilder {
+export class QueryBuilder {
   /**
    * Find a record by its identity.
    */

--- a/packages/@orbit/data/src/query.ts
+++ b/packages/@orbit/data/src/query.ts
@@ -1,7 +1,7 @@
-import Orbit from './main';
+import { Orbit } from '@orbit/core';
 import { QueryExpression } from './query-expression';
 import { QueryTerm } from './query-term';
-import QueryBuilder from './query-builder';
+import { QueryBuilder } from './query-builder';
 import { isObject } from '@orbit/utils';
 import { RequestOptions } from './request';
 

--- a/packages/@orbit/data/src/schema.ts
+++ b/packages/@orbit/data/src/schema.ts
@@ -1,5 +1,5 @@
 /* eslint-disable valid-jsdoc */
-import Orbit from './main';
+import { Orbit } from '@orbit/core';
 import { ModelNotFound } from './exception';
 import { Dict } from '@orbit/utils';
 import { evented, Evented, Listener } from '@orbit/core';
@@ -85,7 +85,7 @@ export interface SchemaSettings {
  * @implements {Evented}
  */
 @evented
-export default class Schema implements Evented, RecordInitializer {
+export class Schema implements Evented, RecordInitializer {
   private _models: Dict<ModelDefinition>;
 
   private _version: number;

--- a/packages/@orbit/data/src/source-interfaces/pullable.ts
+++ b/packages/@orbit/data/src/source-interfaces/pullable.ts
@@ -1,4 +1,4 @@
-import Orbit, { settleInSeries, fulfillInSeries } from '@orbit/core';
+import { Orbit, settleInSeries, fulfillInSeries } from '@orbit/core';
 import { Source, SourceClass } from '../source';
 import { Query, QueryOrExpressions, buildQuery } from '../query';
 import { Transform } from '../transform';
@@ -6,7 +6,7 @@ import { RequestOptions } from '../request';
 
 const { assert } = Orbit;
 
-export const PULLABLE = '__pullable__';
+const PULLABLE = '__pullable__';
 
 /**
  * Has a source been decorated as `@pullable`?
@@ -59,7 +59,7 @@ export interface Pullable {
  * the processing required for `pull` and returns a promise that resolves to an
  * array of `Transform` instances.
  */
-export default function pullable(Klass: SourceClass): void {
+export function pullable(Klass: SourceClass): void {
   let proto = Klass.prototype;
 
   if (isPullable(proto)) {

--- a/packages/@orbit/data/src/source-interfaces/pushable.ts
+++ b/packages/@orbit/data/src/source-interfaces/pushable.ts
@@ -1,11 +1,11 @@
-import Orbit, { settleInSeries, fulfillInSeries } from '@orbit/core';
+import { Orbit, settleInSeries, fulfillInSeries } from '@orbit/core';
 import { Source, SourceClass } from '../source';
 import { Transform, TransformOrOperations, buildTransform } from '../transform';
 import { RequestOptions } from '../request';
 
 const { assert } = Orbit;
 
-export const PUSHABLE = '__pushable__';
+const PUSHABLE = '__pushable__';
 
 /**
  * Has a source been decorated as `@pushable`?
@@ -62,7 +62,7 @@ export interface Pushable {
  * the processing required for `push` and returns a promise that resolves to an
  * array of `Transform` instances.
  */
-export default function pushable(Klass: SourceClass): void {
+export function pushable(Klass: SourceClass): void {
   let proto = Klass.prototype;
 
   if (isPushable(proto)) {

--- a/packages/@orbit/data/src/source-interfaces/queryable.ts
+++ b/packages/@orbit/data/src/source-interfaces/queryable.ts
@@ -1,11 +1,11 @@
-import Orbit, { settleInSeries, fulfillInSeries } from '@orbit/core';
+import { Orbit, settleInSeries, fulfillInSeries } from '@orbit/core';
 import { Query, QueryOrExpressions, buildQuery } from '../query';
 import { Source, SourceClass } from '../source';
 import { RequestOptions } from '../request';
 
 const { assert } = Orbit;
 
-export const QUERYABLE = '__queryable__';
+const QUERYABLE = '__queryable__';
 
 /**
  * Has a source been decorated as `@queryable`?
@@ -55,7 +55,7 @@ export interface Queryable {
  * the processing required for `query` and returns a promise that resolves to a
  * set of results.
  */
-export default function queryable(Klass: SourceClass): void {
+export function queryable(Klass: SourceClass): void {
   let proto = Klass.prototype;
 
   if (isQueryable(proto)) {

--- a/packages/@orbit/data/src/source-interfaces/syncable.ts
+++ b/packages/@orbit/data/src/source-interfaces/syncable.ts
@@ -1,10 +1,10 @@
-import Orbit, { fulfillInSeries, settleInSeries } from '@orbit/core';
+import { Orbit, fulfillInSeries, settleInSeries } from '@orbit/core';
 import { Source, SourceClass } from '../source';
 import { Transform } from '../transform';
 
 const { assert } = Orbit;
 
-export const SYNCABLE = '__syncable__';
+const SYNCABLE = '__syncable__';
 
 /**
  * Has a source been decorated as `@syncable`?
@@ -38,7 +38,7 @@ export interface Syncable {
  * `transform` event, which is emitted whenever a new `Transform` is applied to
  * a source.
  */
-export default function syncable(Klass: SourceClass): void {
+export function syncable(Klass: SourceClass): void {
   let proto = Klass.prototype;
 
   if (isSyncable(proto)) {

--- a/packages/@orbit/data/src/source-interfaces/updatable.ts
+++ b/packages/@orbit/data/src/source-interfaces/updatable.ts
@@ -1,11 +1,11 @@
-import Orbit, { settleInSeries, fulfillInSeries } from '@orbit/core';
+import { Orbit, settleInSeries, fulfillInSeries } from '@orbit/core';
 import { Source, SourceClass } from '../source';
 import { Transform, TransformOrOperations, buildTransform } from '../transform';
 import { RequestOptions } from '../request';
 
 const { assert } = Orbit;
 
-export const UPDATABLE = '__updatable__';
+const UPDATABLE = '__updatable__';
 
 /**
  * Has a source been decorated as `@updatable`?
@@ -56,7 +56,7 @@ export interface Updatable {
  * the processing required for `update` and returns a promise that resolves when
  * complete.
  */
-export default function updatable(Klass: SourceClass): void {
+export function updatable(Klass: SourceClass): void {
   let proto = Klass.prototype;
 
   if (isUpdatable(proto)) {

--- a/packages/@orbit/data/src/source.ts
+++ b/packages/@orbit/data/src/source.ts
@@ -1,4 +1,5 @@
-import Orbit, {
+import {
+  Orbit,
   evented,
   Evented,
   settleInSeries,
@@ -10,11 +11,11 @@ import Orbit, {
   Listener,
   Log
 } from '@orbit/core';
-import KeyMap from './key-map';
-import Schema from './schema';
-import QueryBuilder from './query-builder';
+import { KeyMap } from './key-map';
+import { Schema } from './schema';
+import { QueryBuilder } from './query-builder';
 import { Transform } from './transform';
-import TransformBuilder from './transform-builder';
+import { TransformBuilder } from './transform-builder';
 
 const { assert } = Orbit;
 

--- a/packages/@orbit/data/src/transform-builder.ts
+++ b/packages/@orbit/data/src/transform-builder.ts
@@ -15,7 +15,7 @@ export interface TransformBuilderSettings {
   recordInitializer?: RecordInitializer;
 }
 
-export default class TransformBuilder {
+export class TransformBuilder {
   private _recordInitializer: RecordInitializer;
 
   constructor(settings: TransformBuilderSettings = {}) {

--- a/packages/@orbit/data/src/transform.ts
+++ b/packages/@orbit/data/src/transform.ts
@@ -1,8 +1,8 @@
 /* eslint-disable valid-jsdoc */
-import Orbit from './main';
-import { Operation } from './operation';
+import { Orbit } from '@orbit/core';
 import { isObject } from '@orbit/utils';
-import TransformBuilder from './transform-builder';
+import { Operation } from './operation';
+import { TransformBuilder } from './transform-builder';
 import { RequestOptions } from './request';
 
 export type TransformBuilderFunc = (

--- a/packages/@orbit/data/test/key-map-test.ts
+++ b/packages/@orbit/data/test/key-map-test.ts
@@ -1,4 +1,4 @@
-import KeyMap from '../src/key-map';
+import { KeyMap } from '../src/key-map';
 import './test-helper';
 
 const { module, test } = QUnit;

--- a/packages/@orbit/data/test/query-builder-test.ts
+++ b/packages/@orbit/data/test/query-builder-test.ts
@@ -1,4 +1,4 @@
-import QueryBuilder from '../src/query-builder';
+import { QueryBuilder } from '../src/query-builder';
 import './test-helper';
 import {
   FindRecord,

--- a/packages/@orbit/data/test/query-test.ts
+++ b/packages/@orbit/data/test/query-test.ts
@@ -1,7 +1,7 @@
 import { buildQuery } from '../src/query';
 import { QueryTerm } from '../src/query-term';
 import { FindRecords } from '../src/query-expression';
-import QueryBuilder from '../src/query-builder';
+import { QueryBuilder } from '../src/query-builder';
 import './test-helper';
 
 const { module, test } = QUnit;

--- a/packages/@orbit/data/test/schema-test.ts
+++ b/packages/@orbit/data/test/schema-test.ts
@@ -1,6 +1,6 @@
-import Schema from '../src/schema';
-import './test-helper';
+import { Schema } from '../src/schema';
 import { Record } from '../src';
+import './test-helper';
 
 const { module, test } = QUnit;
 

--- a/packages/@orbit/data/test/source-interfaces/pullable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/pullable-test.ts
@@ -2,7 +2,8 @@ import { Query, QueryOrExpressions } from '../../src/query';
 import { Source } from '../../src/source';
 import { buildTransform, Transform } from '../../src/transform';
 import { RequestOptions } from '../../src/request';
-import pullable, {
+import {
+  pullable,
   isPullable,
   Pullable
 } from '../../src/source-interfaces/pullable';

--- a/packages/@orbit/data/test/source-interfaces/pushable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/pushable-test.ts
@@ -5,7 +5,8 @@ import {
 } from '../../src/transform';
 import { Source } from '../../src/source';
 import { RequestOptions } from '../../src/request';
-import pushable, {
+import {
+  pushable,
   isPushable,
   Pushable
 } from '../../src/source-interfaces/pushable';

--- a/packages/@orbit/data/test/source-interfaces/queryable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/queryable-test.ts
@@ -1,7 +1,8 @@
 import { Query, QueryOrExpressions } from '../../src/query';
 import { Source } from '../../src/source';
 import { RequestOptions } from '../../src/request';
-import queryable, {
+import {
+  queryable,
   isQueryable,
   Queryable
 } from '../../src/source-interfaces/queryable';

--- a/packages/@orbit/data/test/source-interfaces/syncable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/syncable-test.ts
@@ -1,6 +1,7 @@
 import { buildTransform, Transform } from '../../src/transform';
 import { Source } from '../../src/source';
-import syncable, {
+import {
+  syncable,
   isSyncable,
   Syncable
 } from '../../src/source-interfaces/syncable';

--- a/packages/@orbit/data/test/source-interfaces/updatable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/updatable-test.ts
@@ -5,7 +5,8 @@ import {
 } from '../../src/transform';
 import { Source } from '../../src/source';
 import { RequestOptions } from '../../src/request';
-import updatable, {
+import {
+  updatable,
   isUpdatable,
   Updatable
 } from '../../src/source-interfaces/updatable';

--- a/packages/@orbit/data/test/source-test.ts
+++ b/packages/@orbit/data/test/source-test.ts
@@ -1,8 +1,8 @@
 import { Source } from '../src/source';
-import Schema from '../src/schema';
+import { Schema } from '../src/schema';
 import { buildTransform, Transform } from '../src/transform';
-import TransformBuilder from '../src/transform-builder';
-import QueryBuilder from '../src/query-builder';
+import { TransformBuilder } from '../src/transform-builder';
+import { QueryBuilder } from '../src/query-builder';
 import { FakeBucket } from './test-helper';
 
 const { module, test } = QUnit;

--- a/packages/@orbit/data/test/support/fake-bucket.ts
+++ b/packages/@orbit/data/test/support/fake-bucket.ts
@@ -6,7 +6,7 @@ import { Dict } from '@orbit/utils';
  * object. Not practical, since Buckets are intended to persist values from
  * memory, but useful for testing.
  */
-export default class FakeBucket extends Bucket {
+export class FakeBucket extends Bucket {
   data: Dict<any>;
 
   constructor(settings = {}) {

--- a/packages/@orbit/data/test/test-helper.ts
+++ b/packages/@orbit/data/test/test-helper.ts
@@ -1,1 +1,1 @@
-export { default as FakeBucket } from './support/fake-bucket';
+export { FakeBucket } from './support/fake-bucket';

--- a/packages/@orbit/data/test/transform-builder-test.ts
+++ b/packages/@orbit/data/test/transform-builder-test.ts
@@ -1,5 +1,5 @@
 import { Record } from '../src/record';
-import TransformBuilder from '../src/transform-builder';
+import { TransformBuilder } from '../src/transform-builder';
 import './test-helper';
 
 const { module, test } = QUnit;

--- a/packages/@orbit/data/test/transform-test.ts
+++ b/packages/@orbit/data/test/transform-test.ts
@@ -1,4 +1,4 @@
-import TransformBuilder from '../src/transform-builder';
+import { TransformBuilder } from '../src/transform-builder';
 import { buildTransform } from '../src/transform';
 import './test-helper';
 

--- a/packages/@orbit/identity-map/src/identity-map.ts
+++ b/packages/@orbit/identity-map/src/identity-map.ts
@@ -1,11 +1,10 @@
-import IdentitySerializer from './identity-serializer';
+import { IdentitySerializer } from './identity-serializer';
 
 export interface IdentityMapSettings<Identity> {
   serializer: IdentitySerializer<Identity>;
 }
 
-export default class IdentityMap<Identity, Model>
-  implements Map<Identity, Model> {
+export class IdentityMap<Identity, Model> implements Map<Identity, Model> {
   protected _serializer: IdentitySerializer<Identity>;
   protected _map: Map<string, Model>;
 

--- a/packages/@orbit/identity-map/src/identity-serializer.ts
+++ b/packages/@orbit/identity-map/src/identity-serializer.ts
@@ -1,4 +1,4 @@
-export default interface IdentitySerializer<Identity> {
+export interface IdentitySerializer<Identity> {
   serialize(identity: Identity): string;
   deserialize(identifier: string): Identity;
 }

--- a/packages/@orbit/identity-map/src/index.ts
+++ b/packages/@orbit/identity-map/src/index.ts
@@ -1,2 +1,3 @@
-export { default, IdentityMapSettings } from './identity-map';
-export { default as IdentitySerializer } from './identity-serializer';
+export { IdentityMap as default } from './identity-map';
+export * from './identity-map';
+export * from './identity-serializer';

--- a/packages/@orbit/identity-map/test/identity-map-test.ts
+++ b/packages/@orbit/identity-map/test/identity-map-test.ts
@@ -1,6 +1,6 @@
 import { RecordIdentity } from '@orbit/data';
-import IdentityMap from '../src/identity-map';
-import RecordIdentitySerializer from './support/record-identity-serializer';
+import { IdentityMap } from '../src/identity-map';
+import { RecordIdentitySerializer } from './support/record-identity-serializer';
 
 const { module, test } = QUnit;
 

--- a/packages/@orbit/identity-map/test/record-identity-serializer-test.ts
+++ b/packages/@orbit/identity-map/test/record-identity-serializer-test.ts
@@ -1,4 +1,4 @@
-import RecordIdentitySerializer from './support/record-identity-serializer';
+import { RecordIdentitySerializer } from './support/record-identity-serializer';
 
 const { module, test } = QUnit;
 

--- a/packages/@orbit/identity-map/test/support/record-identity-serializer.ts
+++ b/packages/@orbit/identity-map/test/support/record-identity-serializer.ts
@@ -5,7 +5,7 @@ import {
 } from '@orbit/data';
 import { IdentitySerializer } from '../../src/index';
 
-export default class RecordIdentitySerializer
+export class RecordIdentitySerializer
   implements IdentitySerializer<RecordIdentity> {
   serialize(identity: RecordIdentity): string {
     return serializeRecordIdentity(identity);

--- a/packages/@orbit/immutable/src/immutable-map.ts
+++ b/packages/@orbit/immutable/src/immutable-map.ts
@@ -1,6 +1,6 @@
-import HAMTMap from './utils/hamt';
+import { HAMTMap } from './utils/hamt';
 
-export default class ImmutableMap<K, V> {
+export class ImmutableMap<K, V> {
   private _data: HAMTMap;
 
   constructor(base?: ImmutableMap<K, V>) {

--- a/packages/@orbit/immutable/src/index.ts
+++ b/packages/@orbit/immutable/src/index.ts
@@ -1,1 +1,1 @@
-export { default as ImmutableMap } from './immutable-map';
+export * from './immutable-map';

--- a/packages/@orbit/immutable/src/utils/hamt.ts
+++ b/packages/@orbit/immutable/src/utils/hamt.ts
@@ -819,7 +819,7 @@ export interface HAMTMapConfig {
   hash?: Function // TODO
 }
 
-export default class HAMTMap {
+export class HAMTMap {
   private _map: any;
   private _editable: boolean;
   private _edit: any;

--- a/packages/@orbit/immutable/test/immutable-map-test.ts
+++ b/packages/@orbit/immutable/test/immutable-map-test.ts
@@ -1,4 +1,4 @@
-import ImmutableMap from '../src/immutable-map';
+import { ImmutableMap } from '../src/immutable-map';
 
 const { module, test } = QUnit;
 

--- a/packages/@orbit/indexeddb-bucket/src/bucket.ts
+++ b/packages/@orbit/indexeddb-bucket/src/bucket.ts
@@ -1,4 +1,4 @@
-import Orbit, { Bucket, BucketSettings } from '@orbit/core';
+import { Orbit, Bucket, BucketSettings } from '@orbit/core';
 import { supportsIndexedDB } from './lib/indexeddb';
 
 const { assert } = Orbit;
@@ -15,7 +15,7 @@ export interface IndexedDBBucketSettings extends BucketSettings {
  * @class IndexedDBBucket
  * @extends Bucket
  */
-export default class IndexedDBBucket extends Bucket {
+export class IndexedDBBucket extends Bucket {
   protected _storeName: string;
   protected _db: any;
 

--- a/packages/@orbit/indexeddb-bucket/src/index.ts
+++ b/packages/@orbit/indexeddb-bucket/src/index.ts
@@ -1,2 +1,3 @@
-export { default, IndexedDBBucketSettings } from './bucket';
+export { IndexedDBBucket as default } from './bucket';
+export * from './bucket';
 export { supportsIndexedDB } from './lib/indexeddb';

--- a/packages/@orbit/indexeddb-bucket/test/bucket-test.ts
+++ b/packages/@orbit/indexeddb-bucket/test/bucket-test.ts
@@ -1,5 +1,5 @@
 import { Bucket } from '@orbit/core';
-import IndexedDBBucket from '../src/bucket';
+import { IndexedDBBucket } from '../src/bucket';
 
 const { module, test } = QUnit;
 

--- a/packages/@orbit/indexeddb/src/index.ts
+++ b/packages/@orbit/indexeddb/src/index.ts
@@ -1,6 +1,4 @@
-export { default, IndexedDBSourceSettings } from './indexeddb-source';
-export {
-  default as IndexedDBCache,
-  IndexedDBCacheSettings
-} from './indexeddb-cache';
-export { supportsIndexedDB } from './lib/indexeddb';
+export { IndexedDBSource as default } from './indexeddb-source';
+export * from './indexeddb-source';
+export * from './indexeddb-cache';
+export * from './lib/indexeddb';

--- a/packages/@orbit/indexeddb/src/indexeddb-cache.ts
+++ b/packages/@orbit/indexeddb/src/indexeddb-cache.ts
@@ -1,4 +1,5 @@
-import Orbit, {
+import { Orbit } from '@orbit/core';
+import {
   serializeRecordIdentity,
   deserializeRecordIdentity,
   Record,
@@ -33,7 +34,7 @@ export interface IndexedDBCacheSettings extends AsyncRecordCacheSettings {
  *
  * Because IndexedDB access is async, this cache extends `AsyncRecordCache`.
  */
-export default class IndexedDBCache extends AsyncRecordCache {
+export class IndexedDBCache extends AsyncRecordCache {
   protected _namespace: string;
   protected _db: IDBDatabase;
   protected _openingDB: Promise<IDBDatabase>;

--- a/packages/@orbit/indexeddb/src/indexeddb-source.ts
+++ b/packages/@orbit/indexeddb/src/indexeddb-source.ts
@@ -1,4 +1,5 @@
-import Orbit, {
+import { Orbit } from '@orbit/core';
+import {
   buildTransform,
   pullable,
   Pullable,
@@ -20,7 +21,7 @@ import Orbit, {
 } from '@orbit/data';
 import { QueryResultData } from '@orbit/record-cache';
 import { supportsIndexedDB } from './lib/indexeddb';
-import IndexedDBCache, { IndexedDBCacheSettings } from './indexeddb-cache';
+import { IndexedDBCache, IndexedDBCacheSettings } from './indexeddb-cache';
 
 const { assert } = Orbit;
 
@@ -35,7 +36,7 @@ export interface IndexedDBSourceSettings extends SourceSettings {
 @pullable
 @pushable
 @syncable
-export default class IndexedDBSource extends Source
+export class IndexedDBSource extends Source
   implements Pullable, Pushable, Resettable, Syncable {
   protected _cache: IndexedDBCache;
 

--- a/packages/@orbit/indexeddb/src/lib/indexeddb.ts
+++ b/packages/@orbit/indexeddb/src/lib/indexeddb.ts
@@ -1,4 +1,4 @@
-import Orbit from '@orbit/core';
+import { Orbit } from '@orbit/core';
 
 export function supportsIndexedDB(): boolean {
   return !!Orbit.globals.indexedDB;

--- a/packages/@orbit/indexeddb/test/indexeddb-cache-test.ts
+++ b/packages/@orbit/indexeddb/test/indexeddb-cache-test.ts
@@ -1,11 +1,11 @@
 import { getRecordFromIndexedDB } from './support/indexeddb';
 import { Record, Schema, KeyMap } from '@orbit/data';
-import Cache from '../src/indexeddb-cache';
+import { IndexedDBCache } from '../src/indexeddb-cache';
 
 const { module, test } = QUnit;
 
-module('Cache', function (hooks) {
-  let schema: Schema, cache: Cache, keyMap: KeyMap;
+module('IndexedDBCache', function (hooks) {
+  let schema: Schema, cache: IndexedDBCache, keyMap: KeyMap;
 
   hooks.beforeEach(async () => {
     schema = new Schema({
@@ -53,7 +53,7 @@ module('Cache', function (hooks) {
 
     keyMap = new KeyMap();
 
-    cache = new Cache({ schema, keyMap });
+    cache = new IndexedDBCache({ schema, keyMap });
     await cache.openDB();
   });
 

--- a/packages/@orbit/indexeddb/test/indexeddb-source-test.ts
+++ b/packages/@orbit/indexeddb/test/indexeddb-source-test.ts
@@ -8,7 +8,7 @@ import {
   Transform,
   RecordIdentity
 } from '@orbit/data';
-import IndexedDBSource from '../src/indexeddb-source';
+import { IndexedDBSource } from '../src/indexeddb-source';
 
 const { module, test } = QUnit;
 

--- a/packages/@orbit/integration-tests/test/memory-bucket-test.ts
+++ b/packages/@orbit/integration-tests/test/memory-bucket-test.ts
@@ -1,6 +1,6 @@
 import { Schema } from '@orbit/data';
-import MemorySource from '@orbit/memory';
-import IndexedDBBucket from '@orbit/indexeddb-bucket';
+import { MemorySource } from '@orbit/memory';
+import { IndexedDBBucket } from '@orbit/indexeddb-bucket';
 
 const { module, test } = QUnit;
 

--- a/packages/@orbit/integration-tests/test/store-jsonapi-clientid-pessimistic-test.ts
+++ b/packages/@orbit/integration-tests/test/store-jsonapi-clientid-pessimistic-test.ts
@@ -1,7 +1,7 @@
 import { Record, Schema } from '@orbit/data';
-import JSONAPISource from '@orbit/jsonapi';
-import MemorySource from '@orbit/memory';
-import Coordinator, { RequestStrategy, SyncStrategy } from '@orbit/coordinator';
+import { JSONAPISource } from '@orbit/jsonapi';
+import { MemorySource } from '@orbit/memory';
+import { Coordinator, RequestStrategy, SyncStrategy } from '@orbit/coordinator';
 import { jsonapiResponse } from './support/jsonapi';
 import { SinonStub } from 'sinon';
 import * as sinon from 'sinon';

--- a/packages/@orbit/integration-tests/test/store-jsonapi-remoteid-optimistic-test.ts
+++ b/packages/@orbit/integration-tests/test/store-jsonapi-remoteid-optimistic-test.ts
@@ -1,7 +1,7 @@
 import { KeyMap, Record, Schema } from '@orbit/data';
-import JSONAPISource from '@orbit/jsonapi';
-import MemorySource from '@orbit/memory';
-import Coordinator, { RequestStrategy, SyncStrategy } from '@orbit/coordinator';
+import { JSONAPISource } from '@orbit/jsonapi';
+import { MemorySource } from '@orbit/memory';
+import { Coordinator, RequestStrategy, SyncStrategy } from '@orbit/coordinator';
 import { jsonapiResponse } from './support/jsonapi';
 import { SinonStub } from 'sinon';
 import * as sinon from 'sinon';

--- a/packages/@orbit/integration-tests/test/store-jsonapi-remoteid-pessimistic-test.ts
+++ b/packages/@orbit/integration-tests/test/store-jsonapi-remoteid-pessimistic-test.ts
@@ -1,7 +1,7 @@
 import { KeyMap, Record, Schema } from '@orbit/data';
-import JSONAPISource from '@orbit/jsonapi';
-import MemorySource from '@orbit/memory';
-import Coordinator, { RequestStrategy, SyncStrategy } from '@orbit/coordinator';
+import { JSONAPISource } from '@orbit/jsonapi';
+import { MemorySource } from '@orbit/memory';
+import { Coordinator, RequestStrategy, SyncStrategy } from '@orbit/coordinator';
 import { jsonapiResponse } from './support/jsonapi';
 import { SinonStub } from 'sinon';
 import * as sinon from 'sinon';

--- a/packages/@orbit/integration-tests/test/support/jsonapi.ts
+++ b/packages/@orbit/integration-tests/test/support/jsonapi.ts
@@ -1,4 +1,4 @@
-import Orbit from '@orbit/core';
+import { Orbit } from '@orbit/core';
 
 export function jsonapiResponse(
   _options: any,

--- a/packages/@orbit/jsonapi/src/index.ts
+++ b/packages/@orbit/jsonapi/src/index.ts
@@ -1,4 +1,5 @@
-export { default, JSONAPISourceSettings } from './jsonapi-source';
+export { JSONAPISource as default } from './jsonapi-source';
+export * from './jsonapi-source';
 export * from './serializers/jsonapi-base-serializer';
 export * from './serializers/jsonapi-document-serializer';
 export * from './serializers/jsonapi-operation-serializer';
@@ -8,15 +9,8 @@ export * from './serializers/jsonapi-resource-identity-serializer';
 export * from './serializers/jsonapi-resource-serializer';
 export * from './serializers/jsonapi-serializer-builder';
 export * from './serializers/jsonapi-serializers';
-export {
-  default as JSONAPIRequestProcessor,
-  JSONAPIRequestProcessorSettings,
-  FetchSettings
-} from './jsonapi-request-processor';
-export {
-  default as JSONAPIURLBuilder,
-  JSONAPIURLBuilderSettings
-} from './jsonapi-url-builder';
+export * from './jsonapi-request-processor';
+export * from './jsonapi-url-builder';
 export * from './resources';
 export * from './resource-operations';
 export * from './lib/exceptions';

--- a/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
@@ -20,7 +20,8 @@ import {
   JSONAPIRequestOptions,
   buildFetchSettings
 } from './lib/jsonapi-request-options';
-import JSONAPIURLBuilder, {
+import {
+  JSONAPIURLBuilder,
   JSONAPIURLBuilderSettings
 } from './jsonapi-url-builder';
 import {
@@ -71,7 +72,7 @@ export interface JSONAPIRequestProcessorSettings {
   keyMap: KeyMap;
 }
 
-export default class JSONAPIRequestProcessor {
+export class JSONAPIRequestProcessor {
   sourceName: string;
   urlBuilder: JSONAPIURLBuilder;
   allowedContentTypes: string[];

--- a/packages/@orbit/jsonapi/src/jsonapi-source.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-source.ts
@@ -21,7 +21,8 @@ import Orbit, {
   TransformNotAllowed,
   QueryNotAllowed
 } from '@orbit/data';
-import JSONAPIRequestProcessor, {
+import {
+  JSONAPIRequestProcessor,
   JSONAPIRequestProcessorSettings,
   FetchSettings
 } from './jsonapi-request-processor';
@@ -29,7 +30,8 @@ import {
   JSONAPISerializer,
   JSONAPISerializerSettings
 } from './jsonapi-serializer';
-import JSONAPIURLBuilder, {
+import {
+  JSONAPIURLBuilder,
   JSONAPIURLBuilderSettings
 } from './jsonapi-url-builder';
 import {
@@ -94,7 +96,7 @@ export interface JSONAPISourceSettings extends SourceSettings {
 @pushable
 @queryable
 @updatable
-export default class JSONAPISource extends Source
+export class JSONAPISource extends Source
   implements Pullable, Pushable, Queryable, Updatable {
   maxRequestsPerTransform?: number;
   maxRequestsPerQuery?: number;

--- a/packages/@orbit/jsonapi/src/jsonapi-url-builder.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-url-builder.ts
@@ -27,7 +27,7 @@ export interface JSONAPIURLBuilderSettings {
   keyMap?: KeyMap;
 }
 
-export default class JSONAPIURLBuilder {
+export class JSONAPIURLBuilder {
   host: string;
   namespace: string;
   serializerFor: SerializerForFn;

--- a/packages/@orbit/jsonapi/src/lib/query-requests.ts
+++ b/packages/@orbit/jsonapi/src/lib/query-requests.ts
@@ -15,7 +15,7 @@ import {
   QueryExpression,
   cloneRecordIdentity
 } from '@orbit/data';
-import JSONAPIRequestProcessor from '../jsonapi-request-processor';
+import { JSONAPIRequestProcessor } from '../jsonapi-request-processor';
 import {
   JSONAPIRequestOptions,
   mergeJSONAPIRequestOptions

--- a/packages/@orbit/jsonapi/src/lib/transform-requests.ts
+++ b/packages/@orbit/jsonapi/src/lib/transform-requests.ts
@@ -18,7 +18,7 @@ import {
   Link
 } from '@orbit/data';
 import { clone, deepSet, Dict } from '@orbit/utils';
-import JSONAPIRequestProcessor from '../jsonapi-request-processor';
+import { JSONAPIRequestProcessor } from '../jsonapi-request-processor';
 import { ResourceDocument, RecordDocument } from '../resources';
 import { JSONAPIRequestOptions } from './jsonapi-request-options';
 import { JSONAPISerializers } from '../serializers/jsonapi-serializers';

--- a/packages/@orbit/jsonapi/test/jsonapi-request-processor-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-request-processor-test.ts
@@ -1,5 +1,5 @@
 import { KeyMap, Schema } from '@orbit/data';
-import JSONAPIRequestProcessor from '../src/jsonapi-request-processor';
+import { JSONAPIRequestProcessor } from '../src/jsonapi-request-processor';
 import { jsonapiResponse } from './support/jsonapi';
 import { SinonStub } from 'sinon';
 import * as sinon from 'sinon';

--- a/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
@@ -18,7 +18,7 @@ import {
   Transform
 } from '@orbit/data';
 import { jsonapiResponse } from './support/jsonapi';
-import JSONAPISource from '../src/jsonapi-source';
+import { JSONAPISource } from '../src/jsonapi-source';
 import { Resource, ResourceDocument } from '../src/resources';
 import { SinonStub } from 'sinon';
 import * as sinon from 'sinon';

--- a/packages/@orbit/jsonapi/test/jsonapi-source-with-legacy-serializer-settings-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-with-legacy-serializer-settings-test.ts
@@ -18,7 +18,7 @@ import {
   Transform
 } from '@orbit/data';
 import { jsonapiResponse } from './support/jsonapi';
-import JSONAPISource from '../src/jsonapi-source';
+import { JSONAPISource } from '../src/jsonapi-source';
 import { Resource, ResourceDocument } from '../src/resources';
 import { SinonStub } from 'sinon';
 import * as sinon from 'sinon';

--- a/packages/@orbit/jsonapi/test/jsonapi-url-builder-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-url-builder-test.ts
@@ -1,5 +1,5 @@
 import { KeyMap, Schema } from '@orbit/data';
-import JSONAPIURLBuilder from '../src/jsonapi-url-builder';
+import { JSONAPIURLBuilder } from '../src/jsonapi-url-builder';
 import { buildJSONAPISerializerFor } from '../src/serializers/jsonapi-serializer-builder';
 
 const { module, test } = QUnit;

--- a/packages/@orbit/jsonapi/test/lib/query-requests-test.ts
+++ b/packages/@orbit/jsonapi/test/lib/query-requests-test.ts
@@ -3,7 +3,7 @@ import {
   QueryRequestProcessors,
   getQueryRequests
 } from '../../src/lib/query-requests';
-import JSONAPIRequestProcessor from '../../src/jsonapi-request-processor';
+import { JSONAPIRequestProcessor } from '../../src/jsonapi-request-processor';
 import { jsonapiResponse } from '../support/jsonapi';
 import { SinonStub } from 'sinon';
 import * as sinon from 'sinon';

--- a/packages/@orbit/jsonapi/test/lib/transform-requests-test.ts
+++ b/packages/@orbit/jsonapi/test/lib/transform-requests-test.ts
@@ -3,7 +3,7 @@ import {
   getTransformRequests,
   TransformRequestProcessors
 } from '../../src/lib/transform-requests';
-import JSONAPIRequestProcessor from '../../src/jsonapi-request-processor';
+import { JSONAPIRequestProcessor } from '../../src/jsonapi-request-processor';
 import { jsonapiResponse } from '../support/jsonapi';
 import { SinonStub } from 'sinon';
 import * as sinon from 'sinon';

--- a/packages/@orbit/jsonapi/test/serializers/jsonapi-resource-identity-serializer-test.ts
+++ b/packages/@orbit/jsonapi/test/serializers/jsonapi-resource-identity-serializer-test.ts
@@ -1,12 +1,7 @@
 import { Dict } from '@orbit/utils';
 import { KeyMap, ModelDefinition, Record, Schema } from '@orbit/data';
 import { JSONAPIResourceIdentitySerializer } from '../../src/serializers/jsonapi-resource-identity-serializer';
-import {
-  Serializer,
-  SerializerForFn,
-  buildSerializerClassFor,
-  buildSerializerSettingsFor
-} from '@orbit/serializers';
+import { buildSerializerSettingsFor } from '@orbit/serializers';
 import { buildJSONAPISerializerFor } from '../../src/serializers/jsonapi-serializer-builder';
 import { JSONAPISerializers } from '../../src/serializers/jsonapi-serializers';
 

--- a/packages/@orbit/jsonapi/test/support/jsonapi.ts
+++ b/packages/@orbit/jsonapi/test/support/jsonapi.ts
@@ -1,4 +1,4 @@
-import Orbit from '@orbit/core';
+import { Orbit } from '@orbit/core';
 
 export function jsonapiResponse(
   _options: any,

--- a/packages/@orbit/local-storage-bucket/src/bucket.ts
+++ b/packages/@orbit/local-storage-bucket/src/bucket.ts
@@ -1,4 +1,4 @@
-import Orbit, { Bucket, BucketSettings } from '@orbit/core';
+import { Orbit, Bucket, BucketSettings } from '@orbit/core';
 import { supportsLocalStorage } from './lib/local-storage';
 
 const { assert } = Orbit;
@@ -13,7 +13,7 @@ export interface LocalStorageBucketSettings extends BucketSettings {
  * @class LocalStorageBucket
  * @extends Bucket
  */
-export default class LocalStorageBucket extends Bucket {
+export class LocalStorageBucket extends Bucket {
   private _delimiter: string;
 
   /**

--- a/packages/@orbit/local-storage-bucket/src/index.ts
+++ b/packages/@orbit/local-storage-bucket/src/index.ts
@@ -1,2 +1,3 @@
-export { default, LocalStorageBucketSettings } from './bucket';
-export { supportsLocalStorage } from './lib/local-storage';
+export { LocalStorageBucket as default } from './bucket';
+export * from './bucket';
+export * from './lib/local-storage';

--- a/packages/@orbit/local-storage-bucket/src/lib/local-storage.ts
+++ b/packages/@orbit/local-storage-bucket/src/lib/local-storage.ts
@@ -1,4 +1,4 @@
-import Orbit from '@orbit/core';
+import { Orbit } from '@orbit/core';
 
 export function supportsLocalStorage(): boolean {
   return !!Orbit.globals.localStorage;

--- a/packages/@orbit/local-storage-bucket/test/bucket-test.ts
+++ b/packages/@orbit/local-storage-bucket/test/bucket-test.ts
@@ -1,5 +1,5 @@
 import { Bucket } from '@orbit/core';
-import LocalStorageBucket from '../src/bucket';
+import { LocalStorageBucket } from '../src/bucket';
 
 const { module, test } = QUnit;
 

--- a/packages/@orbit/local-storage/src/index.ts
+++ b/packages/@orbit/local-storage/src/index.ts
@@ -1,6 +1,4 @@
-export { default, LocalStorageSourceSettings } from './local-storage-source';
-export {
-  default as LocalStorageCache,
-  LocalStorageCacheSettings
-} from './local-storage-cache';
-export { supportsLocalStorage } from './lib/local-storage';
+export { LocalStorageSource as default } from './local-storage-source';
+export * from './local-storage-source';
+export * from './local-storage-cache';
+export * from './lib/local-storage';

--- a/packages/@orbit/local-storage/src/lib/local-storage.ts
+++ b/packages/@orbit/local-storage/src/lib/local-storage.ts
@@ -1,4 +1,4 @@
-import Orbit from '@orbit/core';
+import { Orbit } from '@orbit/core';
 
 export function supportsLocalStorage(): boolean {
   return !!Orbit.globals.localStorage;

--- a/packages/@orbit/local-storage/src/local-storage-cache.ts
+++ b/packages/@orbit/local-storage/src/local-storage-cache.ts
@@ -1,10 +1,7 @@
 /* eslint-disable valid-jsdoc */
 import { isNone } from '@orbit/utils';
-import Orbit, {
-  Record,
-  RecordIdentity,
-  equalRecordIdentities
-} from '@orbit/data';
+import { Orbit } from '@orbit/core';
+import { Record, RecordIdentity, equalRecordIdentities } from '@orbit/data';
 import {
   RecordRelationshipIdentity,
   SyncRecordCache,
@@ -21,7 +18,7 @@ export interface LocalStorageCacheSettings extends SyncRecordCacheSettings {
  *
  * Because local storage access is synchronous, this cache extends `SyncRecordCache`.
  */
-export default class LocalStorageCache extends SyncRecordCache {
+export class LocalStorageCache extends SyncRecordCache {
   protected _namespace: string;
   protected _delimiter: string;
 

--- a/packages/@orbit/local-storage/src/local-storage-source.ts
+++ b/packages/@orbit/local-storage/src/local-storage-source.ts
@@ -1,4 +1,5 @@
-import Orbit, {
+import { Orbit } from '@orbit/core';
+import {
   buildTransform,
   Operation,
   pullable,
@@ -22,7 +23,8 @@ import Orbit, {
 } from '@orbit/data';
 import { QueryResultData } from '@orbit/record-cache';
 import { supportsLocalStorage } from './lib/local-storage';
-import LocalStorageCache, {
+import {
+  LocalStorageCache,
   LocalStorageCacheSettings
 } from './local-storage-cache';
 
@@ -40,7 +42,7 @@ export interface LocalStorageSourceSettings extends SourceSettings {
 @pullable
 @pushable
 @syncable
-export default class LocalStorageSource extends Source
+export class LocalStorageSource extends Source
   implements Pullable, Pushable, Resettable, Syncable {
   protected _cache: LocalStorageCache;
 

--- a/packages/@orbit/local-storage/test/local-storage-source-test.ts
+++ b/packages/@orbit/local-storage/test/local-storage-source-test.ts
@@ -2,6 +2,7 @@ import {
   getRecordFromLocalStorage,
   isLocalStorageEmpty
 } from './support/local-storage';
+import { Orbit } from '@orbit/core';
 import {
   buildTransform,
   AddRecordOperation,
@@ -12,8 +13,7 @@ import {
   KeyMap,
   Transform
 } from '@orbit/data';
-import Orbit from '@orbit/core';
-import LocalStorageSource from '../src/local-storage-source';
+import { LocalStorageSource } from '../src/local-storage-source';
 
 const { module, test } = QUnit;
 

--- a/packages/@orbit/local-storage/test/support/local-storage.ts
+++ b/packages/@orbit/local-storage/test/support/local-storage.ts
@@ -1,6 +1,6 @@
-import Orbit from '@orbit/core';
-import LocalStorageSource from '../../src/index';
+import { Orbit } from '@orbit/core';
 import { Record } from '@orbit/data';
+import { LocalStorageSource } from '../../src/local-storage-source';
 
 export function getRecordFromLocalStorage(
   source: LocalStorageSource,

--- a/packages/@orbit/memory/src/index.ts
+++ b/packages/@orbit/memory/src/index.ts
@@ -1,15 +1,3 @@
-export {
-  default,
-  MemorySourceSettings,
-  MemorySourceMergeOptions
-} from './memory-source';
-export { default as MemoryCache, MemoryCacheSettings } from './memory-cache';
-
-// LEGACY EXPORTS
-export {
-  SyncOperationProcessorClass as OperationProcessorClass,
-  SyncOperationProcessor as OperationProcessor,
-  SyncCacheIntegrityProcessor as CacheIntegrityProcessor,
-  SyncSchemaConsistencyProcessor as SchemaConsistencyProcessor,
-  SyncSchemaValidationProcessor as SchemaValidationProcessor
-} from '@orbit/record-cache';
+export { MemorySource as default } from './memory-source';
+export * from './memory-source';
+export * from './memory-cache';

--- a/packages/@orbit/memory/src/memory-cache.ts
+++ b/packages/@orbit/memory/src/memory-cache.ts
@@ -18,7 +18,7 @@ export interface MemoryCacheSettings extends SyncRecordCacheSettings {
  * Because data is stored in immutable maps, this type of cache can be forked
  * efficiently.
  */
-export default class MemoryCache extends SyncRecordCache {
+export class MemoryCache extends SyncRecordCache {
   protected _records: Dict<ImmutableMap<string, Record>>;
   protected _inverseRelationships: Dict<
     ImmutableMap<string, RecordRelationshipIdentity[]>

--- a/packages/@orbit/memory/src/memory-source.ts
+++ b/packages/@orbit/memory/src/memory-source.ts
@@ -1,4 +1,5 @@
-import Orbit, {
+import { Orbit } from '@orbit/core';
+import {
   KeyMap,
   RecordOperation,
   Schema,
@@ -20,7 +21,7 @@ import Orbit, {
   RecordIdentity
 } from '@orbit/data';
 import { Dict } from '@orbit/utils';
-import MemoryCache, { MemoryCacheSettings } from './memory-cache';
+import { MemoryCache, MemoryCacheSettings } from './memory-cache';
 import { PatchResultData } from '@orbit/record-cache';
 
 const { assert } = Orbit;
@@ -39,7 +40,7 @@ export interface MemorySourceMergeOptions {
 @syncable
 @queryable
 @updatable
-export default class MemorySource extends Source
+export class MemorySource extends Source
   implements Syncable, Queryable, Updatable {
   private _cache: MemoryCache;
   private _base: MemorySource;

--- a/packages/@orbit/memory/test/memory-cache-test.ts
+++ b/packages/@orbit/memory/test/memory-cache-test.ts
@@ -8,7 +8,7 @@ import {
   recordsIncludeAll
 } from '@orbit/data';
 import { clone } from '@orbit/utils';
-import MemoryCache from '../src/memory-cache';
+import { MemoryCache } from '../src/memory-cache';
 import { arrayMembershipMatches } from './support/matchers';
 
 const { module, test } = QUnit;

--- a/packages/@orbit/memory/test/memory-source-test.ts
+++ b/packages/@orbit/memory/test/memory-source-test.ts
@@ -15,7 +15,7 @@ import {
   SyncCacheIntegrityProcessor,
   SyncSchemaConsistencyProcessor
 } from '@orbit/record-cache';
-import MemorySource from '../src/memory-source';
+import { MemorySource } from '../src/memory-source';
 
 const { module, test } = QUnit;
 

--- a/packages/@orbit/record-cache/src/async-record-cache.ts
+++ b/packages/@orbit/record-cache/src/async-record-cache.ts
@@ -1,4 +1,4 @@
-import Orbit, { evented, Evented, Listener } from '@orbit/core';
+import { Orbit, evented, Evented, Listener } from '@orbit/core';
 import { deepGet, Dict } from '@orbit/utils';
 import {
   KeyMap,
@@ -18,9 +18,9 @@ import {
   AsyncOperationProcessor,
   AsyncOperationProcessorClass
 } from './async-operation-processor';
-import AsyncCacheIntegrityProcessor from './operation-processors/async-cache-integrity-processor';
-import AsyncSchemaConsistencyProcessor from './operation-processors/async-schema-consistency-processor';
-import AsyncSchemaValidationProcessor from './operation-processors/async-schema-validation-processor';
+import { AsyncCacheIntegrityProcessor } from './operation-processors/async-cache-integrity-processor';
+import { AsyncSchemaConsistencyProcessor } from './operation-processors/async-schema-consistency-processor';
+import { AsyncSchemaValidationProcessor } from './operation-processors/async-schema-validation-processor';
 import {
   AsyncPatchOperators,
   AsyncPatchOperator

--- a/packages/@orbit/record-cache/src/index.ts
+++ b/packages/@orbit/record-cache/src/index.ts
@@ -19,9 +19,9 @@ export * from './operators/sync-patch-operators';
 export * from './operators/sync-query-operators';
 
 // Operation processors
-export { default as AsyncCacheIntegrityProcessor } from './operation-processors/async-cache-integrity-processor';
-export { default as AsyncSchemaConsistencyProcessor } from './operation-processors/async-schema-consistency-processor';
-export { default as AsyncSchemaValidationProcessor } from './operation-processors/async-schema-validation-processor';
-export { default as SyncCacheIntegrityProcessor } from './operation-processors/sync-cache-integrity-processor';
-export { default as SyncSchemaConsistencyProcessor } from './operation-processors/sync-schema-consistency-processor';
-export { default as SyncSchemaValidationProcessor } from './operation-processors/sync-schema-validation-processor';
+export * from './operation-processors/async-cache-integrity-processor';
+export * from './operation-processors/async-schema-consistency-processor';
+export * from './operation-processors/async-schema-validation-processor';
+export * from './operation-processors/sync-cache-integrity-processor';
+export * from './operation-processors/sync-schema-consistency-processor';
+export * from './operation-processors/sync-schema-validation-processor';

--- a/packages/@orbit/record-cache/src/live-query/live-query.ts
+++ b/packages/@orbit/record-cache/src/live-query/live-query.ts
@@ -1,4 +1,4 @@
-import Orbit, { Evented } from '@orbit/core';
+import { Orbit, Evented } from '@orbit/core';
 import {
   QueryExpression,
   FindRecord,

--- a/packages/@orbit/record-cache/src/operation-processors/async-cache-integrity-processor.ts
+++ b/packages/@orbit/record-cache/src/operation-processors/async-cache-integrity-processor.ts
@@ -15,7 +15,7 @@ import {
  * record. When a record is removed, any references to it can also be identified
  * and removed.
  */
-export default class AsyncCacheIntegrityProcessor extends AsyncOperationProcessor {
+export class AsyncCacheIntegrityProcessor extends AsyncOperationProcessor {
   async after(operation: RecordOperation): Promise<RecordOperation[]> {
     switch (operation.op) {
       case 'replaceRelatedRecord':

--- a/packages/@orbit/record-cache/src/operation-processors/async-schema-consistency-processor.ts
+++ b/packages/@orbit/record-cache/src/operation-processors/async-schema-consistency-processor.ts
@@ -15,7 +15,7 @@ import {
  * its associated schema. This includes maintenance of inverse and dependent
  * relationships.
  */
-export default class AsyncSchemaConsistencyProcessor extends AsyncOperationProcessor {
+export class AsyncSchemaConsistencyProcessor extends AsyncOperationProcessor {
   async after(operation: RecordOperation): Promise<RecordOperation[]> {
     switch (operation.op) {
       case 'addRecord':

--- a/packages/@orbit/record-cache/src/operation-processors/async-schema-validation-processor.ts
+++ b/packages/@orbit/record-cache/src/operation-processors/async-schema-validation-processor.ts
@@ -11,7 +11,7 @@ import { AsyncOperationProcessor } from '../async-operation-processor';
  * An operation processor that ensures that an operation is compatible with
  * its associated schema.
  */
-export default class AsyncSchemaValidationProcessor extends AsyncOperationProcessor {
+export class AsyncSchemaValidationProcessor extends AsyncOperationProcessor {
   async validate(operation: RecordOperation): Promise<void> {
     switch (operation.op) {
       case 'addRecord':

--- a/packages/@orbit/record-cache/src/operation-processors/sync-cache-integrity-processor.ts
+++ b/packages/@orbit/record-cache/src/operation-processors/sync-cache-integrity-processor.ts
@@ -15,7 +15,7 @@ import {
  * record. When a record is removed, any references to it can also be identified
  * and removed.
  */
-export default class SyncCacheIntegrityProcessor extends SyncOperationProcessor {
+export class SyncCacheIntegrityProcessor extends SyncOperationProcessor {
   after(operation: RecordOperation): RecordOperation[] {
     switch (operation.op) {
       case 'replaceRelatedRecord':

--- a/packages/@orbit/record-cache/src/operation-processors/sync-schema-consistency-processor.ts
+++ b/packages/@orbit/record-cache/src/operation-processors/sync-schema-consistency-processor.ts
@@ -15,7 +15,7 @@ import {
  * its associated schema. This includes maintenance of inverse and dependent
  * relationships.
  */
-export default class SyncSchemaConsistencyProcessor extends SyncOperationProcessor {
+export class SyncSchemaConsistencyProcessor extends SyncOperationProcessor {
   after(operation: RecordOperation): RecordOperation[] {
     switch (operation.op) {
       case 'addRecord':

--- a/packages/@orbit/record-cache/src/operation-processors/sync-schema-validation-processor.ts
+++ b/packages/@orbit/record-cache/src/operation-processors/sync-schema-validation-processor.ts
@@ -11,7 +11,7 @@ import { SyncOperationProcessor } from '../sync-operation-processor';
  * An operation processor that ensures that an operation is compatible with
  * its associated schema.
  */
-export default class SyncSchemaValidationProcessor extends SyncOperationProcessor {
+export class SyncSchemaValidationProcessor extends SyncOperationProcessor {
   validate(operation: RecordOperation) {
     switch (operation.op) {
       case 'addRecord':

--- a/packages/@orbit/record-cache/src/sync-record-cache.ts
+++ b/packages/@orbit/record-cache/src/sync-record-cache.ts
@@ -18,9 +18,9 @@ import {
   SyncOperationProcessor,
   SyncOperationProcessorClass
 } from './sync-operation-processor';
-import SyncCacheIntegrityProcessor from './operation-processors/sync-cache-integrity-processor';
-import SyncSchemaConsistencyProcessor from './operation-processors/sync-schema-consistency-processor';
-import SyncSchemaValidationProcessor from './operation-processors/sync-schema-validation-processor';
+import { SyncCacheIntegrityProcessor } from './operation-processors/sync-cache-integrity-processor';
+import { SyncSchemaConsistencyProcessor } from './operation-processors/sync-schema-consistency-processor';
+import { SyncSchemaValidationProcessor } from './operation-processors/sync-schema-validation-processor';
 import {
   SyncPatchOperators,
   SyncPatchOperator

--- a/packages/@orbit/record-cache/test/async-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/async-record-cache-test.ts
@@ -7,8 +7,8 @@ import {
   recordsInclude,
   recordsIncludeAll
 } from '@orbit/data';
-import AsyncSchemaValidationProcessor from '../src/operation-processors/async-schema-validation-processor';
-import Cache from './support/example-async-record-cache';
+import { AsyncSchemaValidationProcessor } from '../src/operation-processors/async-schema-validation-processor';
+import { ExampleAsyncRecordCache } from './support/example-async-record-cache';
 import { arrayMembershipMatches } from './support/matchers';
 
 const { module, test } = QUnit;
@@ -78,7 +78,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('it exists', async function (assert) {
-    const cache = new Cache({ schema });
+    const cache = new ExampleAsyncRecordCache({ schema });
 
     assert.ok(cache);
     assert.equal(
@@ -90,11 +90,11 @@ module('AsyncRecordCache', function (hooks) {
 
   test('it requires a schema', function (assert) {
     assert.expect(1);
-    assert.throws(() => new Cache({ schema: null }));
+    assert.throws(() => new ExampleAsyncRecordCache({ schema: null }));
   });
 
   test('can be assigned processors', async function (assert) {
-    let cache = new Cache({
+    let cache = new ExampleAsyncRecordCache({
       schema,
       processors: [AsyncSchemaValidationProcessor]
     });
@@ -102,14 +102,18 @@ module('AsyncRecordCache', function (hooks) {
 
     class FakeProcessor {}
     assert.throws(
-      () => (cache = new Cache({ schema, processors: [FakeProcessor as any] }))
+      () =>
+        (cache = new ExampleAsyncRecordCache({
+          schema,
+          processors: [FakeProcessor as any]
+        }))
     );
   });
 
   test('#patch sets data and #records retrieves it', async function (assert) {
     assert.expect(4);
 
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const earth = {
       type: 'planet',
@@ -143,7 +147,7 @@ module('AsyncRecordCache', function (hooks) {
   test('#patch can replace records', async function (assert) {
     assert.expect(5);
 
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const earth = {
       type: 'planet',
@@ -182,7 +186,7 @@ module('AsyncRecordCache', function (hooks) {
   test('#patch can replace keys', async function (assert) {
     assert.expect(4);
 
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const earth = { type: 'planet', id: '1' };
 
@@ -215,7 +219,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#patch updates the cache and returns arrays of primary data and inverse ops', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     let p1 = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
     let p2 = { type: 'planet', id: '2' };
@@ -239,7 +243,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#patch updates inverse hasOne relationship when a record with relationships unspecified is added - record added after', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -266,7 +270,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#patch updates inverse hasOne relationship when a record with relationships unspecified is added - record added before', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -293,7 +297,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#patch updates inverse hasMany relationship when a record with relationships unspecified is added - record added after', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const io: Record = {
       type: 'moon',
@@ -324,7 +328,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#patch updates inverse hasMany relationship when a record with relationships unspecified is added - record added before', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const io: Record = {
       type: 'moon',
@@ -355,7 +359,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#patch updates inverse hasOne relationship when a record with an empty relationship is added', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const io: Record = {
       type: 'moon',
@@ -387,7 +391,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#patch updates inverse hasMany relationship when a record with an empty relationship is added', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -419,7 +423,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#patch updates inverse hasMany polymorphic relationship', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const sun: Record = {
       type: 'star',
@@ -471,7 +475,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#patch updates inverse hasOne polymorphic relationship', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -517,7 +521,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#patch tracks refs and clears them from hasOne relationships when a referenced record is removed', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -580,7 +584,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#patch tracks refs and clears them from hasMany relationships when a referenced record is removed', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const io: Record = {
       type: 'moon',
@@ -661,7 +665,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test("#patch adds link to hasMany if record doesn't exist", async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     await cache.patch((t) =>
       t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
@@ -688,7 +692,7 @@ module('AsyncRecordCache', function (hooks) {
   test("#patch does not remove hasMany relationship if record doesn't exist", async function (assert) {
     assert.expect(1);
 
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     cache.on('patch', () => {
       assert.ok(false, 'no operations were applied');
@@ -711,7 +715,7 @@ module('AsyncRecordCache', function (hooks) {
   test("#patch adds hasOne if record doesn't exist", async function (assert) {
     assert.expect(2);
 
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const tb = cache.transformBuilder;
     const replacePlanet = tb.replaceRelatedRecord(
@@ -744,7 +748,7 @@ module('AsyncRecordCache', function (hooks) {
   test("#patch will add empty hasOne link if record doesn't exist", async function (assert) {
     assert.expect(2);
 
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const tb = cache.transformBuilder;
     const clearPlanet = tb.replaceRelatedRecord(
@@ -771,7 +775,7 @@ module('AsyncRecordCache', function (hooks) {
   test('#patch does not add link to hasMany if link already exists', async function (assert) {
     assert.expect(1);
 
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       id: 'p1',
@@ -796,7 +800,7 @@ module('AsyncRecordCache', function (hooks) {
   test("#patch does not remove relationship from hasMany if relationship doesn't exist", async function (assert) {
     assert.expect(1);
 
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       id: 'p1',
@@ -820,7 +824,7 @@ module('AsyncRecordCache', function (hooks) {
   test('#patch can add and remove to has-many relationship', async function (assert) {
     assert.expect(2);
 
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = { id: 'jupiter', type: 'planet' };
     await cache.patch((t) => t.addRecord(jupiter));
@@ -859,7 +863,7 @@ module('AsyncRecordCache', function (hooks) {
   test('#patch can add and clear has-one relationship', async function (assert) {
     assert.expect(2);
 
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = { id: 'jupiter', type: 'planet' };
     await cache.patch((t) => t.addRecord(jupiter));
@@ -896,7 +900,7 @@ module('AsyncRecordCache', function (hooks) {
   test('does not replace hasOne if relationship already exists', async function (assert) {
     assert.expect(1);
 
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const europa: Record = {
       id: 'm1',
@@ -921,7 +925,7 @@ module('AsyncRecordCache', function (hooks) {
   test("does not remove hasOne if relationship doesn't exist", async function (assert) {
     assert.expect(1);
 
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const europa: Record = {
       type: 'moon',
@@ -959,7 +963,7 @@ module('AsyncRecordCache', function (hooks) {
       }
     });
 
-    const cache = new Cache({ schema: hasOneSchema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema: hasOneSchema, keyMap });
 
     await cache.patch((t) => [
       t.addRecord({
@@ -1019,7 +1023,10 @@ module('AsyncRecordCache', function (hooks) {
       }
     });
 
-    const cache = new Cache({ schema: dependentSchema, keyMap });
+    const cache = new ExampleAsyncRecordCache({
+      schema: dependentSchema,
+      keyMap
+    });
 
     const jupiter: Record = {
       type: 'planet',
@@ -1077,7 +1084,10 @@ module('AsyncRecordCache', function (hooks) {
       }
     });
 
-    const cache = new Cache({ schema: dependentSchema, keyMap });
+    const cache = new ExampleAsyncRecordCache({
+      schema: dependentSchema,
+      keyMap
+    });
 
     const jupiter: Record = {
       type: 'planet',
@@ -1135,7 +1145,10 @@ module('AsyncRecordCache', function (hooks) {
       }
     });
 
-    const cache = new Cache({ schema: dependentSchema, keyMap });
+    const cache = new ExampleAsyncRecordCache({
+      schema: dependentSchema,
+      keyMap
+    });
 
     const jupiter: Record = {
       type: 'planet',
@@ -1178,7 +1191,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#patch merges records when "replacing" and will not stomp on attributes and relationships that are not replaced', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
     await cache.patch((t) => [
@@ -1240,7 +1253,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#patch can replace related records but only if they are different', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
     await cache.patch((t) => [
@@ -1313,7 +1326,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#patch merges records when updating and _will_ replace only specified attributes and relationships', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
     const earth: Record = {
@@ -1375,7 +1388,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#patch can update existing record with empty relationship', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
     let result = await cache.patch((t) => [
@@ -1433,7 +1446,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#patch will not overwrite an existing relationship with a missing relationship', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
     let result = await cache.patch((t) => [
@@ -1482,7 +1495,7 @@ module('AsyncRecordCache', function (hooks) {
   test('#patch allows replaceRelatedRecord to be called on a relationship with no inverse and to be followed up by removing the replaced record', async function (assert) {
     assert.expect(2);
 
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const star1 = {
       id: 'star1',
@@ -1548,7 +1561,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query can retrieve an individual record', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -1568,7 +1581,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query can retrieve multiple expressions', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -1600,7 +1613,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query can find records by type', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -1654,7 +1667,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query can find records by identities', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -1714,7 +1727,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query can perform a simple attribute filter by value equality', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -1770,7 +1783,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query can perform a simple attribute filter by value comparison (gt, lt, gte & lte)', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -1855,7 +1868,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query can perform relatedRecords filters with operators `equal`, `all`, `some` and `none`', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -2039,7 +2052,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query can perform relatedRecord filters', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -2195,7 +2208,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query can perform a complex attribute filter by value', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -2256,7 +2269,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query can perform a filter on attributes, even when a particular record has none', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = { type: 'planet', id: 'jupiter' };
     const earth: Record = {
@@ -2309,7 +2322,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query can sort by an attribute', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -2362,7 +2375,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query can sort by an attribute, even when a particular record has none', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = { type: 'planet', id: 'jupiter' };
     const earth: Record = {
@@ -2407,7 +2420,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query can filter and sort by attributes', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -2468,7 +2481,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query can sort by an attribute in descending order', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -2521,7 +2534,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query can sort by according to multiple criteria', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -2576,7 +2589,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query - findRecord - finds record', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       id: 'jupiter',
@@ -2594,7 +2607,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test("#query - findRecord - throws RecordNotFoundException if record doesn't exist", async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     try {
       await cache.query((q) => q.findRecord({ type: 'planet', id: 'jupiter' }));
@@ -2604,7 +2617,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query - findRecords - finds matching records', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       id: 'jupiter',
@@ -2628,7 +2641,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query - page - can paginate records by offset and limit', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       id: 'jupiter',
@@ -2682,7 +2695,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       id: 'jupiter',
@@ -2709,7 +2722,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords - returns empty array if there are no related records', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       id: 'jupiter',
@@ -2728,7 +2741,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test("#query - findRelatedRecords - throws RecordNotFoundException if primary record doesn't exist", async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     try {
       await cache.query((q) =>
@@ -2740,7 +2753,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecord', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       id: 'jupiter',
@@ -2767,7 +2780,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecord - return null if no related record is found', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const callisto: Record = {
       id: 'callisto',
@@ -2786,7 +2799,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test("#query - findRelatedRecord - throws RecordNotFoundException if primary record doesn't exist", async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     try {
       await cache.query((q) =>
@@ -2798,7 +2811,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords can perform a simple attribute filter by value equality', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const sun: Record = {
       type: 'star',
@@ -2876,7 +2889,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords - can perform a simple attribute filter by value comparison (gt, lt, gte & lte)', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const sun: Record = {
       type: 'star',
@@ -2984,7 +2997,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords - can perform relatedRecords filters with operators `equal`, `all`, `some` and `none`', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const sun: Record = {
       type: 'star',
@@ -3190,7 +3203,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords - can perform relatedRecord filters', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const sun: Record = {
       type: 'star',
@@ -3403,7 +3416,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords - can perform a complex attribute filter by value', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const sun: Record = {
       type: 'star',
@@ -3484,7 +3497,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords - can perform a filter on attributes, even when a particular record has none', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const sun: Record = {
       type: 'star',
@@ -3560,7 +3573,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords - can sort by an attribute', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const sun: Record = {
       type: 'star',
@@ -3635,7 +3648,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords - can sort by an attribute, even when a particular record has none', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const sun: Record = {
       type: 'star',
@@ -3701,7 +3714,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords - can filter and sort by attributes', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const sun: Record = {
       type: 'star',
@@ -3782,7 +3795,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords - can sort by an attribute in descending order', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const sun: Record = {
       type: 'star',
@@ -3857,7 +3870,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords - can sort by according to multiple criteria', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const sun: Record = {
       type: 'star',
@@ -3934,7 +3947,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords - page - can paginate records by offset and limit', async function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const sun: Record = {
       type: 'star',
@@ -4016,7 +4029,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#liveQuery', async function (assert) {
-    let cache = new Cache({ schema, keyMap });
+    let cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       id: 'jupiter',
@@ -4250,7 +4263,7 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#liveQuery findRecords (debounce)', async function (assert) {
-    let cache = new Cache({ schema, keyMap });
+    let cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
     const planets: Record[] = [
       {
@@ -4288,7 +4301,11 @@ module('AsyncRecordCache', function (hooks) {
   });
 
   test('#liveQuery findRecords (no debounce)', async function (assert) {
-    let cache = new Cache({ schema, keyMap, debounceLiveQueries: false });
+    let cache = new ExampleAsyncRecordCache({
+      schema,
+      keyMap,
+      debounceLiveQueries: false
+    });
 
     const planets: Record[] = [
       {

--- a/packages/@orbit/record-cache/test/operation-processors/cache-integrity-processor-test.ts
+++ b/packages/@orbit/record-cache/test/operation-processors/cache-integrity-processor-test.ts
@@ -9,14 +9,14 @@ import {
   RemoveRecordOperation,
   UpdateRecordOperation
 } from '@orbit/data';
-import SyncCacheIntegrityProcessor from '../../src/operation-processors/sync-cache-integrity-processor';
-import Cache from '../support/example-sync-record-cache';
+import { SyncCacheIntegrityProcessor } from '../../src/operation-processors/sync-cache-integrity-processor';
+import { ExampleSyncRecordCache } from '../support/example-sync-record-cache';
 
 const { module, test } = QUnit;
 
 module('CacheIntegrityProcessor', function (hooks) {
   let schema: Schema;
-  let cache: Cache;
+  let cache: ExampleSyncRecordCache;
   let processor: SyncCacheIntegrityProcessor;
 
   const schemaDefinition: SchemaSettings = {
@@ -66,7 +66,7 @@ module('CacheIntegrityProcessor', function (hooks) {
   hooks.beforeEach(function () {
     let keyMap = new KeyMap();
     schema = new Schema(schemaDefinition);
-    cache = new Cache({
+    cache = new ExampleSyncRecordCache({
       schema,
       keyMap,
       processors: [SyncCacheIntegrityProcessor]

--- a/packages/@orbit/record-cache/test/operation-processors/schema-consistency-processor-test.ts
+++ b/packages/@orbit/record-cache/test/operation-processors/schema-consistency-processor-test.ts
@@ -11,15 +11,15 @@ import {
   RemoveRecordOperation,
   UpdateRecordOperation
 } from '@orbit/data';
-import SyncCacheIntegrityProcessor from '../../src/operation-processors/sync-cache-integrity-processor';
-import SyncSchemaConsistencyProcessor from '../../src/operation-processors/sync-schema-consistency-processor';
-import Cache from '../support/example-sync-record-cache';
+import { SyncCacheIntegrityProcessor } from '../../src/operation-processors/sync-cache-integrity-processor';
+import { SyncSchemaConsistencyProcessor } from '../../src/operation-processors/sync-schema-consistency-processor';
+import { ExampleSyncRecordCache } from '../support/example-sync-record-cache';
 
 const { module, test } = QUnit;
 
 module('SchemaConsistencyProcessor', function (hooks) {
   let schema: Schema;
-  let cache: Cache;
+  let cache: ExampleSyncRecordCache;
   let processor: SyncSchemaConsistencyProcessor;
 
   const schemaDefinition: SchemaSettings = {
@@ -62,7 +62,7 @@ module('SchemaConsistencyProcessor', function (hooks) {
   hooks.beforeEach(function () {
     let keyMap = new KeyMap();
     schema = new Schema(schemaDefinition);
-    cache = new Cache({
+    cache = new ExampleSyncRecordCache({
       schema,
       keyMap,
       processors: [SyncCacheIntegrityProcessor, SyncSchemaConsistencyProcessor]
@@ -1000,7 +1000,7 @@ module('SchemaConsistencyProcessor', function (hooks) {
     });
 
     const keyMap = new KeyMap();
-    const cache = new Cache({
+    const cache = new ExampleSyncRecordCache({
       schema,
       keyMap,
       processors: [SyncSchemaConsistencyProcessor]
@@ -1090,7 +1090,7 @@ module('SchemaConsistencyProcessor', function (hooks) {
     });
 
     const keyMap = new KeyMap();
-    const cache = new Cache({
+    const cache = new ExampleSyncRecordCache({
       schema,
       keyMap,
       processors: [SyncSchemaConsistencyProcessor]

--- a/packages/@orbit/record-cache/test/operation-processors/schema-validation-processor-test.ts
+++ b/packages/@orbit/record-cache/test/operation-processors/schema-validation-processor-test.ts
@@ -6,14 +6,14 @@ import {
   RelationshipNotFound,
   IncorrectRelatedRecordType
 } from '@orbit/data';
-import Cache from '../support/example-sync-record-cache';
-import SyncSchemaValidationProcessor from '../../src/operation-processors/sync-schema-validation-processor';
+import { ExampleSyncRecordCache } from '../support/example-sync-record-cache';
+import { SyncSchemaValidationProcessor } from '../../src/operation-processors/sync-schema-validation-processor';
 
 const { module, test } = QUnit;
 
 module('SchemaValidationProcessor', function (hooks) {
   let schema: Schema;
-  let cache: Cache;
+  let cache: ExampleSyncRecordCache;
 
   const schemaDefinition: SchemaSettings = {
     models: {
@@ -61,7 +61,7 @@ module('SchemaValidationProcessor', function (hooks) {
   hooks.beforeEach(function () {
     let keyMap = new KeyMap();
     schema = new Schema(schemaDefinition);
-    cache = new Cache({
+    cache = new ExampleSyncRecordCache({
       schema,
       keyMap,
       processors: [SyncSchemaValidationProcessor]

--- a/packages/@orbit/record-cache/test/support/example-async-record-cache.ts
+++ b/packages/@orbit/record-cache/test/support/example-async-record-cache.ts
@@ -10,7 +10,7 @@ import {
 /**
  * A minimal implementation of `AsyncRecordCache`.
  */
-export default class ExampleAsyncRecordCache extends AsyncRecordCache {
+export class ExampleAsyncRecordCache extends AsyncRecordCache {
   protected _records: Dict<Dict<Record>>;
   protected _inverseRelationships: Dict<Dict<RecordRelationshipIdentity[]>>;
 

--- a/packages/@orbit/record-cache/test/support/example-sync-record-cache.ts
+++ b/packages/@orbit/record-cache/test/support/example-sync-record-cache.ts
@@ -10,7 +10,7 @@ import {
 /**
  * A minimal implementation of `SyncRecordCache`.
  */
-export default class ExampleSyncRecordCache extends SyncRecordCache {
+export class ExampleSyncRecordCache extends SyncRecordCache {
   protected _records: Dict<Dict<Record>>;
   protected _inverseRelationships: Dict<Dict<RecordRelationshipIdentity[]>>;
 

--- a/packages/@orbit/record-cache/test/sync-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/sync-record-cache-test.ts
@@ -7,8 +7,8 @@ import {
   recordsIncludeAll,
   Record
 } from '@orbit/data';
-import SyncSchemaValidationProcessor from '../src/operation-processors/sync-schema-validation-processor';
-import Cache from './support/example-sync-record-cache';
+import { SyncSchemaValidationProcessor } from '../src/operation-processors/sync-schema-validation-processor';
+import { ExampleSyncRecordCache } from './support/example-sync-record-cache';
 import { arrayMembershipMatches } from './support/matchers';
 
 const { module, test } = QUnit;
@@ -78,7 +78,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('it exists', function (assert) {
-    const cache = new Cache({ schema });
+    const cache = new ExampleSyncRecordCache({ schema });
 
     assert.ok(cache);
     assert.equal(
@@ -90,11 +90,11 @@ module('SyncRecordCache', function (hooks) {
 
   test('it requires a schema', function (assert) {
     assert.expect(1);
-    assert.throws(() => new Cache({ schema: null }));
+    assert.throws(() => new ExampleSyncRecordCache({ schema: null }));
   });
 
   test('can be assigned processors', function (assert) {
-    let cache = new Cache({
+    let cache = new ExampleSyncRecordCache({
       schema,
       processors: [SyncSchemaValidationProcessor]
     });
@@ -102,14 +102,18 @@ module('SyncRecordCache', function (hooks) {
 
     class FakeProcessor {}
     assert.throws(
-      () => (cache = new Cache({ schema, processors: [FakeProcessor as any] }))
+      () =>
+        (cache = new ExampleSyncRecordCache({
+          schema,
+          processors: [FakeProcessor as any]
+        }))
     );
   });
 
   test('#patch sets data and #records retrieves it', function (assert) {
     assert.expect(4);
 
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const earth: Record = {
       type: 'planet',
@@ -143,7 +147,7 @@ module('SyncRecordCache', function (hooks) {
   test('#patch can replace records', function (assert) {
     assert.expect(5);
 
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const earth: Record = {
       type: 'planet',
@@ -182,7 +186,7 @@ module('SyncRecordCache', function (hooks) {
   test('#patch can replace keys', function (assert) {
     assert.expect(4);
 
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const earth: Record = { type: 'planet', id: '1' };
 
@@ -215,7 +219,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#patch updates the cache and returns arrays of primary data and inverse ops', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     let p1 = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
     let p2 = { type: 'planet', id: '2' };
@@ -236,7 +240,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#patch updates inverse hasOne relationship when a record with relationships unspecified is added - record added after', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -262,7 +266,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#patch updates inverse hasOne relationship when a record with relationships unspecified is added - record added before', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -288,7 +292,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#patch updates inverse hasMany relationship when a record with relationships unspecified is added - record added after', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const io: Record = {
       type: 'moon',
@@ -318,7 +322,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#patch updates inverse hasMany relationship when a record with relationships unspecified is added - record added before', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const io: Record = {
       type: 'moon',
@@ -348,7 +352,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#patch updates inverse hasOne relationship when a record with an empty relationship is added', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const io: Record = {
       type: 'moon',
@@ -379,7 +383,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#patch updates inverse hasMany relationship when a record with an empty relationship is added', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -410,7 +414,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#patch updates inverse hasMany polymorphic relationship', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const sun: Record = {
       type: 'star',
@@ -460,7 +464,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#patch updates inverse hasOne polymorphic relationship', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -504,7 +508,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#patch tracks refs and clears them from hasOne relationships when a referenced record is removed', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -563,7 +567,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#patch tracks refs and clears them from hasMany relationships when a referenced record is removed', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const io: Record = {
       type: 'moon',
@@ -638,7 +642,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test("#patch adds link to hasMany if record doesn't exist", function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     cache.patch((t) =>
       t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
@@ -665,7 +669,7 @@ module('SyncRecordCache', function (hooks) {
   test("#patch does not remove hasMany relationship if record doesn't exist", function (assert) {
     assert.expect(1);
 
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     cache.on('patch', () => {
       assert.ok(false, 'no operations were applied');
@@ -688,7 +692,7 @@ module('SyncRecordCache', function (hooks) {
   test("#patch adds hasOne if record doesn't exist", function (assert) {
     assert.expect(2);
 
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const tb = cache.transformBuilder;
     const replacePlanet = tb.replaceRelatedRecord(
@@ -721,7 +725,7 @@ module('SyncRecordCache', function (hooks) {
   test("#patch will add empty hasOne link if record doesn't exist", function (assert) {
     assert.expect(2);
 
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const tb = cache.transformBuilder;
     const clearPlanet = tb.replaceRelatedRecord(
@@ -748,7 +752,7 @@ module('SyncRecordCache', function (hooks) {
   test('#patch does not add link to hasMany if link already exists', function (assert) {
     assert.expect(1);
 
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       id: 'p1',
@@ -773,7 +777,7 @@ module('SyncRecordCache', function (hooks) {
   test("#patch does not remove relationship from hasMany if relationship doesn't exist", function (assert) {
     assert.expect(1);
 
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       id: 'p1',
@@ -797,7 +801,7 @@ module('SyncRecordCache', function (hooks) {
   test('#patch can add and remove to has-many relationship', function (assert) {
     assert.expect(2);
 
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = { id: 'jupiter', type: 'planet' };
     cache.patch((t) => t.addRecord(jupiter));
@@ -830,7 +834,7 @@ module('SyncRecordCache', function (hooks) {
   test('#patch can add and clear has-one relationship', function (assert) {
     assert.expect(2);
 
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = { id: 'jupiter', type: 'planet' };
     cache.patch((t) => t.addRecord(jupiter));
@@ -867,7 +871,7 @@ module('SyncRecordCache', function (hooks) {
   test('does not replace hasOne if relationship already exists', function (assert) {
     assert.expect(1);
 
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const europa: Record = {
       id: 'm1',
@@ -892,7 +896,7 @@ module('SyncRecordCache', function (hooks) {
   test("does not remove hasOne if relationship doesn't exist", function (assert) {
     assert.expect(1);
 
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const europa: Record = {
       type: 'moon',
@@ -930,7 +934,7 @@ module('SyncRecordCache', function (hooks) {
       }
     });
 
-    const cache = new Cache({ schema: hasOneSchema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema: hasOneSchema, keyMap });
 
     cache.patch((t) => [
       t.addRecord({
@@ -989,7 +993,10 @@ module('SyncRecordCache', function (hooks) {
       }
     });
 
-    const cache = new Cache({ schema: dependentSchema, keyMap });
+    const cache = new ExampleSyncRecordCache({
+      schema: dependentSchema,
+      keyMap
+    });
 
     const jupiter: Record = {
       type: 'planet',
@@ -1047,7 +1054,10 @@ module('SyncRecordCache', function (hooks) {
       }
     });
 
-    const cache = new Cache({ schema: dependentSchema, keyMap });
+    const cache = new ExampleSyncRecordCache({
+      schema: dependentSchema,
+      keyMap
+    });
 
     const jupiter: Record = {
       type: 'planet',
@@ -1105,7 +1115,10 @@ module('SyncRecordCache', function (hooks) {
       }
     });
 
-    const cache = new Cache({ schema: dependentSchema, keyMap });
+    const cache = new ExampleSyncRecordCache({
+      schema: dependentSchema,
+      keyMap
+    });
 
     const jupiter: Record = {
       type: 'planet',
@@ -1150,7 +1163,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#patch merges records when "replacing" and will not stomp on attributes and relationships that are not replaced', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
     cache.patch((t) => [
@@ -1212,7 +1225,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#patch can replace related records but only if they are different', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
     cache.patch((t) => [
@@ -1285,7 +1298,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#patch merges records when "replacing" and _will_ replace specified attributes and relationships', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
     const earth: Record = {
@@ -1347,7 +1360,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#patch can update existing record with empty relationship', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
     let result = cache.patch((t) => [t.addRecord({ id: '1', type: 'planet' })]);
@@ -1403,7 +1416,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#patch will not overwrite an existing relationship with a missing relationship', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
     let result = cache.patch((t) => [
@@ -1452,7 +1465,7 @@ module('SyncRecordCache', function (hooks) {
   test('#patch allows replaceRelatedRecord to be called on a relationship with no inverse and to be followed up by removing the replaced record', function (assert) {
     assert.expect(2);
 
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const star1 = {
       id: 'star1',
@@ -1518,7 +1531,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query can retrieve an individual record', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -1538,7 +1551,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query can retrieve multiple expressions', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -1570,7 +1583,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query can find records by type', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -1624,7 +1637,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query can find records by identities', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -1684,7 +1697,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query can perform a simple attribute filter by value equality', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -1740,7 +1753,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query can perform a simple attribute filter by value comparison (gt, lt, gte & lte)', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -1824,7 +1837,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query can perform relatedRecords filters with operators `equal`, `all`, `some` and `none`', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -2008,7 +2021,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query can perform relatedRecord filters', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -2164,7 +2177,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query can perform a complex attribute filter by value', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -2225,7 +2238,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query can perform a filter on attributes, even when a particular record has none', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = { type: 'planet', id: 'jupiter' };
     const earth: Record = {
@@ -2278,7 +2291,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query can sort by an attribute', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -2331,7 +2344,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query can sort by an attribute, even when a particular record has none', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = { type: 'planet', id: 'jupiter' };
     const earth: Record = {
@@ -2376,7 +2389,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query can filter and sort by attributes', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -2437,7 +2450,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query can sort by an attribute in descending order', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -2490,7 +2503,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query can sort by according to multiple criteria', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -2545,7 +2558,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query - findRecord - finds record', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       id: 'jupiter',
@@ -2563,7 +2576,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test("#query - findRecord - throws RecordNotFoundException if record doesn't exist", function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     assert.throws(
       () => cache.query((q) => q.findRecord({ type: 'planet', id: 'jupiter' })),
@@ -2572,7 +2585,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query - findRecords - finds matching records', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       id: 'jupiter',
@@ -2597,7 +2610,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query - page - can paginate records by offset and limit', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       id: 'jupiter',
@@ -2651,7 +2664,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       id: 'jupiter',
@@ -2678,7 +2691,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords - returns empty array if there are no related records', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       id: 'jupiter',
@@ -2697,7 +2710,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test("#query - findRelatedRecords - throws RecordNotFoundException if primary record doesn't exist", function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     assert.throws(
       () =>
@@ -2709,7 +2722,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecord', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       id: 'jupiter',
@@ -2736,7 +2749,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecord - return null if no related record is found', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const callisto: Record = {
       id: 'callisto',
@@ -2755,7 +2768,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test("#query - findRelatedRecord - throws RecordNotFoundException if primary record doesn't exist", function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     assert.throws(
       () =>
@@ -2767,7 +2780,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords can perform a simple attribute filter by value equality', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const sun: Record = {
       type: 'star',
@@ -2845,7 +2858,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords - can perform a simple attribute filter by value comparison (gt, lt, gte & lte)', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const sun: Record = {
       type: 'star',
@@ -2953,7 +2966,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords - can perform relatedRecords filters with operators `equal`, `all`, `some` and `none`', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const sun: Record = {
       type: 'star',
@@ -3159,7 +3172,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords - can perform relatedRecord filters', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const sun: Record = {
       type: 'star',
@@ -3372,7 +3385,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords - can perform a complex attribute filter by value', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const sun: Record = {
       type: 'star',
@@ -3453,7 +3466,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords - can perform a filter on attributes, even when a particular record has none', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const sun: Record = {
       type: 'star',
@@ -3529,7 +3542,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords - can sort by an attribute', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const sun: Record = {
       type: 'star',
@@ -3604,7 +3617,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords - can sort by an attribute, even when a particular record has none', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const sun: Record = {
       type: 'star',
@@ -3670,7 +3683,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords - can filter and sort by attributes', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const sun: Record = {
       type: 'star',
@@ -3751,7 +3764,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords - can sort by an attribute in descending order', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const sun: Record = {
       type: 'star',
@@ -3826,7 +3839,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords - can sort by according to multiple criteria', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const sun: Record = {
       type: 'star',
@@ -3903,7 +3916,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#query - findRelatedRecords - page - can paginate records by offset and limit', function (assert) {
-    const cache = new Cache({ schema, keyMap });
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const sun: Record = {
       type: 'star',
@@ -3985,7 +3998,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#liveQuery', async function (assert) {
-    let cache = new Cache({ schema, keyMap });
+    let cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const jupiter: Record = {
       id: 'jupiter',
@@ -4211,7 +4224,7 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#liveQuery findRecords (debounce)', async function (assert) {
-    let cache = new Cache({ schema, keyMap });
+    let cache = new ExampleSyncRecordCache({ schema, keyMap });
 
     const planets: Record[] = [
       {
@@ -4249,7 +4262,11 @@ module('SyncRecordCache', function (hooks) {
   });
 
   test('#liveQuery findRecords (no debounce)', async function (assert) {
-    let cache = new Cache({ schema, keyMap, debounceLiveQueries: false });
+    let cache = new ExampleSyncRecordCache({
+      schema,
+      keyMap,
+      debounceLiveQueries: false
+    });
 
     const planets: Record[] = [
       {


### PR DESCRIPTION
Refactoring default module exports to named exports:
* streamlines re-exports at the package level
* makes module usage more consistent throughout

This is a non-breaking refactor that maintains the same default exports for packages (that already have one).