### PR TITLE
Expand exports in @orbit/jsonapi

### DIFF
--- a/packages/@orbit/jsonapi/src/index.ts
+++ b/packages/@orbit/jsonapi/src/index.ts
@@ -17,3 +17,5 @@ export * from './resource-operations';
 export * from './lib/exceptions';
 export * from './lib/jsonapi-request-options';
 export * from './lib/query-params';
+export * from './lib/query-requests';
+export * from './lib/transform-requests';

--- a/packages/@orbit/jsonapi/src/index.ts
+++ b/packages/@orbit/jsonapi/src/index.ts
@@ -1,5 +1,6 @@
 export { JSONAPISource as default } from './jsonapi-source';
 export * from './jsonapi-source';
+export * from './jsonapi-serializer';
 export * from './serializers/jsonapi-base-serializer';
 export * from './serializers/jsonapi-document-serializer';
 export * from './serializers/jsonapi-operation-serializer';

--- a/packages/@orbit/jsonapi/src/jsonapi-source.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-source.ts
@@ -293,7 +293,7 @@ export class JSONAPISource extends Source
     }
   }
 
-  private getQueryRequests(query: Query): QueryRequest[] {
+  protected getQueryRequests(query: Query): QueryRequest[] {
     const queryRequests = getQueryRequests(this.requestProcessor, query);
     if (
       this.maxRequestsPerQuery &&
@@ -307,13 +307,15 @@ export class JSONAPISource extends Source
     return queryRequests;
   }
 
-  private getQueryRequestProcessor(
+  protected getQueryRequestProcessor(
     request: QueryRequest
   ): QueryRequestProcessor {
     return QueryRequestProcessors[request.op];
   }
 
-  private getTransformRequests(transform: Transform): TransformRecordRequest[] {
+  protected getTransformRequests(
+    transform: Transform
+  ): TransformRecordRequest[] {
     const transformRequests = getTransformRequests(
       this.requestProcessor,
       transform
@@ -330,7 +332,7 @@ export class JSONAPISource extends Source
     return transformRequests;
   }
 
-  private getTransformRequestProcessor(
+  protected getTransformRequestProcessor(
     request: TransformRecordRequest
   ): TransformRequestProcessor {
     return TransformRequestProcessors[request.op];


### PR DESCRIPTION
This PR fixes an oversight in which the deprecated jsonapi-serializer module was no longer exported. This should be exported until it's removed in v0.18.

This PR also exposes methods on the `JSONAPISource` related to transform and query request processing, as well as the supporting lib modules, to allow for easier customization on a per-request level.