### PR TITLE
Improve flexibility of term handling when building queries and transforms

### DIFF
--- a/packages/@orbit/data/src/query.ts
+++ b/packages/@orbit/data/src/query.ts
@@ -2,7 +2,6 @@ import { Orbit } from '@orbit/core';
 import { QueryExpression } from './query-expression';
 import { QueryTerm } from './query-term';
 import { QueryBuilder } from './query-builder';
-import { isObject } from '@orbit/utils';
 import { RequestOptions } from './request';
 
 export type QueryBuilderFunc = (
@@ -59,19 +58,13 @@ export function buildQuery(
     } else if (Array.isArray(queryOrExpressions)) {
       expressions = [];
       for (let queryOrExpression of queryOrExpressions) {
-        if (queryOrExpression instanceof QueryTerm) {
-          expressions.push(queryOrExpression.toQueryExpression());
-        } else {
-          expressions.push(queryOrExpression);
-        }
+        expressions.push(toQueryExpression(queryOrExpression));
       }
       options = queryOptions;
     } else {
-      if (queryOrExpressions instanceof QueryTerm) {
-        expressions = [queryOrExpressions.toQueryExpression()];
-      } else {
-        expressions = [queryOrExpressions] as QueryExpression[];
-      }
+      expressions = [
+        toQueryExpression(queryOrExpressions as QueryExpression | QueryTerm)
+      ];
       options = queryOptions;
     }
 
@@ -85,6 +78,22 @@ export function buildQuery(
   }
 }
 
+function toQueryExpression(
+  expression: QueryExpression | QueryTerm
+): QueryExpression {
+  if (isQueryTerm(expression)) {
+    return expression.toQueryExpression();
+  } else {
+    return expression;
+  }
+}
+
+function isQueryTerm(
+  expression: QueryExpression | QueryTerm
+): expression is QueryTerm {
+  return typeof (expression as QueryTerm).toQueryExpression === 'function';
+}
+
 function isQuery(query: QueryOrExpressions): query is Query {
-  return isObject(query) && (query as any).expressions;
+  return Array.isArray((query as Query).expressions);
 }

--- a/packages/@orbit/data/src/transform.ts
+++ b/packages/@orbit/data/src/transform.ts
@@ -1,6 +1,5 @@
 /* eslint-disable valid-jsdoc */
 import { Orbit } from '@orbit/core';
-import { isObject } from '@orbit/utils';
 import { Operation } from './operation';
 import { OperationTerm } from './operation-term';
 import { TransformBuilder } from './transform-builder';
@@ -64,19 +63,13 @@ export function buildTransform(
     } else if (Array.isArray(transformOrOperations)) {
       operations = [];
       for (let transformOrOperation of transformOrOperations) {
-        if (transformOrOperation instanceof OperationTerm) {
-          operations.push(transformOrOperation.toOperation());
-        } else {
-          operations.push(transformOrOperation);
-        }
+        operations.push(toOperation(transformOrOperation));
       }
       options = transformOptions;
     } else {
-      if (transformOrOperations instanceof OperationTerm) {
-        operations = [transformOrOperations.toOperation()];
-      } else {
-        operations = [transformOrOperations as Operation];
-      }
+      operations = [
+        toOperation(transformOrOperations as Operation | OperationTerm)
+      ];
       options = transformOptions;
     }
 
@@ -86,6 +79,20 @@ export function buildTransform(
   }
 }
 
+function toOperation(operation: Operation | OperationTerm): Operation {
+  if (isOperationTerm(operation)) {
+    return operation.toOperation();
+  } else {
+    return operation;
+  }
+}
+
+function isOperationTerm(
+  operation: Operation | OperationTerm
+): operation is OperationTerm {
+  return typeof (operation as OperationTerm).toOperation === 'function';
+}
+
 function isTransform(transform: TransformOrOperations): transform is Transform {
-  return isObject(transform) && (transform as any).operations;
+  return Array.isArray((transform as Transform).operations);
 }

--- a/packages/@orbit/data/test/query-test.ts
+++ b/packages/@orbit/data/test/query-test.ts
@@ -25,7 +25,7 @@ module('buildQuery', function () {
     assert.ok(query.id, 'query has an id');
   });
 
-  test('can instantiate a query with an expression, options, and an id', function (assert) {
+  test('can instantiate a query with a single expression, options, and an id', function (assert) {
     let expression: FindRecords = {
       op: 'findRecords'
     };
@@ -36,6 +36,65 @@ module('buildQuery', function () {
     assert.strictEqual(
       query.expressions[0],
       expression,
+      'expression was populated'
+    );
+    assert.strictEqual(query.options, options, 'options was populated');
+  });
+
+  test('can instantiate a query with an array of expressions, options, and an id', function (assert) {
+    let expression: FindRecords = {
+      op: 'findRecords'
+    };
+    let expressions = [expression];
+    let options = { sources: { jsonapi: { include: 'comments' } } };
+    let query = buildQuery(expression, options, 'abc123');
+
+    assert.strictEqual(query.id, 'abc123', 'id was populated');
+    assert.deepEqual(
+      query.expressions,
+      expressions,
+      'expression was populated'
+    );
+    assert.strictEqual(query.options, options, 'options was populated');
+  });
+
+  test('can instantiate a query with a single query expression term, options, and an id', function (assert) {
+    let term1 = {
+      toQueryExpression: () => {
+        return { op: 'findRecords' };
+      }
+    } as QueryTerm;
+    let options = { sources: { jsonapi: { include: 'comments' } } };
+    let query = buildQuery(term1, options, 'abc123');
+
+    assert.strictEqual(query.id, 'abc123', 'id was populated');
+    assert.deepEqual(
+      query.expressions,
+      [{ op: 'findRecords' }],
+      'expression was populated'
+    );
+    assert.strictEqual(query.options, options, 'options was populated');
+  });
+
+  test('can instantiate a query with a single query expression term, options, and an id', function (assert) {
+    let term1 = {
+      toQueryExpression: () => {
+        return { op: 'findRecords' };
+      }
+    } as QueryTerm;
+    let term2 = {
+      toQueryExpression: () => {
+        return { op: 'findRecord' };
+      }
+    } as QueryTerm;
+    let expressions = [term1, term2];
+    let options = { sources: { jsonapi: { include: 'comments' } } };
+    let query = buildQuery(expressions, options, 'abc123');
+
+    assert.strictEqual(query.id, 'abc123', 'id was populated');
+    assert.deepEqual(
+      query.expressions,
+      [{ op: 'findRecords' }, { op: 'findRecord' }],
       'expression was populated'
     );
     assert.strictEqual(query.options, options, 'options was populated');

--- a/packages/@orbit/data/test/transform-test.ts
+++ b/packages/@orbit/data/test/transform-test.ts
@@ -1,6 +1,7 @@
 import { TransformBuilder } from '../src/transform-builder';
 import { buildTransform } from '../src/transform';
 import './test-helper';
+import { OperationTerm } from '../src/operation-term';
 
 const { module, test } = QUnit;
 
@@ -17,7 +18,23 @@ module('buildTransform', function () {
     assert.ok(transform.id, 'transform has an id');
   });
 
-  test('can instantiate a transform with operations, options, and an id', function (assert) {
+  test('can instantiate a transform with a single operation, options, and an id', function (assert) {
+    let operation = { op: 'addRecord' };
+    let options = { sources: { jsonapi: { include: 'comments' } } };
+    let id = 'abc123';
+
+    let transform = buildTransform([operation], options, id);
+
+    assert.strictEqual(transform.id, id, 'id was populated');
+    assert.deepEqual(
+      transform.operations,
+      [operation],
+      'operations was populated'
+    );
+    assert.strictEqual(transform.options, options, 'options was populated');
+  });
+
+  test('can instantiate a transform with an array of operations, options, and an id', function (assert) {
     let operations = [{ op: 'addRecord' }];
     let options = { sources: { jsonapi: { include: 'comments' } } };
     let id = 'abc123';
@@ -28,6 +45,52 @@ module('buildTransform', function () {
     assert.deepEqual(
       transform.operations,
       operations,
+      'operations was populated'
+    );
+    assert.strictEqual(transform.options, options, 'options was populated');
+  });
+
+  test('can instantiate a transform with a single operation term, options, and an id', function (assert) {
+    let term1 = {
+      toOperation: () => {
+        return { op: 'addRecord' };
+      }
+    } as OperationTerm;
+    let options = { sources: { jsonapi: { include: 'comments' } } };
+    let id = 'abc123';
+
+    let transform = buildTransform([term1], options, id);
+
+    assert.strictEqual(transform.id, id, 'id was populated');
+    assert.deepEqual(
+      transform.operations,
+      [{ op: 'addRecord' }],
+      'operations was populated'
+    );
+    assert.strictEqual(transform.options, options, 'options was populated');
+  });
+
+  test('can instantiate a transform with an array of operation terms, options, and an id', function (assert) {
+    let term1 = {
+      toOperation: () => {
+        return { op: 'addRecord' };
+      }
+    } as OperationTerm;
+    let term2 = {
+      toOperation: () => {
+        return { op: 'updateRecord' };
+      }
+    } as OperationTerm;
+    let operations = [term1, term2];
+    let options = { sources: { jsonapi: { include: 'comments' } } };
+    let id = 'abc123';
+
+    let transform = buildTransform(operations, options, id);
+
+    assert.strictEqual(transform.id, id, 'id was populated');
+    assert.deepEqual(
+      transform.operations,
+      [{ op: 'addRecord' }, { op: 'updateRecord' }],
       'operations was populated'
     );
     assert.strictEqual(transform.options, options, 'options was populated');


### PR DESCRIPTION
Instead of relying on an instanceof check, check for the presence of a coercion function.  `isQueryTerm` checks for `toQueryExpression`, while `isOperationTerm` checks for `toOperation`.

This allows for more flexibility in what is considered a "term" and is consistent with the strategy used by `isTransform` and `isQuery`.