### PR TITLE
[jsonapi] Register `object` and `array` types to use NoopSerializer by default

### DIFF
--- a/packages/@orbit/jsonapi/src/serializers/jsonapi-serializer-builder.ts
+++ b/packages/@orbit/jsonapi/src/serializers/jsonapi-serializer-builder.ts
@@ -32,6 +32,8 @@ export function buildJSONAPISerializerFor(settings: {
 
   const defaultSerializerClassFor = buildSerializerClassFor({
     unknown: NoopSerializer,
+    object: NoopSerializer,
+    array: NoopSerializer,
     boolean: BooleanSerializer,
     string: StringSerializer,
     date: DateSerializer,

--- a/packages/@orbit/jsonapi/test/serializers/jsonapi-resource-serializer-test.ts
+++ b/packages/@orbit/jsonapi/test/serializers/jsonapi-resource-serializer-test.ts
@@ -18,7 +18,9 @@ module('JSONAPIResourceSerializer', function (hooks) {
         attributes: {
           name: { type: 'string' },
           classification: { type: 'string' },
-          mystery: {}
+          mystery: {}, // an example of the 'unknown' type
+          object1: { type: 'object' }, // an example of the 'object' type
+          array1: { type: 'array' } // an example of the 'array' type
         },
         relationships: {
           moons: { kind: 'hasMany', type: 'moon', inverse: 'planet' },
@@ -96,6 +98,32 @@ module('JSONAPIResourceSerializer', function (hooks) {
               mystery: {
                 whatDoWeHaveHere: 234
               }
+            }
+          },
+          'serialized resource matches'
+        );
+      });
+
+      test('#serialize - serializes attributes with `object` and `array` types with NoopSerializer by default', function (assert) {
+        assert.deepEqual(
+          serializer.serialize({
+            type: 'planet',
+            id: '123',
+            attributes: {
+              object1: {
+                whatDoWeHaveHere: 234
+              },
+              array1: ['a', 'b', 'c']
+            }
+          }),
+          {
+            type: 'planet',
+            id: '123',
+            attributes: {
+              object1: {
+                whatDoWeHaveHere: 234
+              },
+              array1: ['a', 'b', 'c']
             }
           },
           'serialized resource matches'


### PR DESCRIPTION
These types are often used for attributes with the expectation that they will be passed through "as-is". Registering them with this expectation should smooth over the transition to the new serializers.