### PR TITLE
Introduce UninitializedRecord interface, with optional `id`

### DIFF
--- a/packages/@orbit/data/src/record.ts
+++ b/packages/@orbit/data/src/record.ts
@@ -28,7 +28,7 @@ export type RecordRelationship =
   | RecordHasOneRelationship
   | RecordHasManyRelationship;
 
-export interface Record extends RecordIdentity {
+export interface RecordFields {
   keys?: Dict<string>;
   attributes?: Dict<any>;
   relationships?: Dict<RecordRelationship>;
@@ -36,8 +36,15 @@ export interface Record extends RecordIdentity {
   meta?: Dict<any>;
 }
 
+export interface Record extends RecordFields, RecordIdentity {}
+
+export interface UninitializedRecord extends RecordFields {
+  type: string;
+  id?: string;
+}
+
 export interface RecordInitializer {
-  initializeRecord(record: Record): void;
+  initializeRecord(record: UninitializedRecord): Record;
 }
 
 export function cloneRecordIdentity(identity: RecordIdentity): RecordIdentity {

--- a/packages/@orbit/data/src/schema.ts
+++ b/packages/@orbit/data/src/schema.ts
@@ -3,7 +3,7 @@ import { Orbit } from '@orbit/core';
 import { ModelNotFound } from './exception';
 import { Dict } from '@orbit/utils';
 import { evented, Evented, Listener } from '@orbit/core';
-import { Record, RecordInitializer } from './record';
+import { Record, RecordInitializer, UninitializedRecord } from './record';
 
 const { uuid, deprecate } = Orbit;
 
@@ -189,10 +189,11 @@ export class Schema implements Evented, RecordInitializer {
     }
   }
 
-  initializeRecord(record: Record): void {
+  initializeRecord(record: UninitializedRecord): Record {
     if (record.id === undefined) {
       record.id = this.generateId(record.type);
     }
+    return record as Record;
   }
 
   get models(): Dict<ModelDefinition> {


### PR DESCRIPTION
The new `UninitializedRecord` interface can be used when adding records with the `TransformBuilder`, which will transform them to full-fledged `Record`s via the `RecordInitializer`.

`RecordInitializer#initializeRecord` has been updated to be expected to return a `Record`, instead of just initializing the passed object. The old behavior is still supported but now deprecated.

These changes should clarify typings and eliminate the need to coerce new records (`as Record`) when adding them without an assigned `id`.