### PR TITLE
Remove includeSources request option

### DIFF
--- a/packages/@orbit/data/src/request.ts
+++ b/packages/@orbit/data/src/request.ts
@@ -2,7 +2,6 @@ import { Options } from './options';
 
 export interface RequestOptions extends Options {
   fullResponse?: true;
-  includeSources?: boolean | string[];
   sources?: { [name: string]: RequestOptions };
 }
 

--- a/packages/@orbit/data/src/response.ts
+++ b/packages/@orbit/data/src/response.ts
@@ -18,16 +18,25 @@ export type TransformsOrFullResponse<
   ? FullResponse<Data, Details, O>
   : Transform<O>[];
 
-export type NamedFullResponse<Data, Details, O extends Operation> = [
-  string,
-  FullResponse<Data, Details, O>
-];
+export type NamedFullResponse<
+  Data,
+  Details = unknown,
+  O extends Operation = Operation
+> = [string, FullResponse<Data, Details, O>];
 
-export interface NamedFullResponseMap<Data, Details, O extends Operation> {
+export interface NamedFullResponseMap<
+  Data,
+  Details = unknown,
+  O extends Operation = Operation
+> {
   [name: string]: FullResponse<Data, Details, O>;
 }
 
-export interface FullResponse<Data, Details, O extends Operation> {
+export interface FullResponse<
+  Data,
+  Details = unknown,
+  O extends Operation = Operation
+> {
   /**
    * Primary data for this response.
    */
@@ -60,13 +69,17 @@ export interface ResponseHints<Data, Details> {
   details?: Details;
 }
 
-export function mapNamedFullResponses<Data, Details, O extends Operation>(
+export function mapNamedFullResponses<
+  Data = unknown,
+  Details = unknown,
+  O extends Operation = Operation
+>(
   responses: (NamedFullResponse<Data, Details, O> | undefined)[]
 ): NamedFullResponseMap<Data, Details, O> {
   let map: NamedFullResponseMap<Data, Details, O> = {};
   for (let r of responses) {
-    if (r) {
-      map[r[0] as string] = r[1];
+    if (typeof r?.[0] === 'string' && r?.[1] !== undefined) {
+      map[r[0]] = r[1];
     }
   }
   return map;

--- a/packages/@orbit/data/src/source-interfaces/pullable.ts
+++ b/packages/@orbit/data/src/source-interfaces/pullable.ts
@@ -107,7 +107,6 @@ export function pullable(Klass: unknown): void {
     query: Query<QueryExpression>
   ): Promise<FullResponse<unknown, unknown, Operation>> {
     try {
-      const options = query.options || {};
       const hints: ResponseHints<unknown, unknown> = {};
       const otherResponses = (await fulfillInSeries(
         this,
@@ -116,10 +115,8 @@ export function pullable(Klass: unknown): void {
         hints
       )) as (NamedFullResponse<unknown, unknown, Operation> | undefined)[];
       const fullResponse = await this._pull(query, hints);
-      if (options.includeSources) {
-        fullResponse.sources = otherResponses
-          ? mapNamedFullResponses<unknown, unknown, Operation>(otherResponses)
-          : {};
+      if (otherResponses.length > 0) {
+        fullResponse.sources = mapNamedFullResponses(otherResponses);
       }
       if (fullResponse.transforms?.length > 0) {
         await this.transformed(fullResponse.transforms);

--- a/packages/@orbit/data/src/source-interfaces/pushable.ts
+++ b/packages/@orbit/data/src/source-interfaces/pushable.ts
@@ -124,7 +124,6 @@ export function pushable(Klass: unknown): void {
     }
 
     try {
-      const options = transform.options || {};
       const hints: ResponseHints<unknown, unknown> = {};
       const otherResponses = (await fulfillInSeries(
         this,
@@ -133,10 +132,8 @@ export function pushable(Klass: unknown): void {
         hints
       )) as (NamedFullResponse<unknown, unknown, Operation> | undefined)[];
       const fullResponse = await this._push(transform, hints);
-      if (options.includeSources) {
-        fullResponse.sources = otherResponses
-          ? mapNamedFullResponses<unknown, unknown, Operation>(otherResponses)
-          : {};
+      if (otherResponses.length > 0) {
+        fullResponse.sources = mapNamedFullResponses(otherResponses);
       }
       if (fullResponse.transforms?.length > 0) {
         await this.transformed(fullResponse.transforms);

--- a/packages/@orbit/data/src/source-interfaces/queryable.ts
+++ b/packages/@orbit/data/src/source-interfaces/queryable.ts
@@ -115,10 +115,8 @@ export function queryable(Klass: unknown): void {
         hints
       )) as (NamedFullResponse<unknown, unknown, Operation> | undefined)[];
       const fullResponse = await this._query(query, hints);
-      if (query.options?.includeSources) {
-        fullResponse.sources = otherResponses
-          ? mapNamedFullResponses<unknown, unknown, Operation>(otherResponses)
-          : {};
+      if (otherResponses.length > 0) {
+        fullResponse.sources = mapNamedFullResponses(otherResponses);
       }
       if (fullResponse.transforms?.length > 0) {
         await this.transformed(fullResponse.transforms);

--- a/packages/@orbit/data/src/source-interfaces/updatable.ts
+++ b/packages/@orbit/data/src/source-interfaces/updatable.ts
@@ -117,7 +117,6 @@ export function updatable(Klass: unknown): void {
     }
 
     try {
-      const options = transform.options || {};
       const hints: ResponseHints<unknown, unknown> = {};
       const otherResponses = (await fulfillInSeries(
         this,
@@ -126,10 +125,8 @@ export function updatable(Klass: unknown): void {
         hints
       )) as (NamedFullResponse<unknown, unknown, Operation> | undefined)[];
       const fullResponse = await this._update(transform, hints);
-      if (options.includeSources) {
-        fullResponse.sources = otherResponses
-          ? mapNamedFullResponses<unknown, unknown, Operation>(otherResponses)
-          : {};
+      if (otherResponses.length > 0) {
+        fullResponse.sources = mapNamedFullResponses(otherResponses);
       }
       if (fullResponse.transforms?.length > 0) {
         await this.transformed(fullResponse.transforms);


### PR DESCRIPTION
Removes the not-fully-implemented `includeSources` option from `RequestOptions`.

Other source responses, if returned in `beforeX` event handlers, will now always be included in full response objects. This simplifies the processing code and costs nothing in efficiency.