### PR TITLE
Improve usage of transform / query options

### DIFF
--- a/packages/@orbit/data/src/source.ts
+++ b/packages/@orbit/data/src/source.ts
@@ -161,10 +161,22 @@ export abstract class Source<
     return this._defaultQueryOptions;
   }
 
+  set defaultQueryOptions(
+    options: DefaultRequestOptions<QueryOptions> | undefined
+  ) {
+    this._defaultQueryOptions = options;
+  }
+
   get defaultTransformOptions():
     | DefaultRequestOptions<TransformOptions>
     | undefined {
     return this._defaultTransformOptions;
+  }
+
+  set defaultTransformOptions(
+    options: DefaultRequestOptions<TransformOptions> | undefined
+  ) {
+    this._defaultTransformOptions = options;
   }
 
   getQueryOptions(

--- a/packages/@orbit/data/test/source-test.ts
+++ b/packages/@orbit/data/test/source-test.ts
@@ -227,6 +227,38 @@ module('Source', function (hooks) {
     );
   });
 
+  test('`defaultQueryOptions` and `defaultTransformOptions` can be modified', function (assert) {
+    const defaultQueryOptions = {
+      maxRequests: 3
+    };
+
+    const defaultTransformOptions = {
+      maxRequests: 1
+    };
+
+    source = new MySource({ defaultQueryOptions, defaultTransformOptions });
+
+    source.defaultQueryOptions = {
+      ...source.defaultQueryOptions,
+      type: 'query'
+    };
+
+    assert.deepEqual(source.defaultQueryOptions, {
+      maxRequests: 3,
+      type: 'query'
+    });
+
+    source.defaultTransformOptions = {
+      ...source.defaultTransformOptions,
+      type: 'transform'
+    };
+
+    assert.deepEqual(source.defaultTransformOptions, {
+      maxRequests: 1,
+      type: 'transform'
+    });
+  });
+
   test('it can get query options that merge default, query, and expression options', function (assert) {
     const defaultQueryOptions = {
       foo: 'bar',

--- a/packages/@orbit/jsonapi/test/jsonapi-source-updatable-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-updatable-test.ts
@@ -778,7 +778,7 @@ module('JSONAPISource - updatable', function (hooks) {
       );
     });
 
-    test('#update - source can limit the number of allowed requests per transform with `maxRequestsPerTransform`', async function (assert) {
+    test('#update - source can limit the number of allowed requests per transform with `maxRequestsPerTransform` (deprecated)', async function (assert) {
       assert.expect(1);
 
       let planet1 = resourceSerializer.deserialize({
@@ -791,6 +791,35 @@ module('JSONAPISource - updatable', function (hooks) {
       }) as Record;
 
       source.maxRequestsPerTransform = 1;
+
+      try {
+        await source.update((t) => [
+          t.removeRecord(planet1),
+          t.removeRecord(planet2)
+        ]);
+      } catch (e) {
+        assert.ok(
+          e instanceof TransformNotAllowed,
+          'TransformNotAllowed thrown'
+        );
+      }
+    });
+
+    test('#update - source can limit the number of allowed requests per transform with `maxRequests` option', async function (assert) {
+      assert.expect(1);
+
+      let planet1 = resourceSerializer.deserialize({
+        type: 'planet',
+        id: '1'
+      }) as Record;
+      let planet2 = resourceSerializer.deserialize({
+        type: 'planet',
+        id: '2'
+      }) as Record;
+
+      source.defaultTransformOptions = {
+        maxRequests: 1
+      };
 
       try {
         await source.update((t) => [


### PR DESCRIPTION
* Allows `defaultQueryOptions` and `defaultTransformOptions` to be modified, even after source instantiation.

* JSONAPISource: Deprecates `maxRequestsPer[Query/Transform]` in favor of `default[Query/Transform]Options.maxRequests`. This allows `maxRequests` to be a general per-query/transform option which can have a default value, or be set as an option at the query/transform level.