### PR TITLE
JSONAPISource: Introduce parallelRequests option

### DIFF
--- a/packages/@orbit/integration-tests/test/support/jsonapi.ts
+++ b/packages/@orbit/integration-tests/test/support/jsonapi.ts
@@ -3,7 +3,7 @@ import { Orbit } from '@orbit/core';
 export function jsonapiResponse(
   _options: unknown,
   body?: unknown,
-  timeout?: number
+  delay?: number
 ): Promise<Response> {
   let options: any;
   let response: Response;
@@ -26,12 +26,12 @@ export function jsonapiResponse(
 
   // console.log('jsonapiResponse', body, options, response.headers.get('Content-Type'));
 
-  if (timeout) {
+  if (delay) {
     return new Promise((resolve: (response: Response) => void) => {
       let timer = Orbit.globals.setTimeout(() => {
         Orbit.globals.clearTimeout(timer);
         resolve(response);
-      }, timeout);
+      }, delay);
     });
   } else {
     return Promise.resolve(response);

--- a/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-test.ts
@@ -47,8 +47,6 @@ module('JSONAPISource', function (hooks) {
   });
 
   test('source has default settings', function (assert) {
-    assert.expect(2);
-
     let schema = new RecordSchema({} as RecordSchemaSettings);
     source = new JSONAPISource({ schema });
     assert.equal(source.name, 'jsonapi', 'name is set to default');
@@ -56,6 +54,18 @@ module('JSONAPISource', function (hooks) {
       source.requestProcessor.allowedContentTypes,
       ['application/vnd.api+json', 'application/json'],
       'allowedContentTypes are set to default'
+    );
+    assert.deepEqual(
+      source.defaultQueryOptions,
+      {
+        parallelRequests: true
+      },
+      'defaultQueryOptions matches expectation'
+    );
+    assert.deepEqual(
+      source.defaultTransformOptions,
+      {},
+      'defaultTransformOptions matches expectation'
     );
   });
 

--- a/packages/@orbit/jsonapi/test/support/jsonapi.ts
+++ b/packages/@orbit/jsonapi/test/support/jsonapi.ts
@@ -3,7 +3,7 @@ import { Orbit } from '@orbit/core';
 export async function jsonapiResponse(
   _options: unknown,
   body?: unknown,
-  timeout?: number
+  delay?: number
 ): Promise<Response> {
   let options: any;
   let response: Response;
@@ -26,12 +26,12 @@ export async function jsonapiResponse(
 
   // console.log('jsonapiResponse', body, options, response.headers.get('Content-Type'));
 
-  if (timeout) {
+  if (delay) {
     return new Promise((resolve: (response: Response) => void) => {
       let timer = Orbit.globals.setTimeout(() => {
         Orbit.globals.clearTimeout(timer);
         resolve(response);
-      }, timeout);
+      }, delay);
     });
   } else {
     return response;


### PR DESCRIPTION
The new `parallelRequests` request option affects whether multiple requests made as part of a single query or transform will be processed in series or parallel. This allows multiple fetch calls to be invoked simultaneously. Previously, all requests were made serially.

By default, `parallelRequests` is `true` for queries (via `defaultQueryOptions`). However, because there's often a dependency order between operations in a single transform, `parallelRequests` is not set for transforms (via `defaultTransformOptions`).

Like all default options, these can be overridden on a per-request basis.