### PR TITLE
Improve typings via separate interface definitions, overloaded methods, and more generics

### DIFF
--- a/packages/@orbit/core/src/bucket.ts
+++ b/packages/@orbit/core/src/bucket.ts
@@ -1,5 +1,4 @@
 import { evented, Evented } from './evented';
-import { Listener } from './notifier';
 
 /**
  * Settings used to instantiate and/or upgrade a `Bucket`.
@@ -26,6 +25,9 @@ export interface BucketSettings {
   version?: number;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface Bucket extends Evented<'upgrade'> {}
+
 /**
  * Buckets can persist state. The base `Bucket` class is abstract and should be
  * extended to create buckets with different persistence strategies.
@@ -40,17 +42,10 @@ export interface BucketSettings {
  * The upgrade process allows buckets to migrate their data between versions.
  */
 @evented
-export abstract class Bucket implements Evented {
+export abstract class Bucket {
   private _name?: string;
   private _namespace!: string;
   private _version!: number;
-
-  // Evented interface stubs
-  on!: (event: string, listener: Listener) => () => void;
-  off!: (event: string, listener?: Listener) => void;
-  one!: (event: string, listener: Listener) => () => void;
-  emit!: (event: string, ...args: any[]) => void;
-  listeners!: (event: string) => Listener[];
 
   constructor(settings: BucketSettings = {}) {
     if (settings.version === undefined) {

--- a/packages/@orbit/core/src/evented.ts
+++ b/packages/@orbit/core/src/evented.ts
@@ -22,12 +22,12 @@ export function isEvented(obj: unknown): boolean {
  * }
  * ```
  */
-export interface Evented {
-  on: (event: string, listener: Listener) => () => void;
-  off: (event: string, listener?: Listener) => void;
-  one: (event: string, listener: Listener) => () => void;
-  emit: (event: string, ...args: unknown[]) => void;
-  listeners: (event: string) => Listener[];
+export interface Evented<Event extends string = string> {
+  on: (event: Event, listener: Listener) => () => void;
+  off: (event: Event, listener?: Listener) => void;
+  one: (event: Event, listener: Listener) => () => void;
+  emit: (event: Event, ...args: unknown[]) => void;
+  listeners: (event: Event) => Listener[];
 }
 
 /**

--- a/packages/@orbit/core/src/log.ts
+++ b/packages/@orbit/core/src/log.ts
@@ -1,6 +1,5 @@
 import { Orbit } from './main';
 import { evented, Evented } from './evented';
-import { Listener } from './notifier';
 import { Bucket } from './bucket';
 import { NotLoggedException, OutOfRangeException } from './exception';
 
@@ -12,6 +11,10 @@ export interface LogOptions {
   bucket?: Bucket;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface Log
+  extends Evented<'append' | 'truncate' | 'rollback' | 'clear' | 'change'> {}
+
 /**
  * Logs track a series of unique events that have occurred. Each event is
  * tracked based on its unique id. The log only tracks the ids but currently
@@ -20,19 +23,12 @@ export interface LogOptions {
  * Logs can automatically be persisted by assigning them a bucket.
  */
 @evented
-export class Log implements Evented {
+export class Log {
   private _name?: string;
   private _bucket?: Bucket;
   private _data: string[] = [];
 
   public reified!: Promise<void>;
-
-  // Evented interface stubs
-  on!: (event: string, listener: Listener) => () => void;
-  off!: (event: string, listener?: Listener) => void;
-  one!: (event: string, listener: Listener) => () => void;
-  emit!: (event: string, ...args: any[]) => void;
-  listeners!: (event: string) => Listener[];
 
   constructor(options: LogOptions = {}) {
     this._name = options.name;

--- a/packages/@orbit/core/src/task-queue.ts
+++ b/packages/@orbit/core/src/task-queue.ts
@@ -3,7 +3,6 @@ import { Task, Performer } from './task';
 import { TaskProcessor } from './task-processor';
 import { Bucket } from './bucket';
 import { evented, Evented, settleInSeries } from './evented';
-import { Listener } from './notifier';
 
 const { assert } = Orbit;
 
@@ -39,6 +38,9 @@ export interface TaskQueueSettings {
   autoActivate?: boolean;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface TaskQueue extends Evented {}
+
 /**
  * `TaskQueue` is a FIFO queue of asynchronous tasks that should be
  * performed sequentially.
@@ -52,7 +54,7 @@ export interface TaskQueueSettings {
  * processing.
  */
 @evented
-export class TaskQueue implements Evented {
+export class TaskQueue {
   public autoProcess: boolean;
 
   private _performer: Performer;
@@ -65,13 +67,6 @@ export class TaskQueue implements Evented {
   private _resolve?: () => void;
   private _reject?: (e: Error) => void;
   private _reified!: Promise<void>;
-
-  // Evented interface stubs
-  on!: (event: string, listener: Listener) => () => void;
-  off!: (event: string, listener?: Listener) => void;
-  one!: (event: string, listener: Listener) => () => void;
-  emit!: (event: string, ...args: any[]) => void;
-  listeners!: (event: string) => Listener[];
 
   /**
    * Creates an instance of `TaskQueue`.

--- a/packages/@orbit/core/test/evented-test.ts
+++ b/packages/@orbit/core/test/evented-test.ts
@@ -22,14 +22,11 @@ function failedOperation() {
 }
 
 module('Evented', function (hooks) {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface Foo extends Evented {}
+
   @evented
-  class Foo implements Evented {
-    on!: (event: string, listener: Listener) => () => void;
-    off!: (event: string, listener?: Listener) => void;
-    one!: (event: string, listener: Listener) => () => void;
-    emit!: (event: string, ...args: any[]) => void;
-    listeners!: (event: string) => Listener[];
-  }
+  class Foo {}
 
   let obj: Foo;
 

--- a/packages/@orbit/data/src/request.ts
+++ b/packages/@orbit/data/src/request.ts
@@ -1,18 +1,17 @@
 import { Options } from './options';
 
 export interface RequestOptions extends Options {
-  fullResponse?: true;
+  fullResponse?: boolean;
   sources?: { [name: string]: RequestOptions };
 }
 
-export type DefaultRequestOptions<RO extends RequestOptions> = Exclude<
-  RO,
-  'fullResponse'
->;
+export type DefaultRequestOptions<RO extends RequestOptions> = RO & {
+  fullResponse?: false;
+};
 
-export interface FullRequestOptions extends RequestOptions {
+export type FullRequestOptions<RO extends RequestOptions> = RO & {
   fullResponse: true;
-}
+};
 
 /**
  * Merges general request options with those specific to a source. The more

--- a/packages/@orbit/data/src/response.ts
+++ b/packages/@orbit/data/src/response.ts
@@ -1,22 +1,5 @@
 import { Operation } from './operation';
-import { FullRequestOptions, RequestOptions } from './request';
 import { Transform } from './transform';
-
-export type DataOrFullResponse<
-  Data,
-  Details,
-  O extends Operation,
-  RO extends RequestOptions
-> = RO extends FullRequestOptions ? FullResponse<Data, Details, O> : Data;
-
-export type TransformsOrFullResponse<
-  Data,
-  Details,
-  O extends Operation,
-  RO extends RequestOptions
-> = RO extends FullRequestOptions
-  ? FullResponse<Data, Details, O>
-  : Transform<O>[];
 
 export type NamedFullResponse<
   Data,

--- a/packages/@orbit/data/src/source.ts
+++ b/packages/@orbit/data/src/source.ts
@@ -8,7 +8,6 @@ import {
   TaskQueueSettings,
   Task,
   Performer,
-  Listener,
   Log
 } from '@orbit/core';
 import { Operation } from './operation';
@@ -52,6 +51,8 @@ export type SourceClass<
   TransformBuilder
 >;
 
+export interface Source extends Evented, Performer {}
+
 /**
  * Base class for sources.
  */
@@ -61,7 +62,7 @@ export abstract class Source<
   TransformOptions extends RequestOptions = RequestOptions,
   QueryBuilder = unknown,
   TransformBuilder = unknown
-> implements Evented, Performer {
+> {
   protected _name?: string;
   protected _bucket?: Bucket;
   protected _transformLog: Log;
@@ -72,13 +73,6 @@ export abstract class Source<
   protected _defaultQueryOptions?: DefaultRequestOptions<QueryOptions>;
   protected _defaultTransformOptions?: DefaultRequestOptions<TransformOptions>;
   private _activated?: Promise<void>;
-
-  // Evented interface stubs
-  on!: (event: string, listener: Listener) => () => void;
-  off!: (event: string, listener?: Listener) => void;
-  one!: (event: string, listener: Listener) => () => void;
-  emit!: (event: string, ...args: any[]) => void;
-  listeners!: (event: string) => Listener[];
 
   constructor(
     settings: SourceSettings<

--- a/packages/@orbit/data/test/source-interfaces/pullable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/pullable-test.ts
@@ -7,49 +7,33 @@ import {
   isPullable,
   Pullable
 } from '../../src/source-interfaces/pullable';
-import {
-  FullResponse,
-  ResponseHints,
-  TransformsOrFullResponse
-} from '../../src/response';
+import { FullResponse, ResponseHints } from '../../src/response';
 import {
   FindRecords,
   RecordResponse,
   RecordOperation,
   RecordQueryExpression,
   RecordQueryBuilder,
-  RecordData
+  RecordData,
+  UpdateRecordOperation
 } from '../support/record-data';
 
 const { module, test } = QUnit;
 
 module('@pullable', function (hooks) {
-  @pullable
-  class MySource
-    extends Source
-    implements
+  interface MySource
+    extends Source,
       Pullable<
         RecordData,
         RecordResponse,
         RecordOperation,
         RecordQueryExpression,
-        RecordQueryBuilder
-      > {
-    pull!: <RO extends RequestOptions>(
-      queryOrExpressions: QueryOrExpressions<
-        RecordQueryExpression,
-        RecordQueryBuilder
-      >,
-      options?: RO,
-      id?: string
-    ) => Promise<
-      TransformsOrFullResponse<RecordData, RecordResponse, RecordOperation, RO>
-    >;
+        RecordQueryBuilder,
+        RequestOptions
+      > {}
 
-    _pull!: (
-      query: Query<RecordQueryExpression>
-    ) => Promise<FullResponse<RecordData, RecordResponse, RecordOperation>>;
-  }
+  @pullable
+  class MySource extends Source {}
 
   let source: MySource;
 
@@ -136,7 +120,7 @@ module('@pullable', function (hooks) {
       assert.strictEqual(result, fullResponse, 'result matches');
     });
 
-    let result = await source.pull(qe);
+    let result = await source.pull<UpdateRecordOperation>(qe);
 
     assert.equal(++order, 3, 'promise resolved last');
     assert.strictEqual(result, fullResponse.transforms, 'success!');

--- a/packages/@orbit/data/test/source-interfaces/queryable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/queryable-test.ts
@@ -1,17 +1,14 @@
-import { Query, QueryOrExpressions } from '../../src/query';
+import { Query } from '../../src/query';
 import { Source } from '../../src/source';
 import { RequestOptions } from '../../src/request';
-import {
-  DataOrFullResponse,
-  FullResponse,
-  ResponseHints
-} from '../../src/response';
+import { ResponseHints } from '../../src/response';
 import {
   queryable,
   isQueryable,
   Queryable
 } from '../../src/source-interfaces/queryable';
 import {
+  Record,
   FindRecords,
   RecordData,
   RecordResponse,
@@ -23,33 +20,19 @@ import {
 const { module, test } = QUnit;
 
 module('@queryable', function (hooks) {
-  @queryable
-  class MySource
-    extends Source
-    implements
+  interface MySource
+    extends Source,
       Queryable<
         RecordData,
         RecordResponse,
         RecordOperation,
         RecordQueryExpression,
-        RecordQueryBuilder
-      > {
-    query!: <RO extends RequestOptions>(
-      queryOrExpressions: QueryOrExpressions<
-        RecordQueryExpression,
-        RecordQueryBuilder
-      >,
-      options?: RO,
-      id?: string
-    ) => Promise<
-      DataOrFullResponse<RecordData, RecordResponse, RecordOperation, RO>
-    >;
+        RecordQueryBuilder,
+        RequestOptions
+      > {}
 
-    _query!: (
-      query: Query<RecordQueryExpression>,
-      hints?: ResponseHints<RecordData, RecordResponse>
-    ) => Promise<FullResponse<RecordData, RecordResponse, RecordOperation>>;
-  }
+  @queryable
+  class MySource extends Source {}
 
   let source: MySource;
 
@@ -121,7 +104,7 @@ module('@queryable', function (hooks) {
       assert.strictEqual(result, fullResponse, 'result matches');
     });
 
-    let result = await source.query(qe);
+    let result = await source.query<Record[]>(qe);
 
     assert.equal(++order, 3, 'promise resolved last');
     assert.deepEqual(result, fullResponse.data, 'success!');
@@ -152,7 +135,7 @@ module('@queryable', function (hooks) {
       assert.equal(result, fullResponse, 'result matches');
     });
 
-    let result = await source.query(qe);
+    let result = await source.query<Record[]>(qe);
 
     assert.equal(++order, 3, 'promise resolved last');
     assert.equal(result, fullResponse.data, 'undefined result');

--- a/packages/@orbit/data/test/source-interfaces/updatable-test.ts
+++ b/packages/@orbit/data/test/source-interfaces/updatable-test.ts
@@ -1,21 +1,13 @@
-import {
-  buildTransform,
-  Transform,
-  TransformOrOperations
-} from '../../src/transform';
+import { buildTransform, Transform } from '../../src/transform';
 import { Source } from '../../src/source';
-import { RequestOptions } from '../../src/request';
+import { ResponseHints } from '../../src/response';
 import {
   updatable,
   isUpdatable,
   Updatable
 } from '../../src/source-interfaces/updatable';
 import {
-  DataOrFullResponse,
-  FullResponse,
-  ResponseHints
-} from '../../src/response';
-import {
+  Record,
   RecordData,
   RecordResponse,
   RecordOperation,
@@ -25,31 +17,17 @@ import {
 const { module, test } = QUnit;
 
 module('@updatable', function (hooks) {
-  @updatable
-  class MySource
-    extends Source
-    implements
+  interface MySource
+    extends Source,
       Updatable<
         RecordData,
         RecordResponse,
         RecordOperation,
         RecordTransformBuilder
-      > {
-    update!: <RO extends RequestOptions>(
-      transformOrOperations: TransformOrOperations<
-        RecordOperation,
-        RecordTransformBuilder
-      >,
-      options?: RO,
-      id?: string
-    ) => Promise<
-      DataOrFullResponse<RecordData, RecordResponse, RecordOperation, RO>
-    >;
-    _update!: (
-      transform: Transform<RecordOperation>,
-      hints?: ResponseHints<RecordData, RecordResponse>
-    ) => Promise<FullResponse<RecordData, RecordResponse, RecordOperation>>;
-  }
+      > {}
+
+  @updatable
+  class MySource extends Source {}
 
   let source: MySource;
 
@@ -103,12 +81,10 @@ module('@updatable', function (hooks) {
       op: 'addRecord',
       record: { type: 'planet', id: '1' }
     });
-    const result1 = [
-      {
-        type: 'planet',
-        id: 'p1'
-      }
-    ];
+    const result1 = {
+      type: 'planet',
+      id: 'p1'
+    };
     const fullResponse = { data: result1, transforms: [addRecordTransform] };
 
     source.on('beforeUpdate', (transform) => {
@@ -151,7 +127,7 @@ module('@updatable', function (hooks) {
       assert.deepEqual(result, fullResponse, 'result matches');
     });
 
-    let result = await source.update(addRecordTransform);
+    let result = await source.update<Record>(addRecordTransform);
 
     assert.equal(++order, 5, 'promise resolved last');
     assert.deepEqual(result, result1, 'success!');
@@ -552,7 +528,7 @@ module('@updatable', function (hooks) {
       assert.deepEqual(result, expectedResult, 'update: result matches');
     });
 
-    let result = await source.update(transform1, {
+    let result = await source.update<Record[]>(transform1, {
       fullResponse: true
     });
 

--- a/packages/@orbit/indexeddb/src/indexeddb-source.ts
+++ b/packages/@orbit/indexeddb/src/indexeddb-source.ts
@@ -5,11 +5,7 @@ import {
   pushable,
   Resettable,
   syncable,
-  QueryOrExpressions,
-  RequestOptions,
-  FullResponse,
-  TransformsOrFullResponse,
-  TransformOrOperations
+  FullResponse
 } from '@orbit/data';
 import {
   RecordOperation,
@@ -20,14 +16,8 @@ import {
   RecordPushable,
   RecordSyncable,
   RecordTransform,
-  RecordQueryExpression,
-  RecordQueryBuilder,
-  RecordTransformResult,
-  RecordTransformBuilder,
-  RecordQueryResult,
   RecordSource,
-  RecordQuery,
-  RecordSourceQueryOptions
+  RecordQuery
 } from '@orbit/records';
 import { supportsIndexedDB } from './lib/indexeddb';
 import { IndexedDBCache, IndexedDBCacheSettings } from './indexeddb-cache';
@@ -39,54 +29,21 @@ export interface IndexedDBSourceSettings extends RecordSourceSettings {
   cacheSettings?: Partial<IndexedDBCacheSettings>;
 }
 
+export interface IndexedDBSource
+  extends RecordSource,
+    RecordSyncable,
+    RecordPullable<unknown>,
+    RecordPushable<unknown>,
+    Resettable {}
+
 /**
  * Source for storing data in IndexedDB.
  */
 @pullable
 @pushable
 @syncable
-export class IndexedDBSource
-  extends RecordSource
-  implements
-    RecordSyncable,
-    RecordPullable<unknown>,
-    RecordPushable<unknown>,
-    Resettable {
+export class IndexedDBSource extends RecordSource {
   protected _cache: IndexedDBCache;
-
-  // Syncable interface stubs
-  sync!: (
-    transformOrTransforms: RecordTransform | RecordTransform[]
-  ) => Promise<void>;
-
-  // Pullable interface stubs
-  pull!: <RO extends RecordSourceQueryOptions>(
-    queryOrExpressions: QueryOrExpressions<
-      RecordQueryExpression,
-      RecordQueryBuilder
-    >,
-    options?: RO,
-    id?: string
-  ) => Promise<
-    TransformsOrFullResponse<RecordQueryResult, unknown, RecordOperation, RO>
-  >;
-
-  // Pushable interface stubs
-  push!: <RO extends RequestOptions>(
-    transformOrOperations: TransformOrOperations<
-      RecordOperation,
-      RecordTransformBuilder
-    >,
-    options?: RO,
-    id?: string
-  ) => Promise<
-    TransformsOrFullResponse<
-      RecordTransformResult,
-      unknown,
-      RecordOperation,
-      RO
-    >
-  >;
 
   constructor(settings: IndexedDBSourceSettings) {
     assert(

--- a/packages/@orbit/jsonapi/src/jsonapi-source.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-source.ts
@@ -1,30 +1,23 @@
 /* eslint-disable valid-jsdoc */
 import Orbit, { Assertion } from '@orbit/core';
 import {
-  QueryOrExpressions,
   RequestOptions,
   pullable,
   pushable,
-  TransformOrOperations,
   queryable,
   updatable,
   TransformNotAllowed,
   QueryNotAllowed,
-  FullResponse,
-  TransformsOrFullResponse,
-  DataOrFullResponse
+  FullResponse
 } from '@orbit/data';
 import {
   RecordSource,
   RecordSourceSettings,
-  RecordQueryExpression,
-  RecordQueryBuilder,
   RecordPullable,
   RecordPushable,
   RecordQueryable,
   RecordUpdatable,
   RecordOperation,
-  RecordTransformBuilder,
   RecordTransform,
   RecordQuery,
   RecordQueryExpressionResult,
@@ -116,6 +109,13 @@ export interface JSONAPISourceSettings
   ) => JSONAPIURLBuilder;
 }
 
+export interface JSONAPISource
+  extends RecordSource<JSONAPIQueryOptions, JSONAPITransformOptions>,
+    RecordPullable<JSONAPIResponse[]>,
+    RecordPushable<JSONAPIResponse[]>,
+    RecordQueryable<JSONAPIResponse[]>,
+    RecordUpdatable<JSONAPIResponse[]> {}
+
 /**
  Source for accessing a JSON API compliant RESTful API with a network fetch
  request.
@@ -134,72 +134,11 @@ export interface JSONAPISourceSettings
 @pushable
 @queryable
 @updatable
-export class JSONAPISource
-  extends RecordSource<JSONAPIQueryOptions, JSONAPITransformOptions>
-  implements
-    RecordPullable<JSONAPIResponse[]>,
-    RecordPushable<JSONAPIResponse[]>,
-    RecordQueryable<JSONAPIResponse[]>,
-    RecordUpdatable<JSONAPIResponse[]> {
+export class JSONAPISource extends RecordSource<
+  JSONAPIQueryOptions,
+  JSONAPITransformOptions
+> {
   requestProcessor: JSONAPIRequestProcessor;
-
-  // Pullable interface stubs
-  pull!: <RO extends RecordSourceQueryOptions>(
-    queryOrExpressions: QueryOrExpressions<
-      RecordQueryExpression,
-      RecordQueryBuilder
-    >,
-    options?: RO,
-    id?: string
-  ) => Promise<
-    TransformsOrFullResponse<undefined, JSONAPIResponse[], RecordOperation, RO>
-  >;
-
-  // Pushable interface stubs
-  push!: <RO extends RequestOptions>(
-    transformOrOperations: TransformOrOperations<
-      RecordOperation,
-      RecordTransformBuilder
-    >,
-    options?: RO,
-    id?: string
-  ) => Promise<
-    TransformsOrFullResponse<undefined, JSONAPIResponse[], RecordOperation, RO>
-  >;
-
-  // Queryable interface stubs
-  query!: <RO extends RecordSourceQueryOptions>(
-    queryOrExpressions: QueryOrExpressions<
-      RecordQueryExpression,
-      RecordQueryBuilder
-    >,
-    options?: RO,
-    id?: string
-  ) => Promise<
-    DataOrFullResponse<
-      RecordQueryResult,
-      JSONAPIResponse[],
-      RecordOperation,
-      RO
-    >
-  >;
-
-  // Updatable interface stubs
-  update!: <RO extends RequestOptions>(
-    transformOrOperations: TransformOrOperations<
-      RecordOperation,
-      RecordTransformBuilder
-    >,
-    options?: RO,
-    id?: string
-  ) => Promise<
-    DataOrFullResponse<
-      RecordTransformResult,
-      JSONAPIResponse[],
-      RecordOperation,
-      RO
-    >
-  >;
 
   constructor(settings: JSONAPISourceSettings) {
     settings.name = settings.name || 'jsonapi';

--- a/packages/@orbit/local-storage/src/local-storage-source.ts
+++ b/packages/@orbit/local-storage/src/local-storage-source.ts
@@ -5,11 +5,7 @@ import {
   pushable,
   Resettable,
   syncable,
-  QueryOrExpressions,
-  RequestOptions,
-  TransformOrOperations,
-  FullResponse,
-  TransformsOrFullResponse
+  FullResponse
 } from '@orbit/data';
 import {
   Record,
@@ -22,14 +18,8 @@ import {
   RecordPushable,
   RecordSyncable,
   RecordTransform,
-  RecordQueryExpression,
-  RecordQueryBuilder,
-  RecordTransformResult,
-  RecordTransformBuilder,
-  RecordQueryResult,
   RecordSource,
-  RecordQuery,
-  RecordSourceQueryOptions
+  RecordQuery
 } from '@orbit/records';
 import { supportsLocalStorage } from './lib/local-storage';
 import {
@@ -45,54 +35,21 @@ export interface LocalStorageSourceSettings extends RecordSourceSettings {
   cacheSettings?: Partial<LocalStorageCacheSettings>;
 }
 
+export interface LocalStorageSource
+  extends RecordSource,
+    RecordSyncable,
+    RecordPullable<unknown>,
+    RecordPushable<unknown>,
+    Resettable {}
+
 /**
  * Source for storing data in localStorage.
  */
 @pullable
 @pushable
 @syncable
-export class LocalStorageSource
-  extends RecordSource
-  implements
-    RecordSyncable,
-    RecordPullable<unknown>,
-    RecordPushable<unknown>,
-    Resettable {
+export class LocalStorageSource extends RecordSource {
   protected _cache: LocalStorageCache;
-
-  // Syncable interface stubs
-  sync!: (
-    transformOrTransforms: RecordTransform | RecordTransform[]
-  ) => Promise<void>;
-
-  // Pullable interface stubs
-  pull!: <RO extends RecordSourceQueryOptions>(
-    queryOrExpressions: QueryOrExpressions<
-      RecordQueryExpression,
-      RecordQueryBuilder
-    >,
-    options?: RO,
-    id?: string
-  ) => Promise<
-    TransformsOrFullResponse<RecordQueryResult, unknown, RecordOperation, RO>
-  >;
-
-  // Pushable interface stubs
-  push!: <RO extends RequestOptions>(
-    transformOrOperations: TransformOrOperations<
-      RecordOperation,
-      RecordTransformBuilder
-    >,
-    options?: RO,
-    id?: string
-  ) => Promise<
-    TransformsOrFullResponse<
-      RecordTransformResult,
-      unknown,
-      RecordOperation,
-      RO
-    >
-  >;
 
   constructor(settings: LocalStorageSourceSettings) {
     assert(

--- a/packages/@orbit/memory/src/memory-source.ts
+++ b/packages/@orbit/memory/src/memory-source.ts
@@ -8,24 +8,17 @@ import {
   RecordTransformResult,
   RecordSource,
   RecordSourceSettings,
-  RecordQueryBuilder,
-  RecordTransformBuilder,
-  RecordQueryExpression,
   RecordTransform,
   RecordQuery,
   RecordSyncable,
   RecordUpdatable,
-  RecordQueryable,
-  RecordSourceQueryOptions
+  RecordQueryable
 } from '@orbit/records';
 import {
-  DataOrFullResponse,
   syncable,
-  QueryOrExpressions,
   RequestOptions,
   queryable,
   updatable,
-  TransformOrOperations,
   buildTransform,
   FullResponse
 } from '@orbit/data';
@@ -44,49 +37,21 @@ export interface MemorySourceMergeOptions {
   transformOptions?: RequestOptions;
 }
 
+export interface MemorySource
+  extends RecordSource,
+    RecordSyncable,
+    RecordQueryable<unknown>,
+    RecordUpdatable<unknown> {}
+
 @syncable
 @queryable
 @updatable
-export class MemorySource
-  extends RecordSource
-  implements
-    RecordSyncable,
-    RecordUpdatable<unknown>,
-    RecordQueryable<unknown> {
+export class MemorySource extends RecordSource {
   private _cache: MemoryCache;
   private _base?: MemorySource;
   private _forkPoint?: string;
   private _transforms: Dict<RecordTransform>;
   private _transformInverses: Dict<RecordOperation[]>;
-
-  // Syncable interface stubs
-  sync!: (
-    transformOrTransforms: RecordTransform | RecordTransform[]
-  ) => Promise<void>;
-
-  // Queryable interface stubs
-  query!: <RO extends RecordSourceQueryOptions>(
-    queryOrExpressions: QueryOrExpressions<
-      RecordQueryExpression,
-      RecordQueryBuilder
-    >,
-    options?: RO,
-    id?: string
-  ) => Promise<
-    DataOrFullResponse<RecordQueryResult, unknown, RecordOperation, RO>
-  >;
-
-  // Updatable interface stubs
-  update!: <RO extends RequestOptions>(
-    transformOrOperations: TransformOrOperations<
-      RecordOperation,
-      RecordTransformBuilder
-    >,
-    options?: RO,
-    id?: string
-  ) => Promise<
-    DataOrFullResponse<RecordTransformResult, unknown, RecordOperation, RO>
-  >;
 
   constructor(settings: MemorySourceSettings) {
     const { keyMap, schema } = settings;

--- a/packages/@orbit/record-cache/src/async-record-cache.ts
+++ b/packages/@orbit/record-cache/src/async-record-cache.ts
@@ -3,7 +3,8 @@ import { deepGet, Dict } from '@orbit/utils';
 import {
   buildQuery,
   buildTransform,
-  DataOrFullResponse,
+  DefaultRequestOptions,
+  FullRequestOptions,
   FullResponse,
   OperationTerm,
   RequestOptions
@@ -175,12 +176,22 @@ export abstract class AsyncRecordCache<
   /**
    * Queries the cache.
    */
-  async query<RO extends RequestOptions>(
+  query<RequestData extends RecordQueryResult = RecordQueryResult>(
     queryOrExpressions: RecordQueryOrExpressions,
-    options?: RO,
+    options?: DefaultRequestOptions<QueryOptions>,
+    id?: string
+  ): Promise<RequestData>;
+  query<RequestData extends RecordQueryResult = RecordQueryResult>(
+    queryOrExpressions: RecordQueryOrExpressions,
+    options: FullRequestOptions<QueryOptions>,
+    id?: string
+  ): Promise<FullResponse<RequestData, undefined, RecordOperation>>;
+  async query<RequestData extends RecordQueryResult = RecordQueryResult>(
+    queryOrExpressions: RecordQueryOrExpressions,
+    options?: QueryOptions,
     id?: string
   ): Promise<
-    DataOrFullResponse<RecordQueryResult, undefined, RecordOperation, RO>
+    RequestData | FullResponse<RequestData, undefined, RecordOperation>
   > {
     const query = buildQuery(
       queryOrExpressions,
@@ -200,30 +211,37 @@ export abstract class AsyncRecordCache<
 
     const data = query.expressions.length === 1 ? results[0] : results;
 
-    const requestedResponse = options?.fullResponse ? { data } : data;
-
-    return requestedResponse as DataOrFullResponse<
-      RecordQueryResult,
-      undefined,
-      RecordOperation,
-      RO
-    >;
+    if (options?.fullResponse) {
+      return { data } as FullResponse<RequestData, undefined, RecordOperation>;
+    } else {
+      return data as RequestData;
+    }
   }
 
   /**
    * Updates the cache.
    */
-  async update<RO extends RequestOptions>(
+  update<RequestData extends RecordTransformResult = RecordTransformResult>(
     transformOrOperations: RecordTransformOrOperations,
-    options?: RO,
+    options?: DefaultRequestOptions<TransformOptions>,
+    id?: string
+  ): Promise<RequestData>;
+  update<RequestData extends RecordTransformResult = RecordTransformResult>(
+    transformOrOperations: RecordTransformOrOperations,
+    options: FullRequestOptions<TransformOptions>,
     id?: string
   ): Promise<
-    DataOrFullResponse<
-      RecordTransformResult,
-      RecordCacheUpdateDetails,
-      RecordOperation,
-      RO
-    >
+    FullResponse<RequestData, RecordCacheUpdateDetails, RecordOperation>
+  >;
+  async update<
+    RequestData extends RecordTransformResult = RecordTransformResult
+  >(
+    transformOrOperations: RecordTransformOrOperations,
+    options?: TransformOptions,
+    id?: string
+  ): Promise<
+    | RequestData
+    | FullResponse<RequestData, RecordCacheUpdateDetails, RecordOperation>
   > {
     const transform = buildTransform(
       transformOrOperations,
@@ -261,25 +279,16 @@ export abstract class AsyncRecordCache<
       data = response.data;
     }
 
-    let requestedResponse;
-
     if (options?.fullResponse) {
       response.details?.inverseOperations.reverse();
 
-      requestedResponse = {
+      return {
         ...response,
         data
-      };
+      } as FullResponse<RequestData, RecordCacheUpdateDetails, RecordOperation>;
     } else {
-      requestedResponse = data;
+      return data as RequestData;
     }
-
-    return requestedResponse as DataOrFullResponse<
-      RecordTransformResult,
-      RecordCacheUpdateDetails,
-      RecordOperation,
-      RO
-    >;
   }
 
   /**
@@ -299,13 +308,14 @@ export abstract class AsyncRecordCache<
       'AsyncRecordCache#patch has been deprecated. Use AsyncRecordCache#update instead.'
     );
 
-    const { data, details } = (await this.update(operationOrOperations, {
-      fullResponse: true
-    })) as FullResponse<
-      RecordTransformResult,
-      RecordCacheUpdateDetails,
-      RecordOperation
-    >;
+    // TODO - Why is this `this` cast necessary for TS to understand the correct
+    // method overload?
+    const { data, details } = await (this as AsyncRecordCache).update(
+      operationOrOperations,
+      {
+        fullResponse: true
+      }
+    );
 
     return {
       inverse: details?.inverseOperations || [],

--- a/packages/@orbit/record-cache/src/async-record-cache.ts
+++ b/packages/@orbit/record-cache/src/async-record-cache.ts
@@ -325,7 +325,7 @@ export abstract class AsyncRecordCache<
 
   liveQuery(
     queryOrExpressions: RecordQueryOrExpressions,
-    options?: RequestOptions,
+    options?: DefaultRequestOptions<QueryOptions>,
     id?: string
   ): AsyncLiveQuery {
     const query = buildQuery(

--- a/packages/@orbit/record-cache/src/live-query/async-live-query.ts
+++ b/packages/@orbit/record-cache/src/live-query/async-live-query.ts
@@ -16,7 +16,9 @@ export class AsyncLiveQueryUpdate {
     this._query = settings.query;
   }
 
-  query(): Promise<RecordQueryResult> {
+  query<Result extends RecordQueryResult = RecordQueryResult>(): Promise<
+    Result
+  > {
     return this._cache.query(this._query);
   }
 }
@@ -44,7 +46,9 @@ export class AsyncLiveQuery extends LiveQuery {
     this.cache = settings.cache;
   }
 
-  async query(): Promise<RecordQueryResult> {
+  query<Result extends RecordQueryResult = RecordQueryResult>(): Promise<
+    Result
+  > {
     return this._update.query();
   }
 

--- a/packages/@orbit/record-cache/src/live-query/sync-live-query.ts
+++ b/packages/@orbit/record-cache/src/live-query/sync-live-query.ts
@@ -16,7 +16,7 @@ export class SyncLiveQueryUpdate {
     this._query = settings.query;
   }
 
-  query(): RecordQueryResult {
+  query<Result extends RecordQueryResult = RecordQueryResult>(): Result {
     return this._cache.query(this._query);
   }
 }
@@ -44,8 +44,8 @@ export class SyncLiveQuery extends LiveQuery {
     this.cache = settings.cache;
   }
 
-  query(): RecordQueryResult {
-    return this._update.query();
+  query<Result extends RecordQueryResult = RecordQueryResult>(): Result {
+    return this._update.query<Result>();
   }
 
   subscribe(cb: (update: SyncLiveQueryUpdate) => void): () => void {

--- a/packages/@orbit/record-cache/src/record-cache.ts
+++ b/packages/@orbit/record-cache/src/record-cache.ts
@@ -1,4 +1,4 @@
-import Orbit, { evented, Evented, Listener } from '@orbit/core';
+import Orbit, { evented, Evented } from '@orbit/core';
 import {
   DefaultRequestOptions,
   RequestOptions,
@@ -33,11 +33,17 @@ export interface RecordCacheSettings<
   defaultTransformOptions?: DefaultRequestOptions<TransformOptions>;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface RecordCache<
+  QueryOptions extends RequestOptions = RecordCacheQueryOptions,
+  TransformOptions extends RequestOptions = RequestOptions
+> extends Evented {}
+
 @evented
 export abstract class RecordCache<
   QueryOptions extends RequestOptions = RecordCacheQueryOptions,
   TransformOptions extends RequestOptions = RequestOptions
-> implements Evented {
+> {
   protected _name?: string;
   protected _keyMap?: RecordKeyMap;
   protected _schema: RecordSchema;
@@ -45,13 +51,6 @@ export abstract class RecordCache<
   protected _queryBuilder: RecordQueryBuilder;
   protected _defaultQueryOptions?: DefaultRequestOptions<QueryOptions>;
   protected _defaultTransformOptions?: DefaultRequestOptions<TransformOptions>;
-
-  // Evented interface stubs
-  on!: (event: string, listener: Listener) => () => void;
-  off!: (event: string, listener?: Listener) => void;
-  one!: (event: string, listener: Listener) => () => void;
-  emit!: (event: string, ...args: any[]) => void;
-  listeners!: (event: string) => Listener[];
 
   constructor(settings: RecordCacheSettings<QueryOptions, TransformOptions>) {
     assert(

--- a/packages/@orbit/record-cache/src/sync-record-cache.ts
+++ b/packages/@orbit/record-cache/src/sync-record-cache.ts
@@ -312,7 +312,7 @@ export abstract class SyncRecordCache<
 
   liveQuery(
     queryOrExpressions: RecordQueryOrExpressions,
-    options?: RequestOptions,
+    options?: DefaultRequestOptions<QueryOptions>,
     id?: string
   ): SyncLiveQuery {
     const query = buildQuery(

--- a/packages/@orbit/record-cache/test/async-record-cache-query-test.ts
+++ b/packages/@orbit/record-cache/test/async-record-cache-query-test.ts
@@ -30,12 +30,17 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    await cache.update((t) => [t.addRecord(jupiter)]);
 
-    assert.deepEqual(
-      await cache.query((q) => q.findRecord({ type: 'planet', id: 'jupiter' })),
-      jupiter
+    const updatedRecord = await cache.update<Record>((t) => [
+      t.addRecord(jupiter)
+    ]);
+
+    const foundRecord = await cache.query<Record>((q) =>
+      q.findRecord({ type: 'planet', id: 'jupiter' })
     );
+
+    assert.strictEqual(updatedRecord, jupiter);
+    assert.strictEqual(foundRecord, jupiter);
   });
 
   test('#query can retrieve multiple expressions', async function (assert) {

--- a/packages/@orbit/record-cache/test/sync-record-cache-query-test.ts
+++ b/packages/@orbit/record-cache/test/sync-record-cache-query-test.ts
@@ -30,12 +30,15 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    cache.update((t) => [t.addRecord(jupiter)]);
 
-    assert.deepEqual(
-      cache.query((q) => q.findRecord({ type: 'planet', id: 'jupiter' })),
-      jupiter
+    const updatedRecord = cache.update<Record>((t) => [t.addRecord(jupiter)]);
+
+    const foundRecord = cache.query<Record>((q) =>
+      q.findRecord({ type: 'planet', id: 'jupiter' })
     );
+
+    assert.strictEqual(updatedRecord, jupiter);
+    assert.strictEqual(foundRecord, jupiter);
   });
 
   test('#query can retrieve multiple expressions', function (assert) {

--- a/packages/@orbit/records/src/record-schema.ts
+++ b/packages/@orbit/records/src/record-schema.ts
@@ -2,7 +2,7 @@
 import { Orbit } from '@orbit/core';
 import { ModelNotFound } from './record-exceptions';
 import { Dict } from '@orbit/utils';
-import { evented, Evented, Listener } from '@orbit/core';
+import { evented, Evented } from '@orbit/core';
 import { Record, RecordInitializer, UninitializedRecord } from './record';
 
 const { uuid, deprecate } = Orbit;
@@ -65,22 +65,21 @@ export interface RecordSchemaSettings {
   models?: Dict<ModelDefinition>;
 }
 
+export type RecordSchemaEvent = 'upgrade';
+
+export interface RecordSchema
+  extends Evented<RecordSchemaEvent>,
+    RecordInitializer {}
+
 /**
  * A `Schema` defines the models allowed in a source, including their keys,
  * attributes, and relationships. A single schema may be shared across multiple
  * sources.
  */
 @evented
-export class RecordSchema implements Evented, RecordInitializer {
+export class RecordSchema {
   private _models!: Dict<ModelDefinition>;
   private _version!: number;
-
-  // Evented interface stubs
-  on!: (event: string, listener: Listener) => () => void;
-  off!: (event: string, listener?: Listener) => void;
-  one!: (event: string, listener: Listener) => () => void;
-  emit!: (event: string, ...args: any[]) => void;
-  listeners!: (event: string) => Listener[];
 
   constructor(settings: RecordSchemaSettings = {}) {
     if (settings.version === undefined) {


### PR DESCRIPTION
* Simplify decorated classes by using separate interface definitions to avoid defining redundant stub methods
* Overload method definitions to avoid needing `DataOrFullResponse` and `TransformsOrFullResponse` interfaces
* Use generics to allow more refined typing of return values