### PR TITLE
Ensure that schema + source upgrades are reliably async

### DIFF
--- a/packages/@orbit/core/src/evented.ts
+++ b/packages/@orbit/core/src/evented.ts
@@ -168,6 +168,30 @@ export async function fulfillInSeries(
   return results;
 }
 
+/**
+ * Fulfills any promises returned by event listeners in parallel, using
+ * `Promise.all`.
+ *
+ * Returns an array of results (or `undefined`) returned by listeners.
+ *
+ * On error, processing will stop and the returned promise will be rejected with
+ * the error that was encountered.
+ */
+export async function fulfillAll(
+  obj: Evented,
+  eventName: string,
+  ...args: unknown[]
+): Promise<unknown[]> {
+  const listeners = obj.listeners(eventName);
+  const promises: Promise<unknown>[] = [];
+
+  for (let listener of listeners) {
+    promises.push(listener(...args));
+  }
+
+  return Promise.all(promises);
+}
+
 function notifierForEvent(
   object: any,
   eventName: string,

--- a/packages/@orbit/core/test/support/timing.ts
+++ b/packages/@orbit/core/test/support/timing.ts
@@ -1,0 +1,7 @@
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, ms);
+  });
+}

--- a/packages/@orbit/indexeddb/src/indexeddb-cache.ts
+++ b/packages/@orbit/indexeddb/src/indexeddb-cache.ts
@@ -54,6 +54,7 @@ export class IndexedDBCache extends AsyncRecordCache {
 
   async upgrade(): Promise<void> {
     await this.reopenDB();
+
     for (let processor of this._processors) {
       await processor.upgrade();
     }

--- a/packages/@orbit/indexeddb/src/indexeddb-source.ts
+++ b/packages/@orbit/indexeddb/src/indexeddb-source.ts
@@ -79,7 +79,7 @@ export class IndexedDBSource extends RecordSource {
   }
 
   async upgrade(): Promise<void> {
-    await this._cache.reopenDB();
+    await this._cache.upgrade();
   }
 
   protected async _activate(): Promise<void> {

--- a/packages/@orbit/local-storage/src/local-storage-cache.ts
+++ b/packages/@orbit/local-storage/src/local-storage-cache.ts
@@ -196,10 +196,14 @@ export class LocalStorageCache extends SyncRecordCache {
       }
     }
 
-    this._processors.forEach((processor) => processor.reset());
+    for (let processor of this._processors) {
+      processor.reset();
+    }
   }
 
   upgrade(): void {
-    this._processors.forEach((processor) => processor.upgrade());
+    for (let processor of this._processors) {
+      processor.upgrade();
+    }
   }
 }

--- a/packages/@orbit/local-storage/src/local-storage-source.ts
+++ b/packages/@orbit/local-storage/src/local-storage-source.ts
@@ -93,6 +93,10 @@ export class LocalStorageSource extends RecordSource {
     return this._cache.getKeyForRecord(record);
   }
 
+  async upgrade(): Promise<void> {
+    this._cache.upgrade();
+  }
+
   /////////////////////////////////////////////////////////////////////////////
   // Resettable interface implementation
   /////////////////////////////////////////////////////////////////////////////

--- a/packages/@orbit/memory/src/memory-cache.ts
+++ b/packages/@orbit/memory/src/memory-cache.ts
@@ -186,7 +186,10 @@ export class MemoryCache extends SyncRecordCache {
     });
 
     this._resetInverseRelationships();
-    this._processors.forEach((processor) => processor.upgrade());
+
+    for (let processor of this._processors) {
+      processor.upgrade();
+    }
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/packages/@orbit/memory/src/memory-source.ts
+++ b/packages/@orbit/memory/src/memory-source.ts
@@ -95,9 +95,8 @@ export class MemorySource extends RecordSource {
     return this._forkPoint;
   }
 
-  upgrade(): Promise<void> {
+  async upgrade(): Promise<void> {
     this._cache.upgrade();
-    return Promise.resolve();
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/packages/@orbit/records/src/record-schema.ts
+++ b/packages/@orbit/records/src/record-schema.ts
@@ -1,5 +1,5 @@
 /* eslint-disable valid-jsdoc */
-import { Orbit } from '@orbit/core';
+import { fulfillAll, Orbit } from '@orbit/core';
 import { ModelNotFound } from './record-exceptions';
 import { Dict } from '@orbit/utils';
 import { evented, Evented } from '@orbit/core';
@@ -105,12 +105,12 @@ export class RecordSchema {
    *
    * Emits the `upgrade` event to cue sources to upgrade their data.
    */
-  upgrade(settings: RecordSchemaSettings = {}): void {
+  async upgrade(settings: RecordSchemaSettings = {}): Promise<void> {
     if (settings.version === undefined) {
       settings.version = this._version + 1;
     }
     this._applySettings(settings);
-    this.emit('upgrade', this._version);
+    await fulfillAll(this as Evented, 'upgrade', this._version);
   }
 
   /**

--- a/packages/@orbit/records/src/record-source.ts
+++ b/packages/@orbit/records/src/record-source.ts
@@ -111,7 +111,7 @@ export abstract class RecordSource<
   /**
    * Upgrade source as part of a schema upgrade.
    */
-  upgrade(): Promise<void> {
-    return Promise.resolve();
+  async upgrade(): Promise<void> {
+    return;
   }
 }

--- a/packages/@orbit/records/test/support/timing.ts
+++ b/packages/@orbit/records/test/support/timing.ts
@@ -1,0 +1,7 @@
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, ms);
+  });
+}


### PR DESCRIPTION
The goal of this PR is to ensure that a call to `await schema.upgrade(settings)` will complete by the time all listeners (i.e. typically sources that share this schema) have completed their upgrades (which may occur async).

Listeners are invoked with a new `fulfillAll` method for `Evented` objects, which uses `Promise.all` to fulfill any promises that may be returned by listeners.

A cleanup pass was also made on sources to ensure that they all provide an async `upgrade` method.