### PR TITLE
Add publishConfig settings to package.json

### DIFF
--- a/packages/@orbit/build/package.json
+++ b/packages/@orbit/build/package.json
@@ -9,6 +9,9 @@
     "orbit",
     "orbit.js"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "dependencies": {

--- a/packages/@orbit/coordinator/package.json
+++ b/packages/@orbit/coordinator/package.json
@@ -11,6 +11,9 @@
     "data",
     "synchronization"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/packages/@orbit/core/package.json
+++ b/packages/@orbit/core/package.json
@@ -11,6 +11,9 @@
     "data",
     "synchronization"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/packages/@orbit/data/package.json
+++ b/packages/@orbit/data/package.json
@@ -11,6 +11,9 @@
     "data",
     "synchronization"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/packages/@orbit/identity-map/package.json
+++ b/packages/@orbit/identity-map/package.json
@@ -12,6 +12,9 @@
     "data",
     "synchronization"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/packages/@orbit/immutable/package.json
+++ b/packages/@orbit/immutable/package.json
@@ -10,6 +10,9 @@
     "orbit.js",
     "immutable"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/packages/@orbit/indexeddb-bucket/package.json
+++ b/packages/@orbit/indexeddb-bucket/package.json
@@ -10,6 +10,9 @@
     "orbit.js",
     "indexeddb"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/packages/@orbit/indexeddb/package.json
+++ b/packages/@orbit/indexeddb/package.json
@@ -10,6 +10,9 @@
     "orbit.js",
     "indexeddb"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/packages/@orbit/jsonapi/package.json
+++ b/packages/@orbit/jsonapi/package.json
@@ -13,6 +13,9 @@
     "API",
     "REST"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/packages/@orbit/local-storage-bucket/package.json
+++ b/packages/@orbit/local-storage-bucket/package.json
@@ -10,6 +10,9 @@
     "orbit.js",
     "local-storage"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/packages/@orbit/local-storage/package.json
+++ b/packages/@orbit/local-storage/package.json
@@ -10,6 +10,9 @@
     "orbit.js",
     "local-storage"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/packages/@orbit/memory/package.json
+++ b/packages/@orbit/memory/package.json
@@ -11,6 +11,9 @@
     "data",
     "synchronization"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/packages/@orbit/record-cache/package.json
+++ b/packages/@orbit/record-cache/package.json
@@ -11,6 +11,9 @@
     "data",
     "synchronization"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/packages/@orbit/records/package.json
+++ b/packages/@orbit/records/package.json
@@ -11,6 +11,9 @@
     "data",
     "synchronization"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/packages/@orbit/serializers/package.json
+++ b/packages/@orbit/serializers/package.json
@@ -11,6 +11,9 @@
     "data",
     "synchronization"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/packages/@orbit/utils/package.json
+++ b/packages/@orbit/utils/package.json
@@ -11,6 +11,9 @@
     "data",
     "synchronization"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": "https://github.com/orbitjs/orbit",
   "license": "MIT",
   "main": "dist/commonjs/index.js",


### PR DESCRIPTION
This setting should override the npm default private scope for publishing new org-scoped packages like `@orbit/records`.

See https://github.com/lerna/lerna/issues/1821#issuecomment-551393580