### PR TITLE
Ensure that query/transform options are shared between sources and their caches

### DIFF
--- a/packages/@orbit/indexeddb/test/indexeddb-source-test.ts
+++ b/packages/@orbit/indexeddb/test/indexeddb-source-test.ts
@@ -60,23 +60,17 @@ module('IndexedDBSource', function (hooks) {
     });
 
     keyMap = new RecordKeyMap();
-
-    source = new IndexedDBSource({ schema, keyMap });
-    await source.activated;
-  });
-
-  hooks.afterEach(async () => {
-    await source.deactivate();
-    await source.cache.deleteDB();
   });
 
   test('it exists', function (assert) {
+    source = new IndexedDBSource({ schema, keyMap, autoActivate: false });
     assert.ok(source);
     assert.strictEqual(source.schema, schema, 'schema has been assigned');
     assert.strictEqual(source.keyMap, keyMap, 'keyMap has been assigned');
   });
 
   test('is assigned a default dbName', function (assert) {
+    source = new IndexedDBSource({ schema, keyMap, autoActivate: false });
     assert.equal(
       source.cache.dbName,
       'orbit',
@@ -84,1184 +78,1279 @@ module('IndexedDBSource', function (hooks) {
     );
   });
 
-  test('will reopen the database when the schema is upgraded', async function (assert) {
-    assert.expect(5);
+  test('shares its `transformBuilder` and `queryBuilder` with its cache', function (assert) {
+    source = new IndexedDBSource({ schema, keyMap, autoActivate: false });
+    assert.strictEqual(
+      source.cache.transformBuilder,
+      source.transformBuilder,
+      'transformBuilder is shared'
+    );
+    assert.strictEqual(
+      source.cache.queryBuilder,
+      source.queryBuilder,
+      'queryBuilder is shared'
+    );
+  });
 
-    assert.equal(source.cache.dbVersion, 1, 'db starts with version == 1');
+  test('shares its `defaultTransformOptions` and `defaultQueryOptions` with its cache', function (assert) {
+    source = new IndexedDBSource({
+      schema,
+      keyMap,
+      autoActivate: false,
+      defaultQueryOptions: {
+        a: 1
+      },
+      defaultTransformOptions: {
+        b: 1
+      }
+    });
 
-    source.cache.migrateDB = function (db, event) {
-      assert.equal(
-        event.oldVersion,
-        1,
-        'migrateDB called with oldVersion == 1'
+    assert.strictEqual(
+      source.cache.defaultTransformOptions,
+      source.defaultTransformOptions,
+      'defaultTransformOptions are shared'
+    );
+    assert.strictEqual(
+      source.cache.defaultTransformOptions?.b,
+      1,
+      'cache.defaultTransformOptions are correct'
+    );
+    assert.strictEqual(
+      source.cache.defaultQueryOptions,
+      source.defaultQueryOptions,
+      'defaultQueryOptions are shared'
+    );
+    assert.strictEqual(
+      source.cache.defaultQueryOptions?.a,
+      1,
+      'cache.defaultQueryOptions are correct'
+    );
+
+    let newQueryOptions = {
+      a: 2
+    };
+    source.defaultQueryOptions = newQueryOptions;
+    assert.strictEqual(
+      source.defaultQueryOptions?.a,
+      2,
+      'defaultQueryOptions are correct'
+    );
+    assert.strictEqual(
+      source.cache.defaultQueryOptions,
+      source.defaultQueryOptions,
+      'updated defaultQueryOptions are shared'
+    );
+
+    let newTransformOptions = {
+      b: 2
+    };
+    source.defaultTransformOptions = newTransformOptions;
+    assert.strictEqual(
+      source.cache.defaultTransformOptions,
+      source.defaultTransformOptions,
+      'updated defaultTransformOptions are shared'
+    );
+    assert.strictEqual(
+      source.cache.defaultTransformOptions?.b,
+      2,
+      'updated cache.defaultTransformOptions are correct'
+    );
+  });
+
+  module('activated', function (hooks) {
+    hooks.beforeEach(async () => {
+      source = new IndexedDBSource({ schema, keyMap });
+      await source.activated;
+    });
+
+    hooks.afterEach(async () => {
+      await source.deactivate();
+      await source.cache.deleteDB();
+    });
+
+    test('will reopen the database when the schema is upgraded', async function (assert) {
+      assert.expect(5);
+
+      assert.equal(source.cache.dbVersion, 1, 'db starts with version == 1');
+
+      source.cache.migrateDB = function (db, event) {
+        assert.equal(
+          event.oldVersion,
+          1,
+          'migrateDB called with oldVersion == 1'
+        );
+        assert.equal(
+          event.newVersion,
+          2,
+          'migrateDB called with newVersion == 2'
+        );
+      };
+
+      schema.on('upgrade', (version) => {
+        assert.equal(version, 2, 'schema has upgraded to v2');
+        assert.equal(source.cache.dbVersion, 2, 'db has the correct version');
+      });
+
+      await source.cache.openDB();
+
+      await schema.upgrade({
+        models: {
+          planet: {
+            attributes: {
+              name: { type: 'string' }
+            }
+          },
+          moon: {
+            attributes: {
+              name: { type: 'string' }
+            }
+          }
+        }
+      });
+    });
+
+    test('#reset is idempotent', async function (assert) {
+      await source.cache.openDB();
+      await source.reset();
+      await source.reset();
+      await source.cache.openDB();
+
+      assert.ok(true, 'db has been reset twice and can still be reopened');
+    });
+
+    test('data persists across re-instantiating source', async function (assert) {
+      assert.expect(2);
+
+      let planet: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        keys: {
+          remoteId: 'j'
+        },
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant'
+        }
+      };
+
+      await source.push((t) => t.addRecord(planet));
+      assert.deepEqual(
+        await getRecordFromIndexedDB(source.cache, planet),
+        planet,
+        'indexeddb contains record'
+      );
+
+      await source.deactivate();
+
+      source = new IndexedDBSource({ schema, keyMap });
+      await source.activated;
+
+      assert.deepEqual(
+        await getRecordFromIndexedDB(source.cache, planet),
+        planet,
+        'indexeddb still contains record'
+      );
+    });
+
+    test('#sync - addRecord', async function (assert) {
+      assert.expect(3);
+
+      let planet: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        keys: {
+          remoteId: 'j'
+        },
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant'
+        }
+      };
+
+      const t = buildTransform({
+        op: 'addRecord',
+        record: planet
+      } as AddRecordOperation);
+
+      await source.sync(t);
+
+      assert.ok(source.transformLog.contains(t.id), 'log contains transform');
+      assert.deepEqual(
+        await getRecordFromIndexedDB(source.cache, planet),
+        planet,
+        'indexeddb contains record'
       );
       assert.equal(
-        event.newVersion,
-        2,
-        'migrateDB called with newVersion == 2'
+        keyMap.keyToId('planet', 'remoteId', 'j'),
+        'jupiter',
+        'key has been mapped'
       );
-    };
-
-    schema.on('upgrade', (version) => {
-      assert.equal(version, 2, 'schema has upgraded to v2');
-      assert.equal(source.cache.dbVersion, 2, 'db has the correct version');
     });
 
-    await source.cache.openDB();
+    test('#push - addRecord', async function (assert) {
+      assert.expect(3);
 
-    await schema.upgrade({
-      models: {
-        planet: {
-          attributes: {
-            name: { type: 'string' }
+      let planet: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        keys: {
+          remoteId: 'j'
+        },
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant'
+        }
+      };
+
+      const t = buildTransform({
+        op: 'addRecord',
+        record: planet
+      } as AddRecordOperation);
+
+      await source.push(t);
+
+      assert.ok(source.transformLog.contains(t.id), 'log contains transform');
+      assert.deepEqual(
+        await getRecordFromIndexedDB(source.cache, planet),
+        planet,
+        'indexeddb contains record'
+      );
+      assert.equal(
+        keyMap.keyToId('planet', 'remoteId', 'j'),
+        'jupiter',
+        'key has been mapped'
+      );
+    });
+
+    test('#push - addRecord - with beforePush listener that syncs transform', async function (assert) {
+      assert.expect(4);
+
+      let planet: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        keys: {
+          remoteId: 'j'
+        },
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant'
+        }
+      };
+
+      const t = buildTransform({
+        op: 'addRecord',
+        record: planet
+      } as AddRecordOperation);
+
+      source.on('beforePush', async function (transform: RecordTransform) {
+        await source.sync(transform);
+      });
+
+      let result = await source.push(t);
+
+      assert.deepEqual(result, [], 'result represents transforms applied');
+      assert.ok(source.transformLog.contains(t.id), 'log contains transform');
+      assert.deepEqual(
+        await getRecordFromIndexedDB(source.cache, planet),
+        planet,
+        'indexeddb contains record'
+      );
+      assert.equal(
+        keyMap.keyToId('planet', 'remoteId', 'j'),
+        'jupiter',
+        'key has been mapped'
+      );
+    });
+
+    test('#push - updateRecord', async function (assert) {
+      assert.expect(2);
+
+      let original: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        keys: {
+          remoteId: 'j'
+        },
+        attributes: {
+          name: 'Jupiter'
+        },
+        relationships: {
+          moons: {
+            data: [{ type: 'moon', id: 'moon1' }]
           }
+        }
+      };
+
+      let updates: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        attributes: {
+          classification: 'gas giant'
         },
-        moon: {
-          attributes: {
-            name: { type: 'string' }
+        relationships: {
+          solarSystem: {
+            data: { type: 'solarSystem', id: 'ss1' }
           }
         }
-      }
-    });
-  });
+      };
 
-  test('#reset is idempotent', async function (assert) {
-    await source.cache.openDB();
-    await source.reset();
-    await source.reset();
-    await source.cache.openDB();
+      let expected: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        keys: {
+          remoteId: 'j'
+        },
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant'
+        },
+        relationships: {
+          moons: {
+            data: [{ type: 'moon', id: 'moon1' }]
+          },
+          solarSystem: {
+            data: { type: 'solarSystem', id: 'ss1' }
+          }
+        }
+      };
 
-    assert.ok(true, 'db has been reset twice and can still be reopened');
-  });
-
-  test('data persists across re-instantiating source', async function (assert) {
-    assert.expect(2);
-
-    let planet: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      keys: {
-        remoteId: 'j'
-      },
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant'
-      }
-    };
-
-    await source.push((t) => t.addRecord(planet));
-    assert.deepEqual(
-      await getRecordFromIndexedDB(source.cache, planet),
-      planet,
-      'indexeddb contains record'
-    );
-
-    await source.deactivate();
-
-    source = new IndexedDBSource({ schema, keyMap });
-    await source.activated;
-
-    assert.deepEqual(
-      await getRecordFromIndexedDB(source.cache, planet),
-      planet,
-      'indexeddb still contains record'
-    );
-  });
-
-  test('#sync - addRecord', async function (assert) {
-    assert.expect(3);
-
-    let planet: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      keys: {
-        remoteId: 'j'
-      },
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant'
-      }
-    };
-
-    const t = buildTransform({
-      op: 'addRecord',
-      record: planet
-    } as AddRecordOperation);
-
-    await source.sync(t);
-
-    assert.ok(source.transformLog.contains(t.id), 'log contains transform');
-    assert.deepEqual(
-      await getRecordFromIndexedDB(source.cache, planet),
-      planet,
-      'indexeddb contains record'
-    );
-    assert.equal(
-      keyMap.keyToId('planet', 'remoteId', 'j'),
-      'jupiter',
-      'key has been mapped'
-    );
-  });
-
-  test('#push - addRecord', async function (assert) {
-    assert.expect(3);
-
-    let planet: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      keys: {
-        remoteId: 'j'
-      },
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant'
-      }
-    };
-
-    const t = buildTransform({
-      op: 'addRecord',
-      record: planet
-    } as AddRecordOperation);
-
-    await source.push(t);
-
-    assert.ok(source.transformLog.contains(t.id), 'log contains transform');
-    assert.deepEqual(
-      await getRecordFromIndexedDB(source.cache, planet),
-      planet,
-      'indexeddb contains record'
-    );
-    assert.equal(
-      keyMap.keyToId('planet', 'remoteId', 'j'),
-      'jupiter',
-      'key has been mapped'
-    );
-  });
-
-  test('#push - addRecord - with beforePush listener that syncs transform', async function (assert) {
-    assert.expect(4);
-
-    let planet: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      keys: {
-        remoteId: 'j'
-      },
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant'
-      }
-    };
-
-    const t = buildTransform({
-      op: 'addRecord',
-      record: planet
-    } as AddRecordOperation);
-
-    source.on('beforePush', async function (transform: RecordTransform) {
-      await source.sync(transform);
+      await source.push((t) => t.addRecord(original));
+      await source.push((t) => t.updateRecord(updates));
+      assert.deepEqual(
+        await getRecordFromIndexedDB(source.cache, expected),
+        expected,
+        'indexeddb contains record'
+      );
+      assert.equal(
+        keyMap.keyToId('planet', 'remoteId', 'j'),
+        'jupiter',
+        'key has been mapped'
+      );
     });
 
-    let result = await source.push(t);
+    test('#push - updateRecord - when record does not exist', async function (assert) {
+      assert.expect(1);
 
-    assert.deepEqual(result, [], 'result represents transforms applied');
-    assert.ok(source.transformLog.contains(t.id), 'log contains transform');
-    assert.deepEqual(
-      await getRecordFromIndexedDB(source.cache, planet),
-      planet,
-      'indexeddb contains record'
-    );
-    assert.equal(
-      keyMap.keyToId('planet', 'remoteId', 'j'),
-      'jupiter',
-      'key has been mapped'
-    );
-  });
-
-  test('#push - updateRecord', async function (assert) {
-    assert.expect(2);
-
-    let original: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      keys: {
-        remoteId: 'j'
-      },
-      attributes: {
-        name: 'Jupiter'
-      },
-      relationships: {
-        moons: {
-          data: [{ type: 'moon', id: 'moon1' }]
+      let revised: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant',
+          revised: true
         }
-      }
-    };
+      };
 
-    let updates: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      attributes: {
-        classification: 'gas giant'
-      },
-      relationships: {
-        solarSystem: {
-          data: { type: 'solarSystem', id: 'ss1' }
+      await source.push((t) => t.updateRecord(revised));
+      assert.deepEqual(
+        await getRecordFromIndexedDB(source.cache, revised),
+        revised,
+        'indexeddb contains record'
+      );
+    });
+
+    test('#push - removeRecord', async function (assert) {
+      assert.expect(1);
+
+      let planet: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant'
         }
-      }
-    };
+      };
 
-    let expected: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      keys: {
-        remoteId: 'j'
-      },
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant'
-      },
-      relationships: {
-        moons: {
-          data: [{ type: 'moon', id: 'moon1' }]
+      await source.push((t) => t.addRecord(planet));
+      await source.push((t) => t.removeRecord(planet));
+      assert.equal(
+        await getRecordFromIndexedDB(source.cache, planet),
+        undefined,
+        'indexeddb does not contain record'
+      );
+    });
+
+    test('#push - removeRecord when part of has many relationship', async function (assert) {
+      assert.expect(2);
+
+      let moon1 = { type: 'moon', id: 'moon1' };
+      let moon2 = { type: 'moon', id: 'moon2' };
+      let planet: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant'
         },
-        solarSystem: {
-          data: { type: 'solarSystem', id: 'ss1' }
+        relationships: {
+          moons: {
+            data: [moon1, moon2]
+          }
         }
-      }
-    };
+      };
 
-    await source.push((t) => t.addRecord(original));
-    await source.push((t) => t.updateRecord(updates));
-    assert.deepEqual(
-      await getRecordFromIndexedDB(source.cache, expected),
-      expected,
-      'indexeddb contains record'
-    );
-    assert.equal(
-      keyMap.keyToId('planet', 'remoteId', 'j'),
-      'jupiter',
-      'key has been mapped'
-    );
-  });
+      await source.push((t) => [
+        t.addRecord(moon1),
+        t.addRecord(moon2),
+        t.addRecord(planet)
+      ]);
 
-  test('#push - updateRecord - when record does not exist', async function (assert) {
-    assert.expect(1);
+      let moons = (await getRecordFromIndexedDB(source.cache, planet))
+        ?.relationships?.moons.data as RecordIdentity[];
+      assert.deepEqual(moons.length, 2, 'record has 2 moons');
 
-    let revised: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant',
-        revised: true
-      }
-    };
+      await source.push((t) => t.removeRecord(moon1));
+      moons = (await getRecordFromIndexedDB(source.cache, planet)).relationships
+        ?.moons.data as RecordIdentity[];
+      assert.deepEqual(moons.length, 1, 'record has 1 moon');
+    });
 
-    await source.push((t) => t.updateRecord(revised));
-    assert.deepEqual(
-      await getRecordFromIndexedDB(source.cache, revised),
-      revised,
-      'indexeddb contains record'
-    );
-  });
+    test('#push - removeRecord - when record does not exist', async function (assert) {
+      assert.expect(1);
 
-  test('#push - removeRecord', async function (assert) {
-    assert.expect(1);
+      let planet: Record = {
+        type: 'planet',
+        id: 'jupiter'
+      };
 
-    let planet: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant'
-      }
-    };
+      await source.push((t) => t.removeRecord(planet));
+      assert.equal(
+        await getRecordFromIndexedDB(source.cache, planet),
+        undefined,
+        'indexeddb does not contain record'
+      );
+    });
 
-    await source.push((t) => t.addRecord(planet));
-    await source.push((t) => t.removeRecord(planet));
-    assert.equal(
-      await getRecordFromIndexedDB(source.cache, planet),
-      undefined,
-      'indexeddb does not contain record'
-    );
-  });
+    test('#push - replaceKey', async function (assert) {
+      assert.expect(2);
 
-  test('#push - removeRecord when part of has many relationship', async function (assert) {
-    assert.expect(2);
-
-    let moon1 = { type: 'moon', id: 'moon1' };
-    let moon2 = { type: 'moon', id: 'moon2' };
-    let planet: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant'
-      },
-      relationships: {
-        moons: {
-          data: [moon1, moon2]
+      let original: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant'
         }
-      }
-    };
-
-    await source.push((t) => [
-      t.addRecord(moon1),
-      t.addRecord(moon2),
-      t.addRecord(planet)
-    ]);
-
-    let moons = (await getRecordFromIndexedDB(source.cache, planet))
-      ?.relationships?.moons.data as RecordIdentity[];
-    assert.deepEqual(moons.length, 2, 'record has 2 moons');
-
-    await source.push((t) => t.removeRecord(moon1));
-    moons = (await getRecordFromIndexedDB(source.cache, planet)).relationships
-      ?.moons.data as RecordIdentity[];
-    assert.deepEqual(moons.length, 1, 'record has 1 moon');
-  });
-
-  test('#push - removeRecord - when record does not exist', async function (assert) {
-    assert.expect(1);
-
-    let planet: Record = {
-      type: 'planet',
-      id: 'jupiter'
-    };
-
-    await source.push((t) => t.removeRecord(planet));
-    assert.equal(
-      await getRecordFromIndexedDB(source.cache, planet),
-      undefined,
-      'indexeddb does not contain record'
-    );
-  });
-
-  test('#push - replaceKey', async function (assert) {
-    assert.expect(2);
-
-    let original: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant'
-      }
-    };
-
-    let revised: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant'
-      },
-      keys: {
-        remoteId: '123'
-      }
-    };
-
-    await source.push((t) => t.addRecord(original));
-    await source.push((t) => t.replaceKey(original, 'remoteId', '123'));
-    assert.deepEqual(
-      await getRecordFromIndexedDB(source.cache, revised),
-      revised,
-      'indexeddb contains record'
-    );
-
-    assert.equal(
-      keyMap.keyToId('planet', 'remoteId', '123'),
-      'jupiter',
-      'key has been mapped'
-    );
-  });
-
-  test('#push - replaceKey - when base record does not exist', async function (assert) {
-    assert.expect(2);
-
-    let revised: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      keys: {
-        remoteId: '123'
-      }
-    };
-
-    await source.push((t) =>
-      t.replaceKey({ type: 'planet', id: 'jupiter' }, 'remoteId', '123')
-    );
-    assert.deepEqual(
-      await getRecordFromIndexedDB(source.cache, revised),
-      revised,
-      'indexeddb contains record'
-    );
-
-    assert.equal(
-      keyMap.keyToId('planet', 'remoteId', '123'),
-      'jupiter',
-      'key has been mapped'
-    );
-  });
-
-  test('#push - replaceAttribute', async function (assert) {
-    assert.expect(1);
-
-    let original: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant'
-      }
-    };
-
-    let revised: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant',
-        order: 5
-      }
-    };
-
-    await source.push((t) => t.addRecord(original));
-    await source.push((t) => t.replaceAttribute(original, 'order', 5));
-    assert.deepEqual(
-      await getRecordFromIndexedDB(source.cache, revised),
-      revised,
-      'indexeddb contains record'
-    );
-  });
-
-  test('#push - replaceAttribute - when base record does not exist', async function (assert) {
-    assert.expect(1);
-
-    let revised: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      attributes: {
-        order: 5
-      }
-    };
-
-    await source.push((t) =>
-      t.replaceAttribute({ type: 'planet', id: 'jupiter' }, 'order', 5)
-    );
-    assert.deepEqual(
-      await getRecordFromIndexedDB(source.cache, revised),
-      revised,
-      'indexeddb contains record'
-    );
-  });
-
-  test('#push - addToRelatedRecords', async function (assert) {
-    assert.expect(1);
-
-    let original: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant'
-      },
-      relationships: {
-        moons: {
-          data: []
-        }
-      }
-    };
-
-    let revised: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant'
-      },
-      relationships: {
-        moons: {
-          data: [{ type: 'moon', id: 'moon1' }]
-        }
-      }
-    };
-
-    await source.push((t) => t.addRecord(original));
-    await source.push((t) =>
-      t.addToRelatedRecords(original, 'moons', { type: 'moon', id: 'moon1' })
-    );
-    assert.deepEqual(
-      await getRecordFromIndexedDB(source.cache, revised),
-      revised,
-      'indexeddb contains record'
-    );
-  });
-
-  test('#push - addToRelatedRecords - when base record does not exist', async function (assert) {
-    assert.expect(1);
-
-    let revised: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      relationships: {
-        moons: {
-          data: [{ type: 'moon', id: 'moon1' }]
-        }
-      }
-    };
-
-    await source.push((t) =>
-      t.addToRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons', {
-        type: 'moon',
-        id: 'moon1'
-      })
-    );
-    assert.deepEqual(
-      await getRecordFromIndexedDB(source.cache, revised),
-      revised,
-      'indexeddb contains record'
-    );
-  });
-
-  test('#push - removeFromRelatedRecords', async function (assert) {
-    assert.expect(1);
-
-    let original: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant'
-      },
-      relationships: {
-        moons: {
-          data: [
-            { type: 'moon', id: 'moon1' },
-            { type: 'moon', id: 'moon2' }
-          ]
-        }
-      }
-    };
-
-    let revised: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant'
-      },
-      relationships: {
-        moons: {
-          data: [{ type: 'moon', id: 'moon1' }]
-        }
-      }
-    };
-
-    await source.push((t) => t.addRecord(original));
-    await source.push((t) =>
-      t.removeFromRelatedRecords(original, 'moons', {
-        type: 'moon',
-        id: 'moon2'
-      })
-    );
-    assert.deepEqual(
-      await getRecordFromIndexedDB(source.cache, revised),
-      revised,
-      'indexeddb contains record'
-    );
-  });
-
-  test('#push - removeFromRelatedRecords - when base record does not exist', async function (assert) {
-    assert.expect(1);
-
-    let revised: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      relationships: {
-        moons: {
-          data: []
-        }
-      }
-    };
-
-    await source.push((t) =>
-      t.removeFromRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons', {
-        type: 'moon',
-        id: 'moon2'
-      })
-    );
-    assert.equal(
-      await getRecordFromIndexedDB(source.cache, revised),
-      undefined,
-      'indexeddb does not contain record'
-    );
-  });
-
-  test('#push - replaceRelatedRecords', async function (assert) {
-    assert.expect(1);
-
-    let original: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant'
-      },
-      relationships: {
-        moons: {
-          data: [{ type: 'moon', id: 'moon1' }]
-        }
-      }
-    };
-
-    let revised: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant'
-      },
-      relationships: {
-        moons: {
-          data: [
-            { type: 'moon', id: 'moon2' },
-            { type: 'moon', id: 'moon3' }
-          ]
-        }
-      }
-    };
-
-    await source.push((t) => t.addRecord(original));
-    await source.push((t) =>
-      t.replaceRelatedRecords(original, 'moons', [
-        { type: 'moon', id: 'moon2' },
-        { type: 'moon', id: 'moon3' }
-      ])
-    );
-    assert.deepEqual(
-      await getRecordFromIndexedDB(source.cache, revised),
-      revised,
-      'indexeddb contains record'
-    );
-  });
-
-  test('#push - replaceRelatedRecords - when base record does not exist', async function (assert) {
-    assert.expect(1);
-
-    let revised: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      relationships: {
-        moons: {
-          data: [
-            { type: 'moon', id: 'moon2' },
-            { type: 'moon', id: 'moon3' }
-          ]
-        }
-      }
-    };
-
-    await source.push((t) =>
-      t.replaceRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons', [
-        { type: 'moon', id: 'moon2' },
-        { type: 'moon', id: 'moon3' }
-      ])
-    );
-    assert.deepEqual(
-      await getRecordFromIndexedDB(source.cache, revised),
-      revised,
-      'indexeddb contains record'
-    );
-  });
-
-  test('#push - replaceRelatedRecord - with record', async function (assert) {
-    assert.expect(1);
-
-    let original: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant'
-      },
-      relationships: {
-        solarSystem: {
-          data: null
-        }
-      }
-    };
-
-    let revised: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant'
-      },
-      relationships: {
-        solarSystem: {
-          data: { type: 'solarSystem', id: 'ss1' }
-        }
-      }
-    };
-
-    await source.push((t) => t.addRecord(original));
-    await source.push((t) =>
-      t.replaceRelatedRecord(original, 'solarSystem', {
-        type: 'solarSystem',
-        id: 'ss1'
-      })
-    );
-    assert.deepEqual(
-      await getRecordFromIndexedDB(source.cache, revised),
-      revised,
-      'indexeddb contains record'
-    );
-  });
-
-  test('#push - replaceRelatedRecord - with record - when base record does not exist', async function (assert) {
-    assert.expect(1);
-
-    let revised: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      relationships: {
-        solarSystem: {
-          data: { type: 'solarSystem', id: 'ss1' }
-        }
-      }
-    };
-
-    await source.push((t) =>
-      t.replaceRelatedRecord({ type: 'planet', id: 'jupiter' }, 'solarSystem', {
-        type: 'solarSystem',
-        id: 'ss1'
-      })
-    );
-    assert.deepEqual(
-      await getRecordFromIndexedDB(source.cache, revised),
-      revised,
-      'indexeddb contains record'
-    );
-  });
-
-  test('#push - replaceRelatedRecord - with null', async function (assert) {
-    assert.expect(1);
-
-    let original: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant'
-      },
-      relationships: {
-        solarSystem: {
-          data: { type: 'solarSystem', id: 'ss1' }
-        }
-      }
-    };
-
-    let revised: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant'
-      },
-      relationships: {
-        solarSystem: {
-          data: null
-        }
-      }
-    };
-
-    await source.push((t) => t.addRecord(original));
-    await source.push((t) =>
-      t.replaceRelatedRecord(original, 'solarSystem', null)
-    );
-    assert.deepEqual(
-      await getRecordFromIndexedDB(source.cache, revised),
-      revised,
-      'indexeddb contains record'
-    );
-  });
-
-  test('#push - replaceRelatedRecord - with null - when base record does not exist', async function (assert) {
-    assert.expect(1);
-
-    let revised: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      relationships: {
-        solarSystem: {
-          data: null
-        }
-      }
-    };
-
-    await source.push((t) =>
-      t.replaceRelatedRecord(
-        { type: 'planet', id: 'jupiter' },
-        'solarSystem',
-        null
-      )
-    );
-    assert.deepEqual(
-      await getRecordFromIndexedDB(source.cache, revised),
-      revised,
-      'indexeddb contains record'
-    );
-  });
-
-  test('#push - inverse relationships are created', async function (assert) {
-    assert.expect(2);
-
-    let ss = {
-      type: 'solarSystem',
-      id: 'ss'
-    };
-
-    let earth: Record = {
-      type: 'planet',
-      id: 'earth',
-      attributes: {
-        name: 'Earth',
-        classification: 'terrestrial'
-      },
-      relationships: {
-        solarSystem: {
-          data: { type: 'solarSystem', id: 'ss' }
-        }
-      }
-    };
-
-    let jupiter: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant'
-      },
-      relationships: {
-        solarSystem: {
-          data: { type: 'solarSystem', id: 'ss' }
-        }
-      }
-    };
-
-    let io: Record = {
-      type: 'moon',
-      id: 'io',
-      attributes: {
-        name: 'Io'
-      },
-      relationships: {
-        planet: {
-          data: { type: 'planet', id: 'jupiter' }
-        }
-      }
-    };
-
-    await source.push((t) => [
-      t.addRecord(ss),
-      t.addRecord(earth),
-      t.addRecord(jupiter),
-      t.addRecord(io)
-    ]);
-
-    let revisedSs = {
-      type: 'solarSystem',
-      id: 'ss',
-      relationships: {
-        planets: {
-          data: [
-            { type: 'planet', id: 'earth' },
-            { type: 'planet', id: 'jupiter' }
-          ]
-        }
-      }
-    };
-
-    assert.deepEqual(
-      await getRecordFromIndexedDB(source.cache, revisedSs),
-      revisedSs,
-      'indexeddb contains record'
-    );
-
-    let revisedJupiter = {
-      type: 'planet',
-      id: 'jupiter',
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant'
-      },
-      relationships: {
-        moons: {
-          data: [{ type: 'moon', id: 'io' }]
+      };
+
+      let revised: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant'
         },
-        solarSystem: {
-          data: { type: 'solarSystem', id: 'ss' }
+        keys: {
+          remoteId: '123'
         }
-      }
-    };
+      };
 
-    assert.deepEqual(
-      await getRecordFromIndexedDB(source.cache, revisedJupiter),
-      revisedJupiter,
-      'indexeddb contains record'
-    );
-  });
+      await source.push((t) => t.addRecord(original));
+      await source.push((t) => t.replaceKey(original, 'remoteId', '123'));
+      assert.deepEqual(
+        await getRecordFromIndexedDB(source.cache, revised),
+        revised,
+        'indexeddb contains record'
+      );
 
-  test('#pull - all records', async function (assert) {
-    assert.expect(5);
+      assert.equal(
+        keyMap.keyToId('planet', 'remoteId', '123'),
+        'jupiter',
+        'key has been mapped'
+      );
+    });
 
-    let earth: Record = {
-      type: 'planet',
-      id: 'earth',
-      keys: {
-        remoteId: 'p1'
-      },
-      attributes: {
-        name: 'Earth',
-        classification: 'terrestrial'
-      }
-    };
+    test('#push - replaceKey - when base record does not exist', async function (assert) {
+      assert.expect(2);
 
-    let jupiter: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      keys: {
-        remoteId: 'p2'
-      },
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant'
-      }
-    };
+      let revised: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        keys: {
+          remoteId: '123'
+        }
+      };
 
-    let io: Record = {
-      type: 'moon',
-      id: 'io',
-      keys: {
-        remoteId: 'm1'
-      },
-      attributes: {
-        name: 'Io'
-      }
-    };
+      await source.push((t) =>
+        t.replaceKey({ type: 'planet', id: 'jupiter' }, 'remoteId', '123')
+      );
+      assert.deepEqual(
+        await getRecordFromIndexedDB(source.cache, revised),
+        revised,
+        'indexeddb contains record'
+      );
 
-    await source.push((t) => [
-      t.addRecord(earth),
-      t.addRecord(jupiter),
-      t.addRecord(io)
-    ]);
+      assert.equal(
+        keyMap.keyToId('planet', 'remoteId', '123'),
+        'jupiter',
+        'key has been mapped'
+      );
+    });
 
-    // reset keyMap to verify that pulling records also adds keys
-    keyMap.reset();
+    test('#push - replaceAttribute', async function (assert) {
+      assert.expect(1);
 
-    let transforms = (await source.pull((q) =>
-      q.findRecords()
-    )) as RecordTransform[];
+      let original: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant'
+        }
+      };
 
-    assert.equal(transforms.length, 1, 'one transform returned');
-    assert.deepEqual(
-      transforms[0].operations.map((o) => o.op),
-      ['updateRecord', 'updateRecord', 'updateRecord'],
-      'operations match expectations'
-    );
-    assert.equal(
-      keyMap.keyToId('planet', 'remoteId', 'p1'),
-      'earth',
-      'key has been mapped'
-    );
-    assert.equal(
-      keyMap.keyToId('planet', 'remoteId', 'p2'),
-      'jupiter',
-      'key has been mapped'
-    );
-    assert.equal(
-      keyMap.keyToId('moon', 'remoteId', 'm1'),
-      'io',
-      'key has been mapped'
-    );
-  });
+      let revised: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant',
+          order: 5
+        }
+      };
 
-  test('#pull - records of one type', async function (assert) {
-    assert.expect(4);
+      await source.push((t) => t.addRecord(original));
+      await source.push((t) => t.replaceAttribute(original, 'order', 5));
+      assert.deepEqual(
+        await getRecordFromIndexedDB(source.cache, revised),
+        revised,
+        'indexeddb contains record'
+      );
+    });
 
-    let earth: Record = {
-      type: 'planet',
-      id: 'earth',
-      attributes: {
-        name: 'Earth',
-        classification: 'terrestrial'
-      }
-    };
+    test('#push - replaceAttribute - when base record does not exist', async function (assert) {
+      assert.expect(1);
 
-    let jupiter: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant'
-      }
-    };
+      let revised: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        attributes: {
+          order: 5
+        }
+      };
 
-    let io: Record = {
-      type: 'moon',
-      id: 'io',
-      attributes: {
-        name: 'Io'
-      }
-    };
+      await source.push((t) =>
+        t.replaceAttribute({ type: 'planet', id: 'jupiter' }, 'order', 5)
+      );
+      assert.deepEqual(
+        await getRecordFromIndexedDB(source.cache, revised),
+        revised,
+        'indexeddb contains record'
+      );
+    });
 
-    await source.push((t) => [
-      t.addRecord(earth),
-      t.addRecord(jupiter),
-      t.addRecord(io)
-    ]);
+    test('#push - addToRelatedRecords', async function (assert) {
+      assert.expect(1);
 
-    let transforms = (await source.pull((q) =>
-      q.findRecords('planet')
-    )) as RecordTransform[];
+      let original: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant'
+        },
+        relationships: {
+          moons: {
+            data: []
+          }
+        }
+      };
 
-    assert.equal(transforms.length, 1, 'one transform returned');
-    assert.ok(
-      source.transformLog.contains(transforms[0].id),
-      'log contains transform'
-    );
-    assert.deepEqual(
-      transforms[0].operations.map((o) => o.op),
-      ['updateRecord', 'updateRecord'],
-      'operations match expectations'
-    );
-    assert.deepEqual(
-      transforms[0].operations.map(
-        (o) => (o as AddRecordOperation)?.record?.type
-      ),
-      ['planet', 'planet'],
-      'operations match expectations'
-    );
-  });
+      let revised: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant'
+        },
+        relationships: {
+          moons: {
+            data: [{ type: 'moon', id: 'moon1' }]
+          }
+        }
+      };
 
-  test('#pull - specific records', async function (assert) {
-    assert.expect(4);
+      await source.push((t) => t.addRecord(original));
+      await source.push((t) =>
+        t.addToRelatedRecords(original, 'moons', { type: 'moon', id: 'moon1' })
+      );
+      assert.deepEqual(
+        await getRecordFromIndexedDB(source.cache, revised),
+        revised,
+        'indexeddb contains record'
+      );
+    });
 
-    let earth: Record = {
-      type: 'planet',
-      id: 'earth',
-      attributes: {
-        name: 'Earth',
-        classification: 'terrestrial'
-      }
-    };
+    test('#push - addToRelatedRecords - when base record does not exist', async function (assert) {
+      assert.expect(1);
 
-    let jupiter: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant'
-      }
-    };
+      let revised: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        relationships: {
+          moons: {
+            data: [{ type: 'moon', id: 'moon1' }]
+          }
+        }
+      };
 
-    let io: Record = {
-      type: 'moon',
-      id: 'io',
-      attributes: {
-        name: 'Io'
-      }
-    };
+      await source.push((t) =>
+        t.addToRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons', {
+          type: 'moon',
+          id: 'moon1'
+        })
+      );
+      assert.deepEqual(
+        await getRecordFromIndexedDB(source.cache, revised),
+        revised,
+        'indexeddb contains record'
+      );
+    });
 
-    await source.push((t) => [
-      t.addRecord(earth),
-      t.addRecord(jupiter),
-      t.addRecord(io)
-    ]);
+    test('#push - removeFromRelatedRecords', async function (assert) {
+      assert.expect(1);
 
-    let transforms = (await source.pull((q) =>
-      q.findRecords([earth, io, { type: 'moon', id: 'FAKE' }])
-    )) as RecordTransform[];
+      let original: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant'
+        },
+        relationships: {
+          moons: {
+            data: [
+              { type: 'moon', id: 'moon1' },
+              { type: 'moon', id: 'moon2' }
+            ]
+          }
+        }
+      };
 
-    assert.equal(transforms.length, 1, 'one transform returned');
-    assert.ok(
-      source.transformLog.contains(transforms[0].id),
-      'log contains transform'
-    );
-    assert.deepEqual(
-      transforms[0].operations.map((o) => o.op),
-      ['updateRecord', 'updateRecord'],
-      'operations match expectations'
-    );
-    assert.deepEqual(
-      transforms[0].operations.map(
-        (o) => (o as AddRecordOperation).record.type
-      ),
-      ['planet', 'moon'],
-      'operations match expectations'
-    );
-  });
+      let revised: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant'
+        },
+        relationships: {
+          moons: {
+            data: [{ type: 'moon', id: 'moon1' }]
+          }
+        }
+      };
 
-  test('#pull - a specific record', async function (assert) {
-    assert.expect(4);
+      await source.push((t) => t.addRecord(original));
+      await source.push((t) =>
+        t.removeFromRelatedRecords(original, 'moons', {
+          type: 'moon',
+          id: 'moon2'
+        })
+      );
+      assert.deepEqual(
+        await getRecordFromIndexedDB(source.cache, revised),
+        revised,
+        'indexeddb contains record'
+      );
+    });
 
-    let earth: Record = {
-      type: 'planet',
-      id: 'earth',
-      attributes: {
-        name: 'Earth',
-        classification: 'terrestrial'
-      }
-    };
+    test('#push - removeFromRelatedRecords - when base record does not exist', async function (assert) {
+      assert.expect(1);
 
-    let jupiter: Record = {
-      type: 'planet',
-      id: 'jupiter',
-      keys: {
-        remoteId: 'p2'
-      },
-      attributes: {
-        name: 'Jupiter',
-        classification: 'gas giant'
-      }
-    };
+      let revised: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        relationships: {
+          moons: {
+            data: []
+          }
+        }
+      };
 
-    let io: Record = {
-      type: 'moon',
-      id: 'io',
-      attributes: {
-        name: 'Io'
-      }
-    };
+      await source.push((t) =>
+        t.removeFromRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons', {
+          type: 'moon',
+          id: 'moon2'
+        })
+      );
+      assert.equal(
+        await getRecordFromIndexedDB(source.cache, revised),
+        undefined,
+        'indexeddb does not contain record'
+      );
+    });
 
-    await source.push((t) => [
-      t.addRecord(earth),
-      t.addRecord(jupiter),
-      t.addRecord(io)
-    ]);
+    test('#push - replaceRelatedRecords', async function (assert) {
+      assert.expect(1);
 
-    // reset keyMap to verify that pulling records also adds keys
-    keyMap.reset();
+      let original: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant'
+        },
+        relationships: {
+          moons: {
+            data: [{ type: 'moon', id: 'moon1' }]
+          }
+        }
+      };
 
-    let transforms = (await source.pull((q) =>
-      q.findRecord(jupiter)
-    )) as RecordTransform[];
+      let revised: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant'
+        },
+        relationships: {
+          moons: {
+            data: [
+              { type: 'moon', id: 'moon2' },
+              { type: 'moon', id: 'moon3' }
+            ]
+          }
+        }
+      };
 
-    assert.equal(transforms.length, 1, 'one transform returned');
-    assert.ok(
-      source.transformLog.contains(transforms[0].id),
-      'log contains transform'
-    );
-    assert.deepEqual(
-      transforms[0].operations.map((o) => o.op),
-      ['updateRecord'],
-      'operations match expectations'
-    );
-    assert.equal(
-      keyMap.keyToId('planet', 'remoteId', 'p2'),
-      'jupiter',
-      'key has been mapped'
-    );
+      await source.push((t) => t.addRecord(original));
+      await source.push((t) =>
+        t.replaceRelatedRecords(original, 'moons', [
+          { type: 'moon', id: 'moon2' },
+          { type: 'moon', id: 'moon3' }
+        ])
+      );
+      assert.deepEqual(
+        await getRecordFromIndexedDB(source.cache, revised),
+        revised,
+        'indexeddb contains record'
+      );
+    });
+
+    test('#push - replaceRelatedRecords - when base record does not exist', async function (assert) {
+      assert.expect(1);
+
+      let revised: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        relationships: {
+          moons: {
+            data: [
+              { type: 'moon', id: 'moon2' },
+              { type: 'moon', id: 'moon3' }
+            ]
+          }
+        }
+      };
+
+      await source.push((t) =>
+        t.replaceRelatedRecords({ type: 'planet', id: 'jupiter' }, 'moons', [
+          { type: 'moon', id: 'moon2' },
+          { type: 'moon', id: 'moon3' }
+        ])
+      );
+      assert.deepEqual(
+        await getRecordFromIndexedDB(source.cache, revised),
+        revised,
+        'indexeddb contains record'
+      );
+    });
+
+    test('#push - replaceRelatedRecord - with record', async function (assert) {
+      assert.expect(1);
+
+      let original: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant'
+        },
+        relationships: {
+          solarSystem: {
+            data: null
+          }
+        }
+      };
+
+      let revised: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant'
+        },
+        relationships: {
+          solarSystem: {
+            data: { type: 'solarSystem', id: 'ss1' }
+          }
+        }
+      };
+
+      await source.push((t) => t.addRecord(original));
+      await source.push((t) =>
+        t.replaceRelatedRecord(original, 'solarSystem', {
+          type: 'solarSystem',
+          id: 'ss1'
+        })
+      );
+      assert.deepEqual(
+        await getRecordFromIndexedDB(source.cache, revised),
+        revised,
+        'indexeddb contains record'
+      );
+    });
+
+    test('#push - replaceRelatedRecord - with record - when base record does not exist', async function (assert) {
+      assert.expect(1);
+
+      let revised: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        relationships: {
+          solarSystem: {
+            data: { type: 'solarSystem', id: 'ss1' }
+          }
+        }
+      };
+
+      await source.push((t) =>
+        t.replaceRelatedRecord(
+          { type: 'planet', id: 'jupiter' },
+          'solarSystem',
+          {
+            type: 'solarSystem',
+            id: 'ss1'
+          }
+        )
+      );
+      assert.deepEqual(
+        await getRecordFromIndexedDB(source.cache, revised),
+        revised,
+        'indexeddb contains record'
+      );
+    });
+
+    test('#push - replaceRelatedRecord - with null', async function (assert) {
+      assert.expect(1);
+
+      let original: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant'
+        },
+        relationships: {
+          solarSystem: {
+            data: { type: 'solarSystem', id: 'ss1' }
+          }
+        }
+      };
+
+      let revised: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant'
+        },
+        relationships: {
+          solarSystem: {
+            data: null
+          }
+        }
+      };
+
+      await source.push((t) => t.addRecord(original));
+      await source.push((t) =>
+        t.replaceRelatedRecord(original, 'solarSystem', null)
+      );
+      assert.deepEqual(
+        await getRecordFromIndexedDB(source.cache, revised),
+        revised,
+        'indexeddb contains record'
+      );
+    });
+
+    test('#push - replaceRelatedRecord - with null - when base record does not exist', async function (assert) {
+      assert.expect(1);
+
+      let revised: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        relationships: {
+          solarSystem: {
+            data: null
+          }
+        }
+      };
+
+      await source.push((t) =>
+        t.replaceRelatedRecord(
+          { type: 'planet', id: 'jupiter' },
+          'solarSystem',
+          null
+        )
+      );
+      assert.deepEqual(
+        await getRecordFromIndexedDB(source.cache, revised),
+        revised,
+        'indexeddb contains record'
+      );
+    });
+
+    test('#push - inverse relationships are created', async function (assert) {
+      assert.expect(2);
+
+      let ss = {
+        type: 'solarSystem',
+        id: 'ss'
+      };
+
+      let earth: Record = {
+        type: 'planet',
+        id: 'earth',
+        attributes: {
+          name: 'Earth',
+          classification: 'terrestrial'
+        },
+        relationships: {
+          solarSystem: {
+            data: { type: 'solarSystem', id: 'ss' }
+          }
+        }
+      };
+
+      let jupiter: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant'
+        },
+        relationships: {
+          solarSystem: {
+            data: { type: 'solarSystem', id: 'ss' }
+          }
+        }
+      };
+
+      let io: Record = {
+        type: 'moon',
+        id: 'io',
+        attributes: {
+          name: 'Io'
+        },
+        relationships: {
+          planet: {
+            data: { type: 'planet', id: 'jupiter' }
+          }
+        }
+      };
+
+      await source.push((t) => [
+        t.addRecord(ss),
+        t.addRecord(earth),
+        t.addRecord(jupiter),
+        t.addRecord(io)
+      ]);
+
+      let revisedSs = {
+        type: 'solarSystem',
+        id: 'ss',
+        relationships: {
+          planets: {
+            data: [
+              { type: 'planet', id: 'earth' },
+              { type: 'planet', id: 'jupiter' }
+            ]
+          }
+        }
+      };
+
+      assert.deepEqual(
+        await getRecordFromIndexedDB(source.cache, revisedSs),
+        revisedSs,
+        'indexeddb contains record'
+      );
+
+      let revisedJupiter = {
+        type: 'planet',
+        id: 'jupiter',
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant'
+        },
+        relationships: {
+          moons: {
+            data: [{ type: 'moon', id: 'io' }]
+          },
+          solarSystem: {
+            data: { type: 'solarSystem', id: 'ss' }
+          }
+        }
+      };
+
+      assert.deepEqual(
+        await getRecordFromIndexedDB(source.cache, revisedJupiter),
+        revisedJupiter,
+        'indexeddb contains record'
+      );
+    });
+
+    test('#pull - all records', async function (assert) {
+      assert.expect(5);
+
+      let earth: Record = {
+        type: 'planet',
+        id: 'earth',
+        keys: {
+          remoteId: 'p1'
+        },
+        attributes: {
+          name: 'Earth',
+          classification: 'terrestrial'
+        }
+      };
+
+      let jupiter: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        keys: {
+          remoteId: 'p2'
+        },
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant'
+        }
+      };
+
+      let io: Record = {
+        type: 'moon',
+        id: 'io',
+        keys: {
+          remoteId: 'm1'
+        },
+        attributes: {
+          name: 'Io'
+        }
+      };
+
+      await source.push((t) => [
+        t.addRecord(earth),
+        t.addRecord(jupiter),
+        t.addRecord(io)
+      ]);
+
+      // reset keyMap to verify that pulling records also adds keys
+      keyMap.reset();
+
+      let transforms = (await source.pull((q) =>
+        q.findRecords()
+      )) as RecordTransform[];
+
+      assert.equal(transforms.length, 1, 'one transform returned');
+      assert.deepEqual(
+        transforms[0].operations.map((o) => o.op),
+        ['updateRecord', 'updateRecord', 'updateRecord'],
+        'operations match expectations'
+      );
+      assert.equal(
+        keyMap.keyToId('planet', 'remoteId', 'p1'),
+        'earth',
+        'key has been mapped'
+      );
+      assert.equal(
+        keyMap.keyToId('planet', 'remoteId', 'p2'),
+        'jupiter',
+        'key has been mapped'
+      );
+      assert.equal(
+        keyMap.keyToId('moon', 'remoteId', 'm1'),
+        'io',
+        'key has been mapped'
+      );
+    });
+
+    test('#pull - records of one type', async function (assert) {
+      assert.expect(4);
+
+      let earth: Record = {
+        type: 'planet',
+        id: 'earth',
+        attributes: {
+          name: 'Earth',
+          classification: 'terrestrial'
+        }
+      };
+
+      let jupiter: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant'
+        }
+      };
+
+      let io: Record = {
+        type: 'moon',
+        id: 'io',
+        attributes: {
+          name: 'Io'
+        }
+      };
+
+      await source.push((t) => [
+        t.addRecord(earth),
+        t.addRecord(jupiter),
+        t.addRecord(io)
+      ]);
+
+      let transforms = (await source.pull((q) =>
+        q.findRecords('planet')
+      )) as RecordTransform[];
+
+      assert.equal(transforms.length, 1, 'one transform returned');
+      assert.ok(
+        source.transformLog.contains(transforms[0].id),
+        'log contains transform'
+      );
+      assert.deepEqual(
+        transforms[0].operations.map((o) => o.op),
+        ['updateRecord', 'updateRecord'],
+        'operations match expectations'
+      );
+      assert.deepEqual(
+        transforms[0].operations.map(
+          (o) => (o as AddRecordOperation)?.record?.type
+        ),
+        ['planet', 'planet'],
+        'operations match expectations'
+      );
+    });
+
+    test('#pull - specific records', async function (assert) {
+      assert.expect(4);
+
+      let earth: Record = {
+        type: 'planet',
+        id: 'earth',
+        attributes: {
+          name: 'Earth',
+          classification: 'terrestrial'
+        }
+      };
+
+      let jupiter: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant'
+        }
+      };
+
+      let io: Record = {
+        type: 'moon',
+        id: 'io',
+        attributes: {
+          name: 'Io'
+        }
+      };
+
+      await source.push((t) => [
+        t.addRecord(earth),
+        t.addRecord(jupiter),
+        t.addRecord(io)
+      ]);
+
+      let transforms = (await source.pull((q) =>
+        q.findRecords([earth, io, { type: 'moon', id: 'FAKE' }])
+      )) as RecordTransform[];
+
+      assert.equal(transforms.length, 1, 'one transform returned');
+      assert.ok(
+        source.transformLog.contains(transforms[0].id),
+        'log contains transform'
+      );
+      assert.deepEqual(
+        transforms[0].operations.map((o) => o.op),
+        ['updateRecord', 'updateRecord'],
+        'operations match expectations'
+      );
+      assert.deepEqual(
+        transforms[0].operations.map(
+          (o) => (o as AddRecordOperation).record.type
+        ),
+        ['planet', 'moon'],
+        'operations match expectations'
+      );
+    });
+
+    test('#pull - a specific record', async function (assert) {
+      assert.expect(4);
+
+      let earth: Record = {
+        type: 'planet',
+        id: 'earth',
+        attributes: {
+          name: 'Earth',
+          classification: 'terrestrial'
+        }
+      };
+
+      let jupiter: Record = {
+        type: 'planet',
+        id: 'jupiter',
+        keys: {
+          remoteId: 'p2'
+        },
+        attributes: {
+          name: 'Jupiter',
+          classification: 'gas giant'
+        }
+      };
+
+      let io: Record = {
+        type: 'moon',
+        id: 'io',
+        attributes: {
+          name: 'Io'
+        }
+      };
+
+      await source.push((t) => [
+        t.addRecord(earth),
+        t.addRecord(jupiter),
+        t.addRecord(io)
+      ]);
+
+      // reset keyMap to verify that pulling records also adds keys
+      keyMap.reset();
+
+      let transforms = (await source.pull((q) =>
+        q.findRecord(jupiter)
+      )) as RecordTransform[];
+
+      assert.equal(transforms.length, 1, 'one transform returned');
+      assert.ok(
+        source.transformLog.contains(transforms[0].id),
+        'log contains transform'
+      );
+      assert.deepEqual(
+        transforms[0].operations.map((o) => o.op),
+        ['updateRecord'],
+        'operations match expectations'
+      );
+      assert.equal(
+        keyMap.keyToId('planet', 'remoteId', 'p2'),
+        'jupiter',
+        'key has been mapped'
+      );
+    });
   });
 });

--- a/packages/@orbit/local-storage/src/local-storage-source.ts
+++ b/packages/@orbit/local-storage/src/local-storage-source.ts
@@ -5,7 +5,9 @@ import {
   pushable,
   Resettable,
   syncable,
-  FullResponse
+  FullResponse,
+  DefaultRequestOptions,
+  RequestOptions
 } from '@orbit/data';
 import {
   Record,
@@ -19,7 +21,8 @@ import {
   RecordSyncable,
   RecordTransform,
   RecordSource,
-  RecordQuery
+  RecordQuery,
+  RecordSourceQueryOptions
 } from '@orbit/records';
 import { supportsLocalStorage } from './lib/local-storage';
 import {
@@ -61,24 +64,32 @@ export class LocalStorageSource extends RecordSource {
       supportsLocalStorage()
     );
 
-    settings.name = settings.name || 'localStorage';
+    settings.name = settings.name ?? 'localStorage';
 
     super(settings);
 
     let cacheSettings: Partial<LocalStorageCacheSettings> =
-      settings.cacheSettings || {};
+      settings.cacheSettings ?? {};
     cacheSettings.schema = settings.schema;
     cacheSettings.keyMap = settings.keyMap;
     cacheSettings.queryBuilder =
-      cacheSettings.queryBuilder || this.queryBuilder;
+      cacheSettings.queryBuilder ?? this.queryBuilder;
     cacheSettings.transformBuilder =
-      cacheSettings.transformBuilder || this.transformBuilder;
-    cacheSettings.namespace = cacheSettings.namespace || settings.namespace;
-    cacheSettings.delimiter = cacheSettings.delimiter || settings.delimiter;
+      cacheSettings.transformBuilder ?? this.transformBuilder;
+    cacheSettings.defaultQueryOptions =
+      cacheSettings.defaultQueryOptions ?? settings.defaultQueryOptions;
+    cacheSettings.defaultTransformOptions =
+      cacheSettings.defaultTransformOptions ?? settings.defaultTransformOptions;
+    cacheSettings.namespace = cacheSettings.namespace ?? settings.namespace;
+    cacheSettings.delimiter = cacheSettings.delimiter ?? settings.delimiter;
 
     this._cache = new LocalStorageCache(
       cacheSettings as LocalStorageCacheSettings
     );
+  }
+
+  get cache(): LocalStorageCache {
+    return this._cache;
   }
 
   get namespace(): string {
@@ -87,6 +98,30 @@ export class LocalStorageSource extends RecordSource {
 
   get delimiter(): string {
     return this._cache.delimiter;
+  }
+
+  get defaultQueryOptions():
+    | DefaultRequestOptions<RecordSourceQueryOptions>
+    | undefined {
+    return super.defaultQueryOptions;
+  }
+
+  set defaultQueryOptions(
+    options: DefaultRequestOptions<RecordSourceQueryOptions> | undefined
+  ) {
+    super.defaultQueryOptions = this.cache.defaultQueryOptions = options;
+  }
+
+  get defaultTransformOptions():
+    | DefaultRequestOptions<RequestOptions>
+    | undefined {
+    return super.defaultTransformOptions;
+  }
+
+  set defaultTransformOptions(
+    options: DefaultRequestOptions<RequestOptions> | undefined
+  ) {
+    this._defaultTransformOptions = this.cache.defaultTransformOptions = options;
   }
 
   getKeyForRecord(record: RecordIdentity | Record): string {

--- a/packages/@orbit/local-storage/test/local-storage-source-test.ts
+++ b/packages/@orbit/local-storage/test/local-storage-source-test.ts
@@ -70,6 +70,84 @@ module('LocalStorageSource', function (hooks) {
     assert.equal(source.delimiter, '/', 'delimiter is `/` by default');
   });
 
+  test('shares its `transformBuilder` and `queryBuilder` with its cache', function (assert) {
+    assert.strictEqual(
+      source.cache.transformBuilder,
+      source.transformBuilder,
+      'transformBuilder is shared'
+    );
+    assert.strictEqual(
+      source.cache.queryBuilder,
+      source.queryBuilder,
+      'queryBuilder is shared'
+    );
+  });
+
+  test('shares its `defaultTransformOptions` and `defaultQueryOptions` with its cache', function (assert) {
+    source = new LocalStorageSource({
+      schema,
+      keyMap,
+      autoActivate: false,
+      defaultQueryOptions: {
+        a: 1
+      },
+      defaultTransformOptions: {
+        b: 1
+      }
+    });
+
+    assert.strictEqual(
+      source.cache.defaultTransformOptions,
+      source.defaultTransformOptions,
+      'defaultTransformOptions are shared'
+    );
+    assert.strictEqual(
+      source.cache.defaultTransformOptions?.b,
+      1,
+      'cache.defaultTransformOptions are correct'
+    );
+    assert.strictEqual(
+      source.cache.defaultQueryOptions,
+      source.defaultQueryOptions,
+      'defaultQueryOptions are shared'
+    );
+    assert.strictEqual(
+      source.cache.defaultQueryOptions?.a,
+      1,
+      'cache.defaultQueryOptions are correct'
+    );
+
+    let newQueryOptions = {
+      a: 2
+    };
+    source.defaultQueryOptions = newQueryOptions;
+    assert.strictEqual(
+      source.defaultQueryOptions?.a,
+      2,
+      'defaultQueryOptions are correct'
+    );
+    assert.strictEqual(
+      source.cache.defaultQueryOptions,
+      source.defaultQueryOptions,
+      'updated defaultQueryOptions are shared'
+    );
+
+    let newTransformOptions = {
+      b: 2
+    };
+    source.defaultTransformOptions = newTransformOptions;
+    assert.strictEqual(
+      source.cache.defaultTransformOptions,
+      source.defaultTransformOptions,
+      'updated defaultTransformOptions are shared'
+    );
+    assert.strictEqual(
+      source.cache.defaultTransformOptions?.b,
+      2,
+      'updated cache.defaultTransformOptions are correct'
+    );
+  });
+
   test('#getKeyForRecord returns the local storage key that will be used for a record', function (assert) {
     assert.equal(
       source.getKeyForRecord({ type: 'planet', id: 'jupiter' }),

--- a/packages/@orbit/memory/test/memory-source-test.ts
+++ b/packages/@orbit/memory/test/memory-source-test.ts
@@ -71,24 +71,23 @@ module('MemorySource', function (hooks) {
     }
   };
 
-  const schema = new RecordSchema(schemaDefinition);
-
-  let source: MemorySource;
+  let schema: RecordSchema;
   let keyMap: RecordKeyMap;
 
   hooks.beforeEach(function () {
+    schema = new RecordSchema(schemaDefinition);
     keyMap = new RecordKeyMap();
-    source = new MemorySource({ schema, keyMap });
   });
 
   test('its prototype chain is correct', function (assert) {
-    assert.ok(source instanceof RecordSource, 'instanceof Source');
+    const source = new MemorySource({ schema, keyMap });
+    assert.ok(source instanceof RecordSource, 'instanceof RecordSource');
     assert.ok(source instanceof MemorySource, 'instanceof MemorySource');
     assert.equal(source.name, 'memory', 'should have default name');
   });
 
   test("internal cache's settings can be specified with `cacheSettings`", function (assert) {
-    let source = new MemorySource({
+    const source = new MemorySource({
       schema,
       keyMap,
       cacheSettings: {
@@ -99,13 +98,13 @@ module('MemorySource', function (hooks) {
         ]
       }
     });
-    let cache = source.cache as any;
 
-    assert.ok(cache, 'cache exists');
-    assert.equal(cache._processors.length, 2, 'cache has 2 processors');
+    assert.ok(source.cache, 'cache exists');
+    assert.equal(source.cache.processors.length, 2, 'cache has 2 processors');
   });
 
-  test('automatically shares its `transformBuilder` and `queryBuilder` with its cache', function (assert) {
+  test('shares its `transformBuilder` and `queryBuilder` with its cache', function (assert) {
+    const source = new MemorySource({ schema, keyMap });
     assert.strictEqual(
       source.cache.transformBuilder,
       source.transformBuilder,
@@ -118,8 +117,74 @@ module('MemorySource', function (hooks) {
     );
   });
 
+  test('shares its `defaultTransformOptions` and `defaultQueryOptions` with its cache', function (assert) {
+    const source = new MemorySource({
+      schema,
+      keyMap,
+      defaultQueryOptions: {
+        a: 1
+      },
+      defaultTransformOptions: {
+        b: 1
+      }
+    });
+
+    assert.strictEqual(
+      source.cache.defaultTransformOptions,
+      source.defaultTransformOptions,
+      'defaultTransformOptions are shared'
+    );
+    assert.strictEqual(
+      source.cache.defaultTransformOptions?.b,
+      1,
+      'cache.defaultTransformOptions are correct'
+    );
+    assert.strictEqual(
+      source.cache.defaultQueryOptions,
+      source.defaultQueryOptions,
+      'defaultQueryOptions are shared'
+    );
+    assert.strictEqual(
+      source.cache.defaultQueryOptions?.a,
+      1,
+      'cache.defaultQueryOptions are correct'
+    );
+
+    let newQueryOptions = {
+      a: 2
+    };
+    source.defaultQueryOptions = newQueryOptions;
+    assert.strictEqual(
+      source.defaultQueryOptions?.a,
+      2,
+      'defaultQueryOptions are correct'
+    );
+    assert.strictEqual(
+      source.cache.defaultQueryOptions,
+      source.defaultQueryOptions,
+      'updated defaultQueryOptions are shared'
+    );
+
+    let newTransformOptions = {
+      b: 2
+    };
+    source.defaultTransformOptions = newTransformOptions;
+    assert.strictEqual(
+      source.cache.defaultTransformOptions,
+      source.defaultTransformOptions,
+      'updated defaultTransformOptions are shared'
+    );
+    assert.strictEqual(
+      source.cache.defaultTransformOptions?.b,
+      2,
+      'updated cache.defaultTransformOptions are correct'
+    );
+  });
+
   test("#update - transforms the source's cache", async function (assert) {
     assert.expect(4);
+
+    const source = new MemorySource({ schema, keyMap });
 
     const jupiter: Record = {
       id: 'jupiter',
@@ -150,6 +215,8 @@ module('MemorySource', function (hooks) {
 
   test('#update - can perform multiple operations and return the results', async function (assert) {
     assert.expect(3);
+
+    const source = new MemorySource({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -188,6 +255,8 @@ module('MemorySource', function (hooks) {
 
   test('#update - replaceRelatedRecord can be followed up by removing the replaced record', async function (assert) {
     assert.expect(2);
+
+    const source = new MemorySource({ schema, keyMap });
 
     const star1 = {
       id: 'star1',
@@ -247,6 +316,8 @@ module('MemorySource', function (hooks) {
   test('#update - accepts hints that can return a single record', async function (assert) {
     assert.expect(2);
 
+    const source = new MemorySource({ schema, keyMap });
+
     let jupiter = {
       id: 'jupiter',
       type: 'planet',
@@ -282,6 +353,8 @@ module('MemorySource', function (hooks) {
 
   test('#update - accepts hints that can return a collection of records', async function (assert) {
     assert.expect(2);
+
+    const source = new MemorySource({ schema, keyMap });
 
     let jupiter = {
       id: 'jupiter',
@@ -338,6 +411,8 @@ module('MemorySource', function (hooks) {
 
   test('#update - accepts hints that can return an array of varied results', async function (assert) {
     assert.expect(2);
+
+    const source = new MemorySource({ schema, keyMap });
 
     let jupiter = {
       id: 'jupiter',
@@ -399,6 +474,8 @@ module('MemorySource', function (hooks) {
   test('#update - hint details can be returned in a full response', async function (assert) {
     assert.expect(2);
 
+    const source = new MemorySource({ schema, keyMap });
+
     let jupiter = {
       id: 'jupiter',
       type: 'planet',
@@ -447,6 +524,8 @@ module('MemorySource', function (hooks) {
   test("#query - queries the source's cache", async function (assert) {
     assert.expect(2);
 
+    const source = new MemorySource({ schema, keyMap });
+
     let jupiter = {
       id: 'jupiter',
       type: 'planet',
@@ -470,6 +549,8 @@ module('MemorySource', function (hooks) {
 
   test('#query - findRecord accepts hints that can influence results', async function (assert) {
     assert.expect(2);
+
+    const source = new MemorySource({ schema, keyMap });
 
     let jupiter2 = {
       id: 'jupiter2',
@@ -500,6 +581,8 @@ module('MemorySource', function (hooks) {
 
   test('#query - findRecords accepts hints that can influence results', async function (assert) {
     assert.expect(2);
+
+    const source = new MemorySource({ schema, keyMap });
 
     let jupiter = {
       id: 'jupiter',
@@ -561,6 +644,8 @@ module('MemorySource', function (hooks) {
   test('#query - catches errors', async function (assert) {
     assert.expect(2);
 
+    const source = new MemorySource({ schema, keyMap });
+
     source.cache.reset();
 
     assert.equal(
@@ -580,6 +665,7 @@ module('MemorySource', function (hooks) {
   });
 
   test('#query - can query with multiple expressions', async function (assert) {
+    const source = new MemorySource({ schema, keyMap });
     const jupiter: Record = {
       type: 'planet',
       id: 'jupiter',
@@ -606,12 +692,12 @@ module('MemorySource', function (hooks) {
   });
 
   test('#sync - appends transform to log', async function (assert) {
+    const source = new MemorySource({ schema, keyMap });
     const recordA = {
       id: 'jupiter',
       type: 'planet',
       attributes: { name: 'Jupiter' }
     };
-
     const addRecordATransform = buildTransform(
       source.transformBuilder.addRecord(recordA)
     );
@@ -625,6 +711,8 @@ module('MemorySource', function (hooks) {
   });
 
   test('#getTransform - returns a particular transform given an id', async function (assert) {
+    const source = new MemorySource({ schema, keyMap });
+
     const recordA = {
       id: 'jupiter',
       type: 'planet',
@@ -644,6 +732,7 @@ module('MemorySource', function (hooks) {
   });
 
   test('#getInverseOperations - returns the inverse operations for a particular transform', async function (assert) {
+    const source = new MemorySource({ schema, keyMap });
     const recordA = {
       id: 'jupiter',
       type: 'planet',
@@ -652,7 +741,6 @@ module('MemorySource', function (hooks) {
     const addRecordATransform = buildTransform(
       source.transformBuilder.addRecord(recordA)
     );
-
     await source.sync(addRecordATransform);
 
     assert.deepEqual(source.getInverseOperations(addRecordATransform.id), [
@@ -661,6 +749,7 @@ module('MemorySource', function (hooks) {
   });
 
   test('#transformsSince - returns all transforms since a specified transformId', async function (assert) {
+    const source = new MemorySource({ schema, keyMap });
     const recordA = {
       id: 'jupiter',
       type: 'planet',
@@ -694,6 +783,7 @@ module('MemorySource', function (hooks) {
   });
 
   test('#allTransforms - returns all tracked transforms', async function (assert) {
+    const source = new MemorySource({ schema, keyMap });
     const recordA = {
       id: 'jupiter',
       type: 'planet',
@@ -727,6 +817,7 @@ module('MemorySource', function (hooks) {
   });
 
   test('transformLog.truncate - clears transforms from log as well as tracked transforms before a specified transform', async function (assert) {
+    const source = new MemorySource({ schema, keyMap });
     const recordA = {
       id: 'jupiter',
       type: 'planet',
@@ -762,6 +853,7 @@ module('MemorySource', function (hooks) {
   });
 
   test('transformLog.clear - clears all transforms from log as well as tracked transforms', async function (assert) {
+    const source = new MemorySource({ schema, keyMap });
     const recordA = {
       id: 'jupiter',
       type: 'planet',
@@ -797,6 +889,8 @@ module('MemorySource', function (hooks) {
   });
 
   test('#fork - creates a new source that starts with the same schema, keyMap, and cache contents as the base source', async function (assert) {
+    const source = new MemorySource({ schema, keyMap });
+
     const jupiter: Record = {
       type: 'planet',
       id: 'jupiter-id',
@@ -843,6 +937,8 @@ module('MemorySource', function (hooks) {
   });
 
   test('#merge - merges transforms from a forked source back into a base source', async function (assert) {
+    const source = new MemorySource({ schema, keyMap });
+
     const jupiter: Record = {
       type: 'planet',
       id: 'jupiter-id',
@@ -870,6 +966,8 @@ module('MemorySource', function (hooks) {
 
   test('#merge - can accept options that will be assigned to the resulting transform', async function (assert) {
     assert.expect(3);
+
+    const source = new MemorySource({ schema, keyMap });
 
     const jupiter: Record = {
       type: 'planet',
@@ -903,6 +1001,8 @@ module('MemorySource', function (hooks) {
   test('#rebase - works with empty sources', function (assert) {
     assert.expect(1);
 
+    const source = new MemorySource({ schema, keyMap });
+
     let child = source.fork();
     child.rebase();
 
@@ -917,6 +1017,8 @@ module('MemorySource', function (hooks) {
       id: 'jupiter-id',
       attributes: { name: 'Jupiter', classification: 'gas giant' }
     };
+
+    const source = new MemorySource({ schema, keyMap });
 
     let child = source.fork();
 
@@ -943,6 +1045,7 @@ module('MemorySource', function (hooks) {
   });
 
   test('#rebase - maintains only unique transforms in fork', async function (assert) {
+    const source = new MemorySource({ schema, keyMap });
     const recordA = {
       id: 'jupiter',
       type: 'planet',
@@ -1002,6 +1105,8 @@ module('MemorySource', function (hooks) {
   test('#rebase - rebase orders conflicting transforms in expected way', async function (assert) {
     assert.expect(6);
 
+    const source = new MemorySource({ schema, keyMap });
+
     const jupiter: Record = {
       type: 'planet',
       id: 'jupiter-id',
@@ -1057,6 +1162,7 @@ module('MemorySource', function (hooks) {
   test('#rebase - calling rebase multiple times', async function (assert) {
     assert.expect(22);
 
+    const source = new MemorySource({ schema, keyMap });
     const jupiter: Record = {
       type: 'planet',
       id: 'jupiter-id',
@@ -1198,6 +1304,7 @@ module('MemorySource', function (hooks) {
   });
 
   test('#rollback - rolls back transform log and replays transform inverses against the cache', async function (assert) {
+    const source = new MemorySource({ schema, keyMap });
     const recordA = {
       id: 'jupiter',
       type: 'planet',
@@ -1265,13 +1372,13 @@ module('MemorySource', function (hooks) {
   });
 
   test('#upgrade upgrades the cache to include new models introduced in a schema', async function (assert) {
-    let person = {
+    const source = new MemorySource({ schema, keyMap });
+    const person = {
       type: 'person',
       id: '1',
       relationships: { planet: { data: { type: 'planet', id: 'earth' } } }
     };
-
-    let models = clone(schema.models);
+    const models = clone(schema.models);
     models.planet.relationships.inhabitants = {
       kind: 'hasMany',
       type: 'person',

--- a/packages/@orbit/record-cache/src/record-cache.ts
+++ b/packages/@orbit/record-cache/src/record-cache.ts
@@ -97,10 +97,22 @@ export abstract class RecordCache<
     return this._defaultQueryOptions;
   }
 
+  set defaultQueryOptions(
+    options: DefaultRequestOptions<QueryOptions> | undefined
+  ) {
+    this._defaultQueryOptions = options;
+  }
+
   get defaultTransformOptions():
     | DefaultRequestOptions<TransformOptions>
     | undefined {
     return this._defaultTransformOptions;
+  }
+
+  set defaultTransformOptions(
+    options: DefaultRequestOptions<TransformOptions> | undefined
+  ) {
+    this._defaultTransformOptions = options;
   }
 
   getQueryOptions(

--- a/packages/@orbit/record-cache/test/record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/record-cache-test.ts
@@ -80,6 +80,42 @@ module('RecordCache', function (hooks) {
     );
   });
 
+  test('`defaultQueryOptions` and `defaultTransformOptions` can be modified', function (assert) {
+    const defaultQueryOptions = {
+      maxRequests: 3
+    };
+
+    const defaultTransformOptions = {
+      maxRequests: 1
+    };
+
+    let cache = new MyRecordCache({
+      schema,
+      defaultQueryOptions,
+      defaultTransformOptions
+    });
+
+    cache.defaultQueryOptions = {
+      ...cache.defaultQueryOptions,
+      type: 'query'
+    };
+
+    assert.deepEqual(cache.defaultQueryOptions, {
+      maxRequests: 3,
+      type: 'query'
+    });
+
+    cache.defaultTransformOptions = {
+      ...cache.defaultTransformOptions,
+      type: 'transform'
+    };
+
+    assert.deepEqual(cache.defaultTransformOptions, {
+      maxRequests: 1,
+      type: 'transform'
+    });
+  });
+
   test('it can get query options that merge default, query, and expression options', function (assert) {
     const defaultQueryOptions = {
       foo: 'bar',

--- a/packages/@orbit/records/src/record-source.ts
+++ b/packages/@orbit/records/src/record-source.ts
@@ -54,8 +54,6 @@ export abstract class RecordSource<
 > {
   protected _keyMap?: RecordKeyMap;
   protected _schema: RecordSchema;
-  protected _queryBuilder!: RecordQueryBuilder;
-  protected _transformBuilder!: RecordTransformBuilder;
 
   constructor(settings: RecordSourceSettings<QueryOptions, TransformOptions>) {
     const autoActivate =
@@ -101,11 +99,11 @@ export abstract class RecordSource<
   }
 
   get queryBuilder(): RecordQueryBuilder {
-    return this._queryBuilder;
+    return this._queryBuilder as RecordQueryBuilder;
   }
 
   get transformBuilder(): RecordTransformBuilder {
-    return this._transformBuilder;
+    return this._transformBuilder as RecordTransformBuilder;
   }
 
   /**

--- a/packages/@orbit/records/test/record-source-test.ts
+++ b/packages/@orbit/records/test/record-source-test.ts
@@ -103,4 +103,68 @@ module('Source', function (hooks) {
       'syncQueue has been assigned bucket'
     );
   });
+
+  test('it can be instantiated with `defaultQueryOptions` and/or `defaultTransformOptions`', function (assert) {
+    const defaultQueryOptions = {
+      foo: 'bar'
+    };
+
+    const defaultTransformOptions = {
+      foo: 'bar'
+    };
+
+    source = new MySource({
+      schema,
+      defaultQueryOptions,
+      defaultTransformOptions
+    });
+
+    assert.strictEqual(
+      source.defaultQueryOptions,
+      defaultQueryOptions,
+      'defaultQueryOptions remains the same'
+    );
+
+    assert.strictEqual(
+      source.defaultTransformOptions,
+      defaultTransformOptions,
+      'defaultTransformOptions remains the same'
+    );
+  });
+
+  test('`defaultQueryOptions` and `defaultTransformOptions` can be modified', function (assert) {
+    const defaultQueryOptions = {
+      maxRequests: 3
+    };
+
+    const defaultTransformOptions = {
+      maxRequests: 1
+    };
+
+    source = new MySource({
+      schema,
+      defaultQueryOptions,
+      defaultTransformOptions
+    });
+
+    source.defaultQueryOptions = {
+      ...source.defaultQueryOptions,
+      type: 'query'
+    };
+
+    assert.deepEqual(source.defaultQueryOptions, {
+      maxRequests: 3,
+      type: 'query'
+    });
+
+    source.defaultTransformOptions = {
+      ...source.defaultTransformOptions,
+      type: 'transform'
+    };
+
+    assert.deepEqual(source.defaultTransformOptions, {
+      maxRequests: 1,
+      type: 'transform'
+    });
+  });
 });


### PR DESCRIPTION
On source instantiation, caches will now be instantiated with any `defaultQueryOptions` and `defaultTransformOptions` passed as source settings (unless the corresponding options are explicitly set in `cacheSettings`).

Furthermore, these settings will be kept in sync when updated on the source.