### PR TITLE
Coordinator: Allow generic typing of getStrategy & getSource

### DIFF
--- a/packages/@orbit/coordinator/src/coordinator.ts
+++ b/packages/@orbit/coordinator/src/coordinator.ts
@@ -84,8 +84,8 @@ export class Coordinator {
     delete this._sources[name];
   }
 
-  getSource(name: string): Source {
-    return this._sources[name];
+  getSource<T extends Source = Source>(name: string): T {
+    return this._sources[name] as T;
   }
 
   get sources(): Source[] {
@@ -126,8 +126,8 @@ export class Coordinator {
     delete this._strategies[name];
   }
 
-  getStrategy(name: string): Strategy {
-    return this._strategies[name];
+  getStrategy<T extends Strategy = Strategy>(name: string): T {
+    return this._strategies[name] as T;
   }
 
   get strategies(): Strategy[] {

--- a/packages/@orbit/coordinator/test/coordinator-test.ts
+++ b/packages/@orbit/coordinator/test/coordinator-test.ts
@@ -28,9 +28,9 @@ module('Coordinator', function (hooks) {
     assert.deepEqual(coordinator.sources, [s1, s2, s3]);
     assert.deepEqual(coordinator.sourceNames, ['s1', 's2', 's3']);
 
-    assert.strictEqual(coordinator.getSource('s1'), s1);
-    assert.strictEqual(coordinator.getSource('s2'), s2);
-    assert.strictEqual(coordinator.getSource('s3'), s3);
+    assert.strictEqual(coordinator.getSource<MySource>('s1'), s1);
+    assert.strictEqual(coordinator.getSource<MySource>('s2'), s2);
+    assert.strictEqual(coordinator.getSource<MySource>('s3'), s3);
   });
 
   test('can not add a source without a name', function (assert) {
@@ -110,9 +110,9 @@ module('Coordinator', function (hooks) {
     assert.deepEqual(coordinator.strategies, [s1, s2, s3]);
     assert.deepEqual(coordinator.strategyNames, ['s1', 's2', 's3']);
 
-    assert.strictEqual(coordinator.getStrategy('s1'), s1);
-    assert.strictEqual(coordinator.getStrategy('s2'), s2);
-    assert.strictEqual(coordinator.getStrategy('s3'), s3);
+    assert.strictEqual(coordinator.getStrategy<MyStrategy>('s1'), s1);
+    assert.strictEqual(coordinator.getStrategy<MyStrategy>('s2'), s2);
+    assert.strictEqual(coordinator.getStrategy<MyStrategy>('s3'), s3);
   });
 
   test('can not add a strategy with a duplicate name', function (assert) {


### PR DESCRIPTION
Makes it possible (but entirely optional) to explicitly type the return from `getSource` and `getStrategy`. For example:

```
const source = coordinator.getSource<MySource>('backup');
const strategy = coordinator.getStrategy<MyStrategy>('sync');
```