### PR TITLE
Introduce `raiseNotFoundException` option for transform requests

### DIFF
--- a/packages/@orbit/indexeddb/test/indexeddb-source-updatable-test.ts
+++ b/packages/@orbit/indexeddb/test/indexeddb-source-updatable-test.ts
@@ -112,6 +112,25 @@ module('IndexedDBSource - updatable', function (hooks) {
     assert.strictEqual(record, jupiter, 'result should be returned');
   });
 
+  test('#update - catches errors', async function (assert) {
+    assert.expect(2);
+
+    assert.equal(
+      (await source.cache.getRecordsAsync('planet')).length,
+      0,
+      'cache should contain no planets'
+    );
+
+    try {
+      await source.update(
+        (t) => t.removeRecord({ type: 'planet', id: 'jupiter' }),
+        { raiseNotFoundExceptions: true }
+      );
+    } catch (e) {
+      assert.equal(e.message, 'Record not found: planet:jupiter');
+    }
+  });
+
   test('#update - can perform multiple operations and return the results', async function (assert) {
     assert.expect(3);
 

--- a/packages/@orbit/local-storage/test/local-storage-source-updatable-test.ts
+++ b/packages/@orbit/local-storage/test/local-storage-source-updatable-test.ts
@@ -108,6 +108,29 @@ module('LocalStorageSource - updatable', function (hooks) {
     assert.strictEqual(record, jupiter, 'result should be returned');
   });
 
+  test('#update - catches errors', async function (assert) {
+    assert.expect(2);
+
+    const source = new LocalStorageSource({ schema, keyMap });
+
+    source.cache.reset();
+
+    assert.equal(
+      source.cache.getRecordsSync('planet').length,
+      0,
+      'cache should contain no planets'
+    );
+
+    try {
+      await source.update(
+        (t) => t.removeRecord({ type: 'planet', id: 'jupiter' }),
+        { raiseNotFoundExceptions: true }
+      );
+    } catch (e) {
+      assert.equal(e.message, 'Record not found: planet:jupiter');
+    }
+  });
+
   test('#update - can perform multiple operations and return the results', async function (assert) {
     assert.expect(3);
 

--- a/packages/@orbit/memory/test/memory-source-updatable-test.ts
+++ b/packages/@orbit/memory/test/memory-source-updatable-test.ts
@@ -102,6 +102,29 @@ module('MemorySource - updatable', function (hooks) {
     assert.strictEqual(record, jupiter, 'result should be returned');
   });
 
+  test('#update - catches errors', async function (assert) {
+    assert.expect(2);
+
+    const source = new MemorySource({ schema, keyMap });
+
+    source.cache.reset();
+
+    assert.equal(
+      source.cache.getRecordsSync('planet').length,
+      0,
+      'cache should contain no planets'
+    );
+
+    try {
+      await source.update(
+        (t) => t.removeRecord({ type: 'planet', id: 'jupiter' }),
+        { raiseNotFoundExceptions: true }
+      );
+    } catch (e) {
+      assert.equal(e.message, 'Record not found: planet:jupiter');
+    }
+  });
+
   test('#update - can perform multiple operations and return the results', async function (assert) {
     assert.expect(3);
 

--- a/packages/@orbit/record-cache/src/async-record-cache.ts
+++ b/packages/@orbit/record-cache/src/async-record-cache.ts
@@ -51,6 +51,7 @@ import { AsyncLiveQuery } from './live-query/async-live-query';
 import {
   RecordCache,
   RecordCacheQueryOptions,
+  RecordCacheTransformOptions,
   RecordCacheSettings
 } from './record-cache';
 
@@ -58,7 +59,7 @@ const { assert, deprecate } = Orbit;
 
 export interface AsyncRecordCacheSettings<
   QueryOptions extends RequestOptions = RecordCacheQueryOptions,
-  TransformOptions extends RequestOptions = RequestOptions
+  TransformOptions extends RequestOptions = RecordCacheTransformOptions
 > extends RecordCacheSettings<QueryOptions, TransformOptions> {
   processors?: AsyncOperationProcessorClass[];
   queryOperators?: Dict<AsyncQueryOperator>;
@@ -69,7 +70,7 @@ export interface AsyncRecordCacheSettings<
 
 export abstract class AsyncRecordCache<
     QueryOptions extends RequestOptions = RecordCacheQueryOptions,
-    TransformOptions extends RequestOptions = RequestOptions
+    TransformOptions extends RequestOptions = RecordCacheTransformOptions
   >
   extends RecordCache<QueryOptions, TransformOptions>
   implements AsyncRecordAccessor {

--- a/packages/@orbit/record-cache/src/operators/async-transform-operators.ts
+++ b/packages/@orbit/record-cache/src/operators/async-transform-operators.ts
@@ -17,7 +17,8 @@ import {
   ReplaceRelatedRecordOperation,
   Record,
   recordsInclude,
-  RecordTransform
+  RecordTransform,
+  RecordNotFoundException
 } from '@orbit/records';
 import { AsyncRecordCache } from '../async-record-cache';
 
@@ -54,6 +55,14 @@ export const AsyncTransformOperators: Dict<AsyncTransformOperator> = {
     const op = operation as UpdateRecordOperation;
     const { record } = op;
     const currentRecord = await cache.getRecordAsync(record);
+
+    if (currentRecord === undefined) {
+      const options = cache.getTransformOptions(transform, operation);
+      if (options?.raiseNotFoundExceptions) {
+        throw new RecordNotFoundException(record.type, record.id);
+      }
+    }
+
     const mergedRecord = mergeRecords(currentRecord || null, record);
 
     await cache.setRecordAsync(mergedRecord);
@@ -71,7 +80,16 @@ export const AsyncTransformOperators: Dict<AsyncTransformOperator> = {
     operation: RecordOperation
   ): Promise<RecordOperationResult> {
     const op = operation as RemoveRecordOperation;
-    return await cache.removeRecordAsync(op.record);
+    const record = await cache.removeRecordAsync(op.record);
+
+    if (record === undefined) {
+      const options = cache.getTransformOptions(transform, operation);
+      if (options?.raiseNotFoundExceptions) {
+        throw new RecordNotFoundException(op.record.type, op.record.id);
+      }
+    }
+
+    return record;
   },
 
   async replaceKey(
@@ -87,6 +105,11 @@ export const AsyncTransformOperators: Dict<AsyncTransformOperator> = {
       record = clone(currentRecord);
     } else {
       record = cloneRecordIdentity(op.record);
+
+      const options = cache.getTransformOptions(transform, operation);
+      if (options?.raiseNotFoundExceptions) {
+        throw new RecordNotFoundException(record.type, record.id);
+      }
     }
 
     deepSet(record, ['keys', op.key], op.value);
@@ -112,6 +135,11 @@ export const AsyncTransformOperators: Dict<AsyncTransformOperator> = {
       record = clone(currentRecord);
     } else {
       record = cloneRecordIdentity(op.record);
+
+      const options = cache.getTransformOptions(transform, operation);
+      if (options?.raiseNotFoundExceptions) {
+        throw new RecordNotFoundException(record.type, record.id);
+      }
     }
 
     deepSet(record, ['attributes', op.attribute], op.value);
@@ -134,6 +162,11 @@ export const AsyncTransformOperators: Dict<AsyncTransformOperator> = {
       record = clone(currentRecord);
     } else {
       record = cloneRecordIdentity(op.record);
+
+      const options = cache.getTransformOptions(transform, operation);
+      if (options?.raiseNotFoundExceptions) {
+        throw new RecordNotFoundException(record.type, record.id);
+      }
     }
 
     const relatedRecords: RecordIdentity[] =
@@ -182,6 +215,11 @@ export const AsyncTransformOperators: Dict<AsyncTransformOperator> = {
         }
       }
       return record;
+    } else {
+      const options = cache.getTransformOptions(transform, operation);
+      if (options?.raiseNotFoundExceptions) {
+        throw new RecordNotFoundException(op.record.type, op.record.id);
+      }
     }
   },
 
@@ -199,6 +237,11 @@ export const AsyncTransformOperators: Dict<AsyncTransformOperator> = {
       record = clone(currentRecord);
     } else {
       record = cloneRecordIdentity(op.record);
+
+      const options = cache.getTransformOptions(transform, operation);
+      if (options?.raiseNotFoundExceptions) {
+        throw new RecordNotFoundException(record.type, record.id);
+      }
     }
 
     if (
@@ -224,6 +267,11 @@ export const AsyncTransformOperators: Dict<AsyncTransformOperator> = {
       record = clone(currentRecord);
     } else {
       record = cloneRecordIdentity(op.record);
+
+      const options = cache.getTransformOptions(transform, operation);
+      if (options?.raiseNotFoundExceptions) {
+        throw new RecordNotFoundException(record.type, record.id);
+      }
     }
 
     if (

--- a/packages/@orbit/record-cache/src/operators/sync-transform-operators.ts
+++ b/packages/@orbit/record-cache/src/operators/sync-transform-operators.ts
@@ -17,7 +17,8 @@ import {
   ReplaceRelatedRecordOperation,
   Record,
   recordsInclude,
-  RecordTransform
+  RecordTransform,
+  RecordNotFoundException
 } from '@orbit/records';
 import { SyncRecordCache } from '../sync-record-cache';
 
@@ -54,6 +55,14 @@ export const SyncTransformOperators: Dict<SyncTransformOperator> = {
     const op = operation as UpdateRecordOperation;
     const { record } = op;
     const currentRecord = cache.getRecordSync(record);
+
+    if (currentRecord === undefined) {
+      const options = cache.getTransformOptions(transform, operation);
+      if (options?.raiseNotFoundExceptions) {
+        throw new RecordNotFoundException(record.type, record.id);
+      }
+    }
+
     const mergedRecord = mergeRecords(currentRecord || null, record);
 
     cache.setRecordSync(mergedRecord);
@@ -71,7 +80,16 @@ export const SyncTransformOperators: Dict<SyncTransformOperator> = {
     operation: RecordOperation
   ): RecordOperationResult {
     const op = operation as RemoveRecordOperation;
-    return cache.removeRecordSync(op.record);
+    const record = cache.removeRecordSync(op.record);
+
+    if (record === undefined) {
+      const options = cache.getTransformOptions(transform, operation);
+      if (options?.raiseNotFoundExceptions) {
+        throw new RecordNotFoundException(op.record.type, op.record.id);
+      }
+    }
+
+    return record;
   },
 
   replaceKey(
@@ -87,6 +105,11 @@ export const SyncTransformOperators: Dict<SyncTransformOperator> = {
       record = clone(currentRecord);
     } else {
       record = cloneRecordIdentity(op.record);
+
+      const options = cache.getTransformOptions(transform, operation);
+      if (options?.raiseNotFoundExceptions) {
+        throw new RecordNotFoundException(record.type, record.id);
+      }
     }
 
     deepSet(record, ['keys', op.key], op.value);
@@ -112,6 +135,11 @@ export const SyncTransformOperators: Dict<SyncTransformOperator> = {
       record = clone(currentRecord);
     } else {
       record = cloneRecordIdentity(op.record);
+
+      const options = cache.getTransformOptions(transform, operation);
+      if (options?.raiseNotFoundExceptions) {
+        throw new RecordNotFoundException(record.type, record.id);
+      }
     }
 
     deepSet(record, ['attributes', op.attribute], op.value);
@@ -134,6 +162,11 @@ export const SyncTransformOperators: Dict<SyncTransformOperator> = {
       record = clone(currentRecord);
     } else {
       record = cloneRecordIdentity(op.record);
+
+      const options = cache.getTransformOptions(transform, operation);
+      if (options?.raiseNotFoundExceptions) {
+        throw new RecordNotFoundException(record.type, record.id);
+      }
     }
 
     const relatedRecords: RecordIdentity[] =
@@ -182,6 +215,11 @@ export const SyncTransformOperators: Dict<SyncTransformOperator> = {
         }
       }
       return record;
+    } else {
+      const options = cache.getTransformOptions(transform, operation);
+      if (options?.raiseNotFoundExceptions) {
+        throw new RecordNotFoundException(op.record.type, op.record.id);
+      }
     }
   },
 
@@ -199,6 +237,11 @@ export const SyncTransformOperators: Dict<SyncTransformOperator> = {
       record = clone(currentRecord);
     } else {
       record = cloneRecordIdentity(op.record);
+
+      const options = cache.getTransformOptions(transform, operation);
+      if (options?.raiseNotFoundExceptions) {
+        throw new RecordNotFoundException(record.type, record.id);
+      }
     }
 
     if (
@@ -224,6 +267,11 @@ export const SyncTransformOperators: Dict<SyncTransformOperator> = {
       record = clone(currentRecord);
     } else {
       record = cloneRecordIdentity(op.record);
+
+      const options = cache.getTransformOptions(transform, operation);
+      if (options?.raiseNotFoundExceptions) {
+        throw new RecordNotFoundException(record.type, record.id);
+      }
     }
 
     if (

--- a/packages/@orbit/record-cache/src/record-cache.ts
+++ b/packages/@orbit/record-cache/src/record-cache.ts
@@ -20,9 +20,13 @@ export interface RecordCacheQueryOptions extends RequestOptions {
   raiseNotFoundExceptions?: boolean;
 }
 
+export interface RecordCacheTransformOptions extends RequestOptions {
+  raiseNotFoundExceptions?: boolean;
+}
+
 export interface RecordCacheSettings<
   QueryOptions extends RequestOptions = RecordCacheQueryOptions,
-  TransformOptions extends RequestOptions = RequestOptions
+  TransformOptions extends RequestOptions = RecordCacheTransformOptions
 > {
   name?: string;
   schema: RecordSchema;
@@ -36,13 +40,13 @@ export interface RecordCacheSettings<
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface RecordCache<
   QueryOptions extends RequestOptions = RecordCacheQueryOptions,
-  TransformOptions extends RequestOptions = RequestOptions
+  TransformOptions extends RequestOptions = RecordCacheTransformOptions
 > extends Evented {}
 
 @evented
 export abstract class RecordCache<
   QueryOptions extends RequestOptions = RecordCacheQueryOptions,
-  TransformOptions extends RequestOptions = RequestOptions
+  TransformOptions extends RequestOptions = RecordCacheTransformOptions
 > {
   protected _name?: string;
   protected _keyMap?: RecordKeyMap;

--- a/packages/@orbit/record-cache/src/sync-record-cache.ts
+++ b/packages/@orbit/record-cache/src/sync-record-cache.ts
@@ -51,6 +51,7 @@ import { SyncLiveQuery } from './live-query/sync-live-query';
 import {
   RecordCache,
   RecordCacheQueryOptions,
+  RecordCacheTransformOptions,
   RecordCacheSettings
 } from './record-cache';
 
@@ -58,7 +59,7 @@ const { assert, deprecate } = Orbit;
 
 export interface SyncRecordCacheSettings<
   QueryOptions extends RequestOptions = RecordCacheQueryOptions,
-  TransformOptions extends RequestOptions = RequestOptions
+  TransformOptions extends RequestOptions = RecordCacheTransformOptions
 > extends RecordCacheSettings<QueryOptions, TransformOptions> {
   processors?: SyncOperationProcessorClass[];
   queryOperators?: Dict<SyncQueryOperator>;
@@ -69,7 +70,7 @@ export interface SyncRecordCacheSettings<
 
 export abstract class SyncRecordCache<
     QueryOptions extends RequestOptions = RecordCacheQueryOptions,
-    TransformOptions extends RequestOptions = RequestOptions
+    TransformOptions extends RequestOptions = RecordCacheTransformOptions
   >
   extends RecordCache<QueryOptions, TransformOptions>
   implements SyncRecordAccessor {

--- a/packages/@orbit/record-cache/test/async-record-cache-update-test.ts
+++ b/packages/@orbit/record-cache/test/async-record-cache-update-test.ts
@@ -5,7 +5,8 @@ import {
   RecordIdentity,
   recordsInclude,
   recordsIncludeAll,
-  RecordSchema
+  RecordSchema,
+  RecordNotFoundException
 } from '@orbit/records';
 import { ExampleAsyncRecordCache } from './support/example-async-record-cache';
 import { createSchemaWithRemoteKey } from './support/setup';
@@ -1684,5 +1685,165 @@ module('AsyncRecordCache', function (hooks) {
       star2.id,
       'The related record was replaced.'
     );
+  });
+
+  test("#update - updateRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
+
+    const earth: Record = {
+      type: 'planet',
+      id: '1',
+      attributes: { name: 'Earth' },
+      keys: { remoteId: 'a' }
+    };
+
+    try {
+      await cache.update((t) =>
+        t.updateRecord(earth).options({
+          raiseNotFoundExceptions: true
+        })
+      );
+    } catch (e) {
+      assert.ok(e instanceof RecordNotFoundException);
+    }
+  });
+
+  test("#update - removeRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
+
+    const earth: Record = {
+      type: 'planet',
+      id: '1'
+    };
+
+    try {
+      await cache.update((t) =>
+        t.removeRecord(earth).options({
+          raiseNotFoundExceptions: true
+        })
+      );
+    } catch (e) {
+      assert.ok(e instanceof RecordNotFoundException);
+    }
+  });
+
+  test("#update - replaceKey - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
+
+    const earth: Record = {
+      type: 'planet',
+      id: '1',
+      attributes: { name: 'Earth' },
+      keys: { remoteId: 'a' }
+    };
+
+    try {
+      await cache.update((t) =>
+        t.replaceKey(earth, 'remoteId', 'b').options({
+          raiseNotFoundExceptions: true
+        })
+      );
+    } catch (e) {
+      assert.ok(e instanceof RecordNotFoundException);
+    }
+  });
+
+  test("#update - replaceAttribute - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
+
+    const earth: Record = {
+      type: 'planet',
+      id: '1',
+      attributes: { name: 'Earth' },
+      keys: { remoteId: 'a' }
+    };
+
+    try {
+      await cache.update((t) =>
+        t.replaceAttribute(earth, 'name', 'Mother Earth').options({
+          raiseNotFoundExceptions: true
+        })
+      );
+    } catch (e) {
+      assert.ok(e instanceof RecordNotFoundException);
+    }
+  });
+
+  test("#update - addToRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
+
+    try {
+      await cache.update((t) =>
+        t
+          .addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+            type: 'moon',
+            id: 'm1'
+          })
+          .options({
+            raiseNotFoundExceptions: true
+          })
+      );
+    } catch (e) {
+      assert.ok(e instanceof RecordNotFoundException);
+    }
+  });
+
+  test("#update - removeFromRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
+
+    try {
+      await cache.update((t) =>
+        t
+          .removeFromRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+            type: 'moon',
+            id: 'm1'
+          })
+          .options({
+            raiseNotFoundExceptions: true
+          })
+      );
+    } catch (e) {
+      assert.ok(e instanceof RecordNotFoundException);
+    }
+  });
+
+  test("#update - replaceRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
+
+    try {
+      await cache.update((t) =>
+        t
+          .replaceRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', [
+            {
+              type: 'moon',
+              id: 'm1'
+            }
+          ])
+          .options({
+            raiseNotFoundExceptions: true
+          })
+      );
+    } catch (e) {
+      assert.ok(e instanceof RecordNotFoundException);
+    }
+  });
+
+  test("#update - replaceRelatedRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
+
+    try {
+      await cache.update((t) =>
+        t
+          .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
+            type: 'planet',
+            id: 'p1'
+          })
+          .options({
+            raiseNotFoundExceptions: true
+          })
+      );
+    } catch (e) {
+      assert.ok(e instanceof RecordNotFoundException);
+    }
   });
 });

--- a/packages/@orbit/record-cache/test/sync-record-cache-update-test.ts
+++ b/packages/@orbit/record-cache/test/sync-record-cache-update-test.ts
@@ -5,7 +5,8 @@ import {
   RecordIdentity,
   recordsInclude,
   recordsIncludeAll,
-  RecordSchema
+  RecordSchema,
+  RecordNotFoundException
 } from '@orbit/records';
 import { ExampleSyncRecordCache } from './support/example-sync-record-cache';
 import { createSchemaWithRemoteKey } from './support/setup';
@@ -1652,6 +1653,166 @@ module('SyncRecordCache', function (hooks) {
       (latestHome?.relationships?.star.data as Record).id,
       star2.id,
       'The related record was replaced.'
+    );
+  });
+
+  test("#update - updateRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+    const earth: Record = {
+      type: 'planet',
+      id: '1',
+      attributes: { name: 'Earth' },
+      keys: { remoteId: 'a' }
+    };
+
+    assert.throws(
+      () =>
+        cache.update((t) =>
+          t.updateRecord(earth).options({
+            raiseNotFoundExceptions: true
+          })
+        ),
+      RecordNotFoundException
+    );
+  });
+
+  test("#update - removeRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+    const earth: Record = {
+      type: 'planet',
+      id: '1'
+    };
+
+    assert.throws(
+      () =>
+        cache.update((t) =>
+          t.removeRecord(earth).options({
+            raiseNotFoundExceptions: true
+          })
+        ),
+      RecordNotFoundException
+    );
+  });
+
+  test("#update - replaceKey - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+    const earth: Record = {
+      type: 'planet',
+      id: '1',
+      attributes: { name: 'Earth' },
+      keys: { remoteId: 'a' }
+    };
+
+    assert.throws(
+      () =>
+        cache.update((t) =>
+          t.replaceKey(earth, 'remoteId', 'b').options({
+            raiseNotFoundExceptions: true
+          })
+        ),
+      RecordNotFoundException
+    );
+  });
+
+  test("#update - replaceAttribute - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+    const earth: Record = {
+      type: 'planet',
+      id: '1',
+      attributes: { name: 'Earth' },
+      keys: { remoteId: 'a' }
+    };
+
+    assert.throws(
+      () =>
+        cache.update((t) =>
+          t.replaceAttribute(earth, 'name', 'Mother Earth').options({
+            raiseNotFoundExceptions: true
+          })
+        ),
+      RecordNotFoundException
+    );
+  });
+
+  test("#update - addToRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+    assert.throws(
+      () =>
+        cache.update((t) =>
+          t
+            .addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+              type: 'moon',
+              id: 'm1'
+            })
+            .options({
+              raiseNotFoundExceptions: true
+            })
+        ),
+      RecordNotFoundException
+    );
+  });
+
+  test("#update - removeFromRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+    assert.throws(
+      () =>
+        cache.update((t) =>
+          t
+            .removeFromRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+              type: 'moon',
+              id: 'm1'
+            })
+            .options({
+              raiseNotFoundExceptions: true
+            })
+        ),
+      RecordNotFoundException
+    );
+  });
+
+  test("#update - replaceRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+    assert.throws(
+      () =>
+        cache.update((t) =>
+          t
+            .replaceRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', [
+              {
+                type: 'moon',
+                id: 'm1'
+              }
+            ])
+            .options({
+              raiseNotFoundExceptions: true
+            })
+        ),
+      RecordNotFoundException
+    );
+  });
+
+  test("#update - replaceRelatedRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+    const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+    assert.throws(
+      () =>
+        cache.update((t) =>
+          t
+            .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
+              type: 'planet',
+              id: 'p1'
+            })
+            .options({
+              raiseNotFoundExceptions: true
+            })
+        ),
+      RecordNotFoundException
     );
   });
 });


### PR DESCRIPTION
`RecordCacheTransformOptions` now parallels `RecordCacheQueryOptions`.

The default behavior (raising no exceptions) is to treat updates as if to a sparse cache, filling in details as requested. By setting `raiseNotFoundException: true`, you can prevent transforms from being applied to records that do not yet exist in a cache.