### PR TITLE
Improve bulk IndexedDB performance

### DIFF
--- a/packages/@orbit/indexeddb/test/indexeddb-cache-test.ts
+++ b/packages/@orbit/indexeddb/test/indexeddb-cache-test.ts
@@ -849,7 +849,7 @@ module('IndexedDBCache', function (hooks) {
     let records = await cache.query((q) => q.findRecords());
     assert.deepEqual(
       records,
-      [io, earth, jupiter],
+      [earth, jupiter, io],
       'query results are expected'
     );
 


### PR DESCRIPTION
Perform multiple IDB operations (get/put/delete) simultaneously rather than serially for bulk operations. Only the last request needs an `onsuccess` handler. This approach is not only more performant but much more robust when applying very large (> 5000 record) updates.

---

This approach results in modest performance gains for IndexedDB. In addition, I'm working on providing much more significant gains via a transform buffer that allows for complex updates that involve many record types and relationships to be truly batched and performed in a single IDB transaction.