### PR TITLE
Introduce RecordTransformBuffer for improving performance and atomicity of cache updates

### DIFF
--- a/packages/@orbit/indexeddb/src/indexeddb-cache.ts
+++ b/packages/@orbit/indexeddb/src/indexeddb-cache.ts
@@ -235,7 +235,7 @@ export class IndexedDBCache extends AsyncRecordCache {
   ): Promise<Record[]> {
     if (!this._db) return Promise.reject(DB_NOT_OPEN);
 
-    if (!typeOrIdentities) {
+    if (typeOrIdentities === undefined) {
       return this._getAllRecords();
     } else if (typeof typeOrIdentities === 'string') {
       const type: string = typeOrIdentities;

--- a/packages/@orbit/indexeddb/src/indexeddb-cache.ts
+++ b/packages/@orbit/indexeddb/src/indexeddb-cache.ts
@@ -408,20 +408,16 @@ export class IndexedDBCache extends AsyncRecordCache {
   }
 
   getInverseRelationshipsAsync(
-    recordIdentity: RecordIdentity
+    recordIdentityOrIdentities: RecordIdentity | RecordIdentity[]
   ): Promise<RecordRelationshipIdentity[]> {
-    // console.log('getInverseRelationshipsAsync', recordIdentity);
+    // console.log('getInverseRelationshipsAsync', recordIdentityOrIdentities);
 
     return new Promise((resolve, reject) => {
       if (!this._db) return reject(DB_NOT_OPEN);
 
+      const results: RecordRelationshipIdentity[] = [];
       const transaction = this._db.transaction([INVERSE_RELS]);
       const objectStore = transaction.objectStore(INVERSE_RELS);
-      const results: RecordRelationshipIdentity[] = [];
-      const keyRange = Orbit.globals.IDBKeyRange.only(
-        serializeRecordIdentity(recordIdentity)
-      );
-
       let index;
       try {
         index = objectStore.index('relatedIdentity');
@@ -434,20 +430,37 @@ export class IndexedDBCache extends AsyncRecordCache {
         return;
       }
 
-      const request = index.openCursor(keyRange);
+      const identities: RecordIdentity[] = Array.isArray(
+        recordIdentityOrIdentities
+      )
+        ? recordIdentityOrIdentities
+        : [recordIdentityOrIdentities];
 
-      request.onsuccess = (event: any) => {
-        const cursor = event.target.result;
-        if (cursor) {
-          let result = this._fromInverseRelationshipForIDB(cursor.value);
-          results.push(result);
-          cursor.continue();
-        } else {
-          resolve(results);
-        }
-      };
+      const len = identities.length;
+      let completed = 0;
+      for (let i = 0; i < len; i++) {
+        const identity = identities[i];
+        const keyRange = Orbit.globals.IDBKeyRange.only(
+          serializeRecordIdentity(identity)
+        );
+        const request = index.openCursor(keyRange);
 
-      request.onerror = () => reject(request.error);
+        request.onsuccess = (event: any) => {
+          const cursor = event.target.result;
+          if (cursor) {
+            let result = this._fromInverseRelationshipForIDB(cursor.value);
+            results.push(result);
+            cursor.continue();
+          } else {
+            completed += 1;
+            if (completed === len) {
+              resolve(results);
+            }
+          }
+        };
+
+        request.onerror = () => reject(request.error);
+      }
     });
   }
 

--- a/packages/@orbit/indexeddb/test/indexeddb-cache-update-test.ts
+++ b/packages/@orbit/indexeddb/test/indexeddb-cache-update-test.ts
@@ -1,0 +1,2056 @@
+import {
+  equalRecordIdentities,
+  RecordKeyMap,
+  Record,
+  RecordIdentity,
+  recordsInclude,
+  recordsIncludeAll,
+  RecordSchema,
+  RecordNotFoundException
+} from '@orbit/records';
+import { IndexedDBCache } from '../src/indexeddb-cache';
+import { createSchemaWithRemoteKey } from './support/setup';
+
+const { module, test } = QUnit;
+
+QUnit.dump.maxDepth = 7;
+
+module('IndexedDBCache - update', function (hooks) {
+  let schema: RecordSchema, keyMap: RecordKeyMap;
+
+  [true, false].forEach((useBuffer) => {
+    module(`useBuffer: ${useBuffer}`, function (hooks) {
+      // All caches in this module share these transform options
+      const defaultTransformOptions = { useBuffer };
+
+      hooks.beforeEach(function () {
+        keyMap = new RecordKeyMap();
+      });
+
+      module('with standard schema', function (hooks) {
+        let cache: IndexedDBCache;
+
+        hooks.beforeEach(async function () {
+          schema = createSchemaWithRemoteKey();
+          cache = new IndexedDBCache({
+            schema,
+            keyMap,
+            defaultTransformOptions
+          });
+          await cache.openDB();
+        });
+
+        hooks.afterEach(async () => {
+          if (cache) {
+            await cache.deleteDB();
+          }
+        });
+
+        test('#update sets data and #records retrieves it', async function (assert) {
+          assert.expect(4);
+
+          const earth: Record = {
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Earth' },
+            keys: { remoteId: 'a' }
+          };
+
+          cache.on('patch', (operation, data) => {
+            assert.deepEqual(operation, {
+              op: 'addRecord',
+              record: earth
+            });
+            assert.deepEqual(data, earth);
+          });
+
+          await cache.update((t) => t.addRecord(earth));
+
+          assert.deepEqual(
+            await cache.getRecordAsync({ type: 'planet', id: '1' }),
+            earth,
+            'objects match'
+          );
+          assert.equal(
+            keyMap.keyToId('planet', 'remoteId', 'a'),
+            '1',
+            'key has been mapped'
+          );
+        });
+
+        test('#update can replace records', async function (assert) {
+          assert.expect(5);
+
+          const earth: Record = {
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Earth' },
+            keys: { remoteId: 'a' }
+          };
+
+          cache.on('patch', (operation, data) => {
+            assert.deepEqual(operation, {
+              op: 'updateRecord',
+              record: earth
+            });
+            assert.deepEqual(data, earth);
+          });
+
+          await cache.update((t) => t.updateRecord(earth));
+
+          assert.deepEqual(
+            await cache.getRecordAsync({ type: 'planet', id: '1' }),
+            earth,
+            'objects deeply match'
+          );
+          assert.notStrictEqual(
+            await cache.getRecordAsync({ type: 'planet', id: '1' }),
+            earth,
+            'objects do not strictly match'
+          );
+          assert.equal(
+            keyMap.keyToId('planet', 'remoteId', 'a'),
+            '1',
+            'key has been mapped'
+          );
+        });
+
+        test('#update can replace keys', async function (assert) {
+          assert.expect(4);
+
+          const earth: Record = { type: 'planet', id: '1' };
+
+          cache.on('patch', (operation, data) => {
+            assert.deepEqual(operation, {
+              op: 'replaceKey',
+              record: earth,
+              key: 'remoteId',
+              value: 'a'
+            });
+            assert.deepEqual(data, {
+              type: 'planet',
+              id: '1',
+              keys: { remoteId: 'a' }
+            });
+          });
+
+          await cache.update((t) => t.replaceKey(earth, 'remoteId', 'a'));
+
+          assert.deepEqual(
+            await cache.getRecordAsync({ type: 'planet', id: '1' }),
+            { type: 'planet', id: '1', keys: { remoteId: 'a' } },
+            'records match'
+          );
+          assert.equal(
+            keyMap.keyToId('planet', 'remoteId', 'a'),
+            '1',
+            'key has been mapped'
+          );
+        });
+
+        test('#update updates the cache and returns primary data', async function (assert) {
+          let p1 = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
+          let p2 = { type: 'planet', id: '2' };
+
+          let result = await cache.update((t) => [
+            t.addRecord(p1),
+            t.removeRecord(p2)
+          ]);
+
+          assert.deepEqual(
+            result,
+            [
+              p1,
+              undefined // p2 didn't exist
+            ],
+            'response includes just primary data'
+          );
+        });
+
+        test('#update updates the cache and returns a full response if requested', async function (assert) {
+          let p1 = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
+          let p2 = { type: 'planet', id: '2' };
+
+          let result = await cache.update(
+            (t) => [t.addRecord(p1), t.removeRecord(p2)],
+            {
+              fullResponse: true
+            }
+          );
+
+          assert.deepEqual(
+            result,
+            {
+              data: [
+                p1,
+                undefined // p2 didn't exist
+              ],
+              details: {
+                appliedOperations: [{ op: 'addRecord', record: p1 }],
+                appliedOperationResults: [p1],
+                inverseOperations: [
+                  { op: 'removeRecord', record: { type: 'planet', id: '1' } }
+                ]
+              }
+            },
+            'full response includes data and details'
+          );
+        });
+
+        test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added after', async function (assert) {
+          const jupiter: Record = {
+            type: 'planet',
+            id: 'p1',
+            attributes: { name: 'Jupiter' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+          };
+          const io: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Io' }
+          };
+
+          await cache.update((t) => [
+            t.updateRecord(jupiter),
+            t.updateRecord(io)
+          ]);
+
+          assert.deepEqual(
+            ((await cache.getRecordAsync({
+              type: 'planet',
+              id: 'p1'
+            })) as Record)?.relationships?.moons.data,
+            [{ type: 'moon', id: 'm1' }],
+            'Io has been assigned to Jupiter'
+          );
+          assert.deepEqual(
+            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+              ?.relationships?.planet.data,
+            { type: 'planet', id: 'p1' },
+            'Jupiter has been assigned to Io'
+          );
+        });
+
+        test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added before', async function (assert) {
+          const jupiter: Record = {
+            type: 'planet',
+            id: 'p1',
+            attributes: { name: 'Jupiter' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+          };
+          const io: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Io' }
+          };
+
+          await cache.update((t) => [
+            t.updateRecord(io),
+            t.updateRecord(jupiter)
+          ]);
+
+          assert.deepEqual(
+            ((await cache.getRecordAsync({
+              type: 'planet',
+              id: 'p1'
+            })) as Record)?.relationships?.moons.data,
+            [{ type: 'moon', id: 'm1' }],
+            'Io has been assigned to Jupiter'
+          );
+          assert.deepEqual(
+            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+              ?.relationships?.planet.data,
+            { type: 'planet', id: 'p1' },
+            'Jupiter has been assigned to Io'
+          );
+        });
+
+        test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added after', async function (assert) {
+          const io: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Io' },
+            relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+          };
+          const jupiter: Record = {
+            type: 'planet',
+            id: 'p1',
+            attributes: { name: 'Jupiter' }
+          };
+
+          await cache.update((t) => [
+            t.updateRecord(io),
+            t.updateRecord(jupiter)
+          ]);
+
+          assert.deepEqual(
+            ((await cache.getRecordAsync({
+              type: 'planet',
+              id: 'p1'
+            })) as Record)?.relationships?.moons.data,
+            [{ type: 'moon', id: 'm1' }],
+            'Io has been assigned to Jupiter'
+          );
+          assert.deepEqual(
+            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+              ?.relationships?.planet.data,
+            { type: 'planet', id: 'p1' },
+            'Jupiter has been assigned to Io'
+          );
+        });
+
+        test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added before', async function (assert) {
+          const io: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Io' },
+            relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+          };
+          const jupiter: Record = {
+            type: 'planet',
+            id: 'p1',
+            attributes: { name: 'Jupiter' }
+          };
+
+          await cache.update((t) => [
+            t.updateRecord(jupiter),
+            t.updateRecord(io)
+          ]);
+
+          assert.deepEqual(
+            ((await cache.getRecordAsync({
+              type: 'planet',
+              id: 'p1'
+            })) as Record)?.relationships?.moons.data,
+            [{ type: 'moon', id: 'm1' }],
+            'Io has been assigned to Jupiter'
+          );
+          assert.deepEqual(
+            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+              ?.relationships?.planet.data,
+            { type: 'planet', id: 'p1' },
+            'Jupiter has been assigned to Io'
+          );
+        });
+
+        test('#update updates inverse hasOne relationship when a record with an empty relationship is added', async function (assert) {
+          const io: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Io' },
+            relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+          };
+          const jupiter: Record = {
+            type: 'planet',
+            id: 'p1',
+            attributes: { name: 'Jupiter' },
+            relationships: { moons: { data: [] } }
+          };
+
+          await cache.update((t) => [
+            t.updateRecord(io),
+            t.updateRecord(jupiter)
+          ]);
+
+          assert.deepEqual(
+            ((await cache.getRecordAsync({
+              type: 'planet',
+              id: 'p1'
+            })) as Record)?.relationships?.moons.data,
+            [],
+            'Jupiter has no moons'
+          );
+          assert.deepEqual(
+            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+              ?.relationships?.planet.data,
+            null,
+            'Jupiter has been cleared from Io'
+          );
+        });
+
+        test('#update updates inverse hasMany relationship when a record with an empty relationship is added', async function (assert) {
+          const jupiter: Record = {
+            type: 'planet',
+            id: 'p1',
+            attributes: { name: 'Jupiter' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+          };
+          const io: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Io' },
+            relationships: { planet: { data: null } }
+          };
+
+          await cache.update((t) => [
+            t.updateRecord(jupiter),
+            t.updateRecord(io)
+          ]);
+
+          assert.deepEqual(
+            ((await cache.getRecordAsync({
+              type: 'planet',
+              id: 'p1'
+            })) as Record)?.relationships?.moons.data,
+            [],
+            'Io has been cleared from Jupiter'
+          );
+          assert.deepEqual(
+            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+              ?.relationships?.planet.data,
+            null,
+            'Io has no planet'
+          );
+        });
+
+        test('#update updates inverse hasMany polymorphic relationship', async function (assert) {
+          const sun: Record = {
+            type: 'star',
+            id: 's1',
+            attributes: { name: 'Sun' },
+            relationships: {
+              celestialObjects: {
+                data: [
+                  { type: 'planet', id: 'p1' },
+                  { type: 'moon', id: 'm1' }
+                ]
+              }
+            }
+          };
+          const jupiter: Record = {
+            type: 'planet',
+            id: 'p1',
+            attributes: { name: 'Jupiter' }
+          };
+          const io: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Io' }
+          };
+
+          await cache.update((t) => [
+            t.updateRecord(sun),
+            t.updateRecord(jupiter),
+            t.updateRecord(io)
+          ]);
+
+          assert.deepEqual(
+            ((await cache.getRecordAsync({ type: 'star', id: 's1' })) as Record)
+              ?.relationships?.celestialObjects.data,
+            [
+              { type: 'planet', id: 'p1' },
+              { type: 'moon', id: 'm1' }
+            ],
+            'Jupiter and Io has been assigned to Sun'
+          );
+          assert.deepEqual(
+            ((await cache.getRecordAsync({
+              type: 'planet',
+              id: 'p1'
+            })) as Record)?.relationships?.star.data,
+            { type: 'star', id: 's1' },
+            'Sun has been assigned to Jupiter'
+          );
+          assert.deepEqual(
+            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+              ?.relationships?.star.data,
+            { type: 'star', id: 's1' },
+            'Sun has been assigned to Io'
+          );
+        });
+
+        test('#update updates inverse hasOne polymorphic relationship', async function (assert) {
+          const jupiter: Record = {
+            type: 'planet',
+            id: 'p1',
+            attributes: { name: 'Jupiter' },
+            relationships: { star: { data: { type: 'star', id: 's1' } } }
+          };
+          const io: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Io' },
+            relationships: { star: { data: { type: 'star', id: 's1' } } }
+          };
+          const sun: Record = {
+            type: 'star',
+            id: 's1',
+            attributes: { name: 'Sun' }
+          };
+
+          await cache.update((t) => [
+            t.updateRecord(jupiter),
+            t.updateRecord(io),
+            t.updateRecord(sun)
+          ]);
+
+          assert.deepEqual(
+            ((await cache.getRecordAsync({ type: 'star', id: 's1' })) as Record)
+              ?.relationships?.celestialObjects.data,
+            [
+              { type: 'planet', id: 'p1' },
+              { type: 'moon', id: 'm1' }
+            ],
+            'Jupiter and Io has been assigned to Sun'
+          );
+          assert.deepEqual(
+            ((await cache.getRecordAsync({
+              type: 'planet',
+              id: 'p1'
+            })) as Record)?.relationships?.star.data,
+            { type: 'star', id: 's1' },
+            'Sun has been assigned to Jupiter'
+          );
+          assert.deepEqual(
+            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+              ?.relationships?.star.data,
+            { type: 'star', id: 's1' },
+            'Sun has been assigned to Io'
+          );
+        });
+
+        test('#update tracks refs and clears them from hasOne relationships when a referenced record is removed', async function (assert) {
+          const jupiter: Record = {
+            type: 'planet',
+            id: 'p1',
+            attributes: { name: 'Jupiter' },
+            relationships: { moons: { data: undefined } }
+          };
+          const io: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Io' },
+            relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+          };
+          const europa: Record = {
+            type: 'moon',
+            id: 'm2',
+            attributes: { name: 'Europa' },
+            relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+          };
+
+          await cache.update((t) => [
+            t.addRecord(jupiter),
+            t.addRecord(io),
+            t.addRecord(europa)
+          ]);
+
+          assert.deepEqual(
+            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+              ?.relationships?.planet.data,
+            { type: 'planet', id: 'p1' },
+            'Jupiter has been assigned to Io'
+          );
+          assert.deepEqual(
+            ((await cache.getRecordAsync({ type: 'moon', id: 'm2' })) as Record)
+              ?.relationships?.planet.data,
+            { type: 'planet', id: 'p1' },
+            'Jupiter has been assigned to Europa'
+          );
+
+          await cache.update((t) => t.removeRecord(jupiter));
+
+          assert.equal(
+            await cache.getRecordAsync({ type: 'planet', id: 'p1' }),
+            undefined,
+            'Jupiter is GONE'
+          );
+
+          assert.equal(
+            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+              ?.relationships?.planet.data,
+            undefined,
+            'Jupiter has been cleared from Io'
+          );
+          assert.equal(
+            ((await cache.getRecordAsync({ type: 'moon', id: 'm2' })) as Record)
+              ?.relationships?.planet.data,
+            undefined,
+            'Jupiter has been cleared from Europa'
+          );
+        });
+
+        test('#update tracks refs and clears them from hasMany relationships when a referenced record is removed', async function (assert) {
+          const io: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Io' },
+            relationships: { planet: { data: null } }
+          };
+          const europa: Record = {
+            type: 'moon',
+            id: 'm2',
+            attributes: { name: 'Europa' },
+            relationships: { planet: { data: null } }
+          };
+          const jupiter: Record = {
+            type: 'planet',
+            id: 'p1',
+            attributes: { name: 'Jupiter' },
+            relationships: {
+              moons: {
+                data: [
+                  { type: 'moon', id: 'm1' },
+                  { type: 'moon', id: 'm2' }
+                ]
+              }
+            }
+          };
+
+          await cache.update((t) => [
+            t.addRecord(io),
+            t.addRecord(europa),
+            t.addRecord(jupiter)
+          ]);
+
+          assert.deepEqual(
+            ((await cache.getRecordAsync({
+              type: 'planet',
+              id: 'p1'
+            })) as Record)?.relationships?.moons.data,
+            [
+              { type: 'moon', id: 'm1' },
+              { type: 'moon', id: 'm2' }
+            ],
+            'Jupiter has been assigned to Io and Europa'
+          );
+          assert.ok(
+            recordsIncludeAll(
+              (await cache.getRelatedRecordsAsync(
+                jupiter,
+                'moons'
+              )) as RecordIdentity[],
+              [io, europa]
+            ),
+            'Jupiter has been assigned to Io and Europa'
+          );
+
+          await cache.update((t) => t.removeRecord(io));
+
+          assert.equal(
+            await cache.getRecordAsync({ type: 'moon', id: 'm1' }),
+            null,
+            'Io is GONE'
+          );
+
+          await cache.update((t) => t.removeRecord(europa));
+
+          assert.equal(
+            await cache.getRecordAsync({ type: 'moon', id: 'm2' }),
+            null,
+            'Europa is GONE'
+          );
+
+          assert.deepEqual(
+            (await cache.getRelatedRecordsAsync(
+              { type: 'planet', id: 'p1' },
+              'moons'
+            )) as RecordIdentity[],
+            [],
+            'moons have been cleared from Jupiter'
+          );
+        });
+
+        test("#update adds link to hasMany if record doesn't exist", async function (assert) {
+          await cache.update((t) =>
+            t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+              type: 'moon',
+              id: 'm1'
+            })
+          );
+
+          await cache.update((t) =>
+            t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+              type: 'moon',
+              id: 'm1'
+            })
+          );
+
+          assert.deepEqual(
+            ((await cache.getRecordAsync({
+              type: 'planet',
+              id: 'p1'
+            })) as Record)?.relationships?.moons.data,
+            [{ type: 'moon', id: 'm1' }],
+            'relationship was added'
+          );
+        });
+
+        test("#update does not remove hasMany relationship if record doesn't exist", async function (assert) {
+          assert.expect(1);
+
+          cache.on('patch', () => {
+            assert.ok(false, 'no operations were applied');
+          });
+
+          await cache.update((t) =>
+            t.removeFromRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+              type: 'moon',
+              id: 'moon1'
+            })
+          );
+
+          assert.equal(
+            await cache.getRecordAsync({ type: 'planet', id: 'p1' }),
+            undefined,
+            'planet does not exist'
+          );
+        });
+
+        test("#update adds hasOne if record doesn't exist", async function (assert) {
+          assert.expect(2);
+
+          const tb = cache.transformBuilder;
+          const replacePlanet = tb.replaceRelatedRecord(
+            { type: 'moon', id: 'moon1' },
+            'planet',
+            { type: 'planet', id: 'p1' }
+          );
+
+          const addToMoons = tb.addToRelatedRecords(
+            { type: 'planet', id: 'p1' },
+            'moons',
+            { type: 'moon', id: 'moon1' }
+          );
+
+          let order = 0;
+          cache.on('patch', (op) => {
+            order++;
+            if (order === 1) {
+              assert.deepEqual(
+                op,
+                replacePlanet.toOperation(),
+                'applied replacePlanet operation'
+              );
+            } else if (order === 2) {
+              assert.deepEqual(
+                op,
+                addToMoons.toOperation(),
+                'applied addToMoons operation'
+              );
+            } else {
+              assert.ok(false, 'too many ops');
+            }
+          });
+
+          await cache.update([replacePlanet]);
+        });
+
+        test("#update will add empty hasOne link if record doesn't exist", async function (assert) {
+          assert.expect(2);
+
+          const tb = cache.transformBuilder;
+          const clearPlanet = tb.replaceRelatedRecord(
+            { type: 'moon', id: 'moon1' },
+            'planet',
+            null
+          );
+
+          let order = 0;
+          cache.on('patch', (op) => {
+            order++;
+            if (order === 1) {
+              assert.deepEqual(
+                op,
+                clearPlanet.toOperation(),
+                'applied clearPlanet operation'
+              );
+            } else {
+              assert.ok(false, 'too many ops');
+            }
+          });
+
+          await cache.update([clearPlanet]);
+
+          assert.ok(true, 'patch applied');
+        });
+
+        test('#update does not add link to hasMany if link already exists', async function (assert) {
+          assert.expect(1);
+
+          const jupiter: Record = {
+            id: 'p1',
+            type: 'planet',
+            attributes: { name: 'Jupiter' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+          };
+
+          await cache.update((t) => t.addRecord(jupiter));
+
+          cache.on('patch', () => {
+            assert.ok(false, 'no operations were applied');
+          });
+
+          await cache.update((t) =>
+            t.addToRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'm1' })
+          );
+
+          assert.ok(true, 'patch completed');
+        });
+
+        test("#update does not remove relationship from hasMany if relationship doesn't exist", async function (assert) {
+          assert.expect(1);
+
+          const jupiter: Record = {
+            id: 'p1',
+            type: 'planet',
+            attributes: { name: 'Jupiter' }
+          };
+
+          await cache.update((t) => t.addRecord(jupiter));
+
+          cache.on('patch', () => {
+            assert.ok(false, 'no operations were applied');
+          });
+
+          await cache.update((t) =>
+            t.removeFromRelatedRecords(jupiter, 'moons', {
+              type: 'moon',
+              id: 'm1'
+            })
+          );
+
+          assert.ok(true, 'patch completed');
+        });
+
+        test('#update can add and remove to has-many relationship', async function (assert) {
+          assert.expect(2);
+
+          const jupiter: Record = { id: 'jupiter', type: 'planet' };
+          await cache.update((t) => t.addRecord(jupiter));
+
+          const callisto: Record = { id: 'callisto', type: 'moon' };
+          await cache.update((t) => t.addRecord(callisto));
+
+          await cache.update((t) =>
+            t.addToRelatedRecords(jupiter, 'moons', {
+              type: 'moon',
+              id: 'callisto'
+            })
+          );
+
+          assert.ok(
+            recordsInclude(
+              (await cache.getRelatedRecordsAsync(
+                jupiter,
+                'moons'
+              )) as RecordIdentity[],
+              callisto
+            ),
+            'moon added'
+          );
+
+          await cache.update((t) =>
+            t.removeFromRelatedRecords(jupiter, 'moons', {
+              type: 'moon',
+              id: 'callisto'
+            })
+          );
+
+          assert.notOk(
+            recordsInclude(
+              (await cache.getRelatedRecordsAsync(
+                jupiter,
+                'moons'
+              )) as RecordIdentity[],
+              callisto
+            ),
+            'moon removed'
+          );
+        });
+
+        test('#update can add and clear has-one relationship', async function (assert) {
+          assert.expect(2);
+
+          const jupiter: Record = { id: 'jupiter', type: 'planet' };
+          await cache.update((t) => t.addRecord(jupiter));
+
+          const callisto: Record = { id: 'callisto', type: 'moon' };
+          await cache.update((t) => t.addRecord(callisto));
+
+          await cache.update((t) =>
+            t.replaceRelatedRecord(callisto, 'planet', {
+              type: 'planet',
+              id: 'jupiter'
+            })
+          );
+
+          assert.ok(
+            equalRecordIdentities(
+              (await cache.getRelatedRecordAsync(
+                callisto,
+                'planet'
+              )) as RecordIdentity,
+              jupiter
+            ),
+            'relationship added'
+          );
+
+          await cache.update((t) =>
+            t.replaceRelatedRecord(callisto, 'planet', null)
+          );
+
+          assert.notOk(
+            equalRecordIdentities(
+              (await cache.getRelatedRecordAsync(
+                callisto,
+                'planet'
+              )) as RecordIdentity,
+              jupiter
+            ),
+            'relationship cleared'
+          );
+        });
+
+        test('does not replace hasOne if relationship already exists', async function (assert) {
+          assert.expect(1);
+
+          const europa: Record = {
+            id: 'm1',
+            type: 'moon',
+            attributes: { name: 'Europa' },
+            relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+          };
+
+          await cache.update((t) => t.addRecord(europa));
+
+          cache.on('patch', () => {
+            assert.ok(false, 'no operations were applied');
+          });
+
+          await cache.update((t) =>
+            t.replaceRelatedRecord(europa, 'planet', {
+              type: 'planet',
+              id: 'p1'
+            })
+          );
+
+          assert.ok(true, 'patch completed');
+        });
+
+        test("does not remove hasOne if relationship doesn't exist", async function (assert) {
+          assert.expect(1);
+
+          const europa: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Europa' },
+            relationships: { planet: { data: null } }
+          };
+
+          await cache.update((t) => t.addRecord(europa));
+
+          cache.on('patch', () => {
+            assert.ok(false, 'no operations were applied');
+          });
+
+          await cache.update((t) =>
+            t.replaceRelatedRecord(europa, 'planet', null)
+          );
+
+          assert.ok(true, 'patch completed');
+        });
+
+        test('#update merges records when "replacing" and will not stomp on attributes and relationships that are not replaced', async function (assert) {
+          const tb = cache.transformBuilder;
+
+          await cache.update((t) => [
+            t.addRecord({
+              type: 'planet',
+              id: '1',
+              attributes: { name: 'Earth' },
+              relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+            })
+          ]);
+
+          let result = await cache.update(
+            (t) => [
+              t.updateRecord({
+                type: 'planet',
+                id: '1',
+                attributes: { classification: 'terrestrial' }
+              })
+            ],
+            { fullResponse: true }
+          );
+
+          assert.deepEqual(
+            await cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
+            {
+              type: 'planet',
+              id: '1',
+              attributes: { name: 'Earth', classification: 'terrestrial' },
+              relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+            },
+            'records have been merged'
+          );
+
+          assert.deepEqual(
+            result,
+            {
+              data: {
+                type: 'planet',
+                id: '1',
+                attributes: {
+                  name: 'Earth',
+                  classification: 'terrestrial'
+                },
+                relationships: {
+                  moons: {
+                    data: [{ type: 'moon', id: 'm1' }]
+                  }
+                }
+              },
+              details: {
+                appliedOperations: [
+                  tb
+                    .updateRecord({
+                      type: 'planet',
+                      id: '1',
+                      attributes: { classification: 'terrestrial' }
+                    })
+                    .toOperation()
+                ],
+                appliedOperationResults: [
+                  {
+                    type: 'planet',
+                    id: '1',
+                    attributes: {
+                      name: 'Earth',
+                      classification: 'terrestrial'
+                    },
+                    relationships: {
+                      moons: {
+                        data: [{ type: 'moon', id: 'm1' }]
+                      }
+                    }
+                  }
+                ],
+                inverseOperations: [
+                  tb
+                    .updateRecord({
+                      type: 'planet',
+                      id: '1',
+                      attributes: { classification: null }
+                    })
+                    .toOperation()
+                ]
+              }
+            },
+            'full response is correct'
+          );
+        });
+
+        test('#update can replace related records but only if they are different', async function (assert) {
+          const tb = cache.transformBuilder;
+
+          await cache.update((t) => [
+            t.addRecord({
+              type: 'planet',
+              id: '1',
+              attributes: { name: 'Earth' },
+              relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+            })
+          ]);
+
+          let result = await cache.update(
+            (t) => [
+              t.replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
+                { type: 'moon', id: 'm1' }
+              ])
+            ],
+            { fullResponse: true }
+          );
+
+          assert.deepEqual(
+            result,
+            {
+              data: undefined,
+              details: {
+                appliedOperations: [],
+                appliedOperationResults: [],
+                inverseOperations: []
+              }
+            },
+            'nothing has changed so there are no appliend or inverse ops'
+          );
+
+          result = await cache.update(
+            (t) =>
+              t.replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
+                { type: 'moon', id: 'm2' }
+              ]),
+            { fullResponse: true }
+          );
+
+          assert.deepEqual(
+            await cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
+            {
+              type: 'planet',
+              id: '1',
+              attributes: { name: 'Earth' },
+              relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
+            },
+            'relationships have been replaced'
+          );
+
+          assert.deepEqual(
+            result,
+            {
+              data: {
+                type: 'planet',
+                id: '1',
+                attributes: { name: 'Earth' },
+                relationships: {
+                  moons: { data: [{ type: 'moon', id: 'm2' }] }
+                }
+              },
+              details: {
+                appliedOperations: [
+                  tb
+                    .replaceRelatedRecords(
+                      { type: 'planet', id: '1' },
+                      'moons',
+                      [{ type: 'moon', id: 'm2' }]
+                    )
+                    .toOperation(),
+                  tb
+                    .replaceRelatedRecord(
+                      { type: 'moon', id: 'm1' },
+                      'planet',
+                      null
+                    )
+                    .toOperation(),
+                  tb
+                    .replaceRelatedRecord(
+                      { type: 'moon', id: 'm2' },
+                      'planet',
+                      {
+                        type: 'planet',
+                        id: '1'
+                      }
+                    )
+                    .toOperation()
+                ],
+                appliedOperationResults: [
+                  {
+                    type: 'planet',
+                    id: '1',
+                    attributes: { name: 'Earth' },
+                    relationships: {
+                      moons: { data: [{ type: 'moon', id: 'm2' }] }
+                    }
+                  },
+                  {
+                    type: 'moon',
+                    id: 'm1',
+                    relationships: {
+                      planet: { data: null }
+                    }
+                  },
+                  {
+                    type: 'moon',
+                    id: 'm2',
+                    relationships: {
+                      planet: { data: { type: 'planet', id: '1' } }
+                    }
+                  }
+                ],
+                inverseOperations: [
+                  tb
+                    .replaceRelatedRecord(
+                      { type: 'moon', id: 'm2' },
+                      'planet',
+                      null
+                    )
+                    .toOperation(),
+                  tb
+                    .replaceRelatedRecord(
+                      { type: 'moon', id: 'm1' },
+                      'planet',
+                      {
+                        type: 'planet',
+                        id: '1'
+                      }
+                    )
+                    .toOperation(),
+                  tb
+                    .replaceRelatedRecords(
+                      { type: 'planet', id: '1' },
+                      'moons',
+                      [{ type: 'moon', id: 'm1' }]
+                    )
+                    .toOperation()
+                ]
+              }
+            },
+            'full response is correct'
+          );
+        });
+
+        test('#update merges records when "replacing" and _will_ replace specified attributes and relationships', async function (assert) {
+          const tb = cache.transformBuilder;
+
+          const earth: Record = {
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Earth' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+          };
+
+          const jupiter: Record = {
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Jupiter', classification: 'terrestrial' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
+          };
+
+          let result = await cache.update([tb.addRecord(earth)], {
+            fullResponse: true
+          });
+
+          assert.deepEqual(
+            result,
+            {
+              data: earth,
+              details: {
+                appliedOperations: [
+                  tb.addRecord(earth).toOperation(),
+                  tb
+                    .replaceRelatedRecord(
+                      { type: 'moon', id: 'm1' },
+                      'planet',
+                      {
+                        type: 'planet',
+                        id: '1'
+                      }
+                    )
+                    .toOperation()
+                ],
+                appliedOperationResults: [
+                  {
+                    type: 'planet',
+                    id: '1',
+                    attributes: { name: 'Earth' },
+                    relationships: {
+                      moons: { data: [{ type: 'moon', id: 'm1' }] }
+                    }
+                  },
+                  {
+                    type: 'moon',
+                    id: 'm1',
+                    relationships: {
+                      planet: { data: { type: 'planet', id: '1' } }
+                    }
+                  }
+                ],
+                inverseOperations: [
+                  tb
+                    .replaceRelatedRecord(
+                      { type: 'moon', id: 'm1' },
+                      'planet',
+                      null
+                    )
+                    .toOperation(),
+                  tb
+                    .removeRecord({
+                      type: 'planet',
+                      id: '1'
+                    })
+                    .toOperation()
+                ]
+              }
+            },
+            'addRecord full response is correct'
+          );
+
+          result = await cache.update([tb.updateRecord(jupiter)], {
+            fullResponse: true
+          });
+
+          assert.deepEqual(result, {
+            data: jupiter,
+            details: {
+              appliedOperations: [
+                tb.updateRecord(jupiter).toOperation(),
+                tb
+                  .replaceRelatedRecord(
+                    { type: 'moon', id: 'm1' },
+                    'planet',
+                    null
+                  )
+                  .toOperation(),
+                tb
+                  .replaceRelatedRecord({ type: 'moon', id: 'm2' }, 'planet', {
+                    type: 'planet',
+                    id: '1'
+                  })
+                  .toOperation()
+              ],
+              appliedOperationResults: [
+                jupiter,
+                {
+                  type: 'moon',
+                  id: 'm1',
+                  relationships: {
+                    planet: { data: null }
+                  }
+                },
+                {
+                  type: 'moon',
+                  id: 'm2',
+                  relationships: {
+                    planet: { data: { type: 'planet', id: '1' } }
+                  }
+                }
+              ],
+              inverseOperations: [
+                tb
+                  .replaceRelatedRecord(
+                    { type: 'moon', id: 'm2' },
+                    'planet',
+                    null
+                  )
+                  .toOperation(),
+                tb
+                  .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
+                    type: 'planet',
+                    id: '1'
+                  })
+                  .toOperation(),
+                tb
+                  .updateRecord({
+                    type: 'planet',
+                    id: '1',
+                    attributes: { name: 'Earth', classification: null },
+                    relationships: {
+                      moons: { data: [{ type: 'moon', id: 'm1' }] }
+                    }
+                  })
+                  .toOperation()
+              ]
+            }
+          });
+
+          assert.deepEqual(
+            await cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
+            {
+              type: 'planet',
+              id: '1',
+              attributes: { name: 'Jupiter', classification: 'terrestrial' },
+              relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
+            },
+            'records have been merged'
+          );
+        });
+
+        test('#update can update existing record with empty relationship', async function (assert) {
+          const tb = cache.transformBuilder;
+
+          let result = await cache.update(
+            (t) => [t.addRecord({ id: '1', type: 'planet' })],
+            { fullResponse: true }
+          );
+
+          assert.deepEqual(
+            result,
+            {
+              data: { id: '1', type: 'planet' },
+              details: {
+                appliedOperations: [
+                  tb
+                    .addRecord({
+                      type: 'planet',
+                      id: '1'
+                    })
+                    .toOperation()
+                ],
+                appliedOperationResults: [
+                  {
+                    id: '1',
+                    type: 'planet'
+                  }
+                ],
+                inverseOperations: [
+                  tb
+                    .removeRecord({
+                      type: 'planet',
+                      id: '1'
+                    })
+                    .toOperation()
+                ]
+              }
+            },
+            'addRecord result is correct'
+          );
+
+          result = await cache.update(
+            (t) => [
+              t.updateRecord({
+                id: '1',
+                type: 'planet',
+                relationships: {
+                  moons: { data: [] }
+                }
+              })
+            ],
+            { fullResponse: true }
+          );
+
+          assert.deepEqual(
+            result,
+            {
+              data: {
+                id: '1',
+                type: 'planet',
+                relationships: {
+                  moons: { data: [] }
+                }
+              },
+              details: {
+                appliedOperations: [
+                  tb
+                    .updateRecord({
+                      id: '1',
+                      type: 'planet',
+                      relationships: {
+                        moons: { data: [] }
+                      }
+                    })
+                    .toOperation()
+                ],
+                appliedOperationResults: [
+                  {
+                    id: '1',
+                    type: 'planet',
+                    relationships: {
+                      moons: { data: [] }
+                    }
+                  }
+                ],
+                inverseOperations: [
+                  tb
+                    .updateRecord({
+                      id: '1',
+                      type: 'planet',
+                      relationships: {
+                        moons: { data: [] }
+                      }
+                    })
+                    .toOperation()
+                ]
+              }
+            },
+            'updateRecord result is correct'
+          );
+
+          const planet = await cache.getRecordAsync({
+            type: 'planet',
+            id: '1'
+          });
+          assert.ok(planet, 'planet exists');
+          assert.deepEqual(
+            planet?.relationships?.moons.data,
+            [],
+            'planet has empty moons relationship'
+          );
+        });
+
+        test('#update will not overwrite an existing relationship with a missing relationship', async function (assert) {
+          const tb = cache.transformBuilder;
+
+          let result = await cache.update(
+            (t) => [
+              t.addRecord({
+                id: '1',
+                type: 'planet',
+                relationships: {
+                  moons: { data: [{ type: 'moon', id: 'm1' }] }
+                }
+              }),
+              t.updateRecord({
+                id: '1',
+                type: 'planet'
+              })
+            ],
+            { fullResponse: true }
+          );
+
+          assert.deepEqual(
+            result,
+            {
+              data: [
+                {
+                  id: '1',
+                  type: 'planet',
+                  relationships: {
+                    moons: { data: [{ type: 'moon', id: 'm1' }] }
+                  }
+                },
+                undefined
+              ],
+              details: {
+                appliedOperations: [
+                  tb
+                    .addRecord({
+                      id: '1',
+                      type: 'planet',
+                      relationships: {
+                        moons: { data: [{ type: 'moon', id: 'm1' }] }
+                      }
+                    })
+                    .toOperation(),
+                  tb
+                    .replaceRelatedRecord(
+                      { type: 'moon', id: 'm1' },
+                      'planet',
+                      {
+                        id: '1',
+                        type: 'planet'
+                      }
+                    )
+                    .toOperation()
+                ],
+                appliedOperationResults: [
+                  {
+                    id: '1',
+                    type: 'planet',
+                    relationships: {
+                      moons: { data: [{ type: 'moon', id: 'm1' }] }
+                    }
+                  },
+                  {
+                    type: 'moon',
+                    id: 'm1',
+                    relationships: {
+                      planet: { data: { id: '1', type: 'planet' } }
+                    }
+                  }
+                ],
+                inverseOperations: [
+                  tb
+                    .replaceRelatedRecord(
+                      { type: 'moon', id: 'm1' },
+                      'planet',
+                      null
+                    )
+                    .toOperation(),
+                  tb
+                    .removeRecord({
+                      id: '1',
+                      type: 'planet'
+                    })
+                    .toOperation()
+                ]
+              }
+            },
+            'update full response is correct'
+          );
+
+          const planet = await cache.getRecordAsync({
+            type: 'planet',
+            id: '1'
+          });
+          assert.ok(planet, 'planet exists');
+          assert.deepEqual(
+            planet?.relationships?.moons.data,
+            [{ type: 'moon', id: 'm1' }],
+            'planet has a moons relationship'
+          );
+        });
+
+        test('#update allows replaceRelatedRecord to be called on a relationship with no inverse and to be followed up by removing the replaced record', async function (assert) {
+          assert.expect(2);
+
+          const star1 = {
+            id: 'star1',
+            type: 'star',
+            attributes: { name: 'sun1' }
+          };
+
+          const star2 = {
+            id: 'star2',
+            type: 'star',
+            attributes: { name: 'sun2' }
+          };
+
+          const home = {
+            id: 'home',
+            type: 'planetarySystem',
+            attributes: { name: 'Home' },
+            relationships: {
+              star: {
+                data: { id: 'star1', type: 'star' }
+              }
+            }
+          };
+
+          await cache.update((t) => [
+            t.addRecord(star1),
+            t.addRecord(star2),
+            t.addRecord(home)
+          ]);
+
+          let latestHome = await cache.getRecordAsync({
+            id: 'home',
+            type: 'planetarySystem'
+          });
+          assert.deepEqual(
+            (latestHome?.relationships?.star.data as Record).id,
+            star1.id,
+            'The original related record is in place.'
+          );
+
+          await cache.update((t) => [
+            t.replaceRelatedRecord(
+              {
+                id: 'home',
+                type: 'planetarySystem'
+              },
+              'star',
+              star2
+            ),
+            t.removeRecord(star1)
+          ]);
+
+          latestHome = await cache.getRecordAsync({
+            id: 'home',
+            type: 'planetarySystem'
+          });
+
+          assert.deepEqual(
+            (latestHome?.relationships?.star.data as Record).id,
+            star2.id,
+            'The related record was replaced.'
+          );
+        });
+
+        test("#update - updateRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+          const earth: Record = {
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Earth' },
+            keys: { remoteId: 'a' }
+          };
+
+          try {
+            await cache.update((t) =>
+              t.updateRecord(earth).options({
+                raiseNotFoundExceptions: true
+              })
+            );
+          } catch (e) {
+            assert.ok(e instanceof RecordNotFoundException);
+          }
+        });
+
+        test("#update - removeRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+          const earth: Record = {
+            type: 'planet',
+            id: '1'
+          };
+
+          try {
+            await cache.update((t) =>
+              t.removeRecord(earth).options({
+                raiseNotFoundExceptions: true
+              })
+            );
+          } catch (e) {
+            assert.ok(e instanceof RecordNotFoundException);
+          }
+        });
+
+        test("#update - replaceKey - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+          const earth: Record = {
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Earth' },
+            keys: { remoteId: 'a' }
+          };
+
+          try {
+            await cache.update((t) =>
+              t.replaceKey(earth, 'remoteId', 'b').options({
+                raiseNotFoundExceptions: true
+              })
+            );
+          } catch (e) {
+            assert.ok(e instanceof RecordNotFoundException);
+          }
+        });
+
+        test("#update - replaceAttribute - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+          const earth: Record = {
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Earth' },
+            keys: { remoteId: 'a' }
+          };
+
+          try {
+            await cache.update((t) =>
+              t.replaceAttribute(earth, 'name', 'Mother Earth').options({
+                raiseNotFoundExceptions: true
+              })
+            );
+          } catch (e) {
+            assert.ok(e instanceof RecordNotFoundException);
+          }
+        });
+
+        test("#update - addToRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+          try {
+            await cache.update((t) =>
+              t
+                .addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+                  type: 'moon',
+                  id: 'm1'
+                })
+                .options({
+                  raiseNotFoundExceptions: true
+                })
+            );
+          } catch (e) {
+            assert.ok(e instanceof RecordNotFoundException);
+          }
+        });
+
+        test("#update - removeFromRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+          try {
+            await cache.update((t) =>
+              t
+                .removeFromRelatedRecords(
+                  { type: 'planet', id: 'p1' },
+                  'moons',
+                  {
+                    type: 'moon',
+                    id: 'm1'
+                  }
+                )
+                .options({
+                  raiseNotFoundExceptions: true
+                })
+            );
+          } catch (e) {
+            assert.ok(e instanceof RecordNotFoundException);
+          }
+        });
+
+        test("#update - replaceRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+          try {
+            await cache.update((t) =>
+              t
+                .replaceRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', [
+                  {
+                    type: 'moon',
+                    id: 'm1'
+                  }
+                ])
+                .options({
+                  raiseNotFoundExceptions: true
+                })
+            );
+          } catch (e) {
+            assert.ok(e instanceof RecordNotFoundException);
+          }
+        });
+
+        test("#update - replaceRelatedRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+          try {
+            await cache.update((t) =>
+              t
+                .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
+                  type: 'planet',
+                  id: 'p1'
+                })
+                .options({
+                  raiseNotFoundExceptions: true
+                })
+            );
+          } catch (e) {
+            assert.ok(e instanceof RecordNotFoundException);
+          }
+        });
+      });
+
+      module('with alt schema', function (hooks) {
+        let cache: IndexedDBCache;
+
+        hooks.afterEach(async () => {
+          if (cache) {
+            await cache.deleteDB();
+          }
+        });
+
+        test('#update removing model with a bi-directional hasOne', async function (assert) {
+          assert.expect(5);
+
+          const hasOneSchema = new RecordSchema({
+            models: {
+              one: {
+                relationships: {
+                  two: { kind: 'hasOne', type: 'two', inverse: 'one' }
+                }
+              },
+              two: {
+                relationships: {
+                  one: { kind: 'hasOne', type: 'one', inverse: 'two' }
+                }
+              }
+            }
+          });
+
+          cache = new IndexedDBCache({
+            schema: hasOneSchema,
+            keyMap,
+            defaultTransformOptions
+          });
+          await cache.openDB();
+
+          await cache.update((t) => [
+            t.addRecord({
+              id: '1',
+              type: 'one',
+              relationships: {
+                two: { data: null }
+              }
+            }),
+            t.addRecord({
+              id: '2',
+              type: 'two',
+              relationships: {
+                one: { data: { type: 'one', id: '1' } }
+              }
+            })
+          ]);
+
+          const one = (await cache.getRecordAsync({
+            type: 'one',
+            id: '1'
+          })) as Record;
+          const two = (await cache.getRecordAsync({
+            type: 'two',
+            id: '2'
+          })) as Record;
+          assert.ok(one, 'one exists');
+          assert.ok(two, 'two exists');
+          assert.deepEqual(
+            one.relationships?.two.data,
+            { type: 'two', id: '2' },
+            'one links to two'
+          );
+          assert.deepEqual(
+            two.relationships?.one.data,
+            { type: 'one', id: '1' },
+            'two links to one'
+          );
+
+          await cache.update((t) => t.removeRecord(two));
+
+          assert.equal(
+            ((await cache.getRecordAsync({ type: 'one', id: '1' })) as Record)
+              .relationships?.two.data,
+            null,
+            'ones link to two got removed'
+          );
+        });
+
+        test('#update removes dependent records in a hasOne relationship', async function (assert) {
+          const dependentSchema = new RecordSchema({
+            models: {
+              planet: {
+                relationships: {
+                  moons: { kind: 'hasMany', type: 'moon' }
+                }
+              },
+              moon: {
+                relationships: {
+                  planet: {
+                    kind: 'hasOne',
+                    type: 'planet',
+                    dependent: 'remove'
+                  }
+                }
+              }
+            }
+          });
+
+          cache = new IndexedDBCache({
+            schema: dependentSchema,
+            keyMap,
+            defaultTransformOptions
+          });
+          await cache.openDB();
+
+          const jupiter: Record = {
+            type: 'planet',
+            id: 'p1',
+            attributes: { name: 'Jupiter' }
+          };
+          const io: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Io' },
+            relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+          };
+          const europa: Record = {
+            type: 'moon',
+            id: 'm2',
+            attributes: { name: 'Europa' },
+            relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+          };
+
+          await cache.update((t) => [
+            t.addRecord(jupiter),
+            t.addRecord(io),
+            t.addRecord(europa),
+            t.addToRelatedRecords(jupiter, 'moons', io),
+            t.addToRelatedRecords(jupiter, 'moons', europa)
+          ]);
+
+          await cache.update((t) => t.removeRecord(io));
+
+          assert.equal(
+            (await cache.getRecordsAsync('moon')).length,
+            1,
+            'Only europa is left in store'
+          );
+          assert.equal(
+            (await cache.getRecordsAsync('planet')).length,
+            0,
+            'Jupiter has been removed from the store'
+          );
+        });
+
+        test('#update removes dependent records in a hasMany relationship', async function (assert) {
+          const dependentSchema = new RecordSchema({
+            models: {
+              planet: {
+                relationships: {
+                  moons: { kind: 'hasMany', type: 'moon', dependent: 'remove' }
+                }
+              },
+              moon: {
+                relationships: {
+                  planet: { kind: 'hasOne', type: 'planet' }
+                }
+              }
+            }
+          });
+
+          cache = new IndexedDBCache({
+            schema: dependentSchema,
+            keyMap,
+            defaultTransformOptions
+          });
+          await cache.openDB();
+
+          const jupiter: Record = {
+            type: 'planet',
+            id: 'p1',
+            attributes: { name: 'Jupiter' }
+          };
+          const io: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Io' },
+            relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+          };
+          const europa: Record = {
+            type: 'moon',
+            id: 'm2',
+            attributes: { name: 'Europa' },
+            relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+          };
+
+          await cache.update((t) => [
+            t.updateRecord(jupiter),
+            t.updateRecord(io),
+            t.updateRecord(europa),
+            t.addToRelatedRecords(jupiter, 'moons', io),
+            t.addToRelatedRecords(jupiter, 'moons', europa)
+          ]);
+
+          await cache.update((t) => t.removeRecord(jupiter));
+
+          assert.equal(
+            (await cache.getRecordsAsync('planet')).length,
+            0,
+            'Jupiter has been removed from the store'
+          );
+          assert.equal(
+            (await cache.getRecordsAsync('moon')).length,
+            0,
+            'All of Jupiters moons are removed from the store'
+          );
+        });
+
+        test('#update does not remove non-dependent records', async function (assert) {
+          const dependentSchema = new RecordSchema({
+            models: {
+              planet: {
+                relationships: {
+                  moons: { kind: 'hasMany', type: 'moon' }
+                }
+              },
+              moon: {
+                relationships: {
+                  planet: { kind: 'hasOne', type: 'planet' }
+                }
+              }
+            }
+          });
+
+          cache = new IndexedDBCache({
+            schema: dependentSchema,
+            keyMap,
+            defaultTransformOptions
+          });
+          await cache.openDB();
+
+          const jupiter: Record = {
+            type: 'planet',
+            id: 'p1',
+            attributes: { name: 'Jupiter' }
+          };
+          const io: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Io' },
+            relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+          };
+          const europa: Record = {
+            type: 'moon',
+            id: 'm2',
+            attributes: { name: 'Europa' },
+            relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+          };
+
+          await cache.update((t) => [
+            t.addRecord(jupiter),
+            t.addRecord(io),
+            t.addRecord(europa),
+            t.addToRelatedRecords(jupiter, 'moons', io),
+            t.addToRelatedRecords(jupiter, 'moons', europa)
+          ]);
+
+          // Since there are no dependent relationships, no other records will be
+          // removed
+          await cache.update((t) => t.removeRecord(io));
+
+          assert.equal(
+            (await cache.getRecordsAsync('moon')).length,
+            1,
+            'One moon left in store'
+          );
+          assert.equal(
+            (await cache.getRecordsAsync('planet')).length,
+            1,
+            'One planet left in store'
+          );
+        });
+      });
+    });
+  });
+});

--- a/packages/@orbit/indexeddb/test/support/setup.ts
+++ b/packages/@orbit/indexeddb/test/support/setup.ts
@@ -1,0 +1,55 @@
+import { RecordSchema } from '@orbit/records';
+
+export function createSchemaWithRemoteKey(): RecordSchema {
+  return new RecordSchema({
+    models: {
+      star: {
+        keys: {
+          remoteId: {}
+        },
+        relationships: {
+          celestialObjects: {
+            kind: 'hasMany',
+            type: ['planet', 'moon'],
+            inverse: 'star'
+          }
+        }
+      },
+      planet: {
+        keys: {
+          remoteId: {}
+        },
+        relationships: {
+          moons: { kind: 'hasMany', type: 'moon', inverse: 'planet' },
+          star: { kind: 'hasOne', type: 'star', inverse: 'celestialObjects' }
+        }
+      },
+      moon: {
+        keys: {
+          remoteId: {}
+        },
+        relationships: {
+          planet: { kind: 'hasOne', type: 'planet', inverse: 'moons' },
+          star: { kind: 'hasOne', type: 'star', inverse: 'celestialObjects' }
+        }
+      },
+      binaryStar: {
+        attributes: {
+          name: { type: 'string' }
+        },
+        relationships: {
+          starOne: { kind: 'hasOne', type: 'star' }, // no inverse
+          starTwo: { kind: 'hasOne', type: 'star' } // no inverse
+        }
+      },
+      planetarySystem: {
+        attributes: {
+          name: { type: 'string' }
+        },
+        relationships: {
+          star: { kind: 'hasOne', type: ['star', 'binaryStar'] } // no inverse
+        }
+      }
+    }
+  });
+}

--- a/packages/@orbit/local-storage/src/local-storage-cache.ts
+++ b/packages/@orbit/local-storage/src/local-storage-cache.ts
@@ -1,5 +1,4 @@
 /* eslint-disable valid-jsdoc */
-import { isNone } from '@orbit/utils';
 import { Orbit } from '@orbit/core';
 import { Record, RecordIdentity, equalRecordIdentities } from '@orbit/records';
 import {
@@ -67,25 +66,21 @@ export class LocalStorageCache extends SyncRecordCache {
   getRecordsSync(typeOrIdentities?: string | RecordIdentity[]): Record[] {
     const records: Record[] = [];
 
-    if (Array.isArray(typeOrIdentities)) {
-      const identities: RecordIdentity[] = typeOrIdentities;
-      for (let identity of identities) {
-        let record = this.getRecordSync(identity);
-        if (record) {
-          records.push(record);
-        }
-      }
-    } else {
+    if (
+      typeOrIdentities === undefined ||
+      typeof typeOrIdentities === 'string'
+    ) {
       const type: string | undefined = typeOrIdentities;
-
       for (let key in Orbit.globals.localStorage) {
         if (key.indexOf(this.namespace + this.delimiter) === 0) {
-          let typesMatch = isNone(type);
+          let typesMatch = type === undefined;
 
           if (!typesMatch) {
             let fragments = key.split(this.delimiter);
             let recordType = fragments[1];
-            typesMatch = recordType === type;
+            typesMatch =
+              recordType === type &&
+              this.schema.models[recordType] !== undefined;
           }
 
           if (typesMatch) {
@@ -97,6 +92,14 @@ export class LocalStorageCache extends SyncRecordCache {
 
             records.push(record);
           }
+        }
+      }
+    } else {
+      const identities: RecordIdentity[] = typeOrIdentities;
+      for (let identity of identities) {
+        let record = this.getRecordSync(identity);
+        if (record) {
+          records.push(record);
         }
       }
     }

--- a/packages/@orbit/local-storage/src/local-storage-cache.ts
+++ b/packages/@orbit/local-storage/src/local-storage-cache.ts
@@ -145,16 +145,25 @@ export class LocalStorageCache extends SyncRecordCache {
   }
 
   getInverseRelationshipsSync(
-    recordIdentity: RecordIdentity
+    recordIdentityOrIdentities: RecordIdentity | RecordIdentity[]
   ): RecordRelationshipIdentity[] {
-    const key = this.getKeyForRecordInverses(recordIdentity);
-    const item = Orbit.globals.localStorage.getItem(key);
+    const results: RecordRelationshipIdentity[] = [];
+    const identities: RecordIdentity[] = Array.isArray(
+      recordIdentityOrIdentities
+    )
+      ? recordIdentityOrIdentities
+      : [recordIdentityOrIdentities];
 
-    if (item) {
-      return JSON.parse(item);
+    for (let identity of identities) {
+      const key = this.getKeyForRecordInverses(identity);
+      const item = Orbit.globals.localStorage.getItem(key);
+
+      if (item) {
+        Array.prototype.push.apply(results, JSON.parse(item));
+      }
     }
 
-    return [];
+    return results;
   }
 
   addInverseRelationshipsSync(

--- a/packages/@orbit/local-storage/test/local-storage-cache-test.ts
+++ b/packages/@orbit/local-storage/test/local-storage-cache-test.ts
@@ -856,6 +856,75 @@ module('LocalStorageCache', function (hooks) {
     );
   });
 
+  test('#query - all records', function (assert) {
+    let earth: Record = {
+      type: 'planet',
+      id: 'earth',
+      keys: {
+        remoteId: 'p1'
+      },
+      attributes: {
+        name: 'Earth',
+        classification: 'terrestrial'
+      }
+    };
+
+    let jupiter: Record = {
+      type: 'planet',
+      id: 'jupiter',
+      keys: {
+        remoteId: 'p2'
+      },
+      attributes: {
+        name: 'Jupiter',
+        classification: 'gas giant'
+      }
+    };
+
+    let io: Record = {
+      type: 'moon',
+      id: 'io',
+      keys: {
+        remoteId: 'm1'
+      },
+      attributes: {
+        name: 'Io'
+      }
+    };
+
+    cache.update((t) => [
+      t.addRecord(earth),
+      t.addRecord(jupiter),
+      t.addRecord(io)
+    ]);
+
+    // reset keyMap to verify that querying records also adds keys
+    keyMap.reset();
+
+    const records = cache.query<Record[]>((q) => q.findRecords());
+    assert.deepEqual(
+      records.map((r) => r.id).sort(),
+      ['earth', 'io', 'jupiter'],
+      'query results match'
+    );
+
+    assert.equal(
+      keyMap.keyToId('planet', 'remoteId', 'p1'),
+      'earth',
+      'key has been mapped'
+    );
+    assert.equal(
+      keyMap.keyToId('planet', 'remoteId', 'p2'),
+      'jupiter',
+      'key has been mapped'
+    );
+    assert.equal(
+      keyMap.keyToId('moon', 'remoteId', 'm1'),
+      'io',
+      'key has been mapped'
+    );
+  });
+
   test('#query - records of one type', function (assert) {
     assert.expect(1);
 

--- a/packages/@orbit/local-storage/test/local-storage-cache-update-test.ts
+++ b/packages/@orbit/local-storage/test/local-storage-cache-update-test.ts
@@ -1,0 +1,2001 @@
+import {
+  equalRecordIdentities,
+  RecordKeyMap,
+  Record,
+  RecordIdentity,
+  recordsInclude,
+  recordsIncludeAll,
+  RecordSchema,
+  RecordNotFoundException
+} from '@orbit/records';
+import { LocalStorageCache } from '../src/local-storage-cache';
+import { createSchemaWithRemoteKey } from './support/setup';
+
+const { module, test } = QUnit;
+
+QUnit.dump.maxDepth = 7;
+
+module('LocalStorageCache - update', function (hooks) {
+  let schema: RecordSchema, cache: LocalStorageCache, keyMap: RecordKeyMap;
+
+  [true, false].forEach((useBuffer) => {
+    module(`useBuffer: ${useBuffer}`, function (hooks) {
+      // All caches in this module share these transform options
+      const defaultTransformOptions = { useBuffer };
+
+      hooks.beforeEach(function () {
+        schema = createSchemaWithRemoteKey();
+        keyMap = new RecordKeyMap();
+      });
+
+      hooks.afterEach(() => {
+        return cache.reset();
+      });
+
+      test('#update sets data and #records retrieves it', function (assert) {
+        assert.expect(4);
+
+        cache = new LocalStorageCache({
+          schema,
+          keyMap,
+          defaultTransformOptions
+        });
+
+        const earth: Record = {
+          type: 'planet',
+          id: '1',
+          attributes: { name: 'Earth' },
+          keys: { remoteId: 'a' }
+        };
+
+        cache.on('patch', (operation, data) => {
+          assert.deepEqual(operation, {
+            op: 'addRecord',
+            record: earth
+          });
+          assert.deepEqual(data, earth);
+        });
+
+        cache.update((t) => t.addRecord(earth));
+
+        assert.deepEqual(
+          cache.getRecordSync({ type: 'planet', id: '1' }),
+          earth,
+          'objects strictly match'
+        );
+        assert.equal(
+          keyMap.keyToId('planet', 'remoteId', 'a'),
+          '1',
+          'key has been mapped'
+        );
+      });
+
+      test('#update can replace records', function (assert) {
+        assert.expect(5);
+
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        const earth: Record = {
+          type: 'planet',
+          id: '1',
+          attributes: { name: 'Earth' },
+          keys: { remoteId: 'a' }
+        };
+
+        cache.on('patch', (operation, data) => {
+          assert.deepEqual(operation, {
+            op: 'updateRecord',
+            record: earth
+          });
+          assert.deepEqual(data, earth);
+        });
+
+        cache.update((t) => t.updateRecord(earth));
+
+        assert.deepEqual(
+          cache.getRecordSync({ type: 'planet', id: '1' }),
+          earth,
+          'objects deeply match'
+        );
+        assert.notStrictEqual(
+          cache.getRecordSync({ type: 'planet', id: '1' }),
+          earth,
+          'objects do not strictly match'
+        );
+        assert.equal(
+          keyMap.keyToId('planet', 'remoteId', 'a'),
+          '1',
+          'key has been mapped'
+        );
+      });
+
+      test('#update can replace keys', function (assert) {
+        assert.expect(4);
+
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        const earth: Record = { type: 'planet', id: '1' };
+
+        cache.on('patch', (operation, data) => {
+          assert.deepEqual(operation, {
+            op: 'replaceKey',
+            record: earth,
+            key: 'remoteId',
+            value: 'a'
+          });
+          assert.deepEqual(data, {
+            type: 'planet',
+            id: '1',
+            keys: { remoteId: 'a' }
+          });
+        });
+
+        cache.update((t) => t.replaceKey(earth, 'remoteId', 'a'));
+
+        assert.deepEqual(
+          cache.getRecordSync({ type: 'planet', id: '1' }),
+          { type: 'planet', id: '1', keys: { remoteId: 'a' } },
+          'records match'
+        );
+        assert.equal(
+          keyMap.keyToId('planet', 'remoteId', 'a'),
+          '1',
+          'key has been mapped'
+        );
+      });
+
+      test('#update updates the cache and returns primary data', function (assert) {
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        let p1 = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
+        let p2 = { type: 'planet', id: '2' };
+
+        let result = cache.update((t) => [t.addRecord(p1), t.removeRecord(p2)]);
+
+        assert.deepEqual(
+          result,
+          [
+            p1,
+            undefined // p2 didn't exist
+          ],
+          'response includes just primary data'
+        );
+      });
+
+      test('#update updates the cache and returns a full response if requested', function (assert) {
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        let p1 = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
+        let p2 = { type: 'planet', id: '2' };
+
+        let result = cache.update(
+          (t) => [t.addRecord(p1), t.removeRecord(p2)],
+          {
+            fullResponse: true
+          }
+        );
+
+        assert.deepEqual(
+          result,
+          {
+            data: [
+              p1,
+              undefined // p2 didn't exist
+            ],
+            details: {
+              appliedOperations: [{ op: 'addRecord', record: p1 }],
+              appliedOperationResults: [p1],
+              inverseOperations: [
+                { op: 'removeRecord', record: { type: 'planet', id: '1' } }
+              ]
+            }
+          },
+          'full response includes data and details'
+        );
+      });
+
+      test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added after', function (assert) {
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' },
+          relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' }
+        };
+
+        cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.moons.data,
+          [{ type: 'moon', id: 'm1' }],
+          'Io has been assigned to Jupiter'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.planet.data,
+          { type: 'planet', id: 'p1' },
+          'Jupiter has been assigned to Io'
+        );
+      });
+
+      test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added before', function (assert) {
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' },
+          relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' }
+        };
+
+        cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.moons.data,
+          [{ type: 'moon', id: 'm1' }],
+          'Io has been assigned to Jupiter'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.planet.data,
+          { type: 'planet', id: 'p1' },
+          'Jupiter has been assigned to Io'
+        );
+      });
+
+      test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added after', function (assert) {
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' }
+        };
+
+        cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.moons.data,
+          [{ type: 'moon', id: 'm1' }],
+          'Io has been assigned to Jupiter'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.planet.data,
+          { type: 'planet', id: 'p1' },
+          'Jupiter has been assigned to Io'
+        );
+      });
+
+      test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added before', function (assert) {
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' }
+        };
+
+        cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.moons.data,
+          [{ type: 'moon', id: 'm1' }],
+          'Io has been assigned to Jupiter'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.planet.data,
+          { type: 'planet', id: 'p1' },
+          'Jupiter has been assigned to Io'
+        );
+      });
+
+      test('#update updates inverse hasOne relationship when a record with an empty relationship is added', function (assert) {
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' },
+          relationships: { moons: { data: [] } }
+        };
+
+        cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.moons.data,
+          [],
+          'Jupiter has no moons'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.planet.data,
+          null,
+          'Jupiter has been cleared from Io'
+        );
+      });
+
+      test('#update updates inverse hasMany relationship when a record with an empty relationship is added', function (assert) {
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' },
+          relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: null } }
+        };
+
+        cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.moons.data,
+          [],
+          'Io has been cleared from Jupiter'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.planet.data,
+          null,
+          'Io has no planet'
+        );
+      });
+
+      test('#update updates inverse hasMany polymorphic relationship', function (assert) {
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        const sun: Record = {
+          type: 'star',
+          id: 's1',
+          attributes: { name: 'Sun' },
+          relationships: {
+            celestialObjects: {
+              data: [
+                { type: 'planet', id: 'p1' },
+                { type: 'moon', id: 'm1' }
+              ]
+            }
+          }
+        };
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' }
+        };
+
+        cache.update((t) => [
+          t.updateRecord(sun),
+          t.updateRecord(jupiter),
+          t.updateRecord(io)
+        ]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'star', id: 's1' }) as Record)
+            ?.relationships?.celestialObjects.data,
+          [
+            { type: 'planet', id: 'p1' },
+            { type: 'moon', id: 'm1' }
+          ],
+          'Jupiter and Io has been assigned to Sun'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.star.data,
+          { type: 'star', id: 's1' },
+          'Sun has been assigned to Jupiter'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.star.data,
+          { type: 'star', id: 's1' },
+          'Sun has been assigned to Io'
+        );
+      });
+
+      test('#update updates inverse hasOne polymorphic relationship', function (assert) {
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' },
+          relationships: { star: { data: { type: 'star', id: 's1' } } }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { star: { data: { type: 'star', id: 's1' } } }
+        };
+        const sun: Record = {
+          type: 'star',
+          id: 's1',
+          attributes: { name: 'Sun' }
+        };
+
+        cache.update((t) => [
+          t.updateRecord(jupiter),
+          t.updateRecord(io),
+          t.updateRecord(sun)
+        ]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'star', id: 's1' }) as Record)
+            ?.relationships?.celestialObjects.data,
+          [
+            { type: 'planet', id: 'p1' },
+            { type: 'moon', id: 'm1' }
+          ],
+          'Jupiter and Io has been assigned to Sun'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.star.data,
+          { type: 'star', id: 's1' },
+          'Sun has been assigned to Jupiter'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.star.data,
+          { type: 'star', id: 's1' },
+          'Sun has been assigned to Io'
+        );
+      });
+
+      test('#update tracks refs and clears them from hasOne relationships when a referenced record is removed', function (assert) {
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' },
+          relationships: { moons: { data: undefined } }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+        const europa: Record = {
+          type: 'moon',
+          id: 'm2',
+          attributes: { name: 'Europa' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+
+        cache.update((t) => [
+          t.addRecord(jupiter),
+          t.addRecord(io),
+          t.addRecord(europa)
+        ]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.planet.data,
+          { type: 'planet', id: 'p1' },
+          'Jupiter has been assigned to Io'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm2' }) as Record)
+            ?.relationships?.planet.data,
+          { type: 'planet', id: 'p1' },
+          'Jupiter has been assigned to Europa'
+        );
+
+        cache.update((t) => t.removeRecord(jupiter));
+
+        assert.equal(
+          cache.getRecordSync({ type: 'planet', id: 'p1' }),
+          undefined,
+          'Jupiter is GONE'
+        );
+
+        assert.equal(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.planet.data,
+          undefined,
+          'Jupiter has been cleared from Io'
+        );
+        assert.equal(
+          (cache.getRecordSync({ type: 'moon', id: 'm2' }) as Record)
+            ?.relationships?.planet.data,
+          undefined,
+          'Jupiter has been cleared from Europa'
+        );
+      });
+
+      test('#update tracks refs and clears them from hasMany relationships when a referenced record is removed', function (assert) {
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: null } }
+        };
+        const europa: Record = {
+          type: 'moon',
+          id: 'm2',
+          attributes: { name: 'Europa' },
+          relationships: { planet: { data: null } }
+        };
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' },
+          relationships: {
+            moons: {
+              data: [
+                { type: 'moon', id: 'm1' },
+                { type: 'moon', id: 'm2' }
+              ]
+            }
+          }
+        };
+
+        cache.update((t) => [
+          t.addRecord(io),
+          t.addRecord(europa),
+          t.addRecord(jupiter)
+        ]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.moons.data,
+          [
+            { type: 'moon', id: 'm1' },
+            { type: 'moon', id: 'm2' }
+          ],
+          'Jupiter has been assigned to Io and Europa'
+        );
+        assert.ok(
+          recordsIncludeAll(
+            cache.getRelatedRecordsSync(jupiter, 'moons') as RecordIdentity[],
+            [io, europa]
+          ),
+          'Jupiter has been assigned to Io and Europa'
+        );
+
+        cache.update((t) => t.removeRecord(io));
+
+        assert.equal(
+          cache.getRecordSync({ type: 'moon', id: 'm1' }),
+          null,
+          'Io is GONE'
+        );
+
+        cache.update((t) => t.removeRecord(europa));
+
+        assert.equal(
+          cache.getRecordSync({ type: 'moon', id: 'm2' }),
+          null,
+          'Europa is GONE'
+        );
+
+        assert.deepEqual(
+          cache.getRelatedRecordsSync(
+            { type: 'planet', id: 'p1' },
+            'moons'
+          ) as RecordIdentity[],
+          [],
+          'moons have been cleared from Jupiter'
+        );
+      });
+
+      test("#update adds link to hasMany if record doesn't exist", function (assert) {
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        cache.update((t) =>
+          t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+            type: 'moon',
+            id: 'm1'
+          })
+        );
+
+        cache.update((t) =>
+          t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+            type: 'moon',
+            id: 'm1'
+          })
+        );
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.moons.data,
+          [{ type: 'moon', id: 'm1' }],
+          'relationship was added'
+        );
+      });
+
+      test("#update does not remove hasMany relationship if record doesn't exist", function (assert) {
+        assert.expect(1);
+
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        cache.on('patch', () => {
+          assert.ok(false, 'no operations were applied');
+        });
+
+        cache.update((t) =>
+          t.removeFromRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+            type: 'moon',
+            id: 'moon1'
+          })
+        );
+
+        assert.equal(
+          cache.getRecordSync({ type: 'planet', id: 'p1' }),
+          undefined,
+          'planet does not exist'
+        );
+      });
+
+      test("#update adds hasOne if record doesn't exist", function (assert) {
+        assert.expect(2);
+
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        const tb = cache.transformBuilder;
+        const replacePlanet = tb.replaceRelatedRecord(
+          { type: 'moon', id: 'moon1' },
+          'planet',
+          { type: 'planet', id: 'p1' }
+        );
+
+        const addToMoons = tb.addToRelatedRecords(
+          { type: 'planet', id: 'p1' },
+          'moons',
+          { type: 'moon', id: 'moon1' }
+        );
+
+        let order = 0;
+        cache.on('patch', (op) => {
+          order++;
+          if (order === 1) {
+            assert.deepEqual(
+              op,
+              replacePlanet.toOperation(),
+              'applied replacePlanet operation'
+            );
+          } else if (order === 2) {
+            assert.deepEqual(
+              op,
+              addToMoons.toOperation(),
+              'applied addToMoons operation'
+            );
+          } else {
+            assert.ok(false, 'too many ops');
+          }
+        });
+
+        cache.update([replacePlanet]);
+      });
+
+      test("#update will add empty hasOne link if record doesn't exist", function (assert) {
+        assert.expect(2);
+
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        const tb = cache.transformBuilder;
+        const clearPlanet = tb.replaceRelatedRecord(
+          { type: 'moon', id: 'moon1' },
+          'planet',
+          null
+        );
+
+        let order = 0;
+        cache.on('patch', (op) => {
+          order++;
+          if (order === 1) {
+            assert.deepEqual(
+              op,
+              clearPlanet.toOperation(),
+              'applied clearPlanet operation'
+            );
+          } else {
+            assert.ok(false, 'too many ops');
+          }
+        });
+
+        cache.update([clearPlanet]);
+
+        assert.ok(true, 'patch applied');
+      });
+
+      test('#update does not add link to hasMany if link already exists', function (assert) {
+        assert.expect(1);
+
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        const jupiter: Record = {
+          id: 'p1',
+          type: 'planet',
+          attributes: { name: 'Jupiter' },
+          relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+        };
+
+        cache.update((t) => t.addRecord(jupiter));
+
+        cache.on('patch', () => {
+          assert.ok(false, 'no operations were applied');
+        });
+
+        cache.update((t) =>
+          t.addToRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'm1' })
+        );
+
+        assert.ok(true, 'patch completed');
+      });
+
+      test("#update does not remove relationship from hasMany if relationship doesn't exist", function (assert) {
+        assert.expect(1);
+
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        const jupiter: Record = {
+          id: 'p1',
+          type: 'planet',
+          attributes: { name: 'Jupiter' }
+        };
+
+        cache.update((t) => t.addRecord(jupiter));
+
+        cache.on('patch', () => {
+          assert.ok(false, 'no operations were applied');
+        });
+
+        cache.update((t) =>
+          t.removeFromRelatedRecords(jupiter, 'moons', {
+            type: 'moon',
+            id: 'm1'
+          })
+        );
+
+        assert.ok(true, 'patch completed');
+      });
+
+      test('#update can add and remove to has-many relationship', function (assert) {
+        assert.expect(2);
+
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        const jupiter: Record = { id: 'jupiter', type: 'planet' };
+        cache.update((t) => t.addRecord(jupiter));
+
+        const callisto: Record = { id: 'callisto', type: 'moon' };
+        cache.update((t) => t.addRecord(callisto));
+
+        cache.update((t) =>
+          t.addToRelatedRecords(jupiter, 'moons', {
+            type: 'moon',
+            id: 'callisto'
+          })
+        );
+
+        assert.ok(
+          recordsInclude(
+            cache.getRelatedRecordsSync(jupiter, 'moons') as RecordIdentity[],
+            callisto
+          ),
+          'moon added'
+        );
+
+        cache.update((t) =>
+          t.removeFromRelatedRecords(jupiter, 'moons', {
+            type: 'moon',
+            id: 'callisto'
+          })
+        );
+
+        assert.notOk(
+          recordsInclude(
+            cache.getRelatedRecordsSync(jupiter, 'moons') as RecordIdentity[],
+            callisto
+          ),
+          'moon removed'
+        );
+      });
+
+      test('#update can add and clear has-one relationship', function (assert) {
+        assert.expect(2);
+
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        const jupiter: Record = { id: 'jupiter', type: 'planet' };
+        cache.update((t) => t.addRecord(jupiter));
+
+        const callisto: Record = { id: 'callisto', type: 'moon' };
+        cache.update((t) => t.addRecord(callisto));
+
+        cache.update((t) =>
+          t.replaceRelatedRecord(callisto, 'planet', {
+            type: 'planet',
+            id: 'jupiter'
+          })
+        );
+
+        assert.ok(
+          equalRecordIdentities(
+            cache.getRelatedRecordSync(callisto, 'planet') as RecordIdentity,
+            jupiter
+          ),
+          'relationship added'
+        );
+
+        cache.update((t) => t.replaceRelatedRecord(callisto, 'planet', null));
+
+        assert.notOk(
+          equalRecordIdentities(
+            cache.getRelatedRecordSync(callisto, 'planet') as RecordIdentity,
+            jupiter
+          ),
+          'relationship cleared'
+        );
+      });
+
+      test('does not replace hasOne if relationship already exists', function (assert) {
+        assert.expect(1);
+
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        const europa: Record = {
+          id: 'm1',
+          type: 'moon',
+          attributes: { name: 'Europa' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+
+        cache.update((t) => t.addRecord(europa));
+
+        cache.on('patch', () => {
+          assert.ok(false, 'no operations were applied');
+        });
+
+        cache.update((t) =>
+          t.replaceRelatedRecord(europa, 'planet', { type: 'planet', id: 'p1' })
+        );
+
+        assert.ok(true, 'patch completed');
+      });
+
+      test("does not remove hasOne if relationship doesn't exist", function (assert) {
+        assert.expect(1);
+
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        const europa: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Europa' },
+          relationships: { planet: { data: null } }
+        };
+
+        cache.update((t) => t.addRecord(europa));
+
+        cache.on('patch', () => {
+          assert.ok(false, 'no operations were applied');
+        });
+
+        cache.update((t) => t.replaceRelatedRecord(europa, 'planet', null));
+
+        assert.ok(true, 'patch completed');
+      });
+
+      test('#update removing model with a bi-directional hasOne', function (assert) {
+        assert.expect(5);
+
+        const hasOneSchema = new RecordSchema({
+          models: {
+            one: {
+              relationships: {
+                two: { kind: 'hasOne', type: 'two', inverse: 'one' }
+              }
+            },
+            two: {
+              relationships: {
+                one: { kind: 'hasOne', type: 'one', inverse: 'two' }
+              }
+            }
+          }
+        });
+
+        cache = new LocalStorageCache({
+          schema: hasOneSchema,
+          keyMap
+        });
+
+        cache.update((t) => [
+          t.addRecord({
+            id: '1',
+            type: 'one',
+            relationships: {
+              two: { data: null }
+            }
+          }),
+          t.addRecord({
+            id: '2',
+            type: 'two',
+            relationships: {
+              one: { data: { type: 'one', id: '1' } }
+            }
+          })
+        ]);
+
+        const one = cache.getRecordSync({ type: 'one', id: '1' }) as Record;
+        const two = cache.getRecordSync({ type: 'two', id: '2' }) as Record;
+        assert.ok(one, 'one exists');
+        assert.ok(two, 'two exists');
+        assert.deepEqual(
+          one.relationships?.two.data,
+          { type: 'two', id: '2' },
+          'one links to two'
+        );
+        assert.deepEqual(
+          two.relationships?.one.data,
+          { type: 'one', id: '1' },
+          'two links to one'
+        );
+
+        cache.update((t) => t.removeRecord(two));
+
+        assert.equal(
+          (cache.getRecordSync({ type: 'one', id: '1' }) as Record)
+            .relationships?.two.data,
+          null,
+          'ones link to two got removed'
+        );
+      });
+
+      test('#update removes dependent records in a hasOne relationship', function (assert) {
+        const dependentSchema = new RecordSchema({
+          models: {
+            planet: {
+              relationships: {
+                moons: { kind: 'hasMany', type: 'moon' }
+              }
+            },
+            moon: {
+              relationships: {
+                planet: { kind: 'hasOne', type: 'planet', dependent: 'remove' }
+              }
+            }
+          }
+        });
+
+        cache = new LocalStorageCache({
+          schema: dependentSchema,
+          keyMap
+        });
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+        const europa: Record = {
+          type: 'moon',
+          id: 'm2',
+          attributes: { name: 'Europa' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+
+        cache.update((t) => [
+          t.addRecord(jupiter),
+          t.addRecord(io),
+          t.addRecord(europa),
+          t.addToRelatedRecords(jupiter, 'moons', io),
+          t.addToRelatedRecords(jupiter, 'moons', europa)
+        ]);
+
+        cache.update((t) => t.removeRecord(io));
+
+        assert.equal(
+          cache.getRecordsSync('moon').length,
+          1,
+          'Only europa is left in store'
+        );
+        assert.equal(
+          cache.getRecordsSync('planet').length,
+          0,
+          'Jupiter has been removed from the store'
+        );
+      });
+
+      test('#update removes dependent records in a hasMany relationship', function (assert) {
+        const dependentSchema = new RecordSchema({
+          models: {
+            planet: {
+              relationships: {
+                moons: { kind: 'hasMany', type: 'moon', dependent: 'remove' }
+              }
+            },
+            moon: {
+              relationships: {
+                planet: { kind: 'hasOne', type: 'planet' }
+              }
+            }
+          }
+        });
+
+        cache = new LocalStorageCache({
+          schema: dependentSchema,
+          keyMap
+        });
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+        const europa: Record = {
+          type: 'moon',
+          id: 'm2',
+          attributes: { name: 'Europa' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+
+        cache.update((t) => [
+          t.updateRecord(jupiter),
+          t.updateRecord(io),
+          t.updateRecord(europa),
+          t.addToRelatedRecords(jupiter, 'moons', io),
+          t.addToRelatedRecords(jupiter, 'moons', europa)
+        ]);
+
+        cache.update((t) => t.removeRecord(jupiter));
+
+        assert.equal(
+          cache.getRecordsSync('planet').length,
+          0,
+          'Jupiter has been removed from the store'
+        );
+        assert.equal(
+          cache.getRecordsSync('moon').length,
+          0,
+          'All of Jupiters moons are removed from the store'
+        );
+      });
+
+      test('#update does not remove non-dependent records', function (assert) {
+        const dependentSchema = new RecordSchema({
+          models: {
+            planet: {
+              relationships: {
+                moons: { kind: 'hasMany', type: 'moon' }
+              }
+            },
+            moon: {
+              relationships: {
+                planet: { kind: 'hasOne', type: 'planet' }
+              }
+            }
+          }
+        });
+
+        cache = new LocalStorageCache({
+          schema: dependentSchema,
+          keyMap
+        });
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+        const europa: Record = {
+          type: 'moon',
+          id: 'm2',
+          attributes: { name: 'Europa' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+
+        cache.update((t) => [
+          t.addRecord(jupiter),
+          t.addRecord(io),
+          t.addRecord(europa),
+          t.addToRelatedRecords(jupiter, 'moons', io),
+          t.addToRelatedRecords(jupiter, 'moons', europa)
+        ]);
+
+        // Since there are no dependent relationships, no other records will be
+        // removed
+        cache.update((t) => t.removeRecord(io));
+
+        assert.equal(
+          cache.getRecordsSync('moon').length,
+          1,
+          'One moon left in store'
+        );
+        assert.equal(
+          cache.getRecordsSync('planet').length,
+          1,
+          'One planet left in store'
+        );
+      });
+
+      test('#update merges records when "replacing" and will not stomp on attributes and relationships that are not replaced', function (assert) {
+        cache = new LocalStorageCache({ schema, keyMap });
+        const tb = cache.transformBuilder;
+
+        cache.update((t) => [
+          t.addRecord({
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Earth' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+          })
+        ]);
+
+        let result = cache.update(
+          (t) => [
+            t.updateRecord({
+              type: 'planet',
+              id: '1',
+              attributes: { classification: 'terrestrial' }
+            })
+          ],
+          { fullResponse: true }
+        );
+
+        assert.deepEqual(
+          cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
+          {
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Earth', classification: 'terrestrial' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+          },
+          'records have been merged'
+        );
+
+        assert.deepEqual(
+          result,
+          {
+            data: {
+              type: 'planet',
+              id: '1',
+              attributes: {
+                name: 'Earth',
+                classification: 'terrestrial'
+              },
+              relationships: {
+                moons: {
+                  data: [{ type: 'moon', id: 'm1' }]
+                }
+              }
+            },
+            details: {
+              appliedOperations: [
+                tb
+                  .updateRecord({
+                    type: 'planet',
+                    id: '1',
+                    attributes: { classification: 'terrestrial' }
+                  })
+                  .toOperation()
+              ],
+              appliedOperationResults: [
+                {
+                  type: 'planet',
+                  id: '1',
+                  attributes: {
+                    name: 'Earth',
+                    classification: 'terrestrial'
+                  },
+                  relationships: {
+                    moons: {
+                      data: [{ type: 'moon', id: 'm1' }]
+                    }
+                  }
+                }
+              ],
+              inverseOperations: [
+                tb
+                  .updateRecord({
+                    type: 'planet',
+                    id: '1',
+                    attributes: { classification: null }
+                  })
+                  .toOperation()
+              ]
+            }
+          },
+          'full response is correct'
+        );
+      });
+
+      test('#update can replace related records but only if they are different', function (assert) {
+        cache = new LocalStorageCache({ schema, keyMap });
+        const tb = cache.transformBuilder;
+
+        cache.update((t) => [
+          t.addRecord({
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Earth' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+          })
+        ]);
+
+        let result = cache.update(
+          (t) => [
+            t.replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
+              { type: 'moon', id: 'm1' }
+            ])
+          ],
+          { fullResponse: true }
+        );
+
+        assert.deepEqual(
+          result,
+          {
+            data: undefined,
+            details: {
+              appliedOperations: [],
+              appliedOperationResults: [],
+              inverseOperations: []
+            }
+          },
+          'nothing has changed so there are no appliend or inverse ops'
+        );
+
+        result = cache.update(
+          (t) =>
+            t.replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
+              { type: 'moon', id: 'm2' }
+            ]),
+          { fullResponse: true }
+        );
+
+        assert.deepEqual(
+          cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
+          {
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Earth' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
+          },
+          'relationships have been replaced'
+        );
+
+        assert.deepEqual(
+          result,
+          {
+            data: {
+              type: 'planet',
+              id: '1',
+              attributes: { name: 'Earth' },
+              relationships: {
+                moons: { data: [{ type: 'moon', id: 'm2' }] }
+              }
+            },
+            details: {
+              appliedOperations: [
+                tb
+                  .replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
+                    { type: 'moon', id: 'm2' }
+                  ])
+                  .toOperation(),
+                tb
+                  .replaceRelatedRecord(
+                    { type: 'moon', id: 'm1' },
+                    'planet',
+                    null
+                  )
+                  .toOperation(),
+                tb
+                  .replaceRelatedRecord({ type: 'moon', id: 'm2' }, 'planet', {
+                    type: 'planet',
+                    id: '1'
+                  })
+                  .toOperation()
+              ],
+              appliedOperationResults: [
+                {
+                  type: 'planet',
+                  id: '1',
+                  attributes: { name: 'Earth' },
+                  relationships: {
+                    moons: { data: [{ type: 'moon', id: 'm2' }] }
+                  }
+                },
+                {
+                  type: 'moon',
+                  id: 'm1',
+                  relationships: {
+                    planet: { data: null }
+                  }
+                },
+                {
+                  type: 'moon',
+                  id: 'm2',
+                  relationships: {
+                    planet: { data: { type: 'planet', id: '1' } }
+                  }
+                }
+              ],
+              inverseOperations: [
+                tb
+                  .replaceRelatedRecord(
+                    { type: 'moon', id: 'm2' },
+                    'planet',
+                    null
+                  )
+                  .toOperation(),
+                tb
+                  .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
+                    type: 'planet',
+                    id: '1'
+                  })
+                  .toOperation(),
+                tb
+                  .replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
+                    { type: 'moon', id: 'm1' }
+                  ])
+                  .toOperation()
+              ]
+            }
+          },
+          'full response is correct'
+        );
+      });
+
+      test('#update merges records when "replacing" and _will_ replace specified attributes and relationships', function (assert) {
+        cache = new LocalStorageCache({ schema, keyMap });
+        const tb = cache.transformBuilder;
+
+        const earth: Record = {
+          type: 'planet',
+          id: '1',
+          attributes: { name: 'Earth' },
+          relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+        };
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: '1',
+          attributes: { name: 'Jupiter', classification: 'terrestrial' },
+          relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
+        };
+
+        let result = cache.update([tb.addRecord(earth)], {
+          fullResponse: true
+        });
+
+        assert.deepEqual(
+          result,
+          {
+            data: earth,
+            details: {
+              appliedOperations: [
+                tb.addRecord(earth).toOperation(),
+                tb
+                  .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
+                    type: 'planet',
+                    id: '1'
+                  })
+                  .toOperation()
+              ],
+              appliedOperationResults: [
+                {
+                  type: 'planet',
+                  id: '1',
+                  attributes: { name: 'Earth' },
+                  relationships: {
+                    moons: { data: [{ type: 'moon', id: 'm1' }] }
+                  }
+                },
+                {
+                  type: 'moon',
+                  id: 'm1',
+                  relationships: {
+                    planet: { data: { type: 'planet', id: '1' } }
+                  }
+                }
+              ],
+              inverseOperations: [
+                tb
+                  .replaceRelatedRecord(
+                    { type: 'moon', id: 'm1' },
+                    'planet',
+                    null
+                  )
+                  .toOperation(),
+                tb
+                  .removeRecord({
+                    type: 'planet',
+                    id: '1'
+                  })
+                  .toOperation()
+              ]
+            }
+          },
+          'addRecord full response is correct'
+        );
+
+        result = cache.update([tb.updateRecord(jupiter)], {
+          fullResponse: true
+        });
+
+        assert.deepEqual(result, {
+          data: jupiter,
+          details: {
+            appliedOperations: [
+              tb.updateRecord(jupiter).toOperation(),
+              tb
+                .replaceRelatedRecord(
+                  { type: 'moon', id: 'm1' },
+                  'planet',
+                  null
+                )
+                .toOperation(),
+              tb
+                .replaceRelatedRecord({ type: 'moon', id: 'm2' }, 'planet', {
+                  type: 'planet',
+                  id: '1'
+                })
+                .toOperation()
+            ],
+            appliedOperationResults: [
+              jupiter,
+              {
+                type: 'moon',
+                id: 'm1',
+                relationships: {
+                  planet: { data: null }
+                }
+              },
+              {
+                type: 'moon',
+                id: 'm2',
+                relationships: {
+                  planet: { data: { type: 'planet', id: '1' } }
+                }
+              }
+            ],
+            inverseOperations: [
+              tb
+                .replaceRelatedRecord(
+                  { type: 'moon', id: 'm2' },
+                  'planet',
+                  null
+                )
+                .toOperation(),
+              tb
+                .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
+                  type: 'planet',
+                  id: '1'
+                })
+                .toOperation(),
+              tb
+                .updateRecord({
+                  type: 'planet',
+                  id: '1',
+                  attributes: { name: 'Earth', classification: null },
+                  relationships: {
+                    moons: { data: [{ type: 'moon', id: 'm1' }] }
+                  }
+                })
+                .toOperation()
+            ]
+          }
+        });
+
+        assert.deepEqual(
+          cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
+          {
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Jupiter', classification: 'terrestrial' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
+          },
+          'records have been merged'
+        );
+      });
+
+      test('#update can update existing record with empty relationship', function (assert) {
+        cache = new LocalStorageCache({ schema, keyMap });
+        const tb = cache.transformBuilder;
+
+        let result = cache.update(
+          (t) => [t.addRecord({ id: '1', type: 'planet' })],
+          { fullResponse: true }
+        );
+
+        assert.deepEqual(
+          result,
+          {
+            data: { id: '1', type: 'planet' },
+            details: {
+              appliedOperations: [
+                tb
+                  .addRecord({
+                    type: 'planet',
+                    id: '1'
+                  })
+                  .toOperation()
+              ],
+              appliedOperationResults: [
+                {
+                  id: '1',
+                  type: 'planet'
+                }
+              ],
+              inverseOperations: [
+                tb
+                  .removeRecord({
+                    type: 'planet',
+                    id: '1'
+                  })
+                  .toOperation()
+              ]
+            }
+          },
+          'addRecord result is correct'
+        );
+
+        result = cache.update(
+          (t) => [
+            t.updateRecord({
+              id: '1',
+              type: 'planet',
+              relationships: {
+                moons: { data: [] }
+              }
+            })
+          ],
+          { fullResponse: true }
+        );
+
+        assert.deepEqual(
+          result,
+          {
+            data: {
+              id: '1',
+              type: 'planet',
+              relationships: {
+                moons: { data: [] }
+              }
+            },
+            details: {
+              appliedOperations: [
+                tb
+                  .updateRecord({
+                    id: '1',
+                    type: 'planet',
+                    relationships: {
+                      moons: { data: [] }
+                    }
+                  })
+                  .toOperation()
+              ],
+              appliedOperationResults: [
+                {
+                  id: '1',
+                  type: 'planet',
+                  relationships: {
+                    moons: { data: [] }
+                  }
+                }
+              ],
+              inverseOperations: [
+                tb
+                  .updateRecord({
+                    id: '1',
+                    type: 'planet',
+                    relationships: {
+                      moons: { data: [] }
+                    }
+                  })
+                  .toOperation()
+              ]
+            }
+          },
+          'updateRecord result is correct'
+        );
+
+        const planet = cache.getRecordSync({ type: 'planet', id: '1' });
+        assert.ok(planet, 'planet exists');
+        assert.deepEqual(
+          planet?.relationships?.moons.data,
+          [],
+          'planet has empty moons relationship'
+        );
+      });
+
+      test('#update will not overwrite an existing relationship with a missing relationship', function (assert) {
+        cache = new LocalStorageCache({ schema, keyMap });
+        const tb = cache.transformBuilder;
+
+        let result = cache.update(
+          (t) => [
+            t.addRecord({
+              id: '1',
+              type: 'planet',
+              relationships: {
+                moons: { data: [{ type: 'moon', id: 'm1' }] }
+              }
+            }),
+            t.updateRecord({
+              id: '1',
+              type: 'planet'
+            })
+          ],
+          { fullResponse: true }
+        );
+
+        assert.deepEqual(
+          result,
+          {
+            data: [
+              {
+                id: '1',
+                type: 'planet',
+                relationships: {
+                  moons: { data: [{ type: 'moon', id: 'm1' }] }
+                }
+              },
+              undefined
+            ],
+            details: {
+              appliedOperations: [
+                tb
+                  .addRecord({
+                    id: '1',
+                    type: 'planet',
+                    relationships: {
+                      moons: { data: [{ type: 'moon', id: 'm1' }] }
+                    }
+                  })
+                  .toOperation(),
+                tb
+                  .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
+                    id: '1',
+                    type: 'planet'
+                  })
+                  .toOperation()
+              ],
+              appliedOperationResults: [
+                {
+                  id: '1',
+                  type: 'planet',
+                  relationships: {
+                    moons: { data: [{ type: 'moon', id: 'm1' }] }
+                  }
+                },
+                {
+                  type: 'moon',
+                  id: 'm1',
+                  relationships: {
+                    planet: { data: { id: '1', type: 'planet' } }
+                  }
+                }
+              ],
+              inverseOperations: [
+                tb
+                  .replaceRelatedRecord(
+                    { type: 'moon', id: 'm1' },
+                    'planet',
+                    null
+                  )
+                  .toOperation(),
+                tb
+                  .removeRecord({
+                    id: '1',
+                    type: 'planet'
+                  })
+                  .toOperation()
+              ]
+            }
+          },
+          'update full response is correct'
+        );
+
+        const planet = cache.getRecordSync({ type: 'planet', id: '1' });
+        assert.ok(planet, 'planet exists');
+        assert.deepEqual(
+          planet?.relationships?.moons.data,
+          [{ type: 'moon', id: 'm1' }],
+          'planet has a moons relationship'
+        );
+      });
+
+      test('#update allows replaceRelatedRecord to be called on a relationship with no inverse and to be followed up by removing the replaced record', function (assert) {
+        assert.expect(2);
+
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        const star1 = {
+          id: 'star1',
+          type: 'star',
+          attributes: { name: 'sun1' }
+        };
+
+        const star2 = {
+          id: 'star2',
+          type: 'star',
+          attributes: { name: 'sun2' }
+        };
+
+        const home = {
+          id: 'home',
+          type: 'planetarySystem',
+          attributes: { name: 'Home' },
+          relationships: {
+            star: {
+              data: { id: 'star1', type: 'star' }
+            }
+          }
+        };
+
+        cache.update((t) => [
+          t.addRecord(star1),
+          t.addRecord(star2),
+          t.addRecord(home)
+        ]);
+
+        let latestHome = cache.getRecordSync({
+          id: 'home',
+          type: 'planetarySystem'
+        });
+        assert.deepEqual(
+          (latestHome?.relationships?.star.data as Record).id,
+          star1.id,
+          'The original related record is in place.'
+        );
+
+        cache.update((t) => [
+          t.replaceRelatedRecord(
+            {
+              id: 'home',
+              type: 'planetarySystem'
+            },
+            'star',
+            star2
+          ),
+          t.removeRecord(star1)
+        ]);
+
+        latestHome = cache.getRecordSync({
+          id: 'home',
+          type: 'planetarySystem'
+        });
+
+        assert.deepEqual(
+          (latestHome?.relationships?.star.data as Record).id,
+          star2.id,
+          'The related record was replaced.'
+        );
+      });
+
+      test("#update - updateRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        const earth: Record = {
+          type: 'planet',
+          id: '1',
+          attributes: { name: 'Earth' },
+          keys: { remoteId: 'a' }
+        };
+
+        assert.throws(
+          () =>
+            cache.update((t) =>
+              t.updateRecord(earth).options({
+                raiseNotFoundExceptions: true
+              })
+            ),
+          RecordNotFoundException
+        );
+      });
+
+      test("#update - removeRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        const earth: Record = {
+          type: 'planet',
+          id: '1'
+        };
+
+        assert.throws(
+          () =>
+            cache.update((t) =>
+              t.removeRecord(earth).options({
+                raiseNotFoundExceptions: true
+              })
+            ),
+          RecordNotFoundException
+        );
+      });
+
+      test("#update - replaceKey - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        const earth: Record = {
+          type: 'planet',
+          id: '1',
+          attributes: { name: 'Earth' },
+          keys: { remoteId: 'a' }
+        };
+
+        assert.throws(
+          () =>
+            cache.update((t) =>
+              t.replaceKey(earth, 'remoteId', 'b').options({
+                raiseNotFoundExceptions: true
+              })
+            ),
+          RecordNotFoundException
+        );
+      });
+
+      test("#update - replaceAttribute - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        const earth: Record = {
+          type: 'planet',
+          id: '1',
+          attributes: { name: 'Earth' },
+          keys: { remoteId: 'a' }
+        };
+
+        assert.throws(
+          () =>
+            cache.update((t) =>
+              t.replaceAttribute(earth, 'name', 'Mother Earth').options({
+                raiseNotFoundExceptions: true
+              })
+            ),
+          RecordNotFoundException
+        );
+      });
+
+      test("#update - addToRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        assert.throws(
+          () =>
+            cache.update((t) =>
+              t
+                .addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+                  type: 'moon',
+                  id: 'm1'
+                })
+                .options({
+                  raiseNotFoundExceptions: true
+                })
+            ),
+          RecordNotFoundException
+        );
+      });
+
+      test("#update - removeFromRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        assert.throws(
+          () =>
+            cache.update((t) =>
+              t
+                .removeFromRelatedRecords(
+                  { type: 'planet', id: 'p1' },
+                  'moons',
+                  {
+                    type: 'moon',
+                    id: 'm1'
+                  }
+                )
+                .options({
+                  raiseNotFoundExceptions: true
+                })
+            ),
+          RecordNotFoundException
+        );
+      });
+
+      test("#update - replaceRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        assert.throws(
+          () =>
+            cache.update((t) =>
+              t
+                .replaceRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', [
+                  {
+                    type: 'moon',
+                    id: 'm1'
+                  }
+                ])
+                .options({
+                  raiseNotFoundExceptions: true
+                })
+            ),
+          RecordNotFoundException
+        );
+      });
+
+      test("#update - replaceRelatedRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+        cache = new LocalStorageCache({ schema, keyMap });
+
+        assert.throws(
+          () =>
+            cache.update((t) =>
+              t
+                .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
+                  type: 'planet',
+                  id: 'p1'
+                })
+                .options({
+                  raiseNotFoundExceptions: true
+                })
+            ),
+          RecordNotFoundException
+        );
+      });
+    });
+  });
+});

--- a/packages/@orbit/local-storage/test/support/local-storage.ts
+++ b/packages/@orbit/local-storage/test/support/local-storage.ts
@@ -1,9 +1,10 @@
 import { Orbit } from '@orbit/core';
 import { Record } from '@orbit/records';
 import { LocalStorageSource } from '../../src/local-storage-source';
+import { LocalStorageCache } from '../../src/local-storage-cache';
 
 export function getRecordFromLocalStorage(
-  source: LocalStorageSource,
+  source: LocalStorageSource | LocalStorageCache,
   record: Record
 ): Record {
   const recordKey = [source.namespace, record.type, record.id].join(

--- a/packages/@orbit/local-storage/test/support/setup.ts
+++ b/packages/@orbit/local-storage/test/support/setup.ts
@@ -1,0 +1,55 @@
+import { RecordSchema } from '@orbit/records';
+
+export function createSchemaWithRemoteKey(): RecordSchema {
+  return new RecordSchema({
+    models: {
+      star: {
+        keys: {
+          remoteId: {}
+        },
+        relationships: {
+          celestialObjects: {
+            kind: 'hasMany',
+            type: ['planet', 'moon'],
+            inverse: 'star'
+          }
+        }
+      },
+      planet: {
+        keys: {
+          remoteId: {}
+        },
+        relationships: {
+          moons: { kind: 'hasMany', type: 'moon', inverse: 'planet' },
+          star: { kind: 'hasOne', type: 'star', inverse: 'celestialObjects' }
+        }
+      },
+      moon: {
+        keys: {
+          remoteId: {}
+        },
+        relationships: {
+          planet: { kind: 'hasOne', type: 'planet', inverse: 'moons' },
+          star: { kind: 'hasOne', type: 'star', inverse: 'celestialObjects' }
+        }
+      },
+      binaryStar: {
+        attributes: {
+          name: { type: 'string' }
+        },
+        relationships: {
+          starOne: { kind: 'hasOne', type: 'star' }, // no inverse
+          starTwo: { kind: 'hasOne', type: 'star' } // no inverse
+        }
+      },
+      planetarySystem: {
+        attributes: {
+          name: { type: 'string' }
+        },
+        relationships: {
+          star: { kind: 'hasOne', type: ['star', 'binaryStar'] } // no inverse
+        }
+      }
+    }
+  });
+}

--- a/packages/@orbit/memory/src/memory-cache.ts
+++ b/packages/@orbit/memory/src/memory-cache.ts
@@ -36,7 +36,20 @@ export class MemoryCache extends SyncRecordCache {
   }
 
   getRecordsSync(typeOrIdentities?: string | RecordIdentity[]): Record[] {
-    if (Array.isArray(typeOrIdentities)) {
+    if (typeOrIdentities === undefined) {
+      const types = Object.keys(this.schema.models);
+      const records: Record[] = [];
+      types.forEach((type) =>
+        Array.prototype.push.apply(
+          records,
+          Array.from(this._records[type].values())
+        )
+      );
+      return records;
+    } else if (typeof typeOrIdentities === 'string') {
+      const type: string = typeOrIdentities;
+      return Array.from(this._records[type].values());
+    } else {
       const records: Record[] = [];
       const identities: RecordIdentity[] = typeOrIdentities;
       for (let identity of identities) {
@@ -46,16 +59,6 @@ export class MemoryCache extends SyncRecordCache {
         }
       }
       return records;
-    } else {
-      const type: string | undefined = typeOrIdentities;
-
-      if (type) {
-        return Array.from(this._records[type].values());
-      } else {
-        throw new Assertion(
-          `MemoryCache does not support getting all records without specifying a 'type'`
-        );
-      }
     }
   }
 

--- a/packages/@orbit/memory/src/memory-cache.ts
+++ b/packages/@orbit/memory/src/memory-cache.ts
@@ -1,6 +1,4 @@
-/* eslint-disable valid-jsdoc */
 import { clone, Dict } from '@orbit/utils';
-import { Assertion } from '@orbit/core';
 import { Record, RecordIdentity, equalRecordIdentities } from '@orbit/records';
 import {
   RecordRelationshipIdentity,

--- a/packages/@orbit/memory/src/memory-cache.ts
+++ b/packages/@orbit/memory/src/memory-cache.ts
@@ -103,12 +103,23 @@ export class MemoryCache extends SyncRecordCache {
   }
 
   getInverseRelationshipsSync(
-    recordIdentity: RecordIdentity
+    recordIdentityOrIdentities: RecordIdentity | RecordIdentity[]
   ): RecordRelationshipIdentity[] {
-    return (
-      this._inverseRelationships[recordIdentity.type].get(recordIdentity.id) ||
-      []
-    );
+    const results: RecordRelationshipIdentity[] = [];
+    const identities: RecordIdentity[] = Array.isArray(
+      recordIdentityOrIdentities
+    )
+      ? recordIdentityOrIdentities
+      : [recordIdentityOrIdentities];
+
+    for (let identity of identities) {
+      const result = this._inverseRelationships[identity.type].get(identity.id);
+      if (result) {
+        Array.prototype.push.apply(results, result);
+      }
+    }
+
+    return results;
   }
 
   addInverseRelationshipsSync(

--- a/packages/@orbit/memory/test/memory-cache-test.ts
+++ b/packages/@orbit/memory/test/memory-cache-test.ts
@@ -444,6 +444,9 @@ module('MemoryCache', function (hooks) {
               record: { type: 'planet', id: '1', attributes: { name: 'Earth' } }
             }
           ],
+          appliedOperationResults: [
+            { type: 'planet', id: '1', attributes: { name: 'Earth' } }
+          ],
           inverseOperations: [
             { op: 'removeRecord', record: { type: 'planet', id: '1' } }
           ]
@@ -1019,6 +1022,21 @@ module('MemoryCache', function (hooks) {
               })
               .toOperation()
           ],
+          appliedOperationResults: [
+            {
+              type: 'planet',
+              id: '1',
+              attributes: {
+                name: 'Earth',
+                classification: 'terrestrial'
+              },
+              relationships: {
+                moons: {
+                  data: [{ type: 'moon', id: 'm1' }]
+                }
+              }
+            }
+          ],
           inverseOperations: [
             tb
               .updateRecord({
@@ -1062,6 +1080,7 @@ module('MemoryCache', function (hooks) {
         data: undefined,
         details: {
           appliedOperations: [],
+          appliedOperationResults: [],
           inverseOperations: []
         }
       },
@@ -1115,6 +1134,30 @@ module('MemoryCache', function (hooks) {
                 id: '1'
               })
               .toOperation()
+          ],
+          appliedOperationResults: [
+            {
+              type: 'planet',
+              id: '1',
+              attributes: { name: 'Earth' },
+              relationships: {
+                moons: { data: [{ type: 'moon', id: 'm2' }] }
+              }
+            },
+            {
+              type: 'moon',
+              id: 'm1',
+              relationships: {
+                planet: { data: null }
+              }
+            },
+            {
+              type: 'moon',
+              id: 'm2',
+              relationships: {
+                planet: { data: { type: 'planet', id: '1' } }
+              }
+            }
           ],
           inverseOperations: [
             tb
@@ -1177,6 +1220,21 @@ module('MemoryCache', function (hooks) {
             })
             .toOperation()
         ],
+        appliedOperationResults: [
+          earth,
+          {
+            type: 'moon',
+            id: 'm1',
+            relationships: {
+              planet: {
+                data: {
+                  type: 'planet',
+                  id: '1'
+                }
+              }
+            }
+          }
+        ],
         inverseOperations: [
           tb
             .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', null)
@@ -1214,6 +1272,32 @@ module('MemoryCache', function (hooks) {
               id: '1'
             })
             .toOperation()
+        ],
+        appliedOperationResults: [
+          {
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Jupiter', classification: 'terrestrial' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
+          },
+          {
+            type: 'moon',
+            id: 'm1',
+            relationships: {
+              planet: {
+                data: null
+              }
+            }
+          },
+          {
+            type: 'moon',
+            id: 'm2',
+            relationships: {
+              planet: {
+                data: { type: 'planet', id: '1' }
+              }
+            }
+          }
         ],
         inverseOperations: [
           tb

--- a/packages/@orbit/memory/test/memory-cache-test.ts
+++ b/packages/@orbit/memory/test/memory-cache-test.ts
@@ -2290,6 +2290,76 @@ module('MemoryCache', function (hooks) {
     );
   });
 
+  test('#query - all records', function (assert) {
+    assert.expect(4);
+
+    let cache = new MemoryCache({ schema, keyMap });
+
+    let earth: Record = {
+      type: 'planet',
+      id: 'earth',
+      keys: {
+        remoteId: 'p1'
+      },
+      attributes: {
+        name: 'Earth',
+        classification: 'terrestrial'
+      }
+    };
+
+    let jupiter: Record = {
+      type: 'planet',
+      id: 'jupiter',
+      keys: {
+        remoteId: 'p2'
+      },
+      attributes: {
+        name: 'Jupiter',
+        classification: 'gas giant'
+      }
+    };
+
+    let io: Record = {
+      type: 'moon',
+      id: 'io',
+      keys: {
+        remoteId: 'm1'
+      },
+      attributes: {
+        name: 'Io'
+      }
+    };
+
+    cache.update((t) => [
+      t.addRecord(earth),
+      t.addRecord(jupiter),
+      t.addRecord(io)
+    ]);
+
+    assert.equal(
+      keyMap.keyToId('planet', 'remoteId', 'p1'),
+      'earth',
+      'key has been mapped'
+    );
+    assert.equal(
+      keyMap.keyToId('planet', 'remoteId', 'p2'),
+      'jupiter',
+      'key has been mapped'
+    );
+    assert.equal(
+      keyMap.keyToId('moon', 'remoteId', 'm1'),
+      'io',
+      'key has been mapped'
+    );
+
+    let records = cache.query((q) => q.findRecords());
+    assert.deepEqual(
+      records,
+      [earth, jupiter, io],
+      'query results are expected'
+    );
+  });
+
   test('#query - findRelatedRecords', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 

--- a/packages/@orbit/memory/test/memory-cache-test.ts
+++ b/packages/@orbit/memory/test/memory-cache-test.ts
@@ -254,6 +254,172 @@ module('MemoryCache', function (hooks) {
     );
   });
 
+  test('sets/gets records individually', function (assert) {
+    const cache = new MemoryCache({ schema, keyMap });
+    const jupiter = {
+      type: 'planet',
+      id: 'jupiter',
+      attributes: { name: 'Jupiter' }
+    };
+    const io = { type: 'moon', id: 'io', attributes: { name: 'Io' } };
+    const europa = {
+      type: 'moon',
+      id: 'europa',
+      attributes: { name: 'Europa' }
+    };
+
+    cache.setRecordSync(jupiter);
+    cache.setRecordSync(io);
+    cache.setRecordSync(europa);
+
+    assert.deepEqual(cache.getRecordSync(jupiter), jupiter);
+    assert.deepEqual(cache.getRecordSync(io), io);
+    assert.deepEqual(cache.getRecordSync(europa), europa);
+
+    cache.removeRecordSync(jupiter);
+    cache.removeRecordSync(io);
+    cache.removeRecordSync(europa);
+
+    assert.deepEqual(cache.getRecordSync(jupiter), undefined);
+    assert.deepEqual(cache.getRecordSync(io), undefined);
+    assert.deepEqual(cache.getRecordSync(europa), undefined);
+  });
+
+  test('sets/gets records in bulk', function (assert) {
+    const cache = new MemoryCache({ schema, keyMap });
+    const jupiter = {
+      type: 'planet',
+      id: 'jupiter',
+      attributes: { name: 'Jupiter' }
+    };
+    const io = { type: 'moon', id: 'io', attributes: { name: 'Io' } };
+    const europa = {
+      type: 'moon',
+      id: 'europa',
+      attributes: { name: 'Europa' }
+    };
+
+    cache.setRecordsSync([jupiter, io, europa]);
+
+    assert.deepEqual(cache.getRecordsSync([jupiter, io, europa]), [
+      jupiter,
+      io,
+      europa
+    ]);
+
+    cache.removeRecordsSync([jupiter, io, europa]);
+
+    assert.deepEqual(cache.getRecordsSync([jupiter, io, europa]), []);
+  });
+
+  test('sets/gets inverse relationships for a single record', function (assert) {
+    const cache = new MemoryCache({ schema, keyMap });
+    const jupiter = { type: 'planet', id: 'jupiter' };
+    const io = { type: 'moon', id: 'io' };
+    const europa = { type: 'moon', id: 'europa' };
+    const callisto = { type: 'moon', id: 'callisto' };
+
+    const earth = { type: 'planet', id: 'earth' };
+    const earthMoon = { type: 'moon', id: 'earthMoon' };
+
+    assert.deepEqual(
+      cache.getInverseRelationshipsSync(jupiter),
+      [],
+      'no inverse relationships to start'
+    );
+
+    cache.addInverseRelationshipsSync([
+      { record: callisto, relationship: 'planet', relatedRecord: jupiter },
+      { record: earthMoon, relationship: 'planet', relatedRecord: earth },
+      { record: europa, relationship: 'planet', relatedRecord: jupiter },
+      { record: io, relationship: 'planet', relatedRecord: jupiter }
+    ]);
+
+    assert.deepEqual(
+      cache.getInverseRelationshipsSync(jupiter),
+      [
+        { record: callisto, relationship: 'planet', relatedRecord: jupiter },
+        { record: europa, relationship: 'planet', relatedRecord: jupiter },
+        { record: io, relationship: 'planet', relatedRecord: jupiter }
+      ],
+      'inverse relationships have been added'
+    );
+
+    assert.deepEqual(
+      cache.getInverseRelationshipsSync(earth),
+      [{ record: earthMoon, relationship: 'planet', relatedRecord: earth }],
+      'inverse relationships have been added'
+    );
+
+    cache.removeInverseRelationshipsSync([
+      { record: callisto, relationship: 'planet', relatedRecord: jupiter },
+      { record: earthMoon, relationship: 'planet', relatedRecord: earth },
+      { record: europa, relationship: 'planet', relatedRecord: jupiter },
+      { record: io, relationship: 'planet', relatedRecord: jupiter }
+    ]);
+
+    assert.deepEqual(
+      cache.getInverseRelationshipsSync(jupiter),
+      [],
+      'inverse relationships have been removed'
+    );
+
+    assert.deepEqual(
+      cache.getInverseRelationshipsSync(earth),
+      [],
+      'inverse relationships have been removed'
+    );
+  });
+
+  test('sets/gets inverse relationships for a multiple records', function (assert) {
+    const cache = new MemoryCache({ schema, keyMap });
+
+    const jupiter = { type: 'planet', id: 'jupiter' };
+    const io = { type: 'moon', id: 'io' };
+    const europa = { type: 'moon', id: 'europa' };
+    const callisto = { type: 'moon', id: 'callisto' };
+
+    const earth = { type: 'planet', id: 'earth' };
+    const earthMoon = { type: 'moon', id: 'earthMoon' };
+
+    assert.deepEqual(
+      cache.getInverseRelationshipsSync([jupiter, earth]),
+      [],
+      'no inverse relationships to start'
+    );
+
+    cache.addInverseRelationshipsSync([
+      { record: callisto, relationship: 'planet', relatedRecord: jupiter },
+      { record: europa, relationship: 'planet', relatedRecord: jupiter },
+      { record: io, relationship: 'planet', relatedRecord: jupiter },
+      { record: earthMoon, relationship: 'planet', relatedRecord: earth }
+    ]);
+
+    assert.deepEqual(
+      cache.getInverseRelationshipsSync([jupiter, earth]),
+      [
+        { record: callisto, relationship: 'planet', relatedRecord: jupiter },
+        { record: europa, relationship: 'planet', relatedRecord: jupiter },
+        { record: io, relationship: 'planet', relatedRecord: jupiter },
+        { record: earthMoon, relationship: 'planet', relatedRecord: earth }
+      ],
+      'inverse relationships have been added'
+    );
+
+    cache.removeInverseRelationshipsSync([
+      { record: callisto, relationship: 'planet', relatedRecord: jupiter },
+      { record: europa, relationship: 'planet', relatedRecord: jupiter },
+      { record: io, relationship: 'planet', relatedRecord: jupiter },
+      { record: earthMoon, relationship: 'planet', relatedRecord: earth }
+    ]);
+
+    assert.deepEqual(
+      cache.getInverseRelationshipsSync([jupiter, earth]),
+      [],
+      'inverse relationships have been removed'
+    );
+  });
+
   test('#update can return a full response that includes applied and inverse ops', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 

--- a/packages/@orbit/memory/test/memory-cache-update-test.ts
+++ b/packages/@orbit/memory/test/memory-cache-update-test.ts
@@ -1,0 +1,1997 @@
+import {
+  equalRecordIdentities,
+  RecordKeyMap,
+  Record,
+  RecordIdentity,
+  recordsInclude,
+  recordsIncludeAll,
+  RecordSchema,
+  RecordNotFoundException
+} from '@orbit/records';
+import { MemoryCache } from '../src/memory-cache';
+import { createSchemaWithRemoteKey } from './support/setup';
+
+const { module, test } = QUnit;
+
+QUnit.dump.maxDepth = 7;
+
+module('MemoryCache - update', function (hooks) {
+  let schema: RecordSchema, keyMap: RecordKeyMap;
+
+  [true, false].forEach((useBuffer) => {
+    module(`useBuffer: ${useBuffer}`, function (hooks) {
+      // All caches in this module share these transform options
+      const defaultTransformOptions = { useBuffer };
+
+      hooks.beforeEach(function () {
+        schema = createSchemaWithRemoteKey();
+        keyMap = new RecordKeyMap();
+      });
+
+      test('#update sets data and #records retrieves it', function (assert) {
+        assert.expect(4);
+
+        const cache = new MemoryCache({
+          schema,
+          keyMap,
+          defaultTransformOptions
+        });
+
+        const earth: Record = {
+          type: 'planet',
+          id: '1',
+          attributes: { name: 'Earth' },
+          keys: { remoteId: 'a' }
+        };
+
+        cache.on('patch', (operation, data) => {
+          assert.deepEqual(operation, {
+            op: 'addRecord',
+            record: earth
+          });
+          assert.deepEqual(data, earth);
+        });
+
+        cache.update((t) => t.addRecord(earth));
+
+        assert.strictEqual(
+          cache.getRecordSync({ type: 'planet', id: '1' }),
+          earth,
+          'objects strictly match'
+        );
+        assert.equal(
+          keyMap.keyToId('planet', 'remoteId', 'a'),
+          '1',
+          'key has been mapped'
+        );
+      });
+
+      test('#update can replace records', function (assert) {
+        assert.expect(5);
+
+        const cache = new MemoryCache({ schema, keyMap });
+
+        const earth: Record = {
+          type: 'planet',
+          id: '1',
+          attributes: { name: 'Earth' },
+          keys: { remoteId: 'a' }
+        };
+
+        cache.on('patch', (operation, data) => {
+          assert.deepEqual(operation, {
+            op: 'updateRecord',
+            record: earth
+          });
+          assert.deepEqual(data, earth);
+        });
+
+        cache.update((t) => t.updateRecord(earth));
+
+        assert.deepEqual(
+          cache.getRecordSync({ type: 'planet', id: '1' }),
+          earth,
+          'objects deeply match'
+        );
+        assert.notStrictEqual(
+          cache.getRecordSync({ type: 'planet', id: '1' }),
+          earth,
+          'objects do not strictly match'
+        );
+        assert.equal(
+          keyMap.keyToId('planet', 'remoteId', 'a'),
+          '1',
+          'key has been mapped'
+        );
+      });
+
+      test('#update can replace keys', function (assert) {
+        assert.expect(4);
+
+        const cache = new MemoryCache({ schema, keyMap });
+
+        const earth: Record = { type: 'planet', id: '1' };
+
+        cache.on('patch', (operation, data) => {
+          assert.deepEqual(operation, {
+            op: 'replaceKey',
+            record: earth,
+            key: 'remoteId',
+            value: 'a'
+          });
+          assert.deepEqual(data, {
+            type: 'planet',
+            id: '1',
+            keys: { remoteId: 'a' }
+          });
+        });
+
+        cache.update((t) => t.replaceKey(earth, 'remoteId', 'a'));
+
+        assert.deepEqual(
+          cache.getRecordSync({ type: 'planet', id: '1' }),
+          { type: 'planet', id: '1', keys: { remoteId: 'a' } },
+          'records match'
+        );
+        assert.equal(
+          keyMap.keyToId('planet', 'remoteId', 'a'),
+          '1',
+          'key has been mapped'
+        );
+      });
+
+      test('#update updates the cache and returns primary data', function (assert) {
+        const cache = new MemoryCache({ schema, keyMap });
+
+        let p1 = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
+        let p2 = { type: 'planet', id: '2' };
+
+        let result = cache.update((t) => [t.addRecord(p1), t.removeRecord(p2)]);
+
+        assert.deepEqual(
+          result,
+          [
+            p1,
+            undefined // p2 didn't exist
+          ],
+          'response includes just primary data'
+        );
+      });
+
+      test('#update updates the cache and returns a full response if requested', function (assert) {
+        const cache = new MemoryCache({ schema, keyMap });
+
+        let p1 = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
+        let p2 = { type: 'planet', id: '2' };
+
+        let result = cache.update(
+          (t) => [t.addRecord(p1), t.removeRecord(p2)],
+          {
+            fullResponse: true
+          }
+        );
+
+        assert.deepEqual(
+          result,
+          {
+            data: [
+              p1,
+              undefined // p2 didn't exist
+            ],
+            details: {
+              appliedOperations: [{ op: 'addRecord', record: p1 }],
+              appliedOperationResults: [p1],
+              inverseOperations: [
+                { op: 'removeRecord', record: { type: 'planet', id: '1' } }
+              ]
+            }
+          },
+          'full response includes data and details'
+        );
+      });
+
+      test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added after', function (assert) {
+        const cache = new MemoryCache({ schema, keyMap });
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' },
+          relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' }
+        };
+
+        cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.moons.data,
+          [{ type: 'moon', id: 'm1' }],
+          'Io has been assigned to Jupiter'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.planet.data,
+          { type: 'planet', id: 'p1' },
+          'Jupiter has been assigned to Io'
+        );
+      });
+
+      test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added before', function (assert) {
+        const cache = new MemoryCache({ schema, keyMap });
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' },
+          relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' }
+        };
+
+        cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.moons.data,
+          [{ type: 'moon', id: 'm1' }],
+          'Io has been assigned to Jupiter'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.planet.data,
+          { type: 'planet', id: 'p1' },
+          'Jupiter has been assigned to Io'
+        );
+      });
+
+      test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added after', function (assert) {
+        const cache = new MemoryCache({ schema, keyMap });
+
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' }
+        };
+
+        cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.moons.data,
+          [{ type: 'moon', id: 'm1' }],
+          'Io has been assigned to Jupiter'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.planet.data,
+          { type: 'planet', id: 'p1' },
+          'Jupiter has been assigned to Io'
+        );
+      });
+
+      test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added before', function (assert) {
+        const cache = new MemoryCache({ schema, keyMap });
+
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' }
+        };
+
+        cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.moons.data,
+          [{ type: 'moon', id: 'm1' }],
+          'Io has been assigned to Jupiter'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.planet.data,
+          { type: 'planet', id: 'p1' },
+          'Jupiter has been assigned to Io'
+        );
+      });
+
+      test('#update updates inverse hasOne relationship when a record with an empty relationship is added', function (assert) {
+        const cache = new MemoryCache({ schema, keyMap });
+
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' },
+          relationships: { moons: { data: [] } }
+        };
+
+        cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.moons.data,
+          [],
+          'Jupiter has no moons'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.planet.data,
+          null,
+          'Jupiter has been cleared from Io'
+        );
+      });
+
+      test('#update updates inverse hasMany relationship when a record with an empty relationship is added', function (assert) {
+        const cache = new MemoryCache({ schema, keyMap });
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' },
+          relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: null } }
+        };
+
+        cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.moons.data,
+          [],
+          'Io has been cleared from Jupiter'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.planet.data,
+          null,
+          'Io has no planet'
+        );
+      });
+
+      test('#update updates inverse hasMany polymorphic relationship', function (assert) {
+        const cache = new MemoryCache({ schema, keyMap });
+
+        const sun: Record = {
+          type: 'star',
+          id: 's1',
+          attributes: { name: 'Sun' },
+          relationships: {
+            celestialObjects: {
+              data: [
+                { type: 'planet', id: 'p1' },
+                { type: 'moon', id: 'm1' }
+              ]
+            }
+          }
+        };
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' }
+        };
+
+        cache.update((t) => [
+          t.updateRecord(sun),
+          t.updateRecord(jupiter),
+          t.updateRecord(io)
+        ]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'star', id: 's1' }) as Record)
+            ?.relationships?.celestialObjects.data,
+          [
+            { type: 'planet', id: 'p1' },
+            { type: 'moon', id: 'm1' }
+          ],
+          'Jupiter and Io has been assigned to Sun'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.star.data,
+          { type: 'star', id: 's1' },
+          'Sun has been assigned to Jupiter'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.star.data,
+          { type: 'star', id: 's1' },
+          'Sun has been assigned to Io'
+        );
+      });
+
+      test('#update updates inverse hasOne polymorphic relationship', function (assert) {
+        const cache = new MemoryCache({ schema, keyMap });
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' },
+          relationships: { star: { data: { type: 'star', id: 's1' } } }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { star: { data: { type: 'star', id: 's1' } } }
+        };
+        const sun: Record = {
+          type: 'star',
+          id: 's1',
+          attributes: { name: 'Sun' }
+        };
+
+        cache.update((t) => [
+          t.updateRecord(jupiter),
+          t.updateRecord(io),
+          t.updateRecord(sun)
+        ]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'star', id: 's1' }) as Record)
+            ?.relationships?.celestialObjects.data,
+          [
+            { type: 'planet', id: 'p1' },
+            { type: 'moon', id: 'm1' }
+          ],
+          'Jupiter and Io has been assigned to Sun'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.star.data,
+          { type: 'star', id: 's1' },
+          'Sun has been assigned to Jupiter'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.star.data,
+          { type: 'star', id: 's1' },
+          'Sun has been assigned to Io'
+        );
+      });
+
+      test('#update tracks refs and clears them from hasOne relationships when a referenced record is removed', function (assert) {
+        const cache = new MemoryCache({ schema, keyMap });
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' },
+          relationships: { moons: { data: undefined } }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+        const europa: Record = {
+          type: 'moon',
+          id: 'm2',
+          attributes: { name: 'Europa' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+
+        cache.update((t) => [
+          t.addRecord(jupiter),
+          t.addRecord(io),
+          t.addRecord(europa)
+        ]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.planet.data,
+          { type: 'planet', id: 'p1' },
+          'Jupiter has been assigned to Io'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm2' }) as Record)
+            ?.relationships?.planet.data,
+          { type: 'planet', id: 'p1' },
+          'Jupiter has been assigned to Europa'
+        );
+
+        cache.update((t) => t.removeRecord(jupiter));
+
+        assert.equal(
+          cache.getRecordSync({ type: 'planet', id: 'p1' }),
+          undefined,
+          'Jupiter is GONE'
+        );
+
+        assert.equal(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.planet.data,
+          undefined,
+          'Jupiter has been cleared from Io'
+        );
+        assert.equal(
+          (cache.getRecordSync({ type: 'moon', id: 'm2' }) as Record)
+            ?.relationships?.planet.data,
+          undefined,
+          'Jupiter has been cleared from Europa'
+        );
+      });
+
+      test('#update tracks refs and clears them from hasMany relationships when a referenced record is removed', function (assert) {
+        const cache = new MemoryCache({ schema, keyMap });
+
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: null } }
+        };
+        const europa: Record = {
+          type: 'moon',
+          id: 'm2',
+          attributes: { name: 'Europa' },
+          relationships: { planet: { data: null } }
+        };
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' },
+          relationships: {
+            moons: {
+              data: [
+                { type: 'moon', id: 'm1' },
+                { type: 'moon', id: 'm2' }
+              ]
+            }
+          }
+        };
+
+        cache.update((t) => [
+          t.addRecord(io),
+          t.addRecord(europa),
+          t.addRecord(jupiter)
+        ]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.moons.data,
+          [
+            { type: 'moon', id: 'm1' },
+            { type: 'moon', id: 'm2' }
+          ],
+          'Jupiter has been assigned to Io and Europa'
+        );
+        assert.ok(
+          recordsIncludeAll(
+            cache.getRelatedRecordsSync(jupiter, 'moons') as RecordIdentity[],
+            [io, europa]
+          ),
+          'Jupiter has been assigned to Io and Europa'
+        );
+
+        cache.update((t) => t.removeRecord(io));
+
+        assert.equal(
+          cache.getRecordSync({ type: 'moon', id: 'm1' }),
+          null,
+          'Io is GONE'
+        );
+
+        cache.update((t) => t.removeRecord(europa));
+
+        assert.equal(
+          cache.getRecordSync({ type: 'moon', id: 'm2' }),
+          null,
+          'Europa is GONE'
+        );
+
+        assert.deepEqual(
+          cache.getRelatedRecordsSync(
+            { type: 'planet', id: 'p1' },
+            'moons'
+          ) as RecordIdentity[],
+          [],
+          'moons have been cleared from Jupiter'
+        );
+      });
+
+      test("#update adds link to hasMany if record doesn't exist", function (assert) {
+        const cache = new MemoryCache({ schema, keyMap });
+
+        cache.update((t) =>
+          t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+            type: 'moon',
+            id: 'm1'
+          })
+        );
+
+        cache.update((t) =>
+          t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+            type: 'moon',
+            id: 'm1'
+          })
+        );
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.moons.data,
+          [{ type: 'moon', id: 'm1' }],
+          'relationship was added'
+        );
+      });
+
+      test("#update does not remove hasMany relationship if record doesn't exist", function (assert) {
+        assert.expect(1);
+
+        const cache = new MemoryCache({ schema, keyMap });
+
+        cache.on('patch', () => {
+          assert.ok(false, 'no operations were applied');
+        });
+
+        cache.update((t) =>
+          t.removeFromRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+            type: 'moon',
+            id: 'moon1'
+          })
+        );
+
+        assert.equal(
+          cache.getRecordSync({ type: 'planet', id: 'p1' }),
+          undefined,
+          'planet does not exist'
+        );
+      });
+
+      test("#update adds hasOne if record doesn't exist", function (assert) {
+        assert.expect(2);
+
+        const cache = new MemoryCache({ schema, keyMap });
+
+        const tb = cache.transformBuilder;
+        const replacePlanet = tb.replaceRelatedRecord(
+          { type: 'moon', id: 'moon1' },
+          'planet',
+          { type: 'planet', id: 'p1' }
+        );
+
+        const addToMoons = tb.addToRelatedRecords(
+          { type: 'planet', id: 'p1' },
+          'moons',
+          { type: 'moon', id: 'moon1' }
+        );
+
+        let order = 0;
+        cache.on('patch', (op) => {
+          order++;
+          if (order === 1) {
+            assert.deepEqual(
+              op,
+              replacePlanet.toOperation(),
+              'applied replacePlanet operation'
+            );
+          } else if (order === 2) {
+            assert.deepEqual(
+              op,
+              addToMoons.toOperation(),
+              'applied addToMoons operation'
+            );
+          } else {
+            assert.ok(false, 'too many ops');
+          }
+        });
+
+        cache.update([replacePlanet]);
+      });
+
+      test("#update will add empty hasOne link if record doesn't exist", function (assert) {
+        assert.expect(2);
+
+        const cache = new MemoryCache({ schema, keyMap });
+
+        const tb = cache.transformBuilder;
+        const clearPlanet = tb.replaceRelatedRecord(
+          { type: 'moon', id: 'moon1' },
+          'planet',
+          null
+        );
+
+        let order = 0;
+        cache.on('patch', (op) => {
+          order++;
+          if (order === 1) {
+            assert.deepEqual(
+              op,
+              clearPlanet.toOperation(),
+              'applied clearPlanet operation'
+            );
+          } else {
+            assert.ok(false, 'too many ops');
+          }
+        });
+
+        cache.update([clearPlanet]);
+
+        assert.ok(true, 'patch applied');
+      });
+
+      test('#update does not add link to hasMany if link already exists', function (assert) {
+        assert.expect(1);
+
+        const cache = new MemoryCache({ schema, keyMap });
+
+        const jupiter: Record = {
+          id: 'p1',
+          type: 'planet',
+          attributes: { name: 'Jupiter' },
+          relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+        };
+
+        cache.update((t) => t.addRecord(jupiter));
+
+        cache.on('patch', () => {
+          assert.ok(false, 'no operations were applied');
+        });
+
+        cache.update((t) =>
+          t.addToRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'm1' })
+        );
+
+        assert.ok(true, 'patch completed');
+      });
+
+      test("#update does not remove relationship from hasMany if relationship doesn't exist", function (assert) {
+        assert.expect(1);
+
+        const cache = new MemoryCache({ schema, keyMap });
+
+        const jupiter: Record = {
+          id: 'p1',
+          type: 'planet',
+          attributes: { name: 'Jupiter' }
+        };
+
+        cache.update((t) => t.addRecord(jupiter));
+
+        cache.on('patch', () => {
+          assert.ok(false, 'no operations were applied');
+        });
+
+        cache.update((t) =>
+          t.removeFromRelatedRecords(jupiter, 'moons', {
+            type: 'moon',
+            id: 'm1'
+          })
+        );
+
+        assert.ok(true, 'patch completed');
+      });
+
+      test('#update can add and remove to has-many relationship', function (assert) {
+        assert.expect(2);
+
+        const cache = new MemoryCache({ schema, keyMap });
+
+        const jupiter: Record = { id: 'jupiter', type: 'planet' };
+        cache.update((t) => t.addRecord(jupiter));
+
+        const callisto: Record = { id: 'callisto', type: 'moon' };
+        cache.update((t) => t.addRecord(callisto));
+
+        cache.update((t) =>
+          t.addToRelatedRecords(jupiter, 'moons', {
+            type: 'moon',
+            id: 'callisto'
+          })
+        );
+
+        assert.ok(
+          recordsInclude(
+            cache.getRelatedRecordsSync(jupiter, 'moons') as RecordIdentity[],
+            callisto
+          ),
+          'moon added'
+        );
+
+        cache.update((t) =>
+          t.removeFromRelatedRecords(jupiter, 'moons', {
+            type: 'moon',
+            id: 'callisto'
+          })
+        );
+
+        assert.notOk(
+          recordsInclude(
+            cache.getRelatedRecordsSync(jupiter, 'moons') as RecordIdentity[],
+            callisto
+          ),
+          'moon removed'
+        );
+      });
+
+      test('#update can add and clear has-one relationship', function (assert) {
+        assert.expect(2);
+
+        const cache = new MemoryCache({ schema, keyMap });
+
+        const jupiter: Record = { id: 'jupiter', type: 'planet' };
+        cache.update((t) => t.addRecord(jupiter));
+
+        const callisto: Record = { id: 'callisto', type: 'moon' };
+        cache.update((t) => t.addRecord(callisto));
+
+        cache.update((t) =>
+          t.replaceRelatedRecord(callisto, 'planet', {
+            type: 'planet',
+            id: 'jupiter'
+          })
+        );
+
+        assert.ok(
+          equalRecordIdentities(
+            cache.getRelatedRecordSync(callisto, 'planet') as RecordIdentity,
+            jupiter
+          ),
+          'relationship added'
+        );
+
+        cache.update((t) => t.replaceRelatedRecord(callisto, 'planet', null));
+
+        assert.notOk(
+          equalRecordIdentities(
+            cache.getRelatedRecordSync(callisto, 'planet') as RecordIdentity,
+            jupiter
+          ),
+          'relationship cleared'
+        );
+      });
+
+      test('does not replace hasOne if relationship already exists', function (assert) {
+        assert.expect(1);
+
+        const cache = new MemoryCache({ schema, keyMap });
+
+        const europa: Record = {
+          id: 'm1',
+          type: 'moon',
+          attributes: { name: 'Europa' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+
+        cache.update((t) => t.addRecord(europa));
+
+        cache.on('patch', () => {
+          assert.ok(false, 'no operations were applied');
+        });
+
+        cache.update((t) =>
+          t.replaceRelatedRecord(europa, 'planet', { type: 'planet', id: 'p1' })
+        );
+
+        assert.ok(true, 'patch completed');
+      });
+
+      test("does not remove hasOne if relationship doesn't exist", function (assert) {
+        assert.expect(1);
+
+        const cache = new MemoryCache({ schema, keyMap });
+
+        const europa: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Europa' },
+          relationships: { planet: { data: null } }
+        };
+
+        cache.update((t) => t.addRecord(europa));
+
+        cache.on('patch', () => {
+          assert.ok(false, 'no operations were applied');
+        });
+
+        cache.update((t) => t.replaceRelatedRecord(europa, 'planet', null));
+
+        assert.ok(true, 'patch completed');
+      });
+
+      test('#update removing model with a bi-directional hasOne', function (assert) {
+        assert.expect(5);
+
+        const hasOneSchema = new RecordSchema({
+          models: {
+            one: {
+              relationships: {
+                two: { kind: 'hasOne', type: 'two', inverse: 'one' }
+              }
+            },
+            two: {
+              relationships: {
+                one: { kind: 'hasOne', type: 'one', inverse: 'two' }
+              }
+            }
+          }
+        });
+
+        const cache = new MemoryCache({
+          schema: hasOneSchema,
+          keyMap
+        });
+
+        cache.update((t) => [
+          t.addRecord({
+            id: '1',
+            type: 'one',
+            relationships: {
+              two: { data: null }
+            }
+          }),
+          t.addRecord({
+            id: '2',
+            type: 'two',
+            relationships: {
+              one: { data: { type: 'one', id: '1' } }
+            }
+          })
+        ]);
+
+        const one = cache.getRecordSync({ type: 'one', id: '1' }) as Record;
+        const two = cache.getRecordSync({ type: 'two', id: '2' }) as Record;
+        assert.ok(one, 'one exists');
+        assert.ok(two, 'two exists');
+        assert.deepEqual(
+          one.relationships?.two.data,
+          { type: 'two', id: '2' },
+          'one links to two'
+        );
+        assert.deepEqual(
+          two.relationships?.one.data,
+          { type: 'one', id: '1' },
+          'two links to one'
+        );
+
+        cache.update((t) => t.removeRecord(two));
+
+        assert.equal(
+          (cache.getRecordSync({ type: 'one', id: '1' }) as Record)
+            .relationships?.two.data,
+          null,
+          'ones link to two got removed'
+        );
+      });
+
+      test('#update removes dependent records in a hasOne relationship', function (assert) {
+        const dependentSchema = new RecordSchema({
+          models: {
+            planet: {
+              relationships: {
+                moons: { kind: 'hasMany', type: 'moon' }
+              }
+            },
+            moon: {
+              relationships: {
+                planet: { kind: 'hasOne', type: 'planet', dependent: 'remove' }
+              }
+            }
+          }
+        });
+
+        const cache = new MemoryCache({
+          schema: dependentSchema,
+          keyMap
+        });
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+        const europa: Record = {
+          type: 'moon',
+          id: 'm2',
+          attributes: { name: 'Europa' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+
+        cache.update((t) => [
+          t.addRecord(jupiter),
+          t.addRecord(io),
+          t.addRecord(europa),
+          t.addToRelatedRecords(jupiter, 'moons', io),
+          t.addToRelatedRecords(jupiter, 'moons', europa)
+        ]);
+
+        cache.update((t) => t.removeRecord(io));
+
+        assert.equal(
+          cache.getRecordsSync('moon').length,
+          1,
+          'Only europa is left in store'
+        );
+        assert.equal(
+          cache.getRecordsSync('planet').length,
+          0,
+          'Jupiter has been removed from the store'
+        );
+      });
+
+      test('#update removes dependent records in a hasMany relationship', function (assert) {
+        const dependentSchema = new RecordSchema({
+          models: {
+            planet: {
+              relationships: {
+                moons: { kind: 'hasMany', type: 'moon', dependent: 'remove' }
+              }
+            },
+            moon: {
+              relationships: {
+                planet: { kind: 'hasOne', type: 'planet' }
+              }
+            }
+          }
+        });
+
+        const cache = new MemoryCache({
+          schema: dependentSchema,
+          keyMap
+        });
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+        const europa: Record = {
+          type: 'moon',
+          id: 'm2',
+          attributes: { name: 'Europa' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+
+        cache.update((t) => [
+          t.updateRecord(jupiter),
+          t.updateRecord(io),
+          t.updateRecord(europa),
+          t.addToRelatedRecords(jupiter, 'moons', io),
+          t.addToRelatedRecords(jupiter, 'moons', europa)
+        ]);
+
+        cache.update((t) => t.removeRecord(jupiter));
+
+        assert.equal(
+          cache.getRecordsSync('planet').length,
+          0,
+          'Jupiter has been removed from the store'
+        );
+        assert.equal(
+          cache.getRecordsSync('moon').length,
+          0,
+          'All of Jupiters moons are removed from the store'
+        );
+      });
+
+      test('#update does not remove non-dependent records', function (assert) {
+        const dependentSchema = new RecordSchema({
+          models: {
+            planet: {
+              relationships: {
+                moons: { kind: 'hasMany', type: 'moon' }
+              }
+            },
+            moon: {
+              relationships: {
+                planet: { kind: 'hasOne', type: 'planet' }
+              }
+            }
+          }
+        });
+
+        const cache = new MemoryCache({
+          schema: dependentSchema,
+          keyMap
+        });
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+        const europa: Record = {
+          type: 'moon',
+          id: 'm2',
+          attributes: { name: 'Europa' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+
+        cache.update((t) => [
+          t.addRecord(jupiter),
+          t.addRecord(io),
+          t.addRecord(europa),
+          t.addToRelatedRecords(jupiter, 'moons', io),
+          t.addToRelatedRecords(jupiter, 'moons', europa)
+        ]);
+
+        // Since there are no dependent relationships, no other records will be
+        // removed
+        cache.update((t) => t.removeRecord(io));
+
+        assert.equal(
+          cache.getRecordsSync('moon').length,
+          1,
+          'One moon left in store'
+        );
+        assert.equal(
+          cache.getRecordsSync('planet').length,
+          1,
+          'One planet left in store'
+        );
+      });
+
+      test('#update merges records when "replacing" and will not stomp on attributes and relationships that are not replaced', function (assert) {
+        const cache = new MemoryCache({ schema, keyMap });
+        const tb = cache.transformBuilder;
+
+        cache.update((t) => [
+          t.addRecord({
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Earth' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+          })
+        ]);
+
+        let result = cache.update(
+          (t) => [
+            t.updateRecord({
+              type: 'planet',
+              id: '1',
+              attributes: { classification: 'terrestrial' }
+            })
+          ],
+          { fullResponse: true }
+        );
+
+        assert.deepEqual(
+          cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
+          {
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Earth', classification: 'terrestrial' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+          },
+          'records have been merged'
+        );
+
+        assert.deepEqual(
+          result,
+          {
+            data: {
+              type: 'planet',
+              id: '1',
+              attributes: {
+                name: 'Earth',
+                classification: 'terrestrial'
+              },
+              relationships: {
+                moons: {
+                  data: [{ type: 'moon', id: 'm1' }]
+                }
+              }
+            },
+            details: {
+              appliedOperations: [
+                tb
+                  .updateRecord({
+                    type: 'planet',
+                    id: '1',
+                    attributes: { classification: 'terrestrial' }
+                  })
+                  .toOperation()
+              ],
+              appliedOperationResults: [
+                {
+                  type: 'planet',
+                  id: '1',
+                  attributes: {
+                    name: 'Earth',
+                    classification: 'terrestrial'
+                  },
+                  relationships: {
+                    moons: {
+                      data: [{ type: 'moon', id: 'm1' }]
+                    }
+                  }
+                }
+              ],
+              inverseOperations: [
+                tb
+                  .updateRecord({
+                    type: 'planet',
+                    id: '1',
+                    attributes: { classification: null }
+                  })
+                  .toOperation()
+              ]
+            }
+          },
+          'full response is correct'
+        );
+      });
+
+      test('#update can replace related records but only if they are different', function (assert) {
+        const cache = new MemoryCache({ schema, keyMap });
+        const tb = cache.transformBuilder;
+
+        cache.update((t) => [
+          t.addRecord({
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Earth' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+          })
+        ]);
+
+        let result = cache.update(
+          (t) => [
+            t.replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
+              { type: 'moon', id: 'm1' }
+            ])
+          ],
+          { fullResponse: true }
+        );
+
+        assert.deepEqual(
+          result,
+          {
+            data: undefined,
+            details: {
+              appliedOperations: [],
+              appliedOperationResults: [],
+              inverseOperations: []
+            }
+          },
+          'nothing has changed so there are no appliend or inverse ops'
+        );
+
+        result = cache.update(
+          (t) =>
+            t.replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
+              { type: 'moon', id: 'm2' }
+            ]),
+          { fullResponse: true }
+        );
+
+        assert.deepEqual(
+          cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
+          {
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Earth' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
+          },
+          'relationships have been replaced'
+        );
+
+        assert.deepEqual(
+          result,
+          {
+            data: {
+              type: 'planet',
+              id: '1',
+              attributes: { name: 'Earth' },
+              relationships: {
+                moons: { data: [{ type: 'moon', id: 'm2' }] }
+              }
+            },
+            details: {
+              appliedOperations: [
+                tb
+                  .replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
+                    { type: 'moon', id: 'm2' }
+                  ])
+                  .toOperation(),
+                tb
+                  .replaceRelatedRecord(
+                    { type: 'moon', id: 'm1' },
+                    'planet',
+                    null
+                  )
+                  .toOperation(),
+                tb
+                  .replaceRelatedRecord({ type: 'moon', id: 'm2' }, 'planet', {
+                    type: 'planet',
+                    id: '1'
+                  })
+                  .toOperation()
+              ],
+              appliedOperationResults: [
+                {
+                  type: 'planet',
+                  id: '1',
+                  attributes: { name: 'Earth' },
+                  relationships: {
+                    moons: { data: [{ type: 'moon', id: 'm2' }] }
+                  }
+                },
+                {
+                  type: 'moon',
+                  id: 'm1',
+                  relationships: {
+                    planet: { data: null }
+                  }
+                },
+                {
+                  type: 'moon',
+                  id: 'm2',
+                  relationships: {
+                    planet: { data: { type: 'planet', id: '1' } }
+                  }
+                }
+              ],
+              inverseOperations: [
+                tb
+                  .replaceRelatedRecord(
+                    { type: 'moon', id: 'm2' },
+                    'planet',
+                    null
+                  )
+                  .toOperation(),
+                tb
+                  .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
+                    type: 'planet',
+                    id: '1'
+                  })
+                  .toOperation(),
+                tb
+                  .replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
+                    { type: 'moon', id: 'm1' }
+                  ])
+                  .toOperation()
+              ]
+            }
+          },
+          'full response is correct'
+        );
+      });
+
+      test('#update merges records when "replacing" and _will_ replace specified attributes and relationships', function (assert) {
+        const cache = new MemoryCache({ schema, keyMap });
+        const tb = cache.transformBuilder;
+
+        const earth: Record = {
+          type: 'planet',
+          id: '1',
+          attributes: { name: 'Earth' },
+          relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+        };
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: '1',
+          attributes: { name: 'Jupiter', classification: 'terrestrial' },
+          relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
+        };
+
+        let result = cache.update([tb.addRecord(earth)], {
+          fullResponse: true
+        });
+
+        assert.deepEqual(
+          result,
+          {
+            data: earth,
+            details: {
+              appliedOperations: [
+                tb.addRecord(earth).toOperation(),
+                tb
+                  .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
+                    type: 'planet',
+                    id: '1'
+                  })
+                  .toOperation()
+              ],
+              appliedOperationResults: [
+                {
+                  type: 'planet',
+                  id: '1',
+                  attributes: { name: 'Earth' },
+                  relationships: {
+                    moons: { data: [{ type: 'moon', id: 'm1' }] }
+                  }
+                },
+                {
+                  type: 'moon',
+                  id: 'm1',
+                  relationships: {
+                    planet: { data: { type: 'planet', id: '1' } }
+                  }
+                }
+              ],
+              inverseOperations: [
+                tb
+                  .replaceRelatedRecord(
+                    { type: 'moon', id: 'm1' },
+                    'planet',
+                    null
+                  )
+                  .toOperation(),
+                tb
+                  .removeRecord({
+                    type: 'planet',
+                    id: '1'
+                  })
+                  .toOperation()
+              ]
+            }
+          },
+          'addRecord full response is correct'
+        );
+
+        result = cache.update([tb.updateRecord(jupiter)], {
+          fullResponse: true
+        });
+
+        assert.deepEqual(result, {
+          data: jupiter,
+          details: {
+            appliedOperations: [
+              tb.updateRecord(jupiter).toOperation(),
+              tb
+                .replaceRelatedRecord(
+                  { type: 'moon', id: 'm1' },
+                  'planet',
+                  null
+                )
+                .toOperation(),
+              tb
+                .replaceRelatedRecord({ type: 'moon', id: 'm2' }, 'planet', {
+                  type: 'planet',
+                  id: '1'
+                })
+                .toOperation()
+            ],
+            appliedOperationResults: [
+              jupiter,
+              {
+                type: 'moon',
+                id: 'm1',
+                relationships: {
+                  planet: { data: null }
+                }
+              },
+              {
+                type: 'moon',
+                id: 'm2',
+                relationships: {
+                  planet: { data: { type: 'planet', id: '1' } }
+                }
+              }
+            ],
+            inverseOperations: [
+              tb
+                .replaceRelatedRecord(
+                  { type: 'moon', id: 'm2' },
+                  'planet',
+                  null
+                )
+                .toOperation(),
+              tb
+                .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
+                  type: 'planet',
+                  id: '1'
+                })
+                .toOperation(),
+              tb
+                .updateRecord({
+                  type: 'planet',
+                  id: '1',
+                  attributes: { name: 'Earth', classification: null },
+                  relationships: {
+                    moons: { data: [{ type: 'moon', id: 'm1' }] }
+                  }
+                })
+                .toOperation()
+            ]
+          }
+        });
+
+        assert.deepEqual(
+          cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
+          {
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Jupiter', classification: 'terrestrial' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
+          },
+          'records have been merged'
+        );
+      });
+
+      test('#update can update existing record with empty relationship', function (assert) {
+        const cache = new MemoryCache({ schema, keyMap });
+        const tb = cache.transformBuilder;
+
+        let result = cache.update(
+          (t) => [t.addRecord({ id: '1', type: 'planet' })],
+          { fullResponse: true }
+        );
+
+        assert.deepEqual(
+          result,
+          {
+            data: { id: '1', type: 'planet' },
+            details: {
+              appliedOperations: [
+                tb
+                  .addRecord({
+                    type: 'planet',
+                    id: '1'
+                  })
+                  .toOperation()
+              ],
+              appliedOperationResults: [
+                {
+                  id: '1',
+                  type: 'planet'
+                }
+              ],
+              inverseOperations: [
+                tb
+                  .removeRecord({
+                    type: 'planet',
+                    id: '1'
+                  })
+                  .toOperation()
+              ]
+            }
+          },
+          'addRecord result is correct'
+        );
+
+        result = cache.update(
+          (t) => [
+            t.updateRecord({
+              id: '1',
+              type: 'planet',
+              relationships: {
+                moons: { data: [] }
+              }
+            })
+          ],
+          { fullResponse: true }
+        );
+
+        assert.deepEqual(
+          result,
+          {
+            data: {
+              id: '1',
+              type: 'planet',
+              relationships: {
+                moons: { data: [] }
+              }
+            },
+            details: {
+              appliedOperations: [
+                tb
+                  .updateRecord({
+                    id: '1',
+                    type: 'planet',
+                    relationships: {
+                      moons: { data: [] }
+                    }
+                  })
+                  .toOperation()
+              ],
+              appliedOperationResults: [
+                {
+                  id: '1',
+                  type: 'planet',
+                  relationships: {
+                    moons: { data: [] }
+                  }
+                }
+              ],
+              inverseOperations: [
+                tb
+                  .updateRecord({
+                    id: '1',
+                    type: 'planet',
+                    relationships: {
+                      moons: { data: [] }
+                    }
+                  })
+                  .toOperation()
+              ]
+            }
+          },
+          'updateRecord result is correct'
+        );
+
+        const planet = cache.getRecordSync({ type: 'planet', id: '1' });
+        assert.ok(planet, 'planet exists');
+        assert.deepEqual(
+          planet?.relationships?.moons.data,
+          [],
+          'planet has empty moons relationship'
+        );
+      });
+
+      test('#update will not overwrite an existing relationship with a missing relationship', function (assert) {
+        const cache = new MemoryCache({ schema, keyMap });
+        const tb = cache.transformBuilder;
+
+        let result = cache.update(
+          (t) => [
+            t.addRecord({
+              id: '1',
+              type: 'planet',
+              relationships: {
+                moons: { data: [{ type: 'moon', id: 'm1' }] }
+              }
+            }),
+            t.updateRecord({
+              id: '1',
+              type: 'planet'
+            })
+          ],
+          { fullResponse: true }
+        );
+
+        assert.deepEqual(
+          result,
+          {
+            data: [
+              {
+                id: '1',
+                type: 'planet',
+                relationships: {
+                  moons: { data: [{ type: 'moon', id: 'm1' }] }
+                }
+              },
+              undefined
+            ],
+            details: {
+              appliedOperations: [
+                tb
+                  .addRecord({
+                    id: '1',
+                    type: 'planet',
+                    relationships: {
+                      moons: { data: [{ type: 'moon', id: 'm1' }] }
+                    }
+                  })
+                  .toOperation(),
+                tb
+                  .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
+                    id: '1',
+                    type: 'planet'
+                  })
+                  .toOperation()
+              ],
+              appliedOperationResults: [
+                {
+                  id: '1',
+                  type: 'planet',
+                  relationships: {
+                    moons: { data: [{ type: 'moon', id: 'm1' }] }
+                  }
+                },
+                {
+                  type: 'moon',
+                  id: 'm1',
+                  relationships: {
+                    planet: { data: { id: '1', type: 'planet' } }
+                  }
+                }
+              ],
+              inverseOperations: [
+                tb
+                  .replaceRelatedRecord(
+                    { type: 'moon', id: 'm1' },
+                    'planet',
+                    null
+                  )
+                  .toOperation(),
+                tb
+                  .removeRecord({
+                    id: '1',
+                    type: 'planet'
+                  })
+                  .toOperation()
+              ]
+            }
+          },
+          'update full response is correct'
+        );
+
+        const planet = cache.getRecordSync({ type: 'planet', id: '1' });
+        assert.ok(planet, 'planet exists');
+        assert.deepEqual(
+          planet?.relationships?.moons.data,
+          [{ type: 'moon', id: 'm1' }],
+          'planet has a moons relationship'
+        );
+      });
+
+      test('#update allows replaceRelatedRecord to be called on a relationship with no inverse and to be followed up by removing the replaced record', function (assert) {
+        assert.expect(2);
+
+        const cache = new MemoryCache({ schema, keyMap });
+
+        const star1 = {
+          id: 'star1',
+          type: 'star',
+          attributes: { name: 'sun1' }
+        };
+
+        const star2 = {
+          id: 'star2',
+          type: 'star',
+          attributes: { name: 'sun2' }
+        };
+
+        const home = {
+          id: 'home',
+          type: 'planetarySystem',
+          attributes: { name: 'Home' },
+          relationships: {
+            star: {
+              data: { id: 'star1', type: 'star' }
+            }
+          }
+        };
+
+        cache.update((t) => [
+          t.addRecord(star1),
+          t.addRecord(star2),
+          t.addRecord(home)
+        ]);
+
+        let latestHome = cache.getRecordSync({
+          id: 'home',
+          type: 'planetarySystem'
+        });
+        assert.deepEqual(
+          (latestHome?.relationships?.star.data as Record).id,
+          star1.id,
+          'The original related record is in place.'
+        );
+
+        cache.update((t) => [
+          t.replaceRelatedRecord(
+            {
+              id: 'home',
+              type: 'planetarySystem'
+            },
+            'star',
+            star2
+          ),
+          t.removeRecord(star1)
+        ]);
+
+        latestHome = cache.getRecordSync({
+          id: 'home',
+          type: 'planetarySystem'
+        });
+
+        assert.deepEqual(
+          (latestHome?.relationships?.star.data as Record).id,
+          star2.id,
+          'The related record was replaced.'
+        );
+      });
+
+      test("#update - updateRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+        const cache = new MemoryCache({ schema, keyMap });
+
+        const earth: Record = {
+          type: 'planet',
+          id: '1',
+          attributes: { name: 'Earth' },
+          keys: { remoteId: 'a' }
+        };
+
+        assert.throws(
+          () =>
+            cache.update((t) =>
+              t.updateRecord(earth).options({
+                raiseNotFoundExceptions: true
+              })
+            ),
+          RecordNotFoundException
+        );
+      });
+
+      test("#update - removeRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+        const cache = new MemoryCache({ schema, keyMap });
+
+        const earth: Record = {
+          type: 'planet',
+          id: '1'
+        };
+
+        assert.throws(
+          () =>
+            cache.update((t) =>
+              t.removeRecord(earth).options({
+                raiseNotFoundExceptions: true
+              })
+            ),
+          RecordNotFoundException
+        );
+      });
+
+      test("#update - replaceKey - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+        const cache = new MemoryCache({ schema, keyMap });
+
+        const earth: Record = {
+          type: 'planet',
+          id: '1',
+          attributes: { name: 'Earth' },
+          keys: { remoteId: 'a' }
+        };
+
+        assert.throws(
+          () =>
+            cache.update((t) =>
+              t.replaceKey(earth, 'remoteId', 'b').options({
+                raiseNotFoundExceptions: true
+              })
+            ),
+          RecordNotFoundException
+        );
+      });
+
+      test("#update - replaceAttribute - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+        const cache = new MemoryCache({ schema, keyMap });
+
+        const earth: Record = {
+          type: 'planet',
+          id: '1',
+          attributes: { name: 'Earth' },
+          keys: { remoteId: 'a' }
+        };
+
+        assert.throws(
+          () =>
+            cache.update((t) =>
+              t.replaceAttribute(earth, 'name', 'Mother Earth').options({
+                raiseNotFoundExceptions: true
+              })
+            ),
+          RecordNotFoundException
+        );
+      });
+
+      test("#update - addToRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+        const cache = new MemoryCache({ schema, keyMap });
+
+        assert.throws(
+          () =>
+            cache.update((t) =>
+              t
+                .addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+                  type: 'moon',
+                  id: 'm1'
+                })
+                .options({
+                  raiseNotFoundExceptions: true
+                })
+            ),
+          RecordNotFoundException
+        );
+      });
+
+      test("#update - removeFromRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+        const cache = new MemoryCache({ schema, keyMap });
+
+        assert.throws(
+          () =>
+            cache.update((t) =>
+              t
+                .removeFromRelatedRecords(
+                  { type: 'planet', id: 'p1' },
+                  'moons',
+                  {
+                    type: 'moon',
+                    id: 'm1'
+                  }
+                )
+                .options({
+                  raiseNotFoundExceptions: true
+                })
+            ),
+          RecordNotFoundException
+        );
+      });
+
+      test("#update - replaceRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+        const cache = new MemoryCache({ schema, keyMap });
+
+        assert.throws(
+          () =>
+            cache.update((t) =>
+              t
+                .replaceRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', [
+                  {
+                    type: 'moon',
+                    id: 'm1'
+                  }
+                ])
+                .options({
+                  raiseNotFoundExceptions: true
+                })
+            ),
+          RecordNotFoundException
+        );
+      });
+
+      test("#update - replaceRelatedRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+        const cache = new MemoryCache({ schema, keyMap });
+
+        assert.throws(
+          () =>
+            cache.update((t) =>
+              t
+                .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
+                  type: 'planet',
+                  id: 'p1'
+                })
+                .options({
+                  raiseNotFoundExceptions: true
+                })
+            ),
+          RecordNotFoundException
+        );
+      });
+    });
+  });
+});

--- a/packages/@orbit/memory/test/support/setup.ts
+++ b/packages/@orbit/memory/test/support/setup.ts
@@ -1,0 +1,55 @@
+import { RecordSchema } from '@orbit/records';
+
+export function createSchemaWithRemoteKey(): RecordSchema {
+  return new RecordSchema({
+    models: {
+      star: {
+        keys: {
+          remoteId: {}
+        },
+        relationships: {
+          celestialObjects: {
+            kind: 'hasMany',
+            type: ['planet', 'moon'],
+            inverse: 'star'
+          }
+        }
+      },
+      planet: {
+        keys: {
+          remoteId: {}
+        },
+        relationships: {
+          moons: { kind: 'hasMany', type: 'moon', inverse: 'planet' },
+          star: { kind: 'hasOne', type: 'star', inverse: 'celestialObjects' }
+        }
+      },
+      moon: {
+        keys: {
+          remoteId: {}
+        },
+        relationships: {
+          planet: { kind: 'hasOne', type: 'planet', inverse: 'moons' },
+          star: { kind: 'hasOne', type: 'star', inverse: 'celestialObjects' }
+        }
+      },
+      binaryStar: {
+        attributes: {
+          name: { type: 'string' }
+        },
+        relationships: {
+          starOne: { kind: 'hasOne', type: 'star' }, // no inverse
+          starTwo: { kind: 'hasOne', type: 'star' } // no inverse
+        }
+      },
+      planetarySystem: {
+        attributes: {
+          name: { type: 'string' }
+        },
+        relationships: {
+          star: { kind: 'hasOne', type: ['star', 'binaryStar'] } // no inverse
+        }
+      }
+    }
+  });
+}

--- a/packages/@orbit/record-cache/src/async-record-cache.ts
+++ b/packages/@orbit/record-cache/src/async-record-cache.ts
@@ -135,7 +135,7 @@ export abstract class AsyncRecordCache<
     typeOrIdentities?: string | RecordIdentity[]
   ): Promise<Record[]>;
   abstract getInverseRelationshipsAsync(
-    record: RecordIdentity
+    recordIdentityOrIdentities: RecordIdentity | RecordIdentity[]
   ): Promise<RecordRelationshipIdentity[]>;
 
   // Abstract methods for setting records and relationships

--- a/packages/@orbit/record-cache/src/async-record-cache.ts
+++ b/packages/@orbit/record-cache/src/async-record-cache.ts
@@ -476,7 +476,10 @@ export abstract class AsyncRecordCache<
       if (primary) {
         response.data?.push(data);
       }
-      response.details?.appliedOperations?.push(operation);
+      if (response.details) {
+        response.details.appliedOperationResults.push(data);
+        response.details.appliedOperations.push(operation);
+      }
 
       // Query and perform related `immediate` operations
       for (let processor of this._processors) {

--- a/packages/@orbit/record-cache/src/async-record-cache.ts
+++ b/packages/@orbit/record-cache/src/async-record-cache.ts
@@ -21,7 +21,8 @@ import {
   RecordTransformBuilderFunc,
   RecordTransformResult,
   RecordOperationResult,
-  RecordTransform
+  RecordTransform,
+  RecordQuery
 } from '@orbit/records';
 import {
   AsyncOperationProcessor,
@@ -201,21 +202,12 @@ export abstract class AsyncRecordCache<
       this._queryBuilder
     );
 
-    const results: RecordQueryExpressionResult[] = [];
-    for (let expression of query.expressions) {
-      const queryOperator = this.getQueryOperator(expression.op);
-      if (!queryOperator) {
-        throw new Error(`Unable to find query operator: ${expression.op}`);
-      }
-      results.push(await queryOperator(this, query, expression));
-    }
-
-    const data = query.expressions.length === 1 ? results[0] : results;
+    const response = await this._query<RequestData>(query, options);
 
     if (options?.fullResponse) {
-      return { data } as FullResponse<RequestData, undefined, RecordOperation>;
+      return response;
     } else {
-      return data as RequestData;
+      return response.data as RequestData;
     }
   }
 
@@ -251,44 +243,12 @@ export abstract class AsyncRecordCache<
       this._transformBuilder
     );
 
-    const response = {
-      data: []
-    } as FullResponse<
-      RecordOperationResult[],
-      RecordCacheUpdateDetails,
-      RecordOperation
-    >;
+    const response = await this._update<RequestData>(transform, options);
 
     if (options?.fullResponse) {
-      response.details = {
-        appliedOperations: [],
-        inverseOperations: []
-      };
-    }
-
-    await this._applyTransformOperations(
-      transform,
-      transform.operations,
-      response,
-      true
-    );
-
-    let data: RecordTransformResult;
-    if (transform.operations.length === 1 && Array.isArray(response.data)) {
-      data = response.data[0];
+      return response;
     } else {
-      data = response.data;
-    }
-
-    if (options?.fullResponse) {
-      response.details?.inverseOperations.reverse();
-
-      return {
-        ...response,
-        data
-      } as FullResponse<RequestData, RecordCacheUpdateDetails, RecordOperation>;
-    } else {
-      return data as RequestData;
+      return response.data as RequestData;
     }
   }
 
@@ -351,6 +311,75 @@ export abstract class AsyncRecordCache<
   /////////////////////////////////////////////////////////////////////////////
   // Protected methods
   /////////////////////////////////////////////////////////////////////////////
+
+  protected async _query<
+    RequestData extends RecordQueryResult = RecordQueryResult
+  >(
+    query: RecordQuery,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    options?: QueryOptions
+  ): Promise<FullResponse<RequestData, undefined, RecordOperation>> {
+    const results: RecordQueryExpressionResult[] = [];
+
+    for (let expression of query.expressions) {
+      const queryOperator = this.getQueryOperator(expression.op);
+      if (!queryOperator) {
+        throw new Error(`Unable to find query operator: ${expression.op}`);
+      }
+      results.push(await queryOperator(this, query, expression));
+    }
+
+    const data = query.expressions.length === 1 ? results[0] : results;
+
+    return { data: data as RequestData };
+  }
+
+  protected async _update<
+    RequestData extends RecordTransformResult = RecordTransformResult
+  >(
+    transform: RecordTransform,
+    options?: TransformOptions
+  ): Promise<
+    FullResponse<RequestData, RecordCacheUpdateDetails, RecordOperation>
+  > {
+    const response = {
+      data: []
+    } as FullResponse<
+      RecordOperationResult[],
+      RecordCacheUpdateDetails,
+      RecordOperation
+    >;
+
+    if (options?.fullResponse) {
+      response.details = {
+        appliedOperations: [],
+        inverseOperations: []
+      };
+    }
+
+    await this._applyTransformOperations(
+      transform,
+      transform.operations,
+      response,
+      true
+    );
+
+    let data: RecordTransformResult;
+    if (transform.operations.length === 1 && Array.isArray(response.data)) {
+      data = response.data[0];
+    } else {
+      data = response.data;
+    }
+
+    if (options?.fullResponse) {
+      response.details?.inverseOperations.reverse();
+    }
+
+    return {
+      ...response,
+      data
+    } as FullResponse<RequestData, RecordCacheUpdateDetails, RecordOperation>;
+  }
 
   protected async _applyTransformOperations(
     transform: RecordTransform,

--- a/packages/@orbit/record-cache/src/async-record-cache.ts
+++ b/packages/@orbit/record-cache/src/async-record-cache.ts
@@ -45,6 +45,7 @@ import {
 } from './operators/async-inverse-transform-operators';
 import {
   AsyncRecordAccessor,
+  RecordChangeset,
   RecordRelationshipIdentity
 } from './record-accessor';
 import { PatchResult, RecordCacheUpdateDetails } from './response';
@@ -152,6 +153,36 @@ export abstract class AsyncRecordCache<
   abstract removeInverseRelationshipsAsync(
     relationships: RecordRelationshipIdentity[]
   ): Promise<void>;
+
+  async applyRecordChangesetAsync(changeset: RecordChangeset): Promise<void> {
+    const {
+      setRecords,
+      removeRecords,
+      addInverseRelationships,
+      removeInverseRelationships
+    } = changeset;
+
+    const promises = [];
+
+    if (setRecords && setRecords.length > 0) {
+      promises.push(await this.setRecordsAsync(setRecords));
+    }
+    if (removeRecords && removeRecords.length > 0) {
+      promises.push(await this.removeRecordsAsync(removeRecords));
+    }
+    if (addInverseRelationships && addInverseRelationships.length > 0) {
+      promises.push(
+        await this.addInverseRelationshipsAsync(addInverseRelationships)
+      );
+    }
+    if (removeInverseRelationships && removeInverseRelationships.length > 0) {
+      promises.push(
+        await this.removeInverseRelationshipsAsync(removeInverseRelationships)
+      );
+    }
+
+    await Promise.all(promises);
+  }
 
   async getRelatedRecordAsync(
     identity: RecordIdentity,

--- a/packages/@orbit/record-cache/src/async-record-cache.ts
+++ b/packages/@orbit/record-cache/src/async-record-cache.ts
@@ -22,7 +22,8 @@ import {
   RecordTransformResult,
   RecordOperationResult,
   RecordTransform,
-  RecordQuery
+  RecordQuery,
+  recordsReferencedByOperations
 } from '@orbit/records';
 import {
   AsyncOperationProcessor,
@@ -56,6 +57,11 @@ import {
   RecordCacheTransformOptions,
   RecordCacheSettings
 } from './record-cache';
+import {
+  RecordTransformBuffer,
+  RecordTransformBufferClass
+} from './record-transform-buffer';
+import { SyncRecordCacheSettings } from './sync-record-cache';
 
 const { assert, deprecate } = Orbit;
 
@@ -68,6 +74,11 @@ export interface AsyncRecordCacheSettings<
   transformOperators?: Dict<AsyncTransformOperator>;
   inverseTransformOperators?: Dict<AsyncInverseTransformOperator>;
   debounceLiveQueries?: boolean;
+  transformBufferClass?: RecordTransformBufferClass;
+  transformBufferSettings?: SyncRecordCacheSettings<
+    QueryOptions,
+    TransformOptions
+  >;
 }
 
 export abstract class AsyncRecordCache<
@@ -81,6 +92,12 @@ export abstract class AsyncRecordCache<
   protected _transformOperators: Dict<AsyncTransformOperator>;
   protected _inverseTransformOperators: Dict<AsyncInverseTransformOperator>;
   protected _debounceLiveQueries: boolean;
+  protected _transformBuffer?: RecordTransformBuffer;
+  protected _transformBufferClass?: RecordTransformBufferClass;
+  protected _transformBufferSettings?: SyncRecordCacheSettings<
+    QueryOptions,
+    TransformOptions
+  >;
 
   constructor(
     settings: AsyncRecordCacheSettings<QueryOptions, TransformOptions>
@@ -373,43 +390,104 @@ export abstract class AsyncRecordCache<
   ): Promise<
     FullResponse<RequestData, RecordCacheUpdateDetails, RecordOperation>
   > {
-    const response = {
-      data: []
-    } as FullResponse<
-      RecordOperationResult[],
-      RecordCacheUpdateDetails,
-      RecordOperation
-    >;
+    if (this.getTransformOptions(transform)?.useBuffer) {
+      const buffer = await this._initTransformBuffer(transform);
 
-    if (options?.fullResponse) {
-      response.details = {
-        appliedOperations: [],
-        inverseOperations: []
-      };
-    }
+      buffer.startTrackingChanges();
 
-    await this._applyTransformOperations(
-      transform,
-      transform.operations,
-      response,
-      true
-    );
+      const response = buffer.update(transform, {
+        fullResponse: true
+      });
 
-    let data: RecordTransformResult;
-    if (transform.operations.length === 1 && Array.isArray(response.data)) {
-      data = response.data[0];
+      const changes = buffer.stopTrackingChanges();
+
+      await this.applyRecordChangesetAsync(changes);
+
+      const {
+        appliedOperations,
+        appliedOperationResults
+      } = response.details as RecordCacheUpdateDetails;
+
+      for (let i = 0, len = appliedOperations.length; i < len; i++) {
+        this.emit('patch', appliedOperations[i], appliedOperationResults[i]);
+      }
+
+      return response as FullResponse<
+        RequestData,
+        RecordCacheUpdateDetails,
+        RecordOperation
+      >;
     } else {
-      data = response.data;
-    }
+      const response = {
+        data: []
+      } as FullResponse<
+        RecordOperationResult[],
+        RecordCacheUpdateDetails,
+        RecordOperation
+      >;
 
-    if (options?.fullResponse) {
-      response.details?.inverseOperations.reverse();
-    }
+      if (options?.fullResponse) {
+        response.details = {
+          appliedOperations: [],
+          appliedOperationResults: [],
+          inverseOperations: []
+        };
+      }
 
-    return {
-      ...response,
-      data
-    } as FullResponse<RequestData, RecordCacheUpdateDetails, RecordOperation>;
+      await this._applyTransformOperations(
+        transform,
+        transform.operations,
+        response,
+        true
+      );
+      let data: RecordTransformResult;
+      if (transform.operations.length === 1 && Array.isArray(response.data)) {
+        data = response.data[0];
+      } else {
+        data = response.data;
+      }
+
+      if (options?.fullResponse) {
+        response.details?.inverseOperations.reverse();
+      }
+
+      return {
+        ...response,
+        data
+      } as FullResponse<RequestData, RecordCacheUpdateDetails, RecordOperation>;
+    }
+  }
+
+  protected _getTransformBuffer(): RecordTransformBuffer {
+    if (this._transformBuffer === undefined) {
+      let transformBufferClass =
+        this._transformBufferClass ?? RecordTransformBuffer;
+      let settings = this._transformBufferSettings ?? { schema: this.schema };
+      settings.schema = settings.schema ?? this.schema;
+      settings.keyMap = settings.keyMap ?? this.keyMap;
+      this._transformBuffer = new transformBufferClass(settings);
+    } else {
+      this._transformBuffer.reset();
+    }
+    return this._transformBuffer;
+  }
+
+  protected async _initTransformBuffer(
+    transform: RecordTransform
+  ): Promise<RecordTransformBuffer> {
+    const buffer = this._getTransformBuffer();
+
+    const records = recordsReferencedByOperations(transform.operations);
+    const inverseRelationships = await this.getInverseRelationshipsAsync(
+      records
+    );
+    const relatedRecords = inverseRelationships.map((ir) => ir.record);
+    Array.prototype.push.apply(records, relatedRecords);
+
+    buffer.setRecordsSync(await this.getRecordsAsync(records));
+    buffer.addInverseRelationshipsSync(inverseRelationships);
+
+    return buffer;
   }
 
   protected async _applyTransformOperations(

--- a/packages/@orbit/record-cache/src/index.ts
+++ b/packages/@orbit/record-cache/src/index.ts
@@ -1,6 +1,7 @@
 export * from './response';
 export * from './record-accessor';
 export * from './record-cache';
+export * from './record-transform-buffer';
 
 export * from './async-record-cache';
 export * from './async-operation-processor';

--- a/packages/@orbit/record-cache/src/record-accessor.ts
+++ b/packages/@orbit/record-cache/src/record-accessor.ts
@@ -22,6 +22,13 @@ export interface BaseRecordAccessor {
   schema: RecordSchema;
 }
 
+export interface RecordChangeset {
+  setRecords?: Record[];
+  removeRecords?: RecordIdentity[];
+  addInverseRelationships?: RecordRelationshipIdentity[];
+  removeInverseRelationships?: RecordRelationshipIdentity[];
+}
+
 export interface SyncRecordAccessor extends BaseRecordAccessor {
   // Getters
   getRecordSync(recordIdentity: RecordIdentity): Record | undefined;
@@ -49,6 +56,7 @@ export interface SyncRecordAccessor extends BaseRecordAccessor {
   removeInverseRelationshipsSync(
     relationships: RecordRelationshipIdentity[]
   ): void;
+  applyRecordChangesetSync(changeset: RecordChangeset): void;
 }
 
 export interface AsyncRecordAccessor extends BaseRecordAccessor {
@@ -82,4 +90,5 @@ export interface AsyncRecordAccessor extends BaseRecordAccessor {
   removeInverseRelationshipsAsync(
     relationships: RecordRelationshipIdentity[]
   ): Promise<void>;
+  applyRecordChangesetAsync(changeset: RecordChangeset): Promise<void>;
 }

--- a/packages/@orbit/record-cache/src/record-accessor.ts
+++ b/packages/@orbit/record-cache/src/record-accessor.ts
@@ -42,7 +42,7 @@ export interface SyncRecordAccessor extends BaseRecordAccessor {
     relationship: string
   ): RecordIdentity[] | undefined;
   getInverseRelationshipsSync(
-    record: RecordIdentity
+    recordIdentityOrIdentities: RecordIdentity | RecordIdentity[]
   ): RecordRelationshipIdentity[];
 
   // Setters
@@ -74,7 +74,7 @@ export interface AsyncRecordAccessor extends BaseRecordAccessor {
     relationship: string
   ): Promise<RecordIdentity[] | undefined>;
   getInverseRelationshipsAsync(
-    recordIdentity: RecordIdentity
+    recordIdentityOrIdentities: RecordIdentity | RecordIdentity[]
   ): Promise<RecordRelationshipIdentity[]>;
 
   // Setters

--- a/packages/@orbit/record-cache/src/record-cache.ts
+++ b/packages/@orbit/record-cache/src/record-cache.ts
@@ -39,10 +39,7 @@ export interface RecordCacheSettings<
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface RecordCache<
-  QueryOptions extends RequestOptions = RecordCacheQueryOptions,
-  TransformOptions extends RequestOptions = RecordCacheTransformOptions
-> extends Evented {}
+export interface RecordCache extends Evented {}
 
 @evented
 export abstract class RecordCache<

--- a/packages/@orbit/record-cache/src/record-cache.ts
+++ b/packages/@orbit/record-cache/src/record-cache.ts
@@ -22,6 +22,7 @@ export interface RecordCacheQueryOptions extends RequestOptions {
 
 export interface RecordCacheTransformOptions extends RequestOptions {
   raiseNotFoundExceptions?: boolean;
+  useBuffer?: boolean;
 }
 
 export interface RecordCacheSettings<

--- a/packages/@orbit/record-cache/src/record-transform-buffer.ts
+++ b/packages/@orbit/record-cache/src/record-transform-buffer.ts
@@ -1,0 +1,243 @@
+import { objectValues, Dict } from '@orbit/utils';
+import {
+  deserializeRecordIdentity,
+  Record,
+  RecordIdentity,
+  serializeRecordIdentity
+} from '@orbit/records';
+import { RecordChangeset, RecordRelationshipIdentity } from './record-accessor';
+import { SyncRecordCache, SyncRecordCacheSettings } from './sync-record-cache';
+
+function serializeRecordRelationshipIdentity(
+  rri: RecordRelationshipIdentity
+): string {
+  return `${serializeRecordIdentity(rri.record)}::${rri.relationship}`;
+}
+
+function deserializeRecordRelationshipIdentity(
+  rri: string
+): { record: RecordIdentity; relationship: string } {
+  const [record, relationship] = rri.split('::');
+  return { record: deserializeRecordIdentity(record), relationship };
+}
+
+export interface RecordTransformBufferState {
+  records: Dict<Record | null>;
+  inverseRelationships: Dict<Dict<RecordRelationshipIdentity | null>>;
+}
+
+export interface RecordTransformBufferClass {
+  new (settings: SyncRecordCacheSettings): RecordTransformBuffer;
+}
+
+export class RecordTransformBuffer extends SyncRecordCache {
+  protected _state!: RecordTransformBufferState;
+  protected _delta?: RecordTransformBufferState;
+
+  constructor(settings: SyncRecordCacheSettings) {
+    super(settings);
+    this.reset();
+  }
+
+  reset(
+    state: RecordTransformBufferState = {
+      records: {},
+      inverseRelationships: {}
+    }
+  ): void {
+    this._state = state;
+  }
+
+  startTrackingChanges(): void {
+    this._delta = {
+      records: {},
+      inverseRelationships: {}
+    };
+  }
+
+  stopTrackingChanges(): RecordChangeset {
+    if (this._delta === undefined) {
+      throw new Error(
+        `Changes are not being tracked. Call 'startTrackingChanges' before 'stopTrackingChanges'`
+      );
+    }
+
+    let { records, inverseRelationships } = this._delta;
+
+    // console.log('buffer#stopTrackingChanges - delta', records, inverseRelationships);
+
+    let changeset: RecordChangeset = {};
+
+    for (let rid of Object.keys(records)) {
+      let rv = records[rid];
+      if (rv === null) {
+        changeset.removeRecords = changeset.removeRecords ?? [];
+        changeset.removeRecords.push(deserializeRecordIdentity(rid));
+      } else {
+        changeset.setRecords = changeset.setRecords ?? [];
+        changeset.setRecords.push(rv);
+      }
+    }
+
+    for (let rid of Object.keys(inverseRelationships)) {
+      let relatedRecord = deserializeRecordIdentity(rid);
+      let rels = inverseRelationships[rid];
+      for (let rel of Object.keys(rels)) {
+        let rv = rels[rel];
+        let { record, relationship } = deserializeRecordRelationshipIdentity(
+          rel
+        );
+        let rri = { relatedRecord, record, relationship };
+        if (rv === null) {
+          changeset.removeInverseRelationships =
+            changeset.removeInverseRelationships ?? [];
+          changeset.removeInverseRelationships.push(rri);
+        } else {
+          changeset.addInverseRelationships =
+            changeset.addInverseRelationships ?? [];
+          changeset.addInverseRelationships.push(rri);
+        }
+      }
+    }
+
+    this._delta = undefined;
+
+    // console.log('buffer#stopTrackingChanges - changeset', changeset);
+
+    return changeset;
+  }
+
+  getRecordSync(identity: RecordIdentity): Record | undefined {
+    return this._state.records[serializeRecordIdentity(identity)] ?? undefined;
+  }
+
+  getRecordsSync(typeOrIdentities?: string | RecordIdentity[]): Record[] {
+    if (typeof typeOrIdentities === 'string') {
+      return objectValues(this._state.records[typeOrIdentities]);
+    } else if (Array.isArray(typeOrIdentities)) {
+      const records: Record[] = [];
+      const identities: RecordIdentity[] = typeOrIdentities;
+      for (let i of identities) {
+        let record = this.getRecordSync(i);
+        if (record) {
+          records.push(record);
+        }
+      }
+      return records;
+    } else {
+      throw new Error('typeOrIdentities must be specified in getRecordsSync');
+    }
+  }
+
+  setRecordSync(record: Record): void {
+    this._state.records[serializeRecordIdentity(record)] = record;
+    if (this._delta) {
+      this._delta.records[serializeRecordIdentity(record)] = record;
+    }
+  }
+
+  setRecordsSync(records: Record[]): void {
+    records.forEach((record) => this.setRecordSync(record));
+  }
+
+  removeRecordSync(recordIdentity: RecordIdentity): Record | undefined {
+    const record = this.getRecordSync(recordIdentity);
+    if (record) {
+      delete this._state.records[serializeRecordIdentity(record)];
+      if (this._delta) {
+        this._delta.records[serializeRecordIdentity(record)] = null;
+      }
+      return record;
+    } else {
+      return undefined;
+    }
+  }
+
+  removeRecordsSync(recordIdentities: RecordIdentity[]): Record[] {
+    const records = [];
+    for (let recordIdentity of recordIdentities) {
+      let record = this.getRecordSync(recordIdentity);
+      if (record) {
+        records.push(record);
+        delete this._state.records[serializeRecordIdentity(record)];
+        if (this._delta) {
+          this._delta.records[serializeRecordIdentity(record)] = null;
+        }
+      }
+    }
+    return records;
+  }
+
+  getInverseRelationshipsSync(
+    recordIdentityOrIdentities: RecordIdentity | RecordIdentity[]
+  ): RecordRelationshipIdentity[] {
+    if (Array.isArray(recordIdentityOrIdentities)) {
+      let relationships: RecordRelationshipIdentity[] = [];
+      recordIdentityOrIdentities.forEach((record) => {
+        Array.prototype.push(
+          relationships,
+          this._getInverseRelationshipsSync(record)
+        );
+      });
+      return relationships;
+    } else {
+      return this._getInverseRelationshipsSync(recordIdentityOrIdentities);
+    }
+  }
+
+  addInverseRelationshipsSync(
+    relationships: RecordRelationshipIdentity[]
+  ): void {
+    // console.log('addInverseRelationshipsSync', relationships);
+
+    for (let relationship of relationships) {
+      const ri = serializeRecordIdentity(relationship.relatedRecord);
+      const rri = serializeRecordRelationshipIdentity(relationship);
+      const rels = this._state.inverseRelationships[ri] ?? {};
+      rels[rri] = relationship;
+      this._state.inverseRelationships[ri] = rels;
+      if (this._delta) {
+        const rels = this._delta.inverseRelationships[ri] ?? {};
+        rels[rri] = relationship;
+        this._delta.inverseRelationships[ri] = rels;
+      }
+    }
+  }
+
+  removeInverseRelationshipsSync(
+    relationships: RecordRelationshipIdentity[]
+  ): void {
+    // console.log('removeInverseRelationshipsSync', relationships);
+
+    for (let relationship of relationships) {
+      const ri = serializeRecordIdentity(relationship.relatedRecord);
+      const rri = serializeRecordRelationshipIdentity(relationship);
+      const rels = this._state.inverseRelationships[ri];
+
+      if (rels) {
+        rels[rri] = null;
+        if (this._delta) {
+          const rels = this._delta.inverseRelationships[ri] ?? {};
+          rels[rri] = null;
+        }
+      }
+    }
+  }
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Protected methods
+  /////////////////////////////////////////////////////////////////////////////
+
+  protected _getInverseRelationshipsSync(
+    recordIdentity: RecordIdentity
+  ): RecordRelationshipIdentity[] {
+    let relationships = this._state.inverseRelationships[
+      serializeRecordIdentity(recordIdentity)
+    ];
+    if (relationships) {
+      return objectValues(relationships).filter((r) => r !== null);
+    } else {
+      return [];
+    }
+  }
+}

--- a/packages/@orbit/record-cache/src/response.ts
+++ b/packages/@orbit/record-cache/src/response.ts
@@ -10,5 +10,6 @@ export interface PatchResult {
 
 export interface RecordCacheUpdateDetails {
   appliedOperations: RecordOperation[];
+  appliedOperationResults: RecordOperationResult[];
   inverseOperations: RecordOperation[];
 }

--- a/packages/@orbit/record-cache/src/sync-record-cache.ts
+++ b/packages/@orbit/record-cache/src/sync-record-cache.ts
@@ -452,7 +452,10 @@ export abstract class SyncRecordCache<
       if (primary) {
         response.data?.push(data);
       }
-      response.details?.appliedOperations?.push(operation);
+      if (response.details) {
+        response.details.appliedOperationResults.push(data);
+        response.details.appliedOperations.push(operation);
+      }
 
       // Query and perform related `immediate` operations
       for (let processor of this._processors) {

--- a/packages/@orbit/record-cache/src/sync-record-cache.ts
+++ b/packages/@orbit/record-cache/src/sync-record-cache.ts
@@ -133,7 +133,7 @@ export abstract class SyncRecordCache<
     typeOrIdentities?: string | RecordIdentity[]
   ): Record[];
   abstract getInverseRelationshipsSync(
-    record: RecordIdentity
+    recordIdentityOrIdentities: RecordIdentity | RecordIdentity[]
   ): RecordRelationshipIdentity[];
 
   // Abstract methods for setting records and relationships

--- a/packages/@orbit/record-cache/src/sync-record-cache.ts
+++ b/packages/@orbit/record-cache/src/sync-record-cache.ts
@@ -45,7 +45,8 @@ import {
 } from './operators/sync-inverse-transform-operators';
 import {
   SyncRecordAccessor,
-  RecordRelationshipIdentity
+  RecordRelationshipIdentity,
+  RecordChangeset
 } from './record-accessor';
 import { PatchResult, RecordCacheUpdateDetails } from './response';
 import { SyncLiveQuery } from './live-query/sync-live-query';
@@ -146,6 +147,28 @@ export abstract class SyncRecordCache<
   abstract removeInverseRelationshipsSync(
     relationships: RecordRelationshipIdentity[]
   ): void;
+
+  applyRecordChangesetSync(changeset: RecordChangeset): void {
+    const {
+      setRecords,
+      removeRecords,
+      addInverseRelationships,
+      removeInverseRelationships
+    } = changeset;
+
+    if (setRecords && setRecords.length > 0) {
+      this.setRecordsSync(setRecords);
+    }
+    if (removeRecords && removeRecords.length > 0) {
+      this.removeRecordsSync(removeRecords);
+    }
+    if (addInverseRelationships && addInverseRelationships.length > 0) {
+      this.addInverseRelationshipsSync(addInverseRelationships);
+    }
+    if (removeInverseRelationships && removeInverseRelationships.length > 0) {
+      this.removeInverseRelationshipsSync(removeInverseRelationships);
+    }
+  }
 
   getRelatedRecordSync(
     identity: RecordIdentity,

--- a/packages/@orbit/record-cache/test/async-record-cache-update-test.ts
+++ b/packages/@orbit/record-cache/test/async-record-cache-update-test.ts
@@ -15,1301 +15,1123 @@ const { module, test } = QUnit;
 
 QUnit.dump.maxDepth = 7;
 
-module('AsyncRecordCache', function (hooks) {
+module('AsyncRecordCache - update without buffer', function (hooks) {
   let schema: RecordSchema, keyMap: RecordKeyMap;
 
+  // All caches in this module share these transform options
+  const defaultTransformOptions = {};
+
   hooks.beforeEach(function () {
-    schema = createSchemaWithRemoteKey();
     keyMap = new RecordKeyMap();
   });
 
-  test('#update sets data and #records retrieves it', async function (assert) {
-    assert.expect(4);
+  module('with standard schema', function (hooks) {
+    let cache: ExampleAsyncRecordCache;
 
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-
-    const earth: Record = {
-      type: 'planet',
-      id: '1',
-      attributes: { name: 'Earth' },
-      keys: { remoteId: 'a' }
-    };
-
-    cache.on('patch', (operation, data) => {
-      assert.deepEqual(operation, {
-        op: 'addRecord',
-        record: earth
+    hooks.beforeEach(function () {
+      schema = createSchemaWithRemoteKey();
+      cache = new ExampleAsyncRecordCache({
+        schema,
+        keyMap,
+        defaultTransformOptions
       });
-      assert.deepEqual(data, earth);
     });
 
-    await cache.update((t) => t.addRecord(earth));
+    test('#update sets data and #records retrieves it', async function (assert) {
+      assert.expect(4);
 
-    assert.strictEqual(
-      await cache.getRecordAsync({ type: 'planet', id: '1' }),
-      earth,
-      'objects strictly match'
-    );
-    assert.equal(
-      keyMap.keyToId('planet', 'remoteId', 'a'),
-      '1',
-      'key has been mapped'
-    );
-  });
-
-  test('#update can replace records', async function (assert) {
-    assert.expect(5);
-
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-
-    const earth: Record = {
-      type: 'planet',
-      id: '1',
-      attributes: { name: 'Earth' },
-      keys: { remoteId: 'a' }
-    };
-
-    cache.on('patch', (operation, data) => {
-      assert.deepEqual(operation, {
-        op: 'updateRecord',
-        record: earth
-      });
-      assert.deepEqual(data, earth);
-    });
-
-    await cache.update((t) => t.updateRecord(earth));
-
-    assert.deepEqual(
-      await cache.getRecordAsync({ type: 'planet', id: '1' }),
-      earth,
-      'objects deeply match'
-    );
-    assert.notStrictEqual(
-      await cache.getRecordAsync({ type: 'planet', id: '1' }),
-      earth,
-      'objects do not strictly match'
-    );
-    assert.equal(
-      keyMap.keyToId('planet', 'remoteId', 'a'),
-      '1',
-      'key has been mapped'
-    );
-  });
-
-  test('#update can replace keys', async function (assert) {
-    assert.expect(4);
-
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-
-    const earth: Record = { type: 'planet', id: '1' };
-
-    cache.on('patch', (operation, data) => {
-      assert.deepEqual(operation, {
-        op: 'replaceKey',
-        record: earth,
-        key: 'remoteId',
-        value: 'a'
-      });
-      assert.deepEqual(data, {
+      const earth: Record = {
         type: 'planet',
         id: '1',
+        attributes: { name: 'Earth' },
         keys: { remoteId: 'a' }
+      };
+
+      cache.on('patch', (operation, data) => {
+        assert.deepEqual(operation, {
+          op: 'addRecord',
+          record: earth
+        });
+        assert.deepEqual(data, earth);
       });
+
+      await cache.update((t) => t.addRecord(earth));
+
+      assert.strictEqual(
+        await cache.getRecordAsync({ type: 'planet', id: '1' }),
+        earth,
+        'objects strictly match'
+      );
+      assert.equal(
+        keyMap.keyToId('planet', 'remoteId', 'a'),
+        '1',
+        'key has been mapped'
+      );
     });
 
-    await cache.update((t) => t.replaceKey(earth, 'remoteId', 'a'));
+    test('#update can replace records', async function (assert) {
+      assert.expect(5);
 
-    assert.deepEqual(
-      await cache.getRecordAsync({ type: 'planet', id: '1' }),
-      { type: 'planet', id: '1', keys: { remoteId: 'a' } },
-      'records match'
-    );
-    assert.equal(
-      keyMap.keyToId('planet', 'remoteId', 'a'),
-      '1',
-      'key has been mapped'
-    );
-  });
+      const earth: Record = {
+        type: 'planet',
+        id: '1',
+        attributes: { name: 'Earth' },
+        keys: { remoteId: 'a' }
+      };
 
-  test('#update updates the cache and returns primary data', async function (assert) {
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
+      cache.on('patch', (operation, data) => {
+        assert.deepEqual(operation, {
+          op: 'updateRecord',
+          record: earth
+        });
+        assert.deepEqual(data, earth);
+      });
 
-    let p1 = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
-    let p2 = { type: 'planet', id: '2' };
+      await cache.update((t) => t.updateRecord(earth));
 
-    let result = await cache.update((t) => [
-      t.addRecord(p1),
-      t.removeRecord(p2)
-    ]);
+      assert.deepEqual(
+        await cache.getRecordAsync({ type: 'planet', id: '1' }),
+        earth,
+        'objects deeply match'
+      );
+      assert.notStrictEqual(
+        await cache.getRecordAsync({ type: 'planet', id: '1' }),
+        earth,
+        'objects do not strictly match'
+      );
+      assert.equal(
+        keyMap.keyToId('planet', 'remoteId', 'a'),
+        '1',
+        'key has been mapped'
+      );
+    });
 
-    assert.deepEqual(
-      result,
-      [
-        p1,
-        undefined // p2 didn't exist
-      ],
-      'response includes just primary data'
-    );
-  });
+    test('#update can replace keys', async function (assert) {
+      assert.expect(4);
 
-  test('#update updates the cache and returns a full response if requested', async function (assert) {
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
+      const earth: Record = { type: 'planet', id: '1' };
 
-    let p1 = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
-    let p2 = { type: 'planet', id: '2' };
+      cache.on('patch', (operation, data) => {
+        assert.deepEqual(operation, {
+          op: 'replaceKey',
+          record: earth,
+          key: 'remoteId',
+          value: 'a'
+        });
+        assert.deepEqual(data, {
+          type: 'planet',
+          id: '1',
+          keys: { remoteId: 'a' }
+        });
+      });
 
-    let result = await cache.update(
-      (t) => [t.addRecord(p1), t.removeRecord(p2)],
-      {
-        fullResponse: true
-      }
-    );
+      await cache.update((t) => t.replaceKey(earth, 'remoteId', 'a'));
 
-    assert.deepEqual(
-      result,
-      {
-        data: [
+      assert.deepEqual(
+        await cache.getRecordAsync({ type: 'planet', id: '1' }),
+        { type: 'planet', id: '1', keys: { remoteId: 'a' } },
+        'records match'
+      );
+      assert.equal(
+        keyMap.keyToId('planet', 'remoteId', 'a'),
+        '1',
+        'key has been mapped'
+      );
+    });
+
+    test('#update updates the cache and returns primary data', async function (assert) {
+      let p1 = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
+      let p2 = { type: 'planet', id: '2' };
+
+      let result = await cache.update((t) => [
+        t.addRecord(p1),
+        t.removeRecord(p2)
+      ]);
+
+      assert.deepEqual(
+        result,
+        [
           p1,
           undefined // p2 didn't exist
         ],
-        details: {
-          appliedOperations: [{ op: 'addRecord', record: p1 }],
-          inverseOperations: [
-            { op: 'removeRecord', record: { type: 'planet', id: '1' } }
-          ]
+        'response includes just primary data'
+      );
+    });
+
+    test('#update updates the cache and returns a full response if requested', async function (assert) {
+      let p1 = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
+      let p2 = { type: 'planet', id: '2' };
+
+      let result = await cache.update(
+        (t) => [t.addRecord(p1), t.removeRecord(p2)],
+        {
+          fullResponse: true
         }
-      },
-      'full response includes data and details'
-    );
-  });
+      );
 
-  test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added after', async function (assert) {
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-
-    const jupiter: Record = {
-      type: 'planet',
-      id: 'p1',
-      attributes: { name: 'Jupiter' },
-      relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-    };
-    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' } };
-
-    await cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
-
-    assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-        ?.relationships?.moons.data,
-      [{ type: 'moon', id: 'm1' }],
-      'Io has been assigned to Jupiter'
-    );
-    assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-        ?.relationships?.planet.data,
-      { type: 'planet', id: 'p1' },
-      'Jupiter has been assigned to Io'
-    );
-  });
-
-  test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added before', async function (assert) {
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-
-    const jupiter: Record = {
-      type: 'planet',
-      id: 'p1',
-      attributes: { name: 'Jupiter' },
-      relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-    };
-    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' } };
-
-    await cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
-
-    assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-        ?.relationships?.moons.data,
-      [{ type: 'moon', id: 'm1' }],
-      'Io has been assigned to Jupiter'
-    );
-    assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-        ?.relationships?.planet.data,
-      { type: 'planet', id: 'p1' },
-      'Jupiter has been assigned to Io'
-    );
-  });
-
-  test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added after', async function (assert) {
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-
-    const io: Record = {
-      type: 'moon',
-      id: 'm1',
-      attributes: { name: 'Io' },
-      relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-    };
-    const jupiter: Record = {
-      type: 'planet',
-      id: 'p1',
-      attributes: { name: 'Jupiter' }
-    };
-
-    await cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
-
-    assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-        ?.relationships?.moons.data,
-      [{ type: 'moon', id: 'm1' }],
-      'Io has been assigned to Jupiter'
-    );
-    assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-        ?.relationships?.planet.data,
-      { type: 'planet', id: 'p1' },
-      'Jupiter has been assigned to Io'
-    );
-  });
-
-  test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added before', async function (assert) {
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-
-    const io: Record = {
-      type: 'moon',
-      id: 'm1',
-      attributes: { name: 'Io' },
-      relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-    };
-    const jupiter: Record = {
-      type: 'planet',
-      id: 'p1',
-      attributes: { name: 'Jupiter' }
-    };
-
-    await cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
-
-    assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-        ?.relationships?.moons.data,
-      [{ type: 'moon', id: 'm1' }],
-      'Io has been assigned to Jupiter'
-    );
-    assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-        ?.relationships?.planet.data,
-      { type: 'planet', id: 'p1' },
-      'Jupiter has been assigned to Io'
-    );
-  });
-
-  test('#update updates inverse hasOne relationship when a record with an empty relationship is added', async function (assert) {
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-
-    const io: Record = {
-      type: 'moon',
-      id: 'm1',
-      attributes: { name: 'Io' },
-      relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-    };
-    const jupiter: Record = {
-      type: 'planet',
-      id: 'p1',
-      attributes: { name: 'Jupiter' },
-      relationships: { moons: { data: [] } }
-    };
-
-    await cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
-
-    assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-        ?.relationships?.moons.data,
-      [],
-      'Jupiter has no moons'
-    );
-    assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-        ?.relationships?.planet.data,
-      null,
-      'Jupiter has been cleared from Io'
-    );
-  });
-
-  test('#update updates inverse hasMany relationship when a record with an empty relationship is added', async function (assert) {
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-
-    const jupiter: Record = {
-      type: 'planet',
-      id: 'p1',
-      attributes: { name: 'Jupiter' },
-      relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-    };
-    const io: Record = {
-      type: 'moon',
-      id: 'm1',
-      attributes: { name: 'Io' },
-      relationships: { planet: { data: null } }
-    };
-
-    await cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
-
-    assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-        ?.relationships?.moons.data,
-      [],
-      'Io has been cleared from Jupiter'
-    );
-    assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-        ?.relationships?.planet.data,
-      null,
-      'Io has no planet'
-    );
-  });
-
-  test('#update updates inverse hasMany polymorphic relationship', async function (assert) {
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-
-    const sun: Record = {
-      type: 'star',
-      id: 's1',
-      attributes: { name: 'Sun' },
-      relationships: {
-        celestialObjects: {
+      assert.deepEqual(
+        result,
+        {
           data: [
-            { type: 'planet', id: 'p1' },
-            { type: 'moon', id: 'm1' }
-          ]
-        }
-      }
-    };
-    const jupiter: Record = {
-      type: 'planet',
-      id: 'p1',
-      attributes: { name: 'Jupiter' }
-    };
-    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' } };
-
-    await cache.update((t) => [
-      t.updateRecord(sun),
-      t.updateRecord(jupiter),
-      t.updateRecord(io)
-    ]);
-
-    assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'star', id: 's1' })) as Record)
-        ?.relationships?.celestialObjects.data,
-      [
-        { type: 'planet', id: 'p1' },
-        { type: 'moon', id: 'm1' }
-      ],
-      'Jupiter and Io has been assigned to Sun'
-    );
-    assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-        ?.relationships?.star.data,
-      { type: 'star', id: 's1' },
-      'Sun has been assigned to Jupiter'
-    );
-    assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-        ?.relationships?.star.data,
-      { type: 'star', id: 's1' },
-      'Sun has been assigned to Io'
-    );
-  });
-
-  test('#update updates inverse hasOne polymorphic relationship', async function (assert) {
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-
-    const jupiter: Record = {
-      type: 'planet',
-      id: 'p1',
-      attributes: { name: 'Jupiter' },
-      relationships: { star: { data: { type: 'star', id: 's1' } } }
-    };
-    const io: Record = {
-      type: 'moon',
-      id: 'm1',
-      attributes: { name: 'Io' },
-      relationships: { star: { data: { type: 'star', id: 's1' } } }
-    };
-    const sun: Record = { type: 'star', id: 's1', attributes: { name: 'Sun' } };
-
-    await cache.update((t) => [
-      t.updateRecord(jupiter),
-      t.updateRecord(io),
-      t.updateRecord(sun)
-    ]);
-
-    assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'star', id: 's1' })) as Record)
-        ?.relationships?.celestialObjects.data,
-      [
-        { type: 'planet', id: 'p1' },
-        { type: 'moon', id: 'm1' }
-      ],
-      'Jupiter and Io has been assigned to Sun'
-    );
-    assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-        ?.relationships?.star.data,
-      { type: 'star', id: 's1' },
-      'Sun has been assigned to Jupiter'
-    );
-    assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-        ?.relationships?.star.data,
-      { type: 'star', id: 's1' },
-      'Sun has been assigned to Io'
-    );
-  });
-
-  test('#update tracks refs and clears them from hasOne relationships when a referenced record is removed', async function (assert) {
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-
-    const jupiter: Record = {
-      type: 'planet',
-      id: 'p1',
-      attributes: { name: 'Jupiter' },
-      relationships: { moons: { data: undefined } }
-    };
-    const io: Record = {
-      type: 'moon',
-      id: 'm1',
-      attributes: { name: 'Io' },
-      relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-    };
-    const europa: Record = {
-      type: 'moon',
-      id: 'm2',
-      attributes: { name: 'Europa' },
-      relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-    };
-
-    await cache.update((t) => [
-      t.addRecord(jupiter),
-      t.addRecord(io),
-      t.addRecord(europa)
-    ]);
-
-    assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-        ?.relationships?.planet.data,
-      { type: 'planet', id: 'p1' },
-      'Jupiter has been assigned to Io'
-    );
-    assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm2' })) as Record)
-        ?.relationships?.planet.data,
-      { type: 'planet', id: 'p1' },
-      'Jupiter has been assigned to Europa'
-    );
-
-    await cache.update((t) => t.removeRecord(jupiter));
-
-    assert.equal(
-      await cache.getRecordAsync({ type: 'planet', id: 'p1' }),
-      undefined,
-      'Jupiter is GONE'
-    );
-
-    assert.equal(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-        ?.relationships?.planet.data,
-      undefined,
-      'Jupiter has been cleared from Io'
-    );
-    assert.equal(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm2' })) as Record)
-        ?.relationships?.planet.data,
-      undefined,
-      'Jupiter has been cleared from Europa'
-    );
-  });
-
-  test('#update tracks refs and clears them from hasMany relationships when a referenced record is removed', async function (assert) {
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-
-    const io: Record = {
-      type: 'moon',
-      id: 'm1',
-      attributes: { name: 'Io' },
-      relationships: { planet: { data: null } }
-    };
-    const europa: Record = {
-      type: 'moon',
-      id: 'm2',
-      attributes: { name: 'Europa' },
-      relationships: { planet: { data: null } }
-    };
-    const jupiter: Record = {
-      type: 'planet',
-      id: 'p1',
-      attributes: { name: 'Jupiter' },
-      relationships: {
-        moons: {
-          data: [
-            { type: 'moon', id: 'm1' },
-            { type: 'moon', id: 'm2' }
-          ]
-        }
-      }
-    };
-
-    await cache.update((t) => [
-      t.addRecord(io),
-      t.addRecord(europa),
-      t.addRecord(jupiter)
-    ]);
-
-    assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-        ?.relationships?.moons.data,
-      [
-        { type: 'moon', id: 'm1' },
-        { type: 'moon', id: 'm2' }
-      ],
-      'Jupiter has been assigned to Io and Europa'
-    );
-    assert.ok(
-      recordsIncludeAll(
-        (await cache.getRelatedRecordsAsync(
-          jupiter,
-          'moons'
-        )) as RecordIdentity[],
-        [io, europa]
-      ),
-      'Jupiter has been assigned to Io and Europa'
-    );
-
-    await cache.update((t) => t.removeRecord(io));
-
-    assert.equal(
-      await cache.getRecordAsync({ type: 'moon', id: 'm1' }),
-      null,
-      'Io is GONE'
-    );
-
-    await cache.update((t) => t.removeRecord(europa));
-
-    assert.equal(
-      await cache.getRecordAsync({ type: 'moon', id: 'm2' }),
-      null,
-      'Europa is GONE'
-    );
-
-    assert.deepEqual(
-      (await cache.getRelatedRecordsAsync(
-        { type: 'planet', id: 'p1' },
-        'moons'
-      )) as RecordIdentity[],
-      [],
-      'moons have been cleared from Jupiter'
-    );
-  });
-
-  test("#update adds link to hasMany if record doesn't exist", async function (assert) {
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-
-    await cache.update((t) =>
-      t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
-        type: 'moon',
-        id: 'm1'
-      })
-    );
-
-    await cache.update((t) =>
-      t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
-        type: 'moon',
-        id: 'm1'
-      })
-    );
-
-    assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-        ?.relationships?.moons.data,
-      [{ type: 'moon', id: 'm1' }],
-      'relationship was added'
-    );
-  });
-
-  test("#update does not remove hasMany relationship if record doesn't exist", async function (assert) {
-    assert.expect(1);
-
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-
-    cache.on('patch', () => {
-      assert.ok(false, 'no operations were applied');
-    });
-
-    await cache.update((t) =>
-      t.removeFromRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
-        type: 'moon',
-        id: 'moon1'
-      })
-    );
-
-    assert.equal(
-      await cache.getRecordAsync({ type: 'planet', id: 'p1' }),
-      undefined,
-      'planet does not exist'
-    );
-  });
-
-  test("#update adds hasOne if record doesn't exist", async function (assert) {
-    assert.expect(2);
-
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-
-    const tb = cache.transformBuilder;
-    const replacePlanet = tb.replaceRelatedRecord(
-      { type: 'moon', id: 'moon1' },
-      'planet',
-      { type: 'planet', id: 'p1' }
-    );
-
-    const addToMoons = tb.addToRelatedRecords(
-      { type: 'planet', id: 'p1' },
-      'moons',
-      { type: 'moon', id: 'moon1' }
-    );
-
-    let order = 0;
-    cache.on('patch', (op) => {
-      order++;
-      if (order === 1) {
-        assert.deepEqual(
-          op,
-          replacePlanet.toOperation(),
-          'applied replacePlanet operation'
-        );
-      } else if (order === 2) {
-        assert.deepEqual(
-          op,
-          addToMoons.toOperation(),
-          'applied addToMoons operation'
-        );
-      } else {
-        assert.ok(false, 'too many ops');
-      }
-    });
-
-    await cache.update([replacePlanet]);
-  });
-
-  test("#update will add empty hasOne link if record doesn't exist", async function (assert) {
-    assert.expect(2);
-
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-
-    const tb = cache.transformBuilder;
-    const clearPlanet = tb.replaceRelatedRecord(
-      { type: 'moon', id: 'moon1' },
-      'planet',
-      null
-    );
-
-    let order = 0;
-    cache.on('patch', (op) => {
-      order++;
-      if (order === 1) {
-        assert.deepEqual(
-          op,
-          clearPlanet.toOperation(),
-          'applied clearPlanet operation'
-        );
-      } else {
-        assert.ok(false, 'too many ops');
-      }
-    });
-
-    await cache.update([clearPlanet]);
-
-    assert.ok(true, 'patch applied');
-  });
-
-  test('#update does not add link to hasMany if link already exists', async function (assert) {
-    assert.expect(1);
-
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-
-    const jupiter: Record = {
-      id: 'p1',
-      type: 'planet',
-      attributes: { name: 'Jupiter' },
-      relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-    };
-
-    await cache.update((t) => t.addRecord(jupiter));
-
-    cache.on('patch', () => {
-      assert.ok(false, 'no operations were applied');
-    });
-
-    await cache.update((t) =>
-      t.addToRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'm1' })
-    );
-
-    assert.ok(true, 'patch completed');
-  });
-
-  test("#update does not remove relationship from hasMany if relationship doesn't exist", async function (assert) {
-    assert.expect(1);
-
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-
-    const jupiter: Record = {
-      id: 'p1',
-      type: 'planet',
-      attributes: { name: 'Jupiter' }
-    };
-
-    await cache.update((t) => t.addRecord(jupiter));
-
-    cache.on('patch', () => {
-      assert.ok(false, 'no operations were applied');
-    });
-
-    await cache.update((t) =>
-      t.removeFromRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'm1' })
-    );
-
-    assert.ok(true, 'patch completed');
-  });
-
-  test('#update can add and remove to has-many relationship', async function (assert) {
-    assert.expect(2);
-
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-
-    const jupiter: Record = { id: 'jupiter', type: 'planet' };
-    await cache.update((t) => t.addRecord(jupiter));
-
-    const callisto: Record = { id: 'callisto', type: 'moon' };
-    await cache.update((t) => t.addRecord(callisto));
-
-    await cache.update((t) =>
-      t.addToRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'callisto' })
-    );
-
-    assert.ok(
-      recordsInclude(
-        (await cache.getRelatedRecordsAsync(
-          jupiter,
-          'moons'
-        )) as RecordIdentity[],
-        callisto
-      ),
-      'moon added'
-    );
-
-    await cache.update((t) =>
-      t.removeFromRelatedRecords(jupiter, 'moons', {
-        type: 'moon',
-        id: 'callisto'
-      })
-    );
-
-    assert.notOk(
-      recordsInclude(
-        (await cache.getRelatedRecordsAsync(
-          jupiter,
-          'moons'
-        )) as RecordIdentity[],
-        callisto
-      ),
-      'moon removed'
-    );
-  });
-
-  test('#update can add and clear has-one relationship', async function (assert) {
-    assert.expect(2);
-
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-
-    const jupiter: Record = { id: 'jupiter', type: 'planet' };
-    await cache.update((t) => t.addRecord(jupiter));
-
-    const callisto: Record = { id: 'callisto', type: 'moon' };
-    await cache.update((t) => t.addRecord(callisto));
-
-    await cache.update((t) =>
-      t.replaceRelatedRecord(callisto, 'planet', {
-        type: 'planet',
-        id: 'jupiter'
-      })
-    );
-
-    assert.ok(
-      equalRecordIdentities(
-        (await cache.getRelatedRecordAsync(
-          callisto,
-          'planet'
-        )) as RecordIdentity,
-        jupiter
-      ),
-      'relationship added'
-    );
-
-    await cache.update((t) => t.replaceRelatedRecord(callisto, 'planet', null));
-
-    assert.notOk(
-      equalRecordIdentities(
-        (await cache.getRelatedRecordAsync(
-          callisto,
-          'planet'
-        )) as RecordIdentity,
-        jupiter
-      ),
-      'relationship cleared'
-    );
-  });
-
-  test('does not replace hasOne if relationship already exists', async function (assert) {
-    assert.expect(1);
-
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-
-    const europa: Record = {
-      id: 'm1',
-      type: 'moon',
-      attributes: { name: 'Europa' },
-      relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-    };
-
-    await cache.update((t) => t.addRecord(europa));
-
-    cache.on('patch', () => {
-      assert.ok(false, 'no operations were applied');
-    });
-
-    await cache.update((t) =>
-      t.replaceRelatedRecord(europa, 'planet', { type: 'planet', id: 'p1' })
-    );
-
-    assert.ok(true, 'patch completed');
-  });
-
-  test("does not remove hasOne if relationship doesn't exist", async function (assert) {
-    assert.expect(1);
-
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-
-    const europa: Record = {
-      type: 'moon',
-      id: 'm1',
-      attributes: { name: 'Europa' },
-      relationships: { planet: { data: null } }
-    };
-
-    await cache.update((t) => t.addRecord(europa));
-
-    cache.on('patch', () => {
-      assert.ok(false, 'no operations were applied');
-    });
-
-    await cache.update((t) => t.replaceRelatedRecord(europa, 'planet', null));
-
-    assert.ok(true, 'patch completed');
-  });
-
-  test('#update removing model with a bi-directional hasOne', async function (assert) {
-    assert.expect(5);
-
-    const hasOneSchema = new RecordSchema({
-      models: {
-        one: {
-          relationships: {
-            two: { kind: 'hasOne', type: 'two', inverse: 'one' }
-          }
-        },
-        two: {
-          relationships: {
-            one: { kind: 'hasOne', type: 'one', inverse: 'two' }
-          }
-        }
-      }
-    });
-
-    const cache = new ExampleAsyncRecordCache({ schema: hasOneSchema, keyMap });
-
-    await cache.update((t) => [
-      t.addRecord({
-        id: '1',
-        type: 'one',
-        relationships: {
-          two: { data: null }
-        }
-      }),
-      t.addRecord({
-        id: '2',
-        type: 'two',
-        relationships: {
-          one: { data: { type: 'one', id: '1' } }
-        }
-      })
-    ]);
-
-    const one = (await cache.getRecordAsync({
-      type: 'one',
-      id: '1'
-    })) as Record;
-    const two = (await cache.getRecordAsync({
-      type: 'two',
-      id: '2'
-    })) as Record;
-    assert.ok(one, 'one exists');
-    assert.ok(two, 'two exists');
-    assert.deepEqual(
-      one.relationships?.two.data,
-      { type: 'two', id: '2' },
-      'one links to two'
-    );
-    assert.deepEqual(
-      two.relationships?.one.data,
-      { type: 'one', id: '1' },
-      'two links to one'
-    );
-
-    await cache.update((t) => t.removeRecord(two));
-
-    assert.equal(
-      ((await cache.getRecordAsync({ type: 'one', id: '1' })) as Record)
-        .relationships?.two.data,
-      null,
-      'ones link to two got removed'
-    );
-  });
-
-  test('#update removes dependent records in a hasOne relationship', async function (assert) {
-    const dependentSchema = new RecordSchema({
-      models: {
-        planet: {
-          relationships: {
-            moons: { kind: 'hasMany', type: 'moon' }
-          }
-        },
-        moon: {
-          relationships: {
-            planet: { kind: 'hasOne', type: 'planet', dependent: 'remove' }
-          }
-        }
-      }
-    });
-
-    const cache = new ExampleAsyncRecordCache({
-      schema: dependentSchema,
-      keyMap
-    });
-
-    const jupiter: Record = {
-      type: 'planet',
-      id: 'p1',
-      attributes: { name: 'Jupiter' }
-    };
-    const io: Record = {
-      type: 'moon',
-      id: 'm1',
-      attributes: { name: 'Io' },
-      relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-    };
-    const europa: Record = {
-      type: 'moon',
-      id: 'm2',
-      attributes: { name: 'Europa' },
-      relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-    };
-
-    await cache.update((t) => [
-      t.addRecord(jupiter),
-      t.addRecord(io),
-      t.addRecord(europa),
-      t.addToRelatedRecords(jupiter, 'moons', io),
-      t.addToRelatedRecords(jupiter, 'moons', europa)
-    ]);
-
-    await cache.update((t) => t.removeRecord(io));
-
-    assert.equal(
-      (await cache.getRecordsAsync('moon')).length,
-      1,
-      'Only europa is left in store'
-    );
-    assert.equal(
-      (await cache.getRecordsAsync('planet')).length,
-      0,
-      'Jupiter has been removed from the store'
-    );
-  });
-
-  test('#update removes dependent records in a hasMany relationship', async function (assert) {
-    const dependentSchema = new RecordSchema({
-      models: {
-        planet: {
-          relationships: {
-            moons: { kind: 'hasMany', type: 'moon', dependent: 'remove' }
-          }
-        },
-        moon: {
-          relationships: {
-            planet: { kind: 'hasOne', type: 'planet' }
-          }
-        }
-      }
-    });
-
-    const cache = new ExampleAsyncRecordCache({
-      schema: dependentSchema,
-      keyMap
-    });
-
-    const jupiter: Record = {
-      type: 'planet',
-      id: 'p1',
-      attributes: { name: 'Jupiter' }
-    };
-    const io: Record = {
-      type: 'moon',
-      id: 'm1',
-      attributes: { name: 'Io' },
-      relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-    };
-    const europa: Record = {
-      type: 'moon',
-      id: 'm2',
-      attributes: { name: 'Europa' },
-      relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-    };
-
-    await cache.update((t) => [
-      t.updateRecord(jupiter),
-      t.updateRecord(io),
-      t.updateRecord(europa),
-      t.addToRelatedRecords(jupiter, 'moons', io),
-      t.addToRelatedRecords(jupiter, 'moons', europa)
-    ]);
-
-    await cache.update((t) => t.removeRecord(jupiter));
-
-    assert.equal(
-      (await cache.getRecordsAsync('planet')).length,
-      0,
-      'Jupiter has been removed from the store'
-    );
-    assert.equal(
-      (await cache.getRecordsAsync('moon')).length,
-      0,
-      'All of Jupiters moons are removed from the store'
-    );
-  });
-
-  test('#update does not remove non-dependent records', async function (assert) {
-    const dependentSchema = new RecordSchema({
-      models: {
-        planet: {
-          relationships: {
-            moons: { kind: 'hasMany', type: 'moon' }
-          }
-        },
-        moon: {
-          relationships: {
-            planet: { kind: 'hasOne', type: 'planet' }
-          }
-        }
-      }
-    });
-
-    const cache = new ExampleAsyncRecordCache({
-      schema: dependentSchema,
-      keyMap
-    });
-
-    const jupiter: Record = {
-      type: 'planet',
-      id: 'p1',
-      attributes: { name: 'Jupiter' }
-    };
-    const io: Record = {
-      type: 'moon',
-      id: 'm1',
-      attributes: { name: 'Io' },
-      relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-    };
-    const europa: Record = {
-      type: 'moon',
-      id: 'm2',
-      attributes: { name: 'Europa' },
-      relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-    };
-
-    await cache.update((t) => [
-      t.addRecord(jupiter),
-      t.addRecord(io),
-      t.addRecord(europa),
-      t.addToRelatedRecords(jupiter, 'moons', io),
-      t.addToRelatedRecords(jupiter, 'moons', europa)
-    ]);
-
-    // Since there are no dependent relationships, no other records will be
-    // removed
-    await cache.update((t) => t.removeRecord(io));
-
-    assert.equal(
-      (await cache.getRecordsAsync('moon')).length,
-      1,
-      'One moon left in store'
-    );
-    assert.equal(
-      (await cache.getRecordsAsync('planet')).length,
-      1,
-      'One planet left in store'
-    );
-  });
-
-  test('#update merges records when "replacing" and will not stomp on attributes and relationships that are not replaced', async function (assert) {
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-    const tb = cache.transformBuilder;
-
-    await cache.update((t) => [
-      t.addRecord({
-        type: 'planet',
-        id: '1',
-        attributes: { name: 'Earth' },
-        relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-      })
-    ]);
-
-    let result = await cache.update(
-      (t) => [
-        t.updateRecord({
-          type: 'planet',
-          id: '1',
-          attributes: { classification: 'terrestrial' }
-        })
-      ],
-      { fullResponse: true }
-    );
-
-    assert.deepEqual(
-      await cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
-      {
-        type: 'planet',
-        id: '1',
-        attributes: { name: 'Earth', classification: 'terrestrial' },
-        relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-      },
-      'records have been merged'
-    );
-
-    assert.deepEqual(
-      result,
-      {
-        data: {
-          type: 'planet',
-          id: '1',
-          attributes: {
-            name: 'Earth',
-            classification: 'terrestrial'
-          },
-          relationships: {
-            moons: {
-              data: [{ type: 'moon', id: 'm1' }]
-            }
-          }
-        },
-        details: {
-          appliedOperations: [
-            tb
-              .updateRecord({
-                type: 'planet',
-                id: '1',
-                attributes: { classification: 'terrestrial' }
-              })
-              .toOperation()
+            p1,
+            undefined // p2 didn't exist
           ],
-          inverseOperations: [
-            tb
-              .updateRecord({
-                type: 'planet',
-                id: '1',
-                attributes: { classification: null }
-              })
-              .toOperation()
-          ]
-        }
-      },
-      'full response is correct'
-    );
-  });
+          details: {
+            appliedOperations: [{ op: 'addRecord', record: p1 }],
+            inverseOperations: [
+              { op: 'removeRecord', record: { type: 'planet', id: '1' } }
+            ]
+          }
+        },
+        'full response includes data and details'
+      );
+    });
 
-  test('#update can replace related records but only if they are different', async function (assert) {
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-    const tb = cache.transformBuilder;
-
-    await cache.update((t) => [
-      t.addRecord({
+    test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added after', async function (assert) {
+      const jupiter: Record = {
         type: 'planet',
-        id: '1',
-        attributes: { name: 'Earth' },
+        id: 'p1',
+        attributes: { name: 'Jupiter' },
         relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-      })
-    ]);
+      };
+      const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' } };
 
-    let result = await cache.update(
-      (t) => [
-        t.replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
-          { type: 'moon', id: 'm1' }
-        ])
-      ],
-      { fullResponse: true }
-    );
+      await cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
 
-    assert.deepEqual(
-      result,
-      {
-        data: undefined,
-        details: {
-          appliedOperations: [],
-          inverseOperations: []
-        }
-      },
-      'nothing has changed so there are no appliend or inverse ops'
-    );
+      assert.deepEqual(
+        ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
+          ?.relationships?.moons.data,
+        [{ type: 'moon', id: 'm1' }],
+        'Io has been assigned to Jupiter'
+      );
+      assert.deepEqual(
+        ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+          ?.relationships?.planet.data,
+        { type: 'planet', id: 'p1' },
+        'Jupiter has been assigned to Io'
+      );
+    });
 
-    result = await cache.update(
-      (t) =>
-        t.replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
-          { type: 'moon', id: 'm2' }
-        ]),
-      { fullResponse: true }
-    );
-
-    assert.deepEqual(
-      await cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
-      {
+    test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added before', async function (assert) {
+      const jupiter: Record = {
         type: 'planet',
-        id: '1',
-        attributes: { name: 'Earth' },
-        relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
-      },
-      'relationships have been replaced'
-    );
+        id: 'p1',
+        attributes: { name: 'Jupiter' },
+        relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+      };
+      const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' } };
 
-    assert.deepEqual(
-      result,
-      {
-        data: {
+      await cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
+
+      assert.deepEqual(
+        ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
+          ?.relationships?.moons.data,
+        [{ type: 'moon', id: 'm1' }],
+        'Io has been assigned to Jupiter'
+      );
+      assert.deepEqual(
+        ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+          ?.relationships?.planet.data,
+        { type: 'planet', id: 'p1' },
+        'Jupiter has been assigned to Io'
+      );
+    });
+
+    test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added after', async function (assert) {
+      const io: Record = {
+        type: 'moon',
+        id: 'm1',
+        attributes: { name: 'Io' },
+        relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+      };
+      const jupiter: Record = {
+        type: 'planet',
+        id: 'p1',
+        attributes: { name: 'Jupiter' }
+      };
+
+      await cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
+
+      assert.deepEqual(
+        ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
+          ?.relationships?.moons.data,
+        [{ type: 'moon', id: 'm1' }],
+        'Io has been assigned to Jupiter'
+      );
+      assert.deepEqual(
+        ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+          ?.relationships?.planet.data,
+        { type: 'planet', id: 'p1' },
+        'Jupiter has been assigned to Io'
+      );
+    });
+
+    test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added before', async function (assert) {
+      const io: Record = {
+        type: 'moon',
+        id: 'm1',
+        attributes: { name: 'Io' },
+        relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+      };
+      const jupiter: Record = {
+        type: 'planet',
+        id: 'p1',
+        attributes: { name: 'Jupiter' }
+      };
+
+      await cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
+
+      assert.deepEqual(
+        ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
+          ?.relationships?.moons.data,
+        [{ type: 'moon', id: 'm1' }],
+        'Io has been assigned to Jupiter'
+      );
+      assert.deepEqual(
+        ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+          ?.relationships?.planet.data,
+        { type: 'planet', id: 'p1' },
+        'Jupiter has been assigned to Io'
+      );
+    });
+
+    test('#update updates inverse hasOne relationship when a record with an empty relationship is added', async function (assert) {
+      const io: Record = {
+        type: 'moon',
+        id: 'm1',
+        attributes: { name: 'Io' },
+        relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+      };
+      const jupiter: Record = {
+        type: 'planet',
+        id: 'p1',
+        attributes: { name: 'Jupiter' },
+        relationships: { moons: { data: [] } }
+      };
+
+      await cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
+
+      assert.deepEqual(
+        ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
+          ?.relationships?.moons.data,
+        [],
+        'Jupiter has no moons'
+      );
+      assert.deepEqual(
+        ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+          ?.relationships?.planet.data,
+        null,
+        'Jupiter has been cleared from Io'
+      );
+    });
+
+    test('#update updates inverse hasMany relationship when a record with an empty relationship is added', async function (assert) {
+      const jupiter: Record = {
+        type: 'planet',
+        id: 'p1',
+        attributes: { name: 'Jupiter' },
+        relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+      };
+      const io: Record = {
+        type: 'moon',
+        id: 'm1',
+        attributes: { name: 'Io' },
+        relationships: { planet: { data: null } }
+      };
+
+      await cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
+
+      assert.deepEqual(
+        ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
+          ?.relationships?.moons.data,
+        [],
+        'Io has been cleared from Jupiter'
+      );
+      assert.deepEqual(
+        ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+          ?.relationships?.planet.data,
+        null,
+        'Io has no planet'
+      );
+    });
+
+    test('#update updates inverse hasMany polymorphic relationship', async function (assert) {
+      const sun: Record = {
+        type: 'star',
+        id: 's1',
+        attributes: { name: 'Sun' },
+        relationships: {
+          celestialObjects: {
+            data: [
+              { type: 'planet', id: 'p1' },
+              { type: 'moon', id: 'm1' }
+            ]
+          }
+        }
+      };
+      const jupiter: Record = {
+        type: 'planet',
+        id: 'p1',
+        attributes: { name: 'Jupiter' }
+      };
+      const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' } };
+
+      await cache.update((t) => [
+        t.updateRecord(sun),
+        t.updateRecord(jupiter),
+        t.updateRecord(io)
+      ]);
+
+      assert.deepEqual(
+        ((await cache.getRecordAsync({ type: 'star', id: 's1' })) as Record)
+          ?.relationships?.celestialObjects.data,
+        [
+          { type: 'planet', id: 'p1' },
+          { type: 'moon', id: 'm1' }
+        ],
+        'Jupiter and Io has been assigned to Sun'
+      );
+      assert.deepEqual(
+        ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
+          ?.relationships?.star.data,
+        { type: 'star', id: 's1' },
+        'Sun has been assigned to Jupiter'
+      );
+      assert.deepEqual(
+        ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+          ?.relationships?.star.data,
+        { type: 'star', id: 's1' },
+        'Sun has been assigned to Io'
+      );
+    });
+
+    test('#update updates inverse hasOne polymorphic relationship', async function (assert) {
+      const jupiter: Record = {
+        type: 'planet',
+        id: 'p1',
+        attributes: { name: 'Jupiter' },
+        relationships: { star: { data: { type: 'star', id: 's1' } } }
+      };
+      const io: Record = {
+        type: 'moon',
+        id: 'm1',
+        attributes: { name: 'Io' },
+        relationships: { star: { data: { type: 'star', id: 's1' } } }
+      };
+      const sun: Record = {
+        type: 'star',
+        id: 's1',
+        attributes: { name: 'Sun' }
+      };
+
+      await cache.update((t) => [
+        t.updateRecord(jupiter),
+        t.updateRecord(io),
+        t.updateRecord(sun)
+      ]);
+
+      assert.deepEqual(
+        ((await cache.getRecordAsync({ type: 'star', id: 's1' })) as Record)
+          ?.relationships?.celestialObjects.data,
+        [
+          { type: 'planet', id: 'p1' },
+          { type: 'moon', id: 'm1' }
+        ],
+        'Jupiter and Io has been assigned to Sun'
+      );
+      assert.deepEqual(
+        ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
+          ?.relationships?.star.data,
+        { type: 'star', id: 's1' },
+        'Sun has been assigned to Jupiter'
+      );
+      assert.deepEqual(
+        ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+          ?.relationships?.star.data,
+        { type: 'star', id: 's1' },
+        'Sun has been assigned to Io'
+      );
+    });
+
+    test('#update tracks refs and clears them from hasOne relationships when a referenced record is removed', async function (assert) {
+      const jupiter: Record = {
+        type: 'planet',
+        id: 'p1',
+        attributes: { name: 'Jupiter' },
+        relationships: { moons: { data: undefined } }
+      };
+      const io: Record = {
+        type: 'moon',
+        id: 'm1',
+        attributes: { name: 'Io' },
+        relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+      };
+      const europa: Record = {
+        type: 'moon',
+        id: 'm2',
+        attributes: { name: 'Europa' },
+        relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+      };
+
+      await cache.update((t) => [
+        t.addRecord(jupiter),
+        t.addRecord(io),
+        t.addRecord(europa)
+      ]);
+
+      assert.deepEqual(
+        ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+          ?.relationships?.planet.data,
+        { type: 'planet', id: 'p1' },
+        'Jupiter has been assigned to Io'
+      );
+      assert.deepEqual(
+        ((await cache.getRecordAsync({ type: 'moon', id: 'm2' })) as Record)
+          ?.relationships?.planet.data,
+        { type: 'planet', id: 'p1' },
+        'Jupiter has been assigned to Europa'
+      );
+
+      await cache.update((t) => t.removeRecord(jupiter));
+
+      assert.equal(
+        await cache.getRecordAsync({ type: 'planet', id: 'p1' }),
+        undefined,
+        'Jupiter is GONE'
+      );
+
+      assert.equal(
+        ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+          ?.relationships?.planet.data,
+        undefined,
+        'Jupiter has been cleared from Io'
+      );
+      assert.equal(
+        ((await cache.getRecordAsync({ type: 'moon', id: 'm2' })) as Record)
+          ?.relationships?.planet.data,
+        undefined,
+        'Jupiter has been cleared from Europa'
+      );
+    });
+
+    test('#update tracks refs and clears them from hasMany relationships when a referenced record is removed', async function (assert) {
+      const io: Record = {
+        type: 'moon',
+        id: 'm1',
+        attributes: { name: 'Io' },
+        relationships: { planet: { data: null } }
+      };
+      const europa: Record = {
+        type: 'moon',
+        id: 'm2',
+        attributes: { name: 'Europa' },
+        relationships: { planet: { data: null } }
+      };
+      const jupiter: Record = {
+        type: 'planet',
+        id: 'p1',
+        attributes: { name: 'Jupiter' },
+        relationships: {
+          moons: {
+            data: [
+              { type: 'moon', id: 'm1' },
+              { type: 'moon', id: 'm2' }
+            ]
+          }
+        }
+      };
+
+      await cache.update((t) => [
+        t.addRecord(io),
+        t.addRecord(europa),
+        t.addRecord(jupiter)
+      ]);
+
+      assert.deepEqual(
+        ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
+          ?.relationships?.moons.data,
+        [
+          { type: 'moon', id: 'm1' },
+          { type: 'moon', id: 'm2' }
+        ],
+        'Jupiter has been assigned to Io and Europa'
+      );
+      assert.ok(
+        recordsIncludeAll(
+          (await cache.getRelatedRecordsAsync(
+            jupiter,
+            'moons'
+          )) as RecordIdentity[],
+          [io, europa]
+        ),
+        'Jupiter has been assigned to Io and Europa'
+      );
+
+      await cache.update((t) => t.removeRecord(io));
+
+      assert.equal(
+        await cache.getRecordAsync({ type: 'moon', id: 'm1' }),
+        null,
+        'Io is GONE'
+      );
+
+      await cache.update((t) => t.removeRecord(europa));
+
+      assert.equal(
+        await cache.getRecordAsync({ type: 'moon', id: 'm2' }),
+        null,
+        'Europa is GONE'
+      );
+
+      assert.deepEqual(
+        (await cache.getRelatedRecordsAsync(
+          { type: 'planet', id: 'p1' },
+          'moons'
+        )) as RecordIdentity[],
+        [],
+        'moons have been cleared from Jupiter'
+      );
+    });
+
+    test("#update adds link to hasMany if record doesn't exist", async function (assert) {
+      await cache.update((t) =>
+        t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+          type: 'moon',
+          id: 'm1'
+        })
+      );
+
+      await cache.update((t) =>
+        t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+          type: 'moon',
+          id: 'm1'
+        })
+      );
+
+      assert.deepEqual(
+        ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
+          ?.relationships?.moons.data,
+        [{ type: 'moon', id: 'm1' }],
+        'relationship was added'
+      );
+    });
+
+    test("#update does not remove hasMany relationship if record doesn't exist", async function (assert) {
+      assert.expect(1);
+
+      cache.on('patch', () => {
+        assert.ok(false, 'no operations were applied');
+      });
+
+      await cache.update((t) =>
+        t.removeFromRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+          type: 'moon',
+          id: 'moon1'
+        })
+      );
+
+      assert.equal(
+        await cache.getRecordAsync({ type: 'planet', id: 'p1' }),
+        undefined,
+        'planet does not exist'
+      );
+    });
+
+    test("#update adds hasOne if record doesn't exist", async function (assert) {
+      assert.expect(2);
+
+      const tb = cache.transformBuilder;
+      const replacePlanet = tb.replaceRelatedRecord(
+        { type: 'moon', id: 'moon1' },
+        'planet',
+        { type: 'planet', id: 'p1' }
+      );
+
+      const addToMoons = tb.addToRelatedRecords(
+        { type: 'planet', id: 'p1' },
+        'moons',
+        { type: 'moon', id: 'moon1' }
+      );
+
+      let order = 0;
+      cache.on('patch', (op) => {
+        order++;
+        if (order === 1) {
+          assert.deepEqual(
+            op,
+            replacePlanet.toOperation(),
+            'applied replacePlanet operation'
+          );
+        } else if (order === 2) {
+          assert.deepEqual(
+            op,
+            addToMoons.toOperation(),
+            'applied addToMoons operation'
+          );
+        } else {
+          assert.ok(false, 'too many ops');
+        }
+      });
+
+      await cache.update([replacePlanet]);
+    });
+
+    test("#update will add empty hasOne link if record doesn't exist", async function (assert) {
+      assert.expect(2);
+
+      const tb = cache.transformBuilder;
+      const clearPlanet = tb.replaceRelatedRecord(
+        { type: 'moon', id: 'moon1' },
+        'planet',
+        null
+      );
+
+      let order = 0;
+      cache.on('patch', (op) => {
+        order++;
+        if (order === 1) {
+          assert.deepEqual(
+            op,
+            clearPlanet.toOperation(),
+            'applied clearPlanet operation'
+          );
+        } else {
+          assert.ok(false, 'too many ops');
+        }
+      });
+
+      await cache.update([clearPlanet]);
+
+      assert.ok(true, 'patch applied');
+    });
+
+    test('#update does not add link to hasMany if link already exists', async function (assert) {
+      assert.expect(1);
+
+      const jupiter: Record = {
+        id: 'p1',
+        type: 'planet',
+        attributes: { name: 'Jupiter' },
+        relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+      };
+
+      await cache.update((t) => t.addRecord(jupiter));
+
+      cache.on('patch', () => {
+        assert.ok(false, 'no operations were applied');
+      });
+
+      await cache.update((t) =>
+        t.addToRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'm1' })
+      );
+
+      assert.ok(true, 'patch completed');
+    });
+
+    test("#update does not remove relationship from hasMany if relationship doesn't exist", async function (assert) {
+      assert.expect(1);
+
+      const jupiter: Record = {
+        id: 'p1',
+        type: 'planet',
+        attributes: { name: 'Jupiter' }
+      };
+
+      await cache.update((t) => t.addRecord(jupiter));
+
+      cache.on('patch', () => {
+        assert.ok(false, 'no operations were applied');
+      });
+
+      await cache.update((t) =>
+        t.removeFromRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'm1' })
+      );
+
+      assert.ok(true, 'patch completed');
+    });
+
+    test('#update can add and remove to has-many relationship', async function (assert) {
+      assert.expect(2);
+
+      const jupiter: Record = { id: 'jupiter', type: 'planet' };
+      await cache.update((t) => t.addRecord(jupiter));
+
+      const callisto: Record = { id: 'callisto', type: 'moon' };
+      await cache.update((t) => t.addRecord(callisto));
+
+      await cache.update((t) =>
+        t.addToRelatedRecords(jupiter, 'moons', {
+          type: 'moon',
+          id: 'callisto'
+        })
+      );
+
+      assert.ok(
+        recordsInclude(
+          (await cache.getRelatedRecordsAsync(
+            jupiter,
+            'moons'
+          )) as RecordIdentity[],
+          callisto
+        ),
+        'moon added'
+      );
+
+      await cache.update((t) =>
+        t.removeFromRelatedRecords(jupiter, 'moons', {
+          type: 'moon',
+          id: 'callisto'
+        })
+      );
+
+      assert.notOk(
+        recordsInclude(
+          (await cache.getRelatedRecordsAsync(
+            jupiter,
+            'moons'
+          )) as RecordIdentity[],
+          callisto
+        ),
+        'moon removed'
+      );
+    });
+
+    test('#update can add and clear has-one relationship', async function (assert) {
+      assert.expect(2);
+
+      const jupiter: Record = { id: 'jupiter', type: 'planet' };
+      await cache.update((t) => t.addRecord(jupiter));
+
+      const callisto: Record = { id: 'callisto', type: 'moon' };
+      await cache.update((t) => t.addRecord(callisto));
+
+      await cache.update((t) =>
+        t.replaceRelatedRecord(callisto, 'planet', {
+          type: 'planet',
+          id: 'jupiter'
+        })
+      );
+
+      assert.ok(
+        equalRecordIdentities(
+          (await cache.getRelatedRecordAsync(
+            callisto,
+            'planet'
+          )) as RecordIdentity,
+          jupiter
+        ),
+        'relationship added'
+      );
+
+      await cache.update((t) =>
+        t.replaceRelatedRecord(callisto, 'planet', null)
+      );
+
+      assert.notOk(
+        equalRecordIdentities(
+          (await cache.getRelatedRecordAsync(
+            callisto,
+            'planet'
+          )) as RecordIdentity,
+          jupiter
+        ),
+        'relationship cleared'
+      );
+    });
+
+    test('does not replace hasOne if relationship already exists', async function (assert) {
+      assert.expect(1);
+
+      const europa: Record = {
+        id: 'm1',
+        type: 'moon',
+        attributes: { name: 'Europa' },
+        relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+      };
+
+      await cache.update((t) => t.addRecord(europa));
+
+      cache.on('patch', () => {
+        assert.ok(false, 'no operations were applied');
+      });
+
+      await cache.update((t) =>
+        t.replaceRelatedRecord(europa, 'planet', { type: 'planet', id: 'p1' })
+      );
+
+      assert.ok(true, 'patch completed');
+    });
+
+    test("does not remove hasOne if relationship doesn't exist", async function (assert) {
+      assert.expect(1);
+
+      const europa: Record = {
+        type: 'moon',
+        id: 'm1',
+        attributes: { name: 'Europa' },
+        relationships: { planet: { data: null } }
+      };
+
+      await cache.update((t) => t.addRecord(europa));
+
+      cache.on('patch', () => {
+        assert.ok(false, 'no operations were applied');
+      });
+
+      await cache.update((t) => t.replaceRelatedRecord(europa, 'planet', null));
+
+      assert.ok(true, 'patch completed');
+    });
+
+    test('#update merges records when "replacing" and will not stomp on attributes and relationships that are not replaced', async function (assert) {
+      const tb = cache.transformBuilder;
+
+      await cache.update((t) => [
+        t.addRecord({
           type: 'planet',
           id: '1',
           attributes: { name: 'Earth' },
-          relationships: {
-            moons: { data: [{ type: 'moon', id: 'm2' }] }
+          relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+        })
+      ]);
+
+      let result = await cache.update(
+        (t) => [
+          t.updateRecord({
+            type: 'planet',
+            id: '1',
+            attributes: { classification: 'terrestrial' }
+          })
+        ],
+        { fullResponse: true }
+      );
+
+      assert.deepEqual(
+        await cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
+        {
+          type: 'planet',
+          id: '1',
+          attributes: { name: 'Earth', classification: 'terrestrial' },
+          relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+        },
+        'records have been merged'
+      );
+
+      assert.deepEqual(
+        result,
+        {
+          data: {
+            type: 'planet',
+            id: '1',
+            attributes: {
+              name: 'Earth',
+              classification: 'terrestrial'
+            },
+            relationships: {
+              moons: {
+                data: [{ type: 'moon', id: 'm1' }]
+              }
+            }
+          },
+          details: {
+            appliedOperations: [
+              tb
+                .updateRecord({
+                  type: 'planet',
+                  id: '1',
+                  attributes: { classification: 'terrestrial' }
+                })
+                .toOperation()
+            ],
+            inverseOperations: [
+              tb
+                .updateRecord({
+                  type: 'planet',
+                  id: '1',
+                  attributes: { classification: null }
+                })
+                .toOperation()
+            ]
           }
         },
+        'full response is correct'
+      );
+    });
+
+    test('#update can replace related records but only if they are different', async function (assert) {
+      const tb = cache.transformBuilder;
+
+      await cache.update((t) => [
+        t.addRecord({
+          type: 'planet',
+          id: '1',
+          attributes: { name: 'Earth' },
+          relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+        })
+      ]);
+
+      let result = await cache.update(
+        (t) => [
+          t.replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
+            { type: 'moon', id: 'm1' }
+          ])
+        ],
+        { fullResponse: true }
+      );
+
+      assert.deepEqual(
+        result,
+        {
+          data: undefined,
+          details: {
+            appliedOperations: [],
+            inverseOperations: []
+          }
+        },
+        'nothing has changed so there are no appliend or inverse ops'
+      );
+
+      result = await cache.update(
+        (t) =>
+          t.replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
+            { type: 'moon', id: 'm2' }
+          ]),
+        { fullResponse: true }
+      );
+
+      assert.deepEqual(
+        await cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
+        {
+          type: 'planet',
+          id: '1',
+          attributes: { name: 'Earth' },
+          relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
+        },
+        'relationships have been replaced'
+      );
+
+      assert.deepEqual(
+        result,
+        {
+          data: {
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Earth' },
+            relationships: {
+              moons: { data: [{ type: 'moon', id: 'm2' }] }
+            }
+          },
+          details: {
+            appliedOperations: [
+              tb
+                .replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
+                  { type: 'moon', id: 'm2' }
+                ])
+                .toOperation(),
+              tb
+                .replaceRelatedRecord(
+                  { type: 'moon', id: 'm1' },
+                  'planet',
+                  null
+                )
+                .toOperation(),
+              tb
+                .replaceRelatedRecord({ type: 'moon', id: 'm2' }, 'planet', {
+                  type: 'planet',
+                  id: '1'
+                })
+                .toOperation()
+            ],
+            inverseOperations: [
+              tb
+                .replaceRelatedRecord(
+                  { type: 'moon', id: 'm2' },
+                  'planet',
+                  null
+                )
+                .toOperation(),
+              tb
+                .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
+                  type: 'planet',
+                  id: '1'
+                })
+                .toOperation(),
+              tb
+                .replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
+                  { type: 'moon', id: 'm1' }
+                ])
+                .toOperation()
+            ]
+          }
+        },
+        'full response is correct'
+      );
+    });
+
+    test('#update merges records when "replacing" and _will_ replace specified attributes and relationships', async function (assert) {
+      const tb = cache.transformBuilder;
+
+      const earth: Record = {
+        type: 'planet',
+        id: '1',
+        attributes: { name: 'Earth' },
+        relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+      };
+
+      const jupiter: Record = {
+        type: 'planet',
+        id: '1',
+        attributes: { name: 'Jupiter', classification: 'terrestrial' },
+        relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
+      };
+
+      let result = await cache.update([tb.addRecord(earth)], {
+        fullResponse: true
+      });
+
+      assert.deepEqual(
+        result,
+        {
+          data: earth,
+          details: {
+            appliedOperations: [
+              tb.addRecord(earth).toOperation(),
+              tb
+                .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
+                  type: 'planet',
+                  id: '1'
+                })
+                .toOperation()
+            ],
+            inverseOperations: [
+              tb
+                .replaceRelatedRecord(
+                  { type: 'moon', id: 'm1' },
+                  'planet',
+                  null
+                )
+                .toOperation(),
+              tb
+                .removeRecord({
+                  type: 'planet',
+                  id: '1'
+                })
+                .toOperation()
+            ]
+          }
+        },
+        'addRecord full response is correct'
+      );
+
+      result = await cache.update([tb.updateRecord(jupiter)], {
+        fullResponse: true
+      });
+
+      assert.deepEqual(result, {
+        data: jupiter,
         details: {
           appliedOperations: [
-            tb
-              .replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
-                { type: 'moon', id: 'm2' }
-              ])
-              .toOperation(),
+            tb.updateRecord(jupiter).toOperation(),
             tb
               .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', null)
               .toOperation(),
@@ -1331,519 +1153,673 @@ module('AsyncRecordCache', function (hooks) {
               })
               .toOperation(),
             tb
-              .replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
-                { type: 'moon', id: 'm1' }
-              ])
-              .toOperation()
-          ]
-        }
-      },
-      'full response is correct'
-    );
-  });
-
-  test('#update merges records when "replacing" and _will_ replace specified attributes and relationships', async function (assert) {
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-    const tb = cache.transformBuilder;
-
-    const earth: Record = {
-      type: 'planet',
-      id: '1',
-      attributes: { name: 'Earth' },
-      relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-    };
-
-    const jupiter: Record = {
-      type: 'planet',
-      id: '1',
-      attributes: { name: 'Jupiter', classification: 'terrestrial' },
-      relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
-    };
-
-    let result = await cache.update([tb.addRecord(earth)], {
-      fullResponse: true
-    });
-
-    assert.deepEqual(
-      result,
-      {
-        data: earth,
-        details: {
-          appliedOperations: [
-            tb.addRecord(earth).toOperation(),
-            tb
-              .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
+              .updateRecord({
                 type: 'planet',
-                id: '1'
-              })
-              .toOperation()
-          ],
-          inverseOperations: [
-            tb
-              .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', null)
-              .toOperation(),
-            tb
-              .removeRecord({
-                type: 'planet',
-                id: '1'
+                id: '1',
+                attributes: { name: 'Earth', classification: null },
+                relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
               })
               .toOperation()
           ]
         }
-      },
-      'addRecord full response is correct'
-    );
+      });
 
-    result = await cache.update([tb.updateRecord(jupiter)], {
-      fullResponse: true
-    });
-
-    assert.deepEqual(result, {
-      data: jupiter,
-      details: {
-        appliedOperations: [
-          tb.updateRecord(jupiter).toOperation(),
-          tb
-            .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', null)
-            .toOperation(),
-          tb
-            .replaceRelatedRecord({ type: 'moon', id: 'm2' }, 'planet', {
-              type: 'planet',
-              id: '1'
-            })
-            .toOperation()
-        ],
-        inverseOperations: [
-          tb
-            .replaceRelatedRecord({ type: 'moon', id: 'm2' }, 'planet', null)
-            .toOperation(),
-          tb
-            .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
-              type: 'planet',
-              id: '1'
-            })
-            .toOperation(),
-          tb
-            .updateRecord({
-              type: 'planet',
-              id: '1',
-              attributes: { name: 'Earth', classification: null },
-              relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-            })
-            .toOperation()
-        ]
-      }
-    });
-
-    assert.deepEqual(
-      await cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
-      {
-        type: 'planet',
-        id: '1',
-        attributes: { name: 'Jupiter', classification: 'terrestrial' },
-        relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
-      },
-      'records have been merged'
-    );
-  });
-
-  test('#update can update existing record with empty relationship', async function (assert) {
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-    const tb = cache.transformBuilder;
-
-    let result = await cache.update(
-      (t) => [t.addRecord({ id: '1', type: 'planet' })],
-      { fullResponse: true }
-    );
-
-    assert.deepEqual(
-      result,
-      {
-        data: { id: '1', type: 'planet' },
-        details: {
-          appliedOperations: [
-            tb
-              .addRecord({
-                type: 'planet',
-                id: '1'
-              })
-              .toOperation()
-          ],
-          inverseOperations: [
-            tb
-              .removeRecord({
-                type: 'planet',
-                id: '1'
-              })
-              .toOperation()
-          ]
-        }
-      },
-      'addRecord result is correct'
-    );
-
-    result = await cache.update(
-      (t) => [
-        t.updateRecord({
-          id: '1',
+      assert.deepEqual(
+        await cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
+        {
           type: 'planet',
-          relationships: {
-            moons: { data: [] }
-          }
-        })
-      ],
-      { fullResponse: true }
-    );
-
-    assert.deepEqual(
-      result,
-      {
-        data: {
           id: '1',
-          type: 'planet',
-          relationships: {
-            moons: { data: [] }
+          attributes: { name: 'Jupiter', classification: 'terrestrial' },
+          relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
+        },
+        'records have been merged'
+      );
+    });
+
+    test('#update can update existing record with empty relationship', async function (assert) {
+      const tb = cache.transformBuilder;
+
+      let result = await cache.update(
+        (t) => [t.addRecord({ id: '1', type: 'planet' })],
+        { fullResponse: true }
+      );
+
+      assert.deepEqual(
+        result,
+        {
+          data: { id: '1', type: 'planet' },
+          details: {
+            appliedOperations: [
+              tb
+                .addRecord({
+                  type: 'planet',
+                  id: '1'
+                })
+                .toOperation()
+            ],
+            inverseOperations: [
+              tb
+                .removeRecord({
+                  type: 'planet',
+                  id: '1'
+                })
+                .toOperation()
+            ]
           }
         },
-        details: {
-          appliedOperations: [
-            tb
-              .updateRecord({
-                id: '1',
-                type: 'planet',
-                relationships: {
-                  moons: { data: [] }
-                }
-              })
-              .toOperation()
-          ],
-          inverseOperations: [
-            tb
-              .updateRecord({
-                id: '1',
-                type: 'planet',
-                relationships: {
-                  moons: { data: [] }
-                }
-              })
-              .toOperation()
-          ]
-        }
-      },
-      'updateRecord result is correct'
-    );
+        'addRecord result is correct'
+      );
 
-    const planet = await cache.getRecordAsync({ type: 'planet', id: '1' });
-    assert.ok(planet, 'planet exists');
-    assert.deepEqual(
-      planet?.relationships?.moons.data,
-      [],
-      'planet has empty moons relationship'
-    );
-  });
+      result = await cache.update(
+        (t) => [
+          t.updateRecord({
+            id: '1',
+            type: 'planet',
+            relationships: {
+              moons: { data: [] }
+            }
+          })
+        ],
+        { fullResponse: true }
+      );
 
-  test('#update will not overwrite an existing relationship with a missing relationship', async function (assert) {
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-    const tb = cache.transformBuilder;
-
-    let result = await cache.update(
-      (t) => [
-        t.addRecord({
-          id: '1',
-          type: 'planet',
-          relationships: {
-            moons: { data: [{ type: 'moon', id: 'm1' }] }
+      assert.deepEqual(
+        result,
+        {
+          data: {
+            id: '1',
+            type: 'planet',
+            relationships: {
+              moons: { data: [] }
+            }
+          },
+          details: {
+            appliedOperations: [
+              tb
+                .updateRecord({
+                  id: '1',
+                  type: 'planet',
+                  relationships: {
+                    moons: { data: [] }
+                  }
+                })
+                .toOperation()
+            ],
+            inverseOperations: [
+              tb
+                .updateRecord({
+                  id: '1',
+                  type: 'planet',
+                  relationships: {
+                    moons: { data: [] }
+                  }
+                })
+                .toOperation()
+            ]
           }
-        }),
-        t.updateRecord({
-          id: '1',
-          type: 'planet'
-        })
-      ],
-      { fullResponse: true }
-    );
+        },
+        'updateRecord result is correct'
+      );
 
-    assert.deepEqual(
-      result,
-      {
-        data: [
-          {
+      const planet = await cache.getRecordAsync({ type: 'planet', id: '1' });
+      assert.ok(planet, 'planet exists');
+      assert.deepEqual(
+        planet?.relationships?.moons.data,
+        [],
+        'planet has empty moons relationship'
+      );
+    });
+
+    test('#update will not overwrite an existing relationship with a missing relationship', async function (assert) {
+      const tb = cache.transformBuilder;
+
+      let result = await cache.update(
+        (t) => [
+          t.addRecord({
             id: '1',
             type: 'planet',
             relationships: {
               moons: { data: [{ type: 'moon', id: 'm1' }] }
             }
-          },
-          undefined
+          }),
+          t.updateRecord({
+            id: '1',
+            type: 'planet'
+          })
         ],
-        details: {
-          appliedOperations: [
-            tb
-              .addRecord({
-                id: '1',
-                type: 'planet',
-                relationships: {
-                  moons: { data: [{ type: 'moon', id: 'm1' }] }
-                }
-              })
-              .toOperation(),
-            tb
-              .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
-                id: '1',
-                type: 'planet'
-              })
-              .toOperation()
-          ],
-          inverseOperations: [
-            tb
-              .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', null)
-              .toOperation(),
-            tb
-              .removeRecord({
-                id: '1',
-                type: 'planet'
-              })
-              .toOperation()
-          ]
-        }
-      },
-      'update full response is correct'
-    );
+        { fullResponse: true }
+      );
 
-    const planet = await cache.getRecordAsync({ type: 'planet', id: '1' });
-    assert.ok(planet, 'planet exists');
-    assert.deepEqual(
-      planet?.relationships?.moons.data,
-      [{ type: 'moon', id: 'm1' }],
-      'planet has a moons relationship'
-    );
-  });
-
-  test('#update allows replaceRelatedRecord to be called on a relationship with no inverse and to be followed up by removing the replaced record', async function (assert) {
-    assert.expect(2);
-
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-
-    const star1 = {
-      id: 'star1',
-      type: 'star',
-      attributes: { name: 'sun1' }
-    };
-
-    const star2 = {
-      id: 'star2',
-      type: 'star',
-      attributes: { name: 'sun2' }
-    };
-
-    const home = {
-      id: 'home',
-      type: 'planetarySystem',
-      attributes: { name: 'Home' },
-      relationships: {
-        star: {
-          data: { id: 'star1', type: 'star' }
-        }
-      }
-    };
-
-    await cache.update((t) => [
-      t.addRecord(star1),
-      t.addRecord(star2),
-      t.addRecord(home)
-    ]);
-
-    let latestHome = await cache.getRecordAsync({
-      id: 'home',
-      type: 'planetarySystem'
-    });
-    assert.deepEqual(
-      (latestHome?.relationships?.star.data as Record).id,
-      star1.id,
-      'The original related record is in place.'
-    );
-
-    await cache.update((t) => [
-      t.replaceRelatedRecord(
+      assert.deepEqual(
+        result,
         {
-          id: 'home',
-          type: 'planetarySystem'
+          data: [
+            {
+              id: '1',
+              type: 'planet',
+              relationships: {
+                moons: { data: [{ type: 'moon', id: 'm1' }] }
+              }
+            },
+            undefined
+          ],
+          details: {
+            appliedOperations: [
+              tb
+                .addRecord({
+                  id: '1',
+                  type: 'planet',
+                  relationships: {
+                    moons: { data: [{ type: 'moon', id: 'm1' }] }
+                  }
+                })
+                .toOperation(),
+              tb
+                .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
+                  id: '1',
+                  type: 'planet'
+                })
+                .toOperation()
+            ],
+            inverseOperations: [
+              tb
+                .replaceRelatedRecord(
+                  { type: 'moon', id: 'm1' },
+                  'planet',
+                  null
+                )
+                .toOperation(),
+              tb
+                .removeRecord({
+                  id: '1',
+                  type: 'planet'
+                })
+                .toOperation()
+            ]
+          }
         },
-        'star',
-        star2
-      ),
-      t.removeRecord(star1)
-    ]);
+        'update full response is correct'
+      );
 
-    latestHome = await cache.getRecordAsync({
-      id: 'home',
-      type: 'planetarySystem'
+      const planet = await cache.getRecordAsync({ type: 'planet', id: '1' });
+      assert.ok(planet, 'planet exists');
+      assert.deepEqual(
+        planet?.relationships?.moons.data,
+        [{ type: 'moon', id: 'm1' }],
+        'planet has a moons relationship'
+      );
     });
 
-    assert.deepEqual(
-      (latestHome?.relationships?.star.data as Record).id,
-      star2.id,
-      'The related record was replaced.'
-    );
-  });
+    test('#update allows replaceRelatedRecord to be called on a relationship with no inverse and to be followed up by removing the replaced record', async function (assert) {
+      assert.expect(2);
 
-  test("#update - updateRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
+      const star1 = {
+        id: 'star1',
+        type: 'star',
+        attributes: { name: 'sun1' }
+      };
 
-    const earth: Record = {
-      type: 'planet',
-      id: '1',
-      attributes: { name: 'Earth' },
-      keys: { remoteId: 'a' }
-    };
+      const star2 = {
+        id: 'star2',
+        type: 'star',
+        attributes: { name: 'sun2' }
+      };
 
-    try {
-      await cache.update((t) =>
-        t.updateRecord(earth).options({
-          raiseNotFoundExceptions: true
-        })
+      const home = {
+        id: 'home',
+        type: 'planetarySystem',
+        attributes: { name: 'Home' },
+        relationships: {
+          star: {
+            data: { id: 'star1', type: 'star' }
+          }
+        }
+      };
+
+      await cache.update((t) => [
+        t.addRecord(star1),
+        t.addRecord(star2),
+        t.addRecord(home)
+      ]);
+
+      let latestHome = await cache.getRecordAsync({
+        id: 'home',
+        type: 'planetarySystem'
+      });
+      assert.deepEqual(
+        (latestHome?.relationships?.star.data as Record).id,
+        star1.id,
+        'The original related record is in place.'
       );
-    } catch (e) {
-      assert.ok(e instanceof RecordNotFoundException);
-    }
-  });
 
-  test("#update - removeRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
+      await cache.update((t) => [
+        t.replaceRelatedRecord(
+          {
+            id: 'home',
+            type: 'planetarySystem'
+          },
+          'star',
+          star2
+        ),
+        t.removeRecord(star1)
+      ]);
 
-    const earth: Record = {
-      type: 'planet',
-      id: '1'
-    };
+      latestHome = await cache.getRecordAsync({
+        id: 'home',
+        type: 'planetarySystem'
+      });
 
-    try {
-      await cache.update((t) =>
-        t.removeRecord(earth).options({
-          raiseNotFoundExceptions: true
-        })
+      assert.deepEqual(
+        (latestHome?.relationships?.star.data as Record).id,
+        star2.id,
+        'The related record was replaced.'
       );
-    } catch (e) {
-      assert.ok(e instanceof RecordNotFoundException);
-    }
-  });
+    });
 
-  test("#update - replaceKey - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
+    test("#update - updateRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+      const earth: Record = {
+        type: 'planet',
+        id: '1',
+        attributes: { name: 'Earth' },
+        keys: { remoteId: 'a' }
+      };
 
-    const earth: Record = {
-      type: 'planet',
-      id: '1',
-      attributes: { name: 'Earth' },
-      keys: { remoteId: 'a' }
-    };
-
-    try {
-      await cache.update((t) =>
-        t.replaceKey(earth, 'remoteId', 'b').options({
-          raiseNotFoundExceptions: true
-        })
-      );
-    } catch (e) {
-      assert.ok(e instanceof RecordNotFoundException);
-    }
-  });
-
-  test("#update - replaceAttribute - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-
-    const earth: Record = {
-      type: 'planet',
-      id: '1',
-      attributes: { name: 'Earth' },
-      keys: { remoteId: 'a' }
-    };
-
-    try {
-      await cache.update((t) =>
-        t.replaceAttribute(earth, 'name', 'Mother Earth').options({
-          raiseNotFoundExceptions: true
-        })
-      );
-    } catch (e) {
-      assert.ok(e instanceof RecordNotFoundException);
-    }
-  });
-
-  test("#update - addToRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
-
-    try {
-      await cache.update((t) =>
-        t
-          .addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
-            type: 'moon',
-            id: 'm1'
-          })
-          .options({
+      try {
+        await cache.update((t) =>
+          t.updateRecord(earth).options({
             raiseNotFoundExceptions: true
           })
-      );
-    } catch (e) {
-      assert.ok(e instanceof RecordNotFoundException);
-    }
-  });
+        );
+      } catch (e) {
+        assert.ok(e instanceof RecordNotFoundException);
+      }
+    });
 
-  test("#update - removeFromRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
+    test("#update - removeRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+      const earth: Record = {
+        type: 'planet',
+        id: '1'
+      };
 
-    try {
-      await cache.update((t) =>
-        t
-          .removeFromRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
-            type: 'moon',
-            id: 'm1'
-          })
-          .options({
+      try {
+        await cache.update((t) =>
+          t.removeRecord(earth).options({
             raiseNotFoundExceptions: true
           })
-      );
-    } catch (e) {
-      assert.ok(e instanceof RecordNotFoundException);
-    }
-  });
+        );
+      } catch (e) {
+        assert.ok(e instanceof RecordNotFoundException);
+      }
+    });
 
-  test("#update - replaceRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
+    test("#update - replaceKey - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+      const earth: Record = {
+        type: 'planet',
+        id: '1',
+        attributes: { name: 'Earth' },
+        keys: { remoteId: 'a' }
+      };
 
-    try {
-      await cache.update((t) =>
-        t
-          .replaceRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', [
-            {
+      try {
+        await cache.update((t) =>
+          t.replaceKey(earth, 'remoteId', 'b').options({
+            raiseNotFoundExceptions: true
+          })
+        );
+      } catch (e) {
+        assert.ok(e instanceof RecordNotFoundException);
+      }
+    });
+
+    test("#update - replaceAttribute - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+      const earth: Record = {
+        type: 'planet',
+        id: '1',
+        attributes: { name: 'Earth' },
+        keys: { remoteId: 'a' }
+      };
+
+      try {
+        await cache.update((t) =>
+          t.replaceAttribute(earth, 'name', 'Mother Earth').options({
+            raiseNotFoundExceptions: true
+          })
+        );
+      } catch (e) {
+        assert.ok(e instanceof RecordNotFoundException);
+      }
+    });
+
+    test("#update - addToRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+      try {
+        await cache.update((t) =>
+          t
+            .addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
               type: 'moon',
               id: 'm1'
-            }
-          ])
-          .options({
-            raiseNotFoundExceptions: true
-          })
-      );
-    } catch (e) {
-      assert.ok(e instanceof RecordNotFoundException);
-    }
+            })
+            .options({
+              raiseNotFoundExceptions: true
+            })
+        );
+      } catch (e) {
+        assert.ok(e instanceof RecordNotFoundException);
+      }
+    });
+
+    test("#update - removeFromRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+      try {
+        await cache.update((t) =>
+          t
+            .removeFromRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+              type: 'moon',
+              id: 'm1'
+            })
+            .options({
+              raiseNotFoundExceptions: true
+            })
+        );
+      } catch (e) {
+        assert.ok(e instanceof RecordNotFoundException);
+      }
+    });
+
+    test("#update - replaceRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+      try {
+        await cache.update((t) =>
+          t
+            .replaceRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', [
+              {
+                type: 'moon',
+                id: 'm1'
+              }
+            ])
+            .options({
+              raiseNotFoundExceptions: true
+            })
+        );
+      } catch (e) {
+        assert.ok(e instanceof RecordNotFoundException);
+      }
+    });
+
+    test("#update - replaceRelatedRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+      try {
+        await cache.update((t) =>
+          t
+            .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
+              type: 'planet',
+              id: 'p1'
+            })
+            .options({
+              raiseNotFoundExceptions: true
+            })
+        );
+      } catch (e) {
+        assert.ok(e instanceof RecordNotFoundException);
+      }
+    });
   });
 
-  test("#update - replaceRelatedRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
-    const cache = new ExampleAsyncRecordCache({ schema, keyMap });
+  module('with alt schema', function (hooks) {
+    test('#update removing model with a bi-directional hasOne', async function (assert) {
+      assert.expect(5);
 
-    try {
-      await cache.update((t) =>
-        t
-          .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
-            type: 'planet',
-            id: 'p1'
-          })
-          .options({
-            raiseNotFoundExceptions: true
-          })
+      const hasOneSchema = new RecordSchema({
+        models: {
+          one: {
+            relationships: {
+              two: { kind: 'hasOne', type: 'two', inverse: 'one' }
+            }
+          },
+          two: {
+            relationships: {
+              one: { kind: 'hasOne', type: 'one', inverse: 'two' }
+            }
+          }
+        }
+      });
+
+      const cache = new ExampleAsyncRecordCache({
+        schema: hasOneSchema,
+        keyMap,
+        defaultTransformOptions
+      });
+
+      await cache.update((t) => [
+        t.addRecord({
+          id: '1',
+          type: 'one',
+          relationships: {
+            two: { data: null }
+          }
+        }),
+        t.addRecord({
+          id: '2',
+          type: 'two',
+          relationships: {
+            one: { data: { type: 'one', id: '1' } }
+          }
+        })
+      ]);
+
+      const one = (await cache.getRecordAsync({
+        type: 'one',
+        id: '1'
+      })) as Record;
+      const two = (await cache.getRecordAsync({
+        type: 'two',
+        id: '2'
+      })) as Record;
+      assert.ok(one, 'one exists');
+      assert.ok(two, 'two exists');
+      assert.deepEqual(
+        one.relationships?.two.data,
+        { type: 'two', id: '2' },
+        'one links to two'
       );
-    } catch (e) {
-      assert.ok(e instanceof RecordNotFoundException);
-    }
+      assert.deepEqual(
+        two.relationships?.one.data,
+        { type: 'one', id: '1' },
+        'two links to one'
+      );
+
+      await cache.update((t) => t.removeRecord(two));
+
+      assert.equal(
+        ((await cache.getRecordAsync({ type: 'one', id: '1' })) as Record)
+          .relationships?.two.data,
+        null,
+        'ones link to two got removed'
+      );
+    });
+
+    test('#update removes dependent records in a hasOne relationship', async function (assert) {
+      const dependentSchema = new RecordSchema({
+        models: {
+          planet: {
+            relationships: {
+              moons: { kind: 'hasMany', type: 'moon' }
+            }
+          },
+          moon: {
+            relationships: {
+              planet: { kind: 'hasOne', type: 'planet', dependent: 'remove' }
+            }
+          }
+        }
+      });
+
+      const cache = new ExampleAsyncRecordCache({
+        schema: dependentSchema,
+        keyMap,
+        defaultTransformOptions
+      });
+
+      const jupiter: Record = {
+        type: 'planet',
+        id: 'p1',
+        attributes: { name: 'Jupiter' }
+      };
+      const io: Record = {
+        type: 'moon',
+        id: 'm1',
+        attributes: { name: 'Io' },
+        relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+      };
+      const europa: Record = {
+        type: 'moon',
+        id: 'm2',
+        attributes: { name: 'Europa' },
+        relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+      };
+
+      await cache.update((t) => [
+        t.addRecord(jupiter),
+        t.addRecord(io),
+        t.addRecord(europa),
+        t.addToRelatedRecords(jupiter, 'moons', io),
+        t.addToRelatedRecords(jupiter, 'moons', europa)
+      ]);
+
+      await cache.update((t) => t.removeRecord(io));
+
+      assert.equal(
+        (await cache.getRecordsAsync('moon')).length,
+        1,
+        'Only europa is left in store'
+      );
+      assert.equal(
+        (await cache.getRecordsAsync('planet')).length,
+        0,
+        'Jupiter has been removed from the store'
+      );
+    });
+
+    test('#update removes dependent records in a hasMany relationship', async function (assert) {
+      const dependentSchema = new RecordSchema({
+        models: {
+          planet: {
+            relationships: {
+              moons: { kind: 'hasMany', type: 'moon', dependent: 'remove' }
+            }
+          },
+          moon: {
+            relationships: {
+              planet: { kind: 'hasOne', type: 'planet' }
+            }
+          }
+        }
+      });
+
+      const cache = new ExampleAsyncRecordCache({
+        schema: dependentSchema,
+        keyMap,
+        defaultTransformOptions
+      });
+
+      const jupiter: Record = {
+        type: 'planet',
+        id: 'p1',
+        attributes: { name: 'Jupiter' }
+      };
+      const io: Record = {
+        type: 'moon',
+        id: 'm1',
+        attributes: { name: 'Io' },
+        relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+      };
+      const europa: Record = {
+        type: 'moon',
+        id: 'm2',
+        attributes: { name: 'Europa' },
+        relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+      };
+
+      await cache.update((t) => [
+        t.updateRecord(jupiter),
+        t.updateRecord(io),
+        t.updateRecord(europa),
+        t.addToRelatedRecords(jupiter, 'moons', io),
+        t.addToRelatedRecords(jupiter, 'moons', europa)
+      ]);
+
+      await cache.update((t) => t.removeRecord(jupiter));
+
+      assert.equal(
+        (await cache.getRecordsAsync('planet')).length,
+        0,
+        'Jupiter has been removed from the store'
+      );
+      assert.equal(
+        (await cache.getRecordsAsync('moon')).length,
+        0,
+        'All of Jupiters moons are removed from the store'
+      );
+    });
+
+    test('#update does not remove non-dependent records', async function (assert) {
+      const dependentSchema = new RecordSchema({
+        models: {
+          planet: {
+            relationships: {
+              moons: { kind: 'hasMany', type: 'moon' }
+            }
+          },
+          moon: {
+            relationships: {
+              planet: { kind: 'hasOne', type: 'planet' }
+            }
+          }
+        }
+      });
+
+      const cache = new ExampleAsyncRecordCache({
+        schema: dependentSchema,
+        keyMap,
+        defaultTransformOptions
+      });
+
+      const jupiter: Record = {
+        type: 'planet',
+        id: 'p1',
+        attributes: { name: 'Jupiter' }
+      };
+      const io: Record = {
+        type: 'moon',
+        id: 'm1',
+        attributes: { name: 'Io' },
+        relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+      };
+      const europa: Record = {
+        type: 'moon',
+        id: 'm2',
+        attributes: { name: 'Europa' },
+        relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+      };
+
+      await cache.update((t) => [
+        t.addRecord(jupiter),
+        t.addRecord(io),
+        t.addRecord(europa),
+        t.addToRelatedRecords(jupiter, 'moons', io),
+        t.addToRelatedRecords(jupiter, 'moons', europa)
+      ]);
+
+      // Since there are no dependent relationships, no other records will be
+      // removed
+      await cache.update((t) => t.removeRecord(io));
+
+      assert.equal(
+        (await cache.getRecordsAsync('moon')).length,
+        1,
+        'One moon left in store'
+      );
+      assert.equal(
+        (await cache.getRecordsAsync('planet')).length,
+        1,
+        'One planet left in store'
+      );
+    });
   });
 });

--- a/packages/@orbit/record-cache/test/async-record-cache-update-test.ts
+++ b/packages/@orbit/record-cache/test/async-record-cache-update-test.ts
@@ -15,1811 +15,2023 @@ const { module, test } = QUnit;
 
 QUnit.dump.maxDepth = 7;
 
-module('AsyncRecordCache - update without buffer', function (hooks) {
+module('AsyncRecordCache - update', function (hooks) {
   let schema: RecordSchema, keyMap: RecordKeyMap;
 
-  // All caches in this module share these transform options
-  const defaultTransformOptions = {};
+  [true, false].forEach((useBuffer) => {
+    module(`useBuffer: ${useBuffer}`, function (hooks) {
+      // All caches in this module share these transform options
+      const defaultTransformOptions = { useBuffer };
 
-  hooks.beforeEach(function () {
-    keyMap = new RecordKeyMap();
-  });
-
-  module('with standard schema', function (hooks) {
-    let cache: ExampleAsyncRecordCache;
-
-    hooks.beforeEach(function () {
-      schema = createSchemaWithRemoteKey();
-      cache = new ExampleAsyncRecordCache({
-        schema,
-        keyMap,
-        defaultTransformOptions
+      hooks.beforeEach(function () {
+        keyMap = new RecordKeyMap();
       });
-    });
 
-    test('#update sets data and #records retrieves it', async function (assert) {
-      assert.expect(4);
+      module('with standard schema', function (hooks) {
+        let cache: ExampleAsyncRecordCache;
 
-      const earth: Record = {
-        type: 'planet',
-        id: '1',
-        attributes: { name: 'Earth' },
-        keys: { remoteId: 'a' }
-      };
-
-      cache.on('patch', (operation, data) => {
-        assert.deepEqual(operation, {
-          op: 'addRecord',
-          record: earth
+        hooks.beforeEach(function () {
+          schema = createSchemaWithRemoteKey();
+          cache = new ExampleAsyncRecordCache({
+            schema,
+            keyMap,
+            defaultTransformOptions
+          });
         });
-        assert.deepEqual(data, earth);
-      });
 
-      await cache.update((t) => t.addRecord(earth));
+        test('#update sets data and #records retrieves it', async function (assert) {
+          assert.expect(4);
 
-      assert.strictEqual(
-        await cache.getRecordAsync({ type: 'planet', id: '1' }),
-        earth,
-        'objects strictly match'
-      );
-      assert.equal(
-        keyMap.keyToId('planet', 'remoteId', 'a'),
-        '1',
-        'key has been mapped'
-      );
-    });
-
-    test('#update can replace records', async function (assert) {
-      assert.expect(5);
-
-      const earth: Record = {
-        type: 'planet',
-        id: '1',
-        attributes: { name: 'Earth' },
-        keys: { remoteId: 'a' }
-      };
-
-      cache.on('patch', (operation, data) => {
-        assert.deepEqual(operation, {
-          op: 'updateRecord',
-          record: earth
-        });
-        assert.deepEqual(data, earth);
-      });
-
-      await cache.update((t) => t.updateRecord(earth));
-
-      assert.deepEqual(
-        await cache.getRecordAsync({ type: 'planet', id: '1' }),
-        earth,
-        'objects deeply match'
-      );
-      assert.notStrictEqual(
-        await cache.getRecordAsync({ type: 'planet', id: '1' }),
-        earth,
-        'objects do not strictly match'
-      );
-      assert.equal(
-        keyMap.keyToId('planet', 'remoteId', 'a'),
-        '1',
-        'key has been mapped'
-      );
-    });
-
-    test('#update can replace keys', async function (assert) {
-      assert.expect(4);
-
-      const earth: Record = { type: 'planet', id: '1' };
-
-      cache.on('patch', (operation, data) => {
-        assert.deepEqual(operation, {
-          op: 'replaceKey',
-          record: earth,
-          key: 'remoteId',
-          value: 'a'
-        });
-        assert.deepEqual(data, {
-          type: 'planet',
-          id: '1',
-          keys: { remoteId: 'a' }
-        });
-      });
-
-      await cache.update((t) => t.replaceKey(earth, 'remoteId', 'a'));
-
-      assert.deepEqual(
-        await cache.getRecordAsync({ type: 'planet', id: '1' }),
-        { type: 'planet', id: '1', keys: { remoteId: 'a' } },
-        'records match'
-      );
-      assert.equal(
-        keyMap.keyToId('planet', 'remoteId', 'a'),
-        '1',
-        'key has been mapped'
-      );
-    });
-
-    test('#update updates the cache and returns primary data', async function (assert) {
-      let p1 = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
-      let p2 = { type: 'planet', id: '2' };
-
-      let result = await cache.update((t) => [
-        t.addRecord(p1),
-        t.removeRecord(p2)
-      ]);
-
-      assert.deepEqual(
-        result,
-        [
-          p1,
-          undefined // p2 didn't exist
-        ],
-        'response includes just primary data'
-      );
-    });
-
-    test('#update updates the cache and returns a full response if requested', async function (assert) {
-      let p1 = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
-      let p2 = { type: 'planet', id: '2' };
-
-      let result = await cache.update(
-        (t) => [t.addRecord(p1), t.removeRecord(p2)],
-        {
-          fullResponse: true
-        }
-      );
-
-      assert.deepEqual(
-        result,
-        {
-          data: [
-            p1,
-            undefined // p2 didn't exist
-          ],
-          details: {
-            appliedOperations: [{ op: 'addRecord', record: p1 }],
-            inverseOperations: [
-              { op: 'removeRecord', record: { type: 'planet', id: '1' } }
-            ]
-          }
-        },
-        'full response includes data and details'
-      );
-    });
-
-    test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added after', async function (assert) {
-      const jupiter: Record = {
-        type: 'planet',
-        id: 'p1',
-        attributes: { name: 'Jupiter' },
-        relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-      };
-      const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' } };
-
-      await cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
-
-      assert.deepEqual(
-        ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-          ?.relationships?.moons.data,
-        [{ type: 'moon', id: 'm1' }],
-        'Io has been assigned to Jupiter'
-      );
-      assert.deepEqual(
-        ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-          ?.relationships?.planet.data,
-        { type: 'planet', id: 'p1' },
-        'Jupiter has been assigned to Io'
-      );
-    });
-
-    test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added before', async function (assert) {
-      const jupiter: Record = {
-        type: 'planet',
-        id: 'p1',
-        attributes: { name: 'Jupiter' },
-        relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-      };
-      const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' } };
-
-      await cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
-
-      assert.deepEqual(
-        ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-          ?.relationships?.moons.data,
-        [{ type: 'moon', id: 'm1' }],
-        'Io has been assigned to Jupiter'
-      );
-      assert.deepEqual(
-        ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-          ?.relationships?.planet.data,
-        { type: 'planet', id: 'p1' },
-        'Jupiter has been assigned to Io'
-      );
-    });
-
-    test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added after', async function (assert) {
-      const io: Record = {
-        type: 'moon',
-        id: 'm1',
-        attributes: { name: 'Io' },
-        relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-      };
-      const jupiter: Record = {
-        type: 'planet',
-        id: 'p1',
-        attributes: { name: 'Jupiter' }
-      };
-
-      await cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
-
-      assert.deepEqual(
-        ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-          ?.relationships?.moons.data,
-        [{ type: 'moon', id: 'm1' }],
-        'Io has been assigned to Jupiter'
-      );
-      assert.deepEqual(
-        ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-          ?.relationships?.planet.data,
-        { type: 'planet', id: 'p1' },
-        'Jupiter has been assigned to Io'
-      );
-    });
-
-    test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added before', async function (assert) {
-      const io: Record = {
-        type: 'moon',
-        id: 'm1',
-        attributes: { name: 'Io' },
-        relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-      };
-      const jupiter: Record = {
-        type: 'planet',
-        id: 'p1',
-        attributes: { name: 'Jupiter' }
-      };
-
-      await cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
-
-      assert.deepEqual(
-        ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-          ?.relationships?.moons.data,
-        [{ type: 'moon', id: 'm1' }],
-        'Io has been assigned to Jupiter'
-      );
-      assert.deepEqual(
-        ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-          ?.relationships?.planet.data,
-        { type: 'planet', id: 'p1' },
-        'Jupiter has been assigned to Io'
-      );
-    });
-
-    test('#update updates inverse hasOne relationship when a record with an empty relationship is added', async function (assert) {
-      const io: Record = {
-        type: 'moon',
-        id: 'm1',
-        attributes: { name: 'Io' },
-        relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-      };
-      const jupiter: Record = {
-        type: 'planet',
-        id: 'p1',
-        attributes: { name: 'Jupiter' },
-        relationships: { moons: { data: [] } }
-      };
-
-      await cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
-
-      assert.deepEqual(
-        ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-          ?.relationships?.moons.data,
-        [],
-        'Jupiter has no moons'
-      );
-      assert.deepEqual(
-        ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-          ?.relationships?.planet.data,
-        null,
-        'Jupiter has been cleared from Io'
-      );
-    });
-
-    test('#update updates inverse hasMany relationship when a record with an empty relationship is added', async function (assert) {
-      const jupiter: Record = {
-        type: 'planet',
-        id: 'p1',
-        attributes: { name: 'Jupiter' },
-        relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-      };
-      const io: Record = {
-        type: 'moon',
-        id: 'm1',
-        attributes: { name: 'Io' },
-        relationships: { planet: { data: null } }
-      };
-
-      await cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
-
-      assert.deepEqual(
-        ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-          ?.relationships?.moons.data,
-        [],
-        'Io has been cleared from Jupiter'
-      );
-      assert.deepEqual(
-        ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-          ?.relationships?.planet.data,
-        null,
-        'Io has no planet'
-      );
-    });
-
-    test('#update updates inverse hasMany polymorphic relationship', async function (assert) {
-      const sun: Record = {
-        type: 'star',
-        id: 's1',
-        attributes: { name: 'Sun' },
-        relationships: {
-          celestialObjects: {
-            data: [
-              { type: 'planet', id: 'p1' },
-              { type: 'moon', id: 'm1' }
-            ]
-          }
-        }
-      };
-      const jupiter: Record = {
-        type: 'planet',
-        id: 'p1',
-        attributes: { name: 'Jupiter' }
-      };
-      const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' } };
-
-      await cache.update((t) => [
-        t.updateRecord(sun),
-        t.updateRecord(jupiter),
-        t.updateRecord(io)
-      ]);
-
-      assert.deepEqual(
-        ((await cache.getRecordAsync({ type: 'star', id: 's1' })) as Record)
-          ?.relationships?.celestialObjects.data,
-        [
-          { type: 'planet', id: 'p1' },
-          { type: 'moon', id: 'm1' }
-        ],
-        'Jupiter and Io has been assigned to Sun'
-      );
-      assert.deepEqual(
-        ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-          ?.relationships?.star.data,
-        { type: 'star', id: 's1' },
-        'Sun has been assigned to Jupiter'
-      );
-      assert.deepEqual(
-        ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-          ?.relationships?.star.data,
-        { type: 'star', id: 's1' },
-        'Sun has been assigned to Io'
-      );
-    });
-
-    test('#update updates inverse hasOne polymorphic relationship', async function (assert) {
-      const jupiter: Record = {
-        type: 'planet',
-        id: 'p1',
-        attributes: { name: 'Jupiter' },
-        relationships: { star: { data: { type: 'star', id: 's1' } } }
-      };
-      const io: Record = {
-        type: 'moon',
-        id: 'm1',
-        attributes: { name: 'Io' },
-        relationships: { star: { data: { type: 'star', id: 's1' } } }
-      };
-      const sun: Record = {
-        type: 'star',
-        id: 's1',
-        attributes: { name: 'Sun' }
-      };
-
-      await cache.update((t) => [
-        t.updateRecord(jupiter),
-        t.updateRecord(io),
-        t.updateRecord(sun)
-      ]);
-
-      assert.deepEqual(
-        ((await cache.getRecordAsync({ type: 'star', id: 's1' })) as Record)
-          ?.relationships?.celestialObjects.data,
-        [
-          { type: 'planet', id: 'p1' },
-          { type: 'moon', id: 'm1' }
-        ],
-        'Jupiter and Io has been assigned to Sun'
-      );
-      assert.deepEqual(
-        ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-          ?.relationships?.star.data,
-        { type: 'star', id: 's1' },
-        'Sun has been assigned to Jupiter'
-      );
-      assert.deepEqual(
-        ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-          ?.relationships?.star.data,
-        { type: 'star', id: 's1' },
-        'Sun has been assigned to Io'
-      );
-    });
-
-    test('#update tracks refs and clears them from hasOne relationships when a referenced record is removed', async function (assert) {
-      const jupiter: Record = {
-        type: 'planet',
-        id: 'p1',
-        attributes: { name: 'Jupiter' },
-        relationships: { moons: { data: undefined } }
-      };
-      const io: Record = {
-        type: 'moon',
-        id: 'm1',
-        attributes: { name: 'Io' },
-        relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-      };
-      const europa: Record = {
-        type: 'moon',
-        id: 'm2',
-        attributes: { name: 'Europa' },
-        relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-      };
-
-      await cache.update((t) => [
-        t.addRecord(jupiter),
-        t.addRecord(io),
-        t.addRecord(europa)
-      ]);
-
-      assert.deepEqual(
-        ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-          ?.relationships?.planet.data,
-        { type: 'planet', id: 'p1' },
-        'Jupiter has been assigned to Io'
-      );
-      assert.deepEqual(
-        ((await cache.getRecordAsync({ type: 'moon', id: 'm2' })) as Record)
-          ?.relationships?.planet.data,
-        { type: 'planet', id: 'p1' },
-        'Jupiter has been assigned to Europa'
-      );
-
-      await cache.update((t) => t.removeRecord(jupiter));
-
-      assert.equal(
-        await cache.getRecordAsync({ type: 'planet', id: 'p1' }),
-        undefined,
-        'Jupiter is GONE'
-      );
-
-      assert.equal(
-        ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-          ?.relationships?.planet.data,
-        undefined,
-        'Jupiter has been cleared from Io'
-      );
-      assert.equal(
-        ((await cache.getRecordAsync({ type: 'moon', id: 'm2' })) as Record)
-          ?.relationships?.planet.data,
-        undefined,
-        'Jupiter has been cleared from Europa'
-      );
-    });
-
-    test('#update tracks refs and clears them from hasMany relationships when a referenced record is removed', async function (assert) {
-      const io: Record = {
-        type: 'moon',
-        id: 'm1',
-        attributes: { name: 'Io' },
-        relationships: { planet: { data: null } }
-      };
-      const europa: Record = {
-        type: 'moon',
-        id: 'm2',
-        attributes: { name: 'Europa' },
-        relationships: { planet: { data: null } }
-      };
-      const jupiter: Record = {
-        type: 'planet',
-        id: 'p1',
-        attributes: { name: 'Jupiter' },
-        relationships: {
-          moons: {
-            data: [
-              { type: 'moon', id: 'm1' },
-              { type: 'moon', id: 'm2' }
-            ]
-          }
-        }
-      };
-
-      await cache.update((t) => [
-        t.addRecord(io),
-        t.addRecord(europa),
-        t.addRecord(jupiter)
-      ]);
-
-      assert.deepEqual(
-        ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-          ?.relationships?.moons.data,
-        [
-          { type: 'moon', id: 'm1' },
-          { type: 'moon', id: 'm2' }
-        ],
-        'Jupiter has been assigned to Io and Europa'
-      );
-      assert.ok(
-        recordsIncludeAll(
-          (await cache.getRelatedRecordsAsync(
-            jupiter,
-            'moons'
-          )) as RecordIdentity[],
-          [io, europa]
-        ),
-        'Jupiter has been assigned to Io and Europa'
-      );
-
-      await cache.update((t) => t.removeRecord(io));
-
-      assert.equal(
-        await cache.getRecordAsync({ type: 'moon', id: 'm1' }),
-        null,
-        'Io is GONE'
-      );
-
-      await cache.update((t) => t.removeRecord(europa));
-
-      assert.equal(
-        await cache.getRecordAsync({ type: 'moon', id: 'm2' }),
-        null,
-        'Europa is GONE'
-      );
-
-      assert.deepEqual(
-        (await cache.getRelatedRecordsAsync(
-          { type: 'planet', id: 'p1' },
-          'moons'
-        )) as RecordIdentity[],
-        [],
-        'moons have been cleared from Jupiter'
-      );
-    });
-
-    test("#update adds link to hasMany if record doesn't exist", async function (assert) {
-      await cache.update((t) =>
-        t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
-          type: 'moon',
-          id: 'm1'
-        })
-      );
-
-      await cache.update((t) =>
-        t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
-          type: 'moon',
-          id: 'm1'
-        })
-      );
-
-      assert.deepEqual(
-        ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-          ?.relationships?.moons.data,
-        [{ type: 'moon', id: 'm1' }],
-        'relationship was added'
-      );
-    });
-
-    test("#update does not remove hasMany relationship if record doesn't exist", async function (assert) {
-      assert.expect(1);
-
-      cache.on('patch', () => {
-        assert.ok(false, 'no operations were applied');
-      });
-
-      await cache.update((t) =>
-        t.removeFromRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
-          type: 'moon',
-          id: 'moon1'
-        })
-      );
-
-      assert.equal(
-        await cache.getRecordAsync({ type: 'planet', id: 'p1' }),
-        undefined,
-        'planet does not exist'
-      );
-    });
-
-    test("#update adds hasOne if record doesn't exist", async function (assert) {
-      assert.expect(2);
-
-      const tb = cache.transformBuilder;
-      const replacePlanet = tb.replaceRelatedRecord(
-        { type: 'moon', id: 'moon1' },
-        'planet',
-        { type: 'planet', id: 'p1' }
-      );
-
-      const addToMoons = tb.addToRelatedRecords(
-        { type: 'planet', id: 'p1' },
-        'moons',
-        { type: 'moon', id: 'moon1' }
-      );
-
-      let order = 0;
-      cache.on('patch', (op) => {
-        order++;
-        if (order === 1) {
-          assert.deepEqual(
-            op,
-            replacePlanet.toOperation(),
-            'applied replacePlanet operation'
-          );
-        } else if (order === 2) {
-          assert.deepEqual(
-            op,
-            addToMoons.toOperation(),
-            'applied addToMoons operation'
-          );
-        } else {
-          assert.ok(false, 'too many ops');
-        }
-      });
-
-      await cache.update([replacePlanet]);
-    });
-
-    test("#update will add empty hasOne link if record doesn't exist", async function (assert) {
-      assert.expect(2);
-
-      const tb = cache.transformBuilder;
-      const clearPlanet = tb.replaceRelatedRecord(
-        { type: 'moon', id: 'moon1' },
-        'planet',
-        null
-      );
-
-      let order = 0;
-      cache.on('patch', (op) => {
-        order++;
-        if (order === 1) {
-          assert.deepEqual(
-            op,
-            clearPlanet.toOperation(),
-            'applied clearPlanet operation'
-          );
-        } else {
-          assert.ok(false, 'too many ops');
-        }
-      });
-
-      await cache.update([clearPlanet]);
-
-      assert.ok(true, 'patch applied');
-    });
-
-    test('#update does not add link to hasMany if link already exists', async function (assert) {
-      assert.expect(1);
-
-      const jupiter: Record = {
-        id: 'p1',
-        type: 'planet',
-        attributes: { name: 'Jupiter' },
-        relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-      };
-
-      await cache.update((t) => t.addRecord(jupiter));
-
-      cache.on('patch', () => {
-        assert.ok(false, 'no operations were applied');
-      });
-
-      await cache.update((t) =>
-        t.addToRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'm1' })
-      );
-
-      assert.ok(true, 'patch completed');
-    });
-
-    test("#update does not remove relationship from hasMany if relationship doesn't exist", async function (assert) {
-      assert.expect(1);
-
-      const jupiter: Record = {
-        id: 'p1',
-        type: 'planet',
-        attributes: { name: 'Jupiter' }
-      };
-
-      await cache.update((t) => t.addRecord(jupiter));
-
-      cache.on('patch', () => {
-        assert.ok(false, 'no operations were applied');
-      });
-
-      await cache.update((t) =>
-        t.removeFromRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'm1' })
-      );
-
-      assert.ok(true, 'patch completed');
-    });
-
-    test('#update can add and remove to has-many relationship', async function (assert) {
-      assert.expect(2);
-
-      const jupiter: Record = { id: 'jupiter', type: 'planet' };
-      await cache.update((t) => t.addRecord(jupiter));
-
-      const callisto: Record = { id: 'callisto', type: 'moon' };
-      await cache.update((t) => t.addRecord(callisto));
-
-      await cache.update((t) =>
-        t.addToRelatedRecords(jupiter, 'moons', {
-          type: 'moon',
-          id: 'callisto'
-        })
-      );
-
-      assert.ok(
-        recordsInclude(
-          (await cache.getRelatedRecordsAsync(
-            jupiter,
-            'moons'
-          )) as RecordIdentity[],
-          callisto
-        ),
-        'moon added'
-      );
-
-      await cache.update((t) =>
-        t.removeFromRelatedRecords(jupiter, 'moons', {
-          type: 'moon',
-          id: 'callisto'
-        })
-      );
-
-      assert.notOk(
-        recordsInclude(
-          (await cache.getRelatedRecordsAsync(
-            jupiter,
-            'moons'
-          )) as RecordIdentity[],
-          callisto
-        ),
-        'moon removed'
-      );
-    });
-
-    test('#update can add and clear has-one relationship', async function (assert) {
-      assert.expect(2);
-
-      const jupiter: Record = { id: 'jupiter', type: 'planet' };
-      await cache.update((t) => t.addRecord(jupiter));
-
-      const callisto: Record = { id: 'callisto', type: 'moon' };
-      await cache.update((t) => t.addRecord(callisto));
-
-      await cache.update((t) =>
-        t.replaceRelatedRecord(callisto, 'planet', {
-          type: 'planet',
-          id: 'jupiter'
-        })
-      );
-
-      assert.ok(
-        equalRecordIdentities(
-          (await cache.getRelatedRecordAsync(
-            callisto,
-            'planet'
-          )) as RecordIdentity,
-          jupiter
-        ),
-        'relationship added'
-      );
-
-      await cache.update((t) =>
-        t.replaceRelatedRecord(callisto, 'planet', null)
-      );
-
-      assert.notOk(
-        equalRecordIdentities(
-          (await cache.getRelatedRecordAsync(
-            callisto,
-            'planet'
-          )) as RecordIdentity,
-          jupiter
-        ),
-        'relationship cleared'
-      );
-    });
-
-    test('does not replace hasOne if relationship already exists', async function (assert) {
-      assert.expect(1);
-
-      const europa: Record = {
-        id: 'm1',
-        type: 'moon',
-        attributes: { name: 'Europa' },
-        relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-      };
-
-      await cache.update((t) => t.addRecord(europa));
-
-      cache.on('patch', () => {
-        assert.ok(false, 'no operations were applied');
-      });
-
-      await cache.update((t) =>
-        t.replaceRelatedRecord(europa, 'planet', { type: 'planet', id: 'p1' })
-      );
-
-      assert.ok(true, 'patch completed');
-    });
-
-    test("does not remove hasOne if relationship doesn't exist", async function (assert) {
-      assert.expect(1);
-
-      const europa: Record = {
-        type: 'moon',
-        id: 'm1',
-        attributes: { name: 'Europa' },
-        relationships: { planet: { data: null } }
-      };
-
-      await cache.update((t) => t.addRecord(europa));
-
-      cache.on('patch', () => {
-        assert.ok(false, 'no operations were applied');
-      });
-
-      await cache.update((t) => t.replaceRelatedRecord(europa, 'planet', null));
-
-      assert.ok(true, 'patch completed');
-    });
-
-    test('#update merges records when "replacing" and will not stomp on attributes and relationships that are not replaced', async function (assert) {
-      const tb = cache.transformBuilder;
-
-      await cache.update((t) => [
-        t.addRecord({
-          type: 'planet',
-          id: '1',
-          attributes: { name: 'Earth' },
-          relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-        })
-      ]);
-
-      let result = await cache.update(
-        (t) => [
-          t.updateRecord({
-            type: 'planet',
-            id: '1',
-            attributes: { classification: 'terrestrial' }
-          })
-        ],
-        { fullResponse: true }
-      );
-
-      assert.deepEqual(
-        await cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
-        {
-          type: 'planet',
-          id: '1',
-          attributes: { name: 'Earth', classification: 'terrestrial' },
-          relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-        },
-        'records have been merged'
-      );
-
-      assert.deepEqual(
-        result,
-        {
-          data: {
-            type: 'planet',
-            id: '1',
-            attributes: {
-              name: 'Earth',
-              classification: 'terrestrial'
-            },
-            relationships: {
-              moons: {
-                data: [{ type: 'moon', id: 'm1' }]
-              }
-            }
-          },
-          details: {
-            appliedOperations: [
-              tb
-                .updateRecord({
-                  type: 'planet',
-                  id: '1',
-                  attributes: { classification: 'terrestrial' }
-                })
-                .toOperation()
-            ],
-            inverseOperations: [
-              tb
-                .updateRecord({
-                  type: 'planet',
-                  id: '1',
-                  attributes: { classification: null }
-                })
-                .toOperation()
-            ]
-          }
-        },
-        'full response is correct'
-      );
-    });
-
-    test('#update can replace related records but only if they are different', async function (assert) {
-      const tb = cache.transformBuilder;
-
-      await cache.update((t) => [
-        t.addRecord({
-          type: 'planet',
-          id: '1',
-          attributes: { name: 'Earth' },
-          relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-        })
-      ]);
-
-      let result = await cache.update(
-        (t) => [
-          t.replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
-            { type: 'moon', id: 'm1' }
-          ])
-        ],
-        { fullResponse: true }
-      );
-
-      assert.deepEqual(
-        result,
-        {
-          data: undefined,
-          details: {
-            appliedOperations: [],
-            inverseOperations: []
-          }
-        },
-        'nothing has changed so there are no appliend or inverse ops'
-      );
-
-      result = await cache.update(
-        (t) =>
-          t.replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
-            { type: 'moon', id: 'm2' }
-          ]),
-        { fullResponse: true }
-      );
-
-      assert.deepEqual(
-        await cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
-        {
-          type: 'planet',
-          id: '1',
-          attributes: { name: 'Earth' },
-          relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
-        },
-        'relationships have been replaced'
-      );
-
-      assert.deepEqual(
-        result,
-        {
-          data: {
+          const earth: Record = {
             type: 'planet',
             id: '1',
             attributes: { name: 'Earth' },
-            relationships: {
-              moons: { data: [{ type: 'moon', id: 'm2' }] }
-            }
-          },
-          details: {
-            appliedOperations: [
-              tb
-                .replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
-                  { type: 'moon', id: 'm2' }
-                ])
-                .toOperation(),
-              tb
-                .replaceRelatedRecord(
-                  { type: 'moon', id: 'm1' },
-                  'planet',
-                  null
-                )
-                .toOperation(),
-              tb
-                .replaceRelatedRecord({ type: 'moon', id: 'm2' }, 'planet', {
-                  type: 'planet',
-                  id: '1'
-                })
-                .toOperation()
-            ],
-            inverseOperations: [
-              tb
-                .replaceRelatedRecord(
-                  { type: 'moon', id: 'm2' },
-                  'planet',
-                  null
-                )
-                .toOperation(),
-              tb
-                .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
-                  type: 'planet',
-                  id: '1'
-                })
-                .toOperation(),
-              tb
-                .replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
-                  { type: 'moon', id: 'm1' }
-                ])
-                .toOperation()
-            ]
-          }
-        },
-        'full response is correct'
-      );
-    });
+            keys: { remoteId: 'a' }
+          };
 
-    test('#update merges records when "replacing" and _will_ replace specified attributes and relationships', async function (assert) {
-      const tb = cache.transformBuilder;
+          cache.on('patch', (operation, data) => {
+            assert.deepEqual(operation, {
+              op: 'addRecord',
+              record: earth
+            });
+            assert.deepEqual(data, earth);
+          });
 
-      const earth: Record = {
-        type: 'planet',
-        id: '1',
-        attributes: { name: 'Earth' },
-        relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-      };
+          await cache.update((t) => t.addRecord(earth));
 
-      const jupiter: Record = {
-        type: 'planet',
-        id: '1',
-        attributes: { name: 'Jupiter', classification: 'terrestrial' },
-        relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
-      };
+          assert.strictEqual(
+            await cache.getRecordAsync({ type: 'planet', id: '1' }),
+            earth,
+            'objects strictly match'
+          );
+          assert.equal(
+            keyMap.keyToId('planet', 'remoteId', 'a'),
+            '1',
+            'key has been mapped'
+          );
+        });
 
-      let result = await cache.update([tb.addRecord(earth)], {
-        fullResponse: true
-      });
+        test('#update can replace records', async function (assert) {
+          assert.expect(5);
 
-      assert.deepEqual(
-        result,
-        {
-          data: earth,
-          details: {
-            appliedOperations: [
-              tb.addRecord(earth).toOperation(),
-              tb
-                .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
-                  type: 'planet',
-                  id: '1'
-                })
-                .toOperation()
-            ],
-            inverseOperations: [
-              tb
-                .replaceRelatedRecord(
-                  { type: 'moon', id: 'm1' },
-                  'planet',
-                  null
-                )
-                .toOperation(),
-              tb
-                .removeRecord({
-                  type: 'planet',
-                  id: '1'
-                })
-                .toOperation()
-            ]
-          }
-        },
-        'addRecord full response is correct'
-      );
-
-      result = await cache.update([tb.updateRecord(jupiter)], {
-        fullResponse: true
-      });
-
-      assert.deepEqual(result, {
-        data: jupiter,
-        details: {
-          appliedOperations: [
-            tb.updateRecord(jupiter).toOperation(),
-            tb
-              .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', null)
-              .toOperation(),
-            tb
-              .replaceRelatedRecord({ type: 'moon', id: 'm2' }, 'planet', {
-                type: 'planet',
-                id: '1'
-              })
-              .toOperation()
-          ],
-          inverseOperations: [
-            tb
-              .replaceRelatedRecord({ type: 'moon', id: 'm2' }, 'planet', null)
-              .toOperation(),
-            tb
-              .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
-                type: 'planet',
-                id: '1'
-              })
-              .toOperation(),
-            tb
-              .updateRecord({
-                type: 'planet',
-                id: '1',
-                attributes: { name: 'Earth', classification: null },
-                relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-              })
-              .toOperation()
-          ]
-        }
-      });
-
-      assert.deepEqual(
-        await cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
-        {
-          type: 'planet',
-          id: '1',
-          attributes: { name: 'Jupiter', classification: 'terrestrial' },
-          relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
-        },
-        'records have been merged'
-      );
-    });
-
-    test('#update can update existing record with empty relationship', async function (assert) {
-      const tb = cache.transformBuilder;
-
-      let result = await cache.update(
-        (t) => [t.addRecord({ id: '1', type: 'planet' })],
-        { fullResponse: true }
-      );
-
-      assert.deepEqual(
-        result,
-        {
-          data: { id: '1', type: 'planet' },
-          details: {
-            appliedOperations: [
-              tb
-                .addRecord({
-                  type: 'planet',
-                  id: '1'
-                })
-                .toOperation()
-            ],
-            inverseOperations: [
-              tb
-                .removeRecord({
-                  type: 'planet',
-                  id: '1'
-                })
-                .toOperation()
-            ]
-          }
-        },
-        'addRecord result is correct'
-      );
-
-      result = await cache.update(
-        (t) => [
-          t.updateRecord({
-            id: '1',
+          const earth: Record = {
             type: 'planet',
-            relationships: {
-              moons: { data: [] }
-            }
-          })
-        ],
-        { fullResponse: true }
-      );
-
-      assert.deepEqual(
-        result,
-        {
-          data: {
             id: '1',
-            type: 'planet',
-            relationships: {
-              moons: { data: [] }
-            }
-          },
-          details: {
-            appliedOperations: [
-              tb
-                .updateRecord({
-                  id: '1',
-                  type: 'planet',
-                  relationships: {
-                    moons: { data: [] }
-                  }
-                })
-                .toOperation()
-            ],
-            inverseOperations: [
-              tb
-                .updateRecord({
-                  id: '1',
-                  type: 'planet',
-                  relationships: {
-                    moons: { data: [] }
-                  }
-                })
-                .toOperation()
-            ]
-          }
-        },
-        'updateRecord result is correct'
-      );
+            attributes: { name: 'Earth' },
+            keys: { remoteId: 'a' }
+          };
 
-      const planet = await cache.getRecordAsync({ type: 'planet', id: '1' });
-      assert.ok(planet, 'planet exists');
-      assert.deepEqual(
-        planet?.relationships?.moons.data,
-        [],
-        'planet has empty moons relationship'
-      );
-    });
+          cache.on('patch', (operation, data) => {
+            assert.deepEqual(operation, {
+              op: 'updateRecord',
+              record: earth
+            });
+            assert.deepEqual(data, earth);
+          });
 
-    test('#update will not overwrite an existing relationship with a missing relationship', async function (assert) {
-      const tb = cache.transformBuilder;
+          await cache.update((t) => t.updateRecord(earth));
 
-      let result = await cache.update(
-        (t) => [
-          t.addRecord({
-            id: '1',
-            type: 'planet',
-            relationships: {
-              moons: { data: [{ type: 'moon', id: 'm1' }] }
-            }
-          }),
-          t.updateRecord({
-            id: '1',
-            type: 'planet'
-          })
-        ],
-        { fullResponse: true }
-      );
+          assert.deepEqual(
+            await cache.getRecordAsync({ type: 'planet', id: '1' }),
+            earth,
+            'objects deeply match'
+          );
+          assert.notStrictEqual(
+            await cache.getRecordAsync({ type: 'planet', id: '1' }),
+            earth,
+            'objects do not strictly match'
+          );
+          assert.equal(
+            keyMap.keyToId('planet', 'remoteId', 'a'),
+            '1',
+            'key has been mapped'
+          );
+        });
 
-      assert.deepEqual(
-        result,
-        {
-          data: [
-            {
-              id: '1',
+        test('#update can replace keys', async function (assert) {
+          assert.expect(4);
+
+          const earth: Record = { type: 'planet', id: '1' };
+
+          cache.on('patch', (operation, data) => {
+            assert.deepEqual(operation, {
+              op: 'replaceKey',
+              record: earth,
+              key: 'remoteId',
+              value: 'a'
+            });
+            assert.deepEqual(data, {
               type: 'planet',
-              relationships: {
-                moons: { data: [{ type: 'moon', id: 'm1' }] }
+              id: '1',
+              keys: { remoteId: 'a' }
+            });
+          });
+
+          await cache.update((t) => t.replaceKey(earth, 'remoteId', 'a'));
+
+          assert.deepEqual(
+            await cache.getRecordAsync({ type: 'planet', id: '1' }),
+            { type: 'planet', id: '1', keys: { remoteId: 'a' } },
+            'records match'
+          );
+          assert.equal(
+            keyMap.keyToId('planet', 'remoteId', 'a'),
+            '1',
+            'key has been mapped'
+          );
+        });
+
+        test('#update updates the cache and returns primary data', async function (assert) {
+          let p1 = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
+          let p2 = { type: 'planet', id: '2' };
+
+          let result = await cache.update((t) => [
+            t.addRecord(p1),
+            t.removeRecord(p2)
+          ]);
+
+          assert.deepEqual(
+            result,
+            [
+              p1,
+              undefined // p2 didn't exist
+            ],
+            'response includes just primary data'
+          );
+        });
+
+        test('#update updates the cache and returns a full response if requested', async function (assert) {
+          let p1 = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
+          let p2 = { type: 'planet', id: '2' };
+
+          let result = await cache.update(
+            (t) => [t.addRecord(p1), t.removeRecord(p2)],
+            {
+              fullResponse: true
+            }
+          );
+
+          assert.deepEqual(
+            result,
+            {
+              data: [
+                p1,
+                undefined // p2 didn't exist
+              ],
+              details: {
+                appliedOperations: [{ op: 'addRecord', record: p1 }],
+                appliedOperationResults: [p1],
+                inverseOperations: [
+                  { op: 'removeRecord', record: { type: 'planet', id: '1' } }
+                ]
               }
             },
-            undefined
-          ],
-          details: {
-            appliedOperations: [
-              tb
-                .addRecord({
+            'full response includes data and details'
+          );
+        });
+
+        test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added after', async function (assert) {
+          const jupiter: Record = {
+            type: 'planet',
+            id: 'p1',
+            attributes: { name: 'Jupiter' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+          };
+          const io: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Io' }
+          };
+
+          await cache.update((t) => [
+            t.updateRecord(jupiter),
+            t.updateRecord(io)
+          ]);
+
+          assert.deepEqual(
+            ((await cache.getRecordAsync({
+              type: 'planet',
+              id: 'p1'
+            })) as Record)?.relationships?.moons.data,
+            [{ type: 'moon', id: 'm1' }],
+            'Io has been assigned to Jupiter'
+          );
+          assert.deepEqual(
+            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+              ?.relationships?.planet.data,
+            { type: 'planet', id: 'p1' },
+            'Jupiter has been assigned to Io'
+          );
+        });
+
+        test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added before', async function (assert) {
+          const jupiter: Record = {
+            type: 'planet',
+            id: 'p1',
+            attributes: { name: 'Jupiter' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+          };
+          const io: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Io' }
+          };
+
+          await cache.update((t) => [
+            t.updateRecord(io),
+            t.updateRecord(jupiter)
+          ]);
+
+          assert.deepEqual(
+            ((await cache.getRecordAsync({
+              type: 'planet',
+              id: 'p1'
+            })) as Record)?.relationships?.moons.data,
+            [{ type: 'moon', id: 'm1' }],
+            'Io has been assigned to Jupiter'
+          );
+          assert.deepEqual(
+            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+              ?.relationships?.planet.data,
+            { type: 'planet', id: 'p1' },
+            'Jupiter has been assigned to Io'
+          );
+        });
+
+        test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added after', async function (assert) {
+          const io: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Io' },
+            relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+          };
+          const jupiter: Record = {
+            type: 'planet',
+            id: 'p1',
+            attributes: { name: 'Jupiter' }
+          };
+
+          await cache.update((t) => [
+            t.updateRecord(io),
+            t.updateRecord(jupiter)
+          ]);
+
+          assert.deepEqual(
+            ((await cache.getRecordAsync({
+              type: 'planet',
+              id: 'p1'
+            })) as Record)?.relationships?.moons.data,
+            [{ type: 'moon', id: 'm1' }],
+            'Io has been assigned to Jupiter'
+          );
+          assert.deepEqual(
+            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+              ?.relationships?.planet.data,
+            { type: 'planet', id: 'p1' },
+            'Jupiter has been assigned to Io'
+          );
+        });
+
+        test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added before', async function (assert) {
+          const io: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Io' },
+            relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+          };
+          const jupiter: Record = {
+            type: 'planet',
+            id: 'p1',
+            attributes: { name: 'Jupiter' }
+          };
+
+          await cache.update((t) => [
+            t.updateRecord(jupiter),
+            t.updateRecord(io)
+          ]);
+
+          assert.deepEqual(
+            ((await cache.getRecordAsync({
+              type: 'planet',
+              id: 'p1'
+            })) as Record)?.relationships?.moons.data,
+            [{ type: 'moon', id: 'm1' }],
+            'Io has been assigned to Jupiter'
+          );
+          assert.deepEqual(
+            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+              ?.relationships?.planet.data,
+            { type: 'planet', id: 'p1' },
+            'Jupiter has been assigned to Io'
+          );
+        });
+
+        test('#update updates inverse hasOne relationship when a record with an empty relationship is added', async function (assert) {
+          const io: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Io' },
+            relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+          };
+          const jupiter: Record = {
+            type: 'planet',
+            id: 'p1',
+            attributes: { name: 'Jupiter' },
+            relationships: { moons: { data: [] } }
+          };
+
+          await cache.update((t) => [
+            t.updateRecord(io),
+            t.updateRecord(jupiter)
+          ]);
+
+          assert.deepEqual(
+            ((await cache.getRecordAsync({
+              type: 'planet',
+              id: 'p1'
+            })) as Record)?.relationships?.moons.data,
+            [],
+            'Jupiter has no moons'
+          );
+          assert.deepEqual(
+            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+              ?.relationships?.planet.data,
+            null,
+            'Jupiter has been cleared from Io'
+          );
+        });
+
+        test('#update updates inverse hasMany relationship when a record with an empty relationship is added', async function (assert) {
+          const jupiter: Record = {
+            type: 'planet',
+            id: 'p1',
+            attributes: { name: 'Jupiter' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+          };
+          const io: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Io' },
+            relationships: { planet: { data: null } }
+          };
+
+          await cache.update((t) => [
+            t.updateRecord(jupiter),
+            t.updateRecord(io)
+          ]);
+
+          assert.deepEqual(
+            ((await cache.getRecordAsync({
+              type: 'planet',
+              id: 'p1'
+            })) as Record)?.relationships?.moons.data,
+            [],
+            'Io has been cleared from Jupiter'
+          );
+          assert.deepEqual(
+            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+              ?.relationships?.planet.data,
+            null,
+            'Io has no planet'
+          );
+        });
+
+        test('#update updates inverse hasMany polymorphic relationship', async function (assert) {
+          const sun: Record = {
+            type: 'star',
+            id: 's1',
+            attributes: { name: 'Sun' },
+            relationships: {
+              celestialObjects: {
+                data: [
+                  { type: 'planet', id: 'p1' },
+                  { type: 'moon', id: 'm1' }
+                ]
+              }
+            }
+          };
+          const jupiter: Record = {
+            type: 'planet',
+            id: 'p1',
+            attributes: { name: 'Jupiter' }
+          };
+          const io: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Io' }
+          };
+
+          await cache.update((t) => [
+            t.updateRecord(sun),
+            t.updateRecord(jupiter),
+            t.updateRecord(io)
+          ]);
+
+          assert.deepEqual(
+            ((await cache.getRecordAsync({ type: 'star', id: 's1' })) as Record)
+              ?.relationships?.celestialObjects.data,
+            [
+              { type: 'planet', id: 'p1' },
+              { type: 'moon', id: 'm1' }
+            ],
+            'Jupiter and Io has been assigned to Sun'
+          );
+          assert.deepEqual(
+            ((await cache.getRecordAsync({
+              type: 'planet',
+              id: 'p1'
+            })) as Record)?.relationships?.star.data,
+            { type: 'star', id: 's1' },
+            'Sun has been assigned to Jupiter'
+          );
+          assert.deepEqual(
+            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+              ?.relationships?.star.data,
+            { type: 'star', id: 's1' },
+            'Sun has been assigned to Io'
+          );
+        });
+
+        test('#update updates inverse hasOne polymorphic relationship', async function (assert) {
+          const jupiter: Record = {
+            type: 'planet',
+            id: 'p1',
+            attributes: { name: 'Jupiter' },
+            relationships: { star: { data: { type: 'star', id: 's1' } } }
+          };
+          const io: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Io' },
+            relationships: { star: { data: { type: 'star', id: 's1' } } }
+          };
+          const sun: Record = {
+            type: 'star',
+            id: 's1',
+            attributes: { name: 'Sun' }
+          };
+
+          await cache.update((t) => [
+            t.updateRecord(jupiter),
+            t.updateRecord(io),
+            t.updateRecord(sun)
+          ]);
+
+          assert.deepEqual(
+            ((await cache.getRecordAsync({ type: 'star', id: 's1' })) as Record)
+              ?.relationships?.celestialObjects.data,
+            [
+              { type: 'planet', id: 'p1' },
+              { type: 'moon', id: 'm1' }
+            ],
+            'Jupiter and Io has been assigned to Sun'
+          );
+          assert.deepEqual(
+            ((await cache.getRecordAsync({
+              type: 'planet',
+              id: 'p1'
+            })) as Record)?.relationships?.star.data,
+            { type: 'star', id: 's1' },
+            'Sun has been assigned to Jupiter'
+          );
+          assert.deepEqual(
+            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+              ?.relationships?.star.data,
+            { type: 'star', id: 's1' },
+            'Sun has been assigned to Io'
+          );
+        });
+
+        test('#update tracks refs and clears them from hasOne relationships when a referenced record is removed', async function (assert) {
+          const jupiter: Record = {
+            type: 'planet',
+            id: 'p1',
+            attributes: { name: 'Jupiter' },
+            relationships: { moons: { data: undefined } }
+          };
+          const io: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Io' },
+            relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+          };
+          const europa: Record = {
+            type: 'moon',
+            id: 'm2',
+            attributes: { name: 'Europa' },
+            relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+          };
+
+          await cache.update((t) => [
+            t.addRecord(jupiter),
+            t.addRecord(io),
+            t.addRecord(europa)
+          ]);
+
+          assert.deepEqual(
+            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+              ?.relationships?.planet.data,
+            { type: 'planet', id: 'p1' },
+            'Jupiter has been assigned to Io'
+          );
+          assert.deepEqual(
+            ((await cache.getRecordAsync({ type: 'moon', id: 'm2' })) as Record)
+              ?.relationships?.planet.data,
+            { type: 'planet', id: 'p1' },
+            'Jupiter has been assigned to Europa'
+          );
+
+          await cache.update((t) => t.removeRecord(jupiter));
+
+          assert.equal(
+            await cache.getRecordAsync({ type: 'planet', id: 'p1' }),
+            undefined,
+            'Jupiter is GONE'
+          );
+
+          assert.equal(
+            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+              ?.relationships?.planet.data,
+            undefined,
+            'Jupiter has been cleared from Io'
+          );
+          assert.equal(
+            ((await cache.getRecordAsync({ type: 'moon', id: 'm2' })) as Record)
+              ?.relationships?.planet.data,
+            undefined,
+            'Jupiter has been cleared from Europa'
+          );
+        });
+
+        test('#update tracks refs and clears them from hasMany relationships when a referenced record is removed', async function (assert) {
+          const io: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Io' },
+            relationships: { planet: { data: null } }
+          };
+          const europa: Record = {
+            type: 'moon',
+            id: 'm2',
+            attributes: { name: 'Europa' },
+            relationships: { planet: { data: null } }
+          };
+          const jupiter: Record = {
+            type: 'planet',
+            id: 'p1',
+            attributes: { name: 'Jupiter' },
+            relationships: {
+              moons: {
+                data: [
+                  { type: 'moon', id: 'm1' },
+                  { type: 'moon', id: 'm2' }
+                ]
+              }
+            }
+          };
+
+          await cache.update((t) => [
+            t.addRecord(io),
+            t.addRecord(europa),
+            t.addRecord(jupiter)
+          ]);
+
+          assert.deepEqual(
+            ((await cache.getRecordAsync({
+              type: 'planet',
+              id: 'p1'
+            })) as Record)?.relationships?.moons.data,
+            [
+              { type: 'moon', id: 'm1' },
+              { type: 'moon', id: 'm2' }
+            ],
+            'Jupiter has been assigned to Io and Europa'
+          );
+          assert.ok(
+            recordsIncludeAll(
+              (await cache.getRelatedRecordsAsync(
+                jupiter,
+                'moons'
+              )) as RecordIdentity[],
+              [io, europa]
+            ),
+            'Jupiter has been assigned to Io and Europa'
+          );
+
+          await cache.update((t) => t.removeRecord(io));
+
+          assert.equal(
+            await cache.getRecordAsync({ type: 'moon', id: 'm1' }),
+            null,
+            'Io is GONE'
+          );
+
+          await cache.update((t) => t.removeRecord(europa));
+
+          assert.equal(
+            await cache.getRecordAsync({ type: 'moon', id: 'm2' }),
+            null,
+            'Europa is GONE'
+          );
+
+          assert.deepEqual(
+            (await cache.getRelatedRecordsAsync(
+              { type: 'planet', id: 'p1' },
+              'moons'
+            )) as RecordIdentity[],
+            [],
+            'moons have been cleared from Jupiter'
+          );
+        });
+
+        test("#update adds link to hasMany if record doesn't exist", async function (assert) {
+          await cache.update((t) =>
+            t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+              type: 'moon',
+              id: 'm1'
+            })
+          );
+
+          await cache.update((t) =>
+            t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+              type: 'moon',
+              id: 'm1'
+            })
+          );
+
+          assert.deepEqual(
+            ((await cache.getRecordAsync({
+              type: 'planet',
+              id: 'p1'
+            })) as Record)?.relationships?.moons.data,
+            [{ type: 'moon', id: 'm1' }],
+            'relationship was added'
+          );
+        });
+
+        test("#update does not remove hasMany relationship if record doesn't exist", async function (assert) {
+          assert.expect(1);
+
+          cache.on('patch', () => {
+            assert.ok(false, 'no operations were applied');
+          });
+
+          await cache.update((t) =>
+            t.removeFromRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+              type: 'moon',
+              id: 'moon1'
+            })
+          );
+
+          assert.equal(
+            await cache.getRecordAsync({ type: 'planet', id: 'p1' }),
+            undefined,
+            'planet does not exist'
+          );
+        });
+
+        test("#update adds hasOne if record doesn't exist", async function (assert) {
+          assert.expect(2);
+
+          const tb = cache.transformBuilder;
+          const replacePlanet = tb.replaceRelatedRecord(
+            { type: 'moon', id: 'moon1' },
+            'planet',
+            { type: 'planet', id: 'p1' }
+          );
+
+          const addToMoons = tb.addToRelatedRecords(
+            { type: 'planet', id: 'p1' },
+            'moons',
+            { type: 'moon', id: 'moon1' }
+          );
+
+          let order = 0;
+          cache.on('patch', (op) => {
+            order++;
+            if (order === 1) {
+              assert.deepEqual(
+                op,
+                replacePlanet.toOperation(),
+                'applied replacePlanet operation'
+              );
+            } else if (order === 2) {
+              assert.deepEqual(
+                op,
+                addToMoons.toOperation(),
+                'applied addToMoons operation'
+              );
+            } else {
+              assert.ok(false, 'too many ops');
+            }
+          });
+
+          await cache.update([replacePlanet]);
+        });
+
+        test("#update will add empty hasOne link if record doesn't exist", async function (assert) {
+          assert.expect(2);
+
+          const tb = cache.transformBuilder;
+          const clearPlanet = tb.replaceRelatedRecord(
+            { type: 'moon', id: 'moon1' },
+            'planet',
+            null
+          );
+
+          let order = 0;
+          cache.on('patch', (op) => {
+            order++;
+            if (order === 1) {
+              assert.deepEqual(
+                op,
+                clearPlanet.toOperation(),
+                'applied clearPlanet operation'
+              );
+            } else {
+              assert.ok(false, 'too many ops');
+            }
+          });
+
+          await cache.update([clearPlanet]);
+
+          assert.ok(true, 'patch applied');
+        });
+
+        test('#update does not add link to hasMany if link already exists', async function (assert) {
+          assert.expect(1);
+
+          const jupiter: Record = {
+            id: 'p1',
+            type: 'planet',
+            attributes: { name: 'Jupiter' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+          };
+
+          await cache.update((t) => t.addRecord(jupiter));
+
+          cache.on('patch', () => {
+            assert.ok(false, 'no operations were applied');
+          });
+
+          await cache.update((t) =>
+            t.addToRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'm1' })
+          );
+
+          assert.ok(true, 'patch completed');
+        });
+
+        test("#update does not remove relationship from hasMany if relationship doesn't exist", async function (assert) {
+          assert.expect(1);
+
+          const jupiter: Record = {
+            id: 'p1',
+            type: 'planet',
+            attributes: { name: 'Jupiter' }
+          };
+
+          await cache.update((t) => t.addRecord(jupiter));
+
+          cache.on('patch', () => {
+            assert.ok(false, 'no operations were applied');
+          });
+
+          await cache.update((t) =>
+            t.removeFromRelatedRecords(jupiter, 'moons', {
+              type: 'moon',
+              id: 'm1'
+            })
+          );
+
+          assert.ok(true, 'patch completed');
+        });
+
+        test('#update can add and remove to has-many relationship', async function (assert) {
+          assert.expect(2);
+
+          const jupiter: Record = { id: 'jupiter', type: 'planet' };
+          await cache.update((t) => t.addRecord(jupiter));
+
+          const callisto: Record = { id: 'callisto', type: 'moon' };
+          await cache.update((t) => t.addRecord(callisto));
+
+          await cache.update((t) =>
+            t.addToRelatedRecords(jupiter, 'moons', {
+              type: 'moon',
+              id: 'callisto'
+            })
+          );
+
+          assert.ok(
+            recordsInclude(
+              (await cache.getRelatedRecordsAsync(
+                jupiter,
+                'moons'
+              )) as RecordIdentity[],
+              callisto
+            ),
+            'moon added'
+          );
+
+          await cache.update((t) =>
+            t.removeFromRelatedRecords(jupiter, 'moons', {
+              type: 'moon',
+              id: 'callisto'
+            })
+          );
+
+          assert.notOk(
+            recordsInclude(
+              (await cache.getRelatedRecordsAsync(
+                jupiter,
+                'moons'
+              )) as RecordIdentity[],
+              callisto
+            ),
+            'moon removed'
+          );
+        });
+
+        test('#update can add and clear has-one relationship', async function (assert) {
+          assert.expect(2);
+
+          const jupiter: Record = { id: 'jupiter', type: 'planet' };
+          await cache.update((t) => t.addRecord(jupiter));
+
+          const callisto: Record = { id: 'callisto', type: 'moon' };
+          await cache.update((t) => t.addRecord(callisto));
+
+          await cache.update((t) =>
+            t.replaceRelatedRecord(callisto, 'planet', {
+              type: 'planet',
+              id: 'jupiter'
+            })
+          );
+
+          assert.ok(
+            equalRecordIdentities(
+              (await cache.getRelatedRecordAsync(
+                callisto,
+                'planet'
+              )) as RecordIdentity,
+              jupiter
+            ),
+            'relationship added'
+          );
+
+          await cache.update((t) =>
+            t.replaceRelatedRecord(callisto, 'planet', null)
+          );
+
+          assert.notOk(
+            equalRecordIdentities(
+              (await cache.getRelatedRecordAsync(
+                callisto,
+                'planet'
+              )) as RecordIdentity,
+              jupiter
+            ),
+            'relationship cleared'
+          );
+        });
+
+        test('does not replace hasOne if relationship already exists', async function (assert) {
+          assert.expect(1);
+
+          const europa: Record = {
+            id: 'm1',
+            type: 'moon',
+            attributes: { name: 'Europa' },
+            relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+          };
+
+          await cache.update((t) => t.addRecord(europa));
+
+          cache.on('patch', () => {
+            assert.ok(false, 'no operations were applied');
+          });
+
+          await cache.update((t) =>
+            t.replaceRelatedRecord(europa, 'planet', {
+              type: 'planet',
+              id: 'p1'
+            })
+          );
+
+          assert.ok(true, 'patch completed');
+        });
+
+        test("does not remove hasOne if relationship doesn't exist", async function (assert) {
+          assert.expect(1);
+
+          const europa: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Europa' },
+            relationships: { planet: { data: null } }
+          };
+
+          await cache.update((t) => t.addRecord(europa));
+
+          cache.on('patch', () => {
+            assert.ok(false, 'no operations were applied');
+          });
+
+          await cache.update((t) =>
+            t.replaceRelatedRecord(europa, 'planet', null)
+          );
+
+          assert.ok(true, 'patch completed');
+        });
+
+        test('#update merges records when "replacing" and will not stomp on attributes and relationships that are not replaced', async function (assert) {
+          const tb = cache.transformBuilder;
+
+          await cache.update((t) => [
+            t.addRecord({
+              type: 'planet',
+              id: '1',
+              attributes: { name: 'Earth' },
+              relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+            })
+          ]);
+
+          let result = await cache.update(
+            (t) => [
+              t.updateRecord({
+                type: 'planet',
+                id: '1',
+                attributes: { classification: 'terrestrial' }
+              })
+            ],
+            { fullResponse: true }
+          );
+
+          assert.deepEqual(
+            await cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
+            {
+              type: 'planet',
+              id: '1',
+              attributes: { name: 'Earth', classification: 'terrestrial' },
+              relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+            },
+            'records have been merged'
+          );
+
+          assert.deepEqual(
+            result,
+            {
+              data: {
+                type: 'planet',
+                id: '1',
+                attributes: {
+                  name: 'Earth',
+                  classification: 'terrestrial'
+                },
+                relationships: {
+                  moons: {
+                    data: [{ type: 'moon', id: 'm1' }]
+                  }
+                }
+              },
+              details: {
+                appliedOperations: [
+                  tb
+                    .updateRecord({
+                      type: 'planet',
+                      id: '1',
+                      attributes: { classification: 'terrestrial' }
+                    })
+                    .toOperation()
+                ],
+                appliedOperationResults: [
+                  {
+                    type: 'planet',
+                    id: '1',
+                    attributes: {
+                      name: 'Earth',
+                      classification: 'terrestrial'
+                    },
+                    relationships: {
+                      moons: {
+                        data: [{ type: 'moon', id: 'm1' }]
+                      }
+                    }
+                  }
+                ],
+                inverseOperations: [
+                  tb
+                    .updateRecord({
+                      type: 'planet',
+                      id: '1',
+                      attributes: { classification: null }
+                    })
+                    .toOperation()
+                ]
+              }
+            },
+            'full response is correct'
+          );
+        });
+
+        test('#update can replace related records but only if they are different', async function (assert) {
+          const tb = cache.transformBuilder;
+
+          await cache.update((t) => [
+            t.addRecord({
+              type: 'planet',
+              id: '1',
+              attributes: { name: 'Earth' },
+              relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+            })
+          ]);
+
+          let result = await cache.update(
+            (t) => [
+              t.replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
+                { type: 'moon', id: 'm1' }
+              ])
+            ],
+            { fullResponse: true }
+          );
+
+          assert.deepEqual(
+            result,
+            {
+              data: undefined,
+              details: {
+                appliedOperations: [],
+                appliedOperationResults: [],
+                inverseOperations: []
+              }
+            },
+            'nothing has changed so there are no appliend or inverse ops'
+          );
+
+          result = await cache.update(
+            (t) =>
+              t.replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
+                { type: 'moon', id: 'm2' }
+              ]),
+            { fullResponse: true }
+          );
+
+          assert.deepEqual(
+            await cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
+            {
+              type: 'planet',
+              id: '1',
+              attributes: { name: 'Earth' },
+              relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
+            },
+            'relationships have been replaced'
+          );
+
+          assert.deepEqual(
+            result,
+            {
+              data: {
+                type: 'planet',
+                id: '1',
+                attributes: { name: 'Earth' },
+                relationships: {
+                  moons: { data: [{ type: 'moon', id: 'm2' }] }
+                }
+              },
+              details: {
+                appliedOperations: [
+                  tb
+                    .replaceRelatedRecords(
+                      { type: 'planet', id: '1' },
+                      'moons',
+                      [{ type: 'moon', id: 'm2' }]
+                    )
+                    .toOperation(),
+                  tb
+                    .replaceRelatedRecord(
+                      { type: 'moon', id: 'm1' },
+                      'planet',
+                      null
+                    )
+                    .toOperation(),
+                  tb
+                    .replaceRelatedRecord(
+                      { type: 'moon', id: 'm2' },
+                      'planet',
+                      {
+                        type: 'planet',
+                        id: '1'
+                      }
+                    )
+                    .toOperation()
+                ],
+                appliedOperationResults: [
+                  {
+                    type: 'planet',
+                    id: '1',
+                    attributes: { name: 'Earth' },
+                    relationships: {
+                      moons: { data: [{ type: 'moon', id: 'm2' }] }
+                    }
+                  },
+                  {
+                    type: 'moon',
+                    id: 'm1',
+                    relationships: {
+                      planet: { data: null }
+                    }
+                  },
+                  {
+                    type: 'moon',
+                    id: 'm2',
+                    relationships: {
+                      planet: { data: { type: 'planet', id: '1' } }
+                    }
+                  }
+                ],
+                inverseOperations: [
+                  tb
+                    .replaceRelatedRecord(
+                      { type: 'moon', id: 'm2' },
+                      'planet',
+                      null
+                    )
+                    .toOperation(),
+                  tb
+                    .replaceRelatedRecord(
+                      { type: 'moon', id: 'm1' },
+                      'planet',
+                      {
+                        type: 'planet',
+                        id: '1'
+                      }
+                    )
+                    .toOperation(),
+                  tb
+                    .replaceRelatedRecords(
+                      { type: 'planet', id: '1' },
+                      'moons',
+                      [{ type: 'moon', id: 'm1' }]
+                    )
+                    .toOperation()
+                ]
+              }
+            },
+            'full response is correct'
+          );
+        });
+
+        test('#update merges records when "replacing" and _will_ replace specified attributes and relationships', async function (assert) {
+          const tb = cache.transformBuilder;
+
+          const earth: Record = {
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Earth' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+          };
+
+          const jupiter: Record = {
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Jupiter', classification: 'terrestrial' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
+          };
+
+          let result = await cache.update([tb.addRecord(earth)], {
+            fullResponse: true
+          });
+
+          assert.deepEqual(
+            result,
+            {
+              data: earth,
+              details: {
+                appliedOperations: [
+                  tb.addRecord(earth).toOperation(),
+                  tb
+                    .replaceRelatedRecord(
+                      { type: 'moon', id: 'm1' },
+                      'planet',
+                      {
+                        type: 'planet',
+                        id: '1'
+                      }
+                    )
+                    .toOperation()
+                ],
+                appliedOperationResults: [
+                  {
+                    type: 'planet',
+                    id: '1',
+                    attributes: { name: 'Earth' },
+                    relationships: {
+                      moons: { data: [{ type: 'moon', id: 'm1' }] }
+                    }
+                  },
+                  {
+                    type: 'moon',
+                    id: 'm1',
+                    relationships: {
+                      planet: { data: { type: 'planet', id: '1' } }
+                    }
+                  }
+                ],
+                inverseOperations: [
+                  tb
+                    .replaceRelatedRecord(
+                      { type: 'moon', id: 'm1' },
+                      'planet',
+                      null
+                    )
+                    .toOperation(),
+                  tb
+                    .removeRecord({
+                      type: 'planet',
+                      id: '1'
+                    })
+                    .toOperation()
+                ]
+              }
+            },
+            'addRecord full response is correct'
+          );
+
+          result = await cache.update([tb.updateRecord(jupiter)], {
+            fullResponse: true
+          });
+
+          assert.deepEqual(result, {
+            data: jupiter,
+            details: {
+              appliedOperations: [
+                tb.updateRecord(jupiter).toOperation(),
+                tb
+                  .replaceRelatedRecord(
+                    { type: 'moon', id: 'm1' },
+                    'planet',
+                    null
+                  )
+                  .toOperation(),
+                tb
+                  .replaceRelatedRecord({ type: 'moon', id: 'm2' }, 'planet', {
+                    type: 'planet',
+                    id: '1'
+                  })
+                  .toOperation()
+              ],
+              appliedOperationResults: [
+                jupiter,
+                {
+                  type: 'moon',
+                  id: 'm1',
+                  relationships: {
+                    planet: { data: null }
+                  }
+                },
+                {
+                  type: 'moon',
+                  id: 'm2',
+                  relationships: {
+                    planet: { data: { type: 'planet', id: '1' } }
+                  }
+                }
+              ],
+              inverseOperations: [
+                tb
+                  .replaceRelatedRecord(
+                    { type: 'moon', id: 'm2' },
+                    'planet',
+                    null
+                  )
+                  .toOperation(),
+                tb
+                  .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
+                    type: 'planet',
+                    id: '1'
+                  })
+                  .toOperation(),
+                tb
+                  .updateRecord({
+                    type: 'planet',
+                    id: '1',
+                    attributes: { name: 'Earth', classification: null },
+                    relationships: {
+                      moons: { data: [{ type: 'moon', id: 'm1' }] }
+                    }
+                  })
+                  .toOperation()
+              ]
+            }
+          });
+
+          assert.deepEqual(
+            await cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
+            {
+              type: 'planet',
+              id: '1',
+              attributes: { name: 'Jupiter', classification: 'terrestrial' },
+              relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
+            },
+            'records have been merged'
+          );
+        });
+
+        test('#update can update existing record with empty relationship', async function (assert) {
+          const tb = cache.transformBuilder;
+
+          let result = await cache.update(
+            (t) => [t.addRecord({ id: '1', type: 'planet' })],
+            { fullResponse: true }
+          );
+
+          assert.deepEqual(
+            result,
+            {
+              data: { id: '1', type: 'planet' },
+              details: {
+                appliedOperations: [
+                  tb
+                    .addRecord({
+                      type: 'planet',
+                      id: '1'
+                    })
+                    .toOperation()
+                ],
+                appliedOperationResults: [
+                  {
+                    id: '1',
+                    type: 'planet'
+                  }
+                ],
+                inverseOperations: [
+                  tb
+                    .removeRecord({
+                      type: 'planet',
+                      id: '1'
+                    })
+                    .toOperation()
+                ]
+              }
+            },
+            'addRecord result is correct'
+          );
+
+          result = await cache.update(
+            (t) => [
+              t.updateRecord({
+                id: '1',
+                type: 'planet',
+                relationships: {
+                  moons: { data: [] }
+                }
+              })
+            ],
+            { fullResponse: true }
+          );
+
+          assert.deepEqual(
+            result,
+            {
+              data: {
+                id: '1',
+                type: 'planet',
+                relationships: {
+                  moons: { data: [] }
+                }
+              },
+              details: {
+                appliedOperations: [
+                  tb
+                    .updateRecord({
+                      id: '1',
+                      type: 'planet',
+                      relationships: {
+                        moons: { data: [] }
+                      }
+                    })
+                    .toOperation()
+                ],
+                appliedOperationResults: [
+                  {
+                    id: '1',
+                    type: 'planet',
+                    relationships: {
+                      moons: { data: [] }
+                    }
+                  }
+                ],
+                inverseOperations: [
+                  tb
+                    .updateRecord({
+                      id: '1',
+                      type: 'planet',
+                      relationships: {
+                        moons: { data: [] }
+                      }
+                    })
+                    .toOperation()
+                ]
+              }
+            },
+            'updateRecord result is correct'
+          );
+
+          const planet = await cache.getRecordAsync({
+            type: 'planet',
+            id: '1'
+          });
+          assert.ok(planet, 'planet exists');
+          assert.deepEqual(
+            planet?.relationships?.moons.data,
+            [],
+            'planet has empty moons relationship'
+          );
+        });
+
+        test('#update will not overwrite an existing relationship with a missing relationship', async function (assert) {
+          const tb = cache.transformBuilder;
+
+          let result = await cache.update(
+            (t) => [
+              t.addRecord({
+                id: '1',
+                type: 'planet',
+                relationships: {
+                  moons: { data: [{ type: 'moon', id: 'm1' }] }
+                }
+              }),
+              t.updateRecord({
+                id: '1',
+                type: 'planet'
+              })
+            ],
+            { fullResponse: true }
+          );
+
+          assert.deepEqual(
+            result,
+            {
+              data: [
+                {
                   id: '1',
                   type: 'planet',
                   relationships: {
                     moons: { data: [{ type: 'moon', id: 'm1' }] }
                   }
-                })
-                .toOperation(),
-              tb
-                .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
-                  id: '1',
-                  type: 'planet'
-                })
-                .toOperation()
-            ],
-            inverseOperations: [
-              tb
-                .replaceRelatedRecord(
-                  { type: 'moon', id: 'm1' },
-                  'planet',
-                  null
-                )
-                .toOperation(),
-              tb
-                .removeRecord({
-                  id: '1',
-                  type: 'planet'
-                })
-                .toOperation()
-            ]
-          }
-        },
-        'update full response is correct'
-      );
+                },
+                undefined
+              ],
+              details: {
+                appliedOperations: [
+                  tb
+                    .addRecord({
+                      id: '1',
+                      type: 'planet',
+                      relationships: {
+                        moons: { data: [{ type: 'moon', id: 'm1' }] }
+                      }
+                    })
+                    .toOperation(),
+                  tb
+                    .replaceRelatedRecord(
+                      { type: 'moon', id: 'm1' },
+                      'planet',
+                      {
+                        id: '1',
+                        type: 'planet'
+                      }
+                    )
+                    .toOperation()
+                ],
+                appliedOperationResults: [
+                  {
+                    id: '1',
+                    type: 'planet',
+                    relationships: {
+                      moons: { data: [{ type: 'moon', id: 'm1' }] }
+                    }
+                  },
+                  {
+                    type: 'moon',
+                    id: 'm1',
+                    relationships: {
+                      planet: { data: { id: '1', type: 'planet' } }
+                    }
+                  }
+                ],
+                inverseOperations: [
+                  tb
+                    .replaceRelatedRecord(
+                      { type: 'moon', id: 'm1' },
+                      'planet',
+                      null
+                    )
+                    .toOperation(),
+                  tb
+                    .removeRecord({
+                      id: '1',
+                      type: 'planet'
+                    })
+                    .toOperation()
+                ]
+              }
+            },
+            'update full response is correct'
+          );
 
-      const planet = await cache.getRecordAsync({ type: 'planet', id: '1' });
-      assert.ok(planet, 'planet exists');
-      assert.deepEqual(
-        planet?.relationships?.moons.data,
-        [{ type: 'moon', id: 'm1' }],
-        'planet has a moons relationship'
-      );
-    });
+          const planet = await cache.getRecordAsync({
+            type: 'planet',
+            id: '1'
+          });
+          assert.ok(planet, 'planet exists');
+          assert.deepEqual(
+            planet?.relationships?.moons.data,
+            [{ type: 'moon', id: 'm1' }],
+            'planet has a moons relationship'
+          );
+        });
 
-    test('#update allows replaceRelatedRecord to be called on a relationship with no inverse and to be followed up by removing the replaced record', async function (assert) {
-      assert.expect(2);
+        test('#update allows replaceRelatedRecord to be called on a relationship with no inverse and to be followed up by removing the replaced record', async function (assert) {
+          assert.expect(2);
 
-      const star1 = {
-        id: 'star1',
-        type: 'star',
-        attributes: { name: 'sun1' }
-      };
+          const star1 = {
+            id: 'star1',
+            type: 'star',
+            attributes: { name: 'sun1' }
+          };
 
-      const star2 = {
-        id: 'star2',
-        type: 'star',
-        attributes: { name: 'sun2' }
-      };
+          const star2 = {
+            id: 'star2',
+            type: 'star',
+            attributes: { name: 'sun2' }
+          };
 
-      const home = {
-        id: 'home',
-        type: 'planetarySystem',
-        attributes: { name: 'Home' },
-        relationships: {
-          star: {
-            data: { id: 'star1', type: 'star' }
-          }
-        }
-      };
+          const home = {
+            id: 'home',
+            type: 'planetarySystem',
+            attributes: { name: 'Home' },
+            relationships: {
+              star: {
+                data: { id: 'star1', type: 'star' }
+              }
+            }
+          };
 
-      await cache.update((t) => [
-        t.addRecord(star1),
-        t.addRecord(star2),
-        t.addRecord(home)
-      ]);
+          await cache.update((t) => [
+            t.addRecord(star1),
+            t.addRecord(star2),
+            t.addRecord(home)
+          ]);
 
-      let latestHome = await cache.getRecordAsync({
-        id: 'home',
-        type: 'planetarySystem'
-      });
-      assert.deepEqual(
-        (latestHome?.relationships?.star.data as Record).id,
-        star1.id,
-        'The original related record is in place.'
-      );
-
-      await cache.update((t) => [
-        t.replaceRelatedRecord(
-          {
+          let latestHome = await cache.getRecordAsync({
             id: 'home',
             type: 'planetarySystem'
-          },
-          'star',
-          star2
-        ),
-        t.removeRecord(star1)
-      ]);
+          });
+          assert.deepEqual(
+            (latestHome?.relationships?.star.data as Record).id,
+            star1.id,
+            'The original related record is in place.'
+          );
 
-      latestHome = await cache.getRecordAsync({
-        id: 'home',
-        type: 'planetarySystem'
-      });
-
-      assert.deepEqual(
-        (latestHome?.relationships?.star.data as Record).id,
-        star2.id,
-        'The related record was replaced.'
-      );
-    });
-
-    test("#update - updateRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
-      const earth: Record = {
-        type: 'planet',
-        id: '1',
-        attributes: { name: 'Earth' },
-        keys: { remoteId: 'a' }
-      };
-
-      try {
-        await cache.update((t) =>
-          t.updateRecord(earth).options({
-            raiseNotFoundExceptions: true
-          })
-        );
-      } catch (e) {
-        assert.ok(e instanceof RecordNotFoundException);
-      }
-    });
-
-    test("#update - removeRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
-      const earth: Record = {
-        type: 'planet',
-        id: '1'
-      };
-
-      try {
-        await cache.update((t) =>
-          t.removeRecord(earth).options({
-            raiseNotFoundExceptions: true
-          })
-        );
-      } catch (e) {
-        assert.ok(e instanceof RecordNotFoundException);
-      }
-    });
-
-    test("#update - replaceKey - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
-      const earth: Record = {
-        type: 'planet',
-        id: '1',
-        attributes: { name: 'Earth' },
-        keys: { remoteId: 'a' }
-      };
-
-      try {
-        await cache.update((t) =>
-          t.replaceKey(earth, 'remoteId', 'b').options({
-            raiseNotFoundExceptions: true
-          })
-        );
-      } catch (e) {
-        assert.ok(e instanceof RecordNotFoundException);
-      }
-    });
-
-    test("#update - replaceAttribute - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
-      const earth: Record = {
-        type: 'planet',
-        id: '1',
-        attributes: { name: 'Earth' },
-        keys: { remoteId: 'a' }
-      };
-
-      try {
-        await cache.update((t) =>
-          t.replaceAttribute(earth, 'name', 'Mother Earth').options({
-            raiseNotFoundExceptions: true
-          })
-        );
-      } catch (e) {
-        assert.ok(e instanceof RecordNotFoundException);
-      }
-    });
-
-    test("#update - addToRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
-      try {
-        await cache.update((t) =>
-          t
-            .addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
-              type: 'moon',
-              id: 'm1'
-            })
-            .options({
-              raiseNotFoundExceptions: true
-            })
-        );
-      } catch (e) {
-        assert.ok(e instanceof RecordNotFoundException);
-      }
-    });
-
-    test("#update - removeFromRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
-      try {
-        await cache.update((t) =>
-          t
-            .removeFromRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
-              type: 'moon',
-              id: 'm1'
-            })
-            .options({
-              raiseNotFoundExceptions: true
-            })
-        );
-      } catch (e) {
-        assert.ok(e instanceof RecordNotFoundException);
-      }
-    });
-
-    test("#update - replaceRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
-      try {
-        await cache.update((t) =>
-          t
-            .replaceRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', [
+          await cache.update((t) => [
+            t.replaceRelatedRecord(
               {
-                type: 'moon',
-                id: 'm1'
+                id: 'home',
+                type: 'planetarySystem'
+              },
+              'star',
+              star2
+            ),
+            t.removeRecord(star1)
+          ]);
+
+          latestHome = await cache.getRecordAsync({
+            id: 'home',
+            type: 'planetarySystem'
+          });
+
+          assert.deepEqual(
+            (latestHome?.relationships?.star.data as Record).id,
+            star2.id,
+            'The related record was replaced.'
+          );
+        });
+
+        test("#update - updateRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+          const earth: Record = {
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Earth' },
+            keys: { remoteId: 'a' }
+          };
+
+          try {
+            await cache.update((t) =>
+              t.updateRecord(earth).options({
+                raiseNotFoundExceptions: true
+              })
+            );
+          } catch (e) {
+            assert.ok(e instanceof RecordNotFoundException);
+          }
+        });
+
+        test("#update - removeRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+          const earth: Record = {
+            type: 'planet',
+            id: '1'
+          };
+
+          try {
+            await cache.update((t) =>
+              t.removeRecord(earth).options({
+                raiseNotFoundExceptions: true
+              })
+            );
+          } catch (e) {
+            assert.ok(e instanceof RecordNotFoundException);
+          }
+        });
+
+        test("#update - replaceKey - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+          const earth: Record = {
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Earth' },
+            keys: { remoteId: 'a' }
+          };
+
+          try {
+            await cache.update((t) =>
+              t.replaceKey(earth, 'remoteId', 'b').options({
+                raiseNotFoundExceptions: true
+              })
+            );
+          } catch (e) {
+            assert.ok(e instanceof RecordNotFoundException);
+          }
+        });
+
+        test("#update - replaceAttribute - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+          const earth: Record = {
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Earth' },
+            keys: { remoteId: 'a' }
+          };
+
+          try {
+            await cache.update((t) =>
+              t.replaceAttribute(earth, 'name', 'Mother Earth').options({
+                raiseNotFoundExceptions: true
+              })
+            );
+          } catch (e) {
+            assert.ok(e instanceof RecordNotFoundException);
+          }
+        });
+
+        test("#update - addToRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+          try {
+            await cache.update((t) =>
+              t
+                .addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+                  type: 'moon',
+                  id: 'm1'
+                })
+                .options({
+                  raiseNotFoundExceptions: true
+                })
+            );
+          } catch (e) {
+            assert.ok(e instanceof RecordNotFoundException);
+          }
+        });
+
+        test("#update - removeFromRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+          try {
+            await cache.update((t) =>
+              t
+                .removeFromRelatedRecords(
+                  { type: 'planet', id: 'p1' },
+                  'moons',
+                  {
+                    type: 'moon',
+                    id: 'm1'
+                  }
+                )
+                .options({
+                  raiseNotFoundExceptions: true
+                })
+            );
+          } catch (e) {
+            assert.ok(e instanceof RecordNotFoundException);
+          }
+        });
+
+        test("#update - replaceRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+          try {
+            await cache.update((t) =>
+              t
+                .replaceRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', [
+                  {
+                    type: 'moon',
+                    id: 'm1'
+                  }
+                ])
+                .options({
+                  raiseNotFoundExceptions: true
+                })
+            );
+          } catch (e) {
+            assert.ok(e instanceof RecordNotFoundException);
+          }
+        });
+
+        test("#update - replaceRelatedRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
+          try {
+            await cache.update((t) =>
+              t
+                .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
+                  type: 'planet',
+                  id: 'p1'
+                })
+                .options({
+                  raiseNotFoundExceptions: true
+                })
+            );
+          } catch (e) {
+            assert.ok(e instanceof RecordNotFoundException);
+          }
+        });
+      });
+
+      module('with alt schema', function (hooks) {
+        test('#update removing model with a bi-directional hasOne', async function (assert) {
+          assert.expect(5);
+
+          const hasOneSchema = new RecordSchema({
+            models: {
+              one: {
+                relationships: {
+                  two: { kind: 'hasOne', type: 'two', inverse: 'one' }
+                }
+              },
+              two: {
+                relationships: {
+                  one: { kind: 'hasOne', type: 'one', inverse: 'two' }
+                }
               }
-            ])
-            .options({
-              raiseNotFoundExceptions: true
+            }
+          });
+
+          const cache = new ExampleAsyncRecordCache({
+            schema: hasOneSchema,
+            keyMap,
+            defaultTransformOptions
+          });
+
+          await cache.update((t) => [
+            t.addRecord({
+              id: '1',
+              type: 'one',
+              relationships: {
+                two: { data: null }
+              }
+            }),
+            t.addRecord({
+              id: '2',
+              type: 'two',
+              relationships: {
+                one: { data: { type: 'one', id: '1' } }
+              }
             })
-        );
-      } catch (e) {
-        assert.ok(e instanceof RecordNotFoundException);
-      }
-    });
+          ]);
 
-    test("#update - replaceRelatedRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
-      try {
-        await cache.update((t) =>
-          t
-            .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
-              type: 'planet',
-              id: 'p1'
-            })
-            .options({
-              raiseNotFoundExceptions: true
-            })
-        );
-      } catch (e) {
-        assert.ok(e instanceof RecordNotFoundException);
-      }
-    });
-  });
+          const one = (await cache.getRecordAsync({
+            type: 'one',
+            id: '1'
+          })) as Record;
+          const two = (await cache.getRecordAsync({
+            type: 'two',
+            id: '2'
+          })) as Record;
+          assert.ok(one, 'one exists');
+          assert.ok(two, 'two exists');
+          assert.deepEqual(
+            one.relationships?.two.data,
+            { type: 'two', id: '2' },
+            'one links to two'
+          );
+          assert.deepEqual(
+            two.relationships?.one.data,
+            { type: 'one', id: '1' },
+            'two links to one'
+          );
 
-  module('with alt schema', function (hooks) {
-    test('#update removing model with a bi-directional hasOne', async function (assert) {
-      assert.expect(5);
+          await cache.update((t) => t.removeRecord(two));
 
-      const hasOneSchema = new RecordSchema({
-        models: {
-          one: {
-            relationships: {
-              two: { kind: 'hasOne', type: 'two', inverse: 'one' }
+          assert.equal(
+            ((await cache.getRecordAsync({ type: 'one', id: '1' })) as Record)
+              .relationships?.two.data,
+            null,
+            'ones link to two got removed'
+          );
+        });
+
+        test('#update removes dependent records in a hasOne relationship', async function (assert) {
+          const dependentSchema = new RecordSchema({
+            models: {
+              planet: {
+                relationships: {
+                  moons: { kind: 'hasMany', type: 'moon' }
+                }
+              },
+              moon: {
+                relationships: {
+                  planet: {
+                    kind: 'hasOne',
+                    type: 'planet',
+                    dependent: 'remove'
+                  }
+                }
+              }
             }
-          },
-          two: {
-            relationships: {
-              one: { kind: 'hasOne', type: 'one', inverse: 'two' }
+          });
+
+          const cache = new ExampleAsyncRecordCache({
+            schema: dependentSchema,
+            keyMap,
+            defaultTransformOptions
+          });
+
+          const jupiter: Record = {
+            type: 'planet',
+            id: 'p1',
+            attributes: { name: 'Jupiter' }
+          };
+          const io: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Io' },
+            relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+          };
+          const europa: Record = {
+            type: 'moon',
+            id: 'm2',
+            attributes: { name: 'Europa' },
+            relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+          };
+
+          await cache.update((t) => [
+            t.addRecord(jupiter),
+            t.addRecord(io),
+            t.addRecord(europa),
+            t.addToRelatedRecords(jupiter, 'moons', io),
+            t.addToRelatedRecords(jupiter, 'moons', europa)
+          ]);
+
+          await cache.update((t) => t.removeRecord(io));
+
+          assert.equal(
+            (await cache.getRecordsAsync('moon')).length,
+            1,
+            'Only europa is left in store'
+          );
+          assert.equal(
+            (await cache.getRecordsAsync('planet')).length,
+            0,
+            'Jupiter has been removed from the store'
+          );
+        });
+
+        test('#update removes dependent records in a hasMany relationship', async function (assert) {
+          const dependentSchema = new RecordSchema({
+            models: {
+              planet: {
+                relationships: {
+                  moons: { kind: 'hasMany', type: 'moon', dependent: 'remove' }
+                }
+              },
+              moon: {
+                relationships: {
+                  planet: { kind: 'hasOne', type: 'planet' }
+                }
+              }
             }
-          }
-        }
-      });
+          });
 
-      const cache = new ExampleAsyncRecordCache({
-        schema: hasOneSchema,
-        keyMap,
-        defaultTransformOptions
-      });
+          const cache = new ExampleAsyncRecordCache({
+            schema: dependentSchema,
+            keyMap,
+            defaultTransformOptions
+          });
 
-      await cache.update((t) => [
-        t.addRecord({
-          id: '1',
-          type: 'one',
-          relationships: {
-            two: { data: null }
-          }
-        }),
-        t.addRecord({
-          id: '2',
-          type: 'two',
-          relationships: {
-            one: { data: { type: 'one', id: '1' } }
-          }
-        })
-      ]);
+          const jupiter: Record = {
+            type: 'planet',
+            id: 'p1',
+            attributes: { name: 'Jupiter' }
+          };
+          const io: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Io' },
+            relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+          };
+          const europa: Record = {
+            type: 'moon',
+            id: 'm2',
+            attributes: { name: 'Europa' },
+            relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+          };
 
-      const one = (await cache.getRecordAsync({
-        type: 'one',
-        id: '1'
-      })) as Record;
-      const two = (await cache.getRecordAsync({
-        type: 'two',
-        id: '2'
-      })) as Record;
-      assert.ok(one, 'one exists');
-      assert.ok(two, 'two exists');
-      assert.deepEqual(
-        one.relationships?.two.data,
-        { type: 'two', id: '2' },
-        'one links to two'
-      );
-      assert.deepEqual(
-        two.relationships?.one.data,
-        { type: 'one', id: '1' },
-        'two links to one'
-      );
+          await cache.update((t) => [
+            t.updateRecord(jupiter),
+            t.updateRecord(io),
+            t.updateRecord(europa),
+            t.addToRelatedRecords(jupiter, 'moons', io),
+            t.addToRelatedRecords(jupiter, 'moons', europa)
+          ]);
 
-      await cache.update((t) => t.removeRecord(two));
+          await cache.update((t) => t.removeRecord(jupiter));
 
-      assert.equal(
-        ((await cache.getRecordAsync({ type: 'one', id: '1' })) as Record)
-          .relationships?.two.data,
-        null,
-        'ones link to two got removed'
-      );
-    });
+          assert.equal(
+            (await cache.getRecordsAsync('planet')).length,
+            0,
+            'Jupiter has been removed from the store'
+          );
+          assert.equal(
+            (await cache.getRecordsAsync('moon')).length,
+            0,
+            'All of Jupiters moons are removed from the store'
+          );
+        });
 
-    test('#update removes dependent records in a hasOne relationship', async function (assert) {
-      const dependentSchema = new RecordSchema({
-        models: {
-          planet: {
-            relationships: {
-              moons: { kind: 'hasMany', type: 'moon' }
+        test('#update does not remove non-dependent records', async function (assert) {
+          const dependentSchema = new RecordSchema({
+            models: {
+              planet: {
+                relationships: {
+                  moons: { kind: 'hasMany', type: 'moon' }
+                }
+              },
+              moon: {
+                relationships: {
+                  planet: { kind: 'hasOne', type: 'planet' }
+                }
+              }
             }
-          },
-          moon: {
-            relationships: {
-              planet: { kind: 'hasOne', type: 'planet', dependent: 'remove' }
-            }
-          }
-        }
+          });
+
+          const cache = new ExampleAsyncRecordCache({
+            schema: dependentSchema,
+            keyMap,
+            defaultTransformOptions
+          });
+
+          const jupiter: Record = {
+            type: 'planet',
+            id: 'p1',
+            attributes: { name: 'Jupiter' }
+          };
+          const io: Record = {
+            type: 'moon',
+            id: 'm1',
+            attributes: { name: 'Io' },
+            relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+          };
+          const europa: Record = {
+            type: 'moon',
+            id: 'm2',
+            attributes: { name: 'Europa' },
+            relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+          };
+
+          await cache.update((t) => [
+            t.addRecord(jupiter),
+            t.addRecord(io),
+            t.addRecord(europa),
+            t.addToRelatedRecords(jupiter, 'moons', io),
+            t.addToRelatedRecords(jupiter, 'moons', europa)
+          ]);
+
+          // Since there are no dependent relationships, no other records will be
+          // removed
+          await cache.update((t) => t.removeRecord(io));
+
+          assert.equal(
+            (await cache.getRecordsAsync('moon')).length,
+            1,
+            'One moon left in store'
+          );
+          assert.equal(
+            (await cache.getRecordsAsync('planet')).length,
+            1,
+            'One planet left in store'
+          );
+        });
       });
-
-      const cache = new ExampleAsyncRecordCache({
-        schema: dependentSchema,
-        keyMap,
-        defaultTransformOptions
-      });
-
-      const jupiter: Record = {
-        type: 'planet',
-        id: 'p1',
-        attributes: { name: 'Jupiter' }
-      };
-      const io: Record = {
-        type: 'moon',
-        id: 'm1',
-        attributes: { name: 'Io' },
-        relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-      };
-      const europa: Record = {
-        type: 'moon',
-        id: 'm2',
-        attributes: { name: 'Europa' },
-        relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-      };
-
-      await cache.update((t) => [
-        t.addRecord(jupiter),
-        t.addRecord(io),
-        t.addRecord(europa),
-        t.addToRelatedRecords(jupiter, 'moons', io),
-        t.addToRelatedRecords(jupiter, 'moons', europa)
-      ]);
-
-      await cache.update((t) => t.removeRecord(io));
-
-      assert.equal(
-        (await cache.getRecordsAsync('moon')).length,
-        1,
-        'Only europa is left in store'
-      );
-      assert.equal(
-        (await cache.getRecordsAsync('planet')).length,
-        0,
-        'Jupiter has been removed from the store'
-      );
-    });
-
-    test('#update removes dependent records in a hasMany relationship', async function (assert) {
-      const dependentSchema = new RecordSchema({
-        models: {
-          planet: {
-            relationships: {
-              moons: { kind: 'hasMany', type: 'moon', dependent: 'remove' }
-            }
-          },
-          moon: {
-            relationships: {
-              planet: { kind: 'hasOne', type: 'planet' }
-            }
-          }
-        }
-      });
-
-      const cache = new ExampleAsyncRecordCache({
-        schema: dependentSchema,
-        keyMap,
-        defaultTransformOptions
-      });
-
-      const jupiter: Record = {
-        type: 'planet',
-        id: 'p1',
-        attributes: { name: 'Jupiter' }
-      };
-      const io: Record = {
-        type: 'moon',
-        id: 'm1',
-        attributes: { name: 'Io' },
-        relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-      };
-      const europa: Record = {
-        type: 'moon',
-        id: 'm2',
-        attributes: { name: 'Europa' },
-        relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-      };
-
-      await cache.update((t) => [
-        t.updateRecord(jupiter),
-        t.updateRecord(io),
-        t.updateRecord(europa),
-        t.addToRelatedRecords(jupiter, 'moons', io),
-        t.addToRelatedRecords(jupiter, 'moons', europa)
-      ]);
-
-      await cache.update((t) => t.removeRecord(jupiter));
-
-      assert.equal(
-        (await cache.getRecordsAsync('planet')).length,
-        0,
-        'Jupiter has been removed from the store'
-      );
-      assert.equal(
-        (await cache.getRecordsAsync('moon')).length,
-        0,
-        'All of Jupiters moons are removed from the store'
-      );
-    });
-
-    test('#update does not remove non-dependent records', async function (assert) {
-      const dependentSchema = new RecordSchema({
-        models: {
-          planet: {
-            relationships: {
-              moons: { kind: 'hasMany', type: 'moon' }
-            }
-          },
-          moon: {
-            relationships: {
-              planet: { kind: 'hasOne', type: 'planet' }
-            }
-          }
-        }
-      });
-
-      const cache = new ExampleAsyncRecordCache({
-        schema: dependentSchema,
-        keyMap,
-        defaultTransformOptions
-      });
-
-      const jupiter: Record = {
-        type: 'planet',
-        id: 'p1',
-        attributes: { name: 'Jupiter' }
-      };
-      const io: Record = {
-        type: 'moon',
-        id: 'm1',
-        attributes: { name: 'Io' },
-        relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-      };
-      const europa: Record = {
-        type: 'moon',
-        id: 'm2',
-        attributes: { name: 'Europa' },
-        relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-      };
-
-      await cache.update((t) => [
-        t.addRecord(jupiter),
-        t.addRecord(io),
-        t.addRecord(europa),
-        t.addToRelatedRecords(jupiter, 'moons', io),
-        t.addToRelatedRecords(jupiter, 'moons', europa)
-      ]);
-
-      // Since there are no dependent relationships, no other records will be
-      // removed
-      await cache.update((t) => t.removeRecord(io));
-
-      assert.equal(
-        (await cache.getRecordsAsync('moon')).length,
-        1,
-        'One moon left in store'
-      );
-      assert.equal(
-        (await cache.getRecordsAsync('planet')).length,
-        1,
-        'One planet left in store'
-      );
     });
   });
 });

--- a/packages/@orbit/record-cache/test/support/example-async-record-cache.ts
+++ b/packages/@orbit/record-cache/test/support/example-async-record-cache.ts
@@ -87,13 +87,28 @@ export class ExampleAsyncRecordCache extends AsyncRecordCache {
   }
 
   async getInverseRelationshipsAsync(
-    recordIdentity: RecordIdentity
+    recordIdentityOrIdentities: RecordIdentity | RecordIdentity[]
   ): Promise<RecordRelationshipIdentity[]> {
+    if (Array.isArray(recordIdentityOrIdentities)) {
+      let inverseRelationships: RecordRelationshipIdentity[] = [];
+      recordIdentityOrIdentities.forEach((record) => {
+        let rirs = this._getInverseRelationships(record);
+        Array.prototype.push.apply(inverseRelationships, rirs);
+      });
+      return inverseRelationships;
+    } else {
+      return this._getInverseRelationships(recordIdentityOrIdentities);
+    }
+  }
+
+  _getInverseRelationships(
+    recordIdentity: RecordIdentity
+  ): RecordRelationshipIdentity[] {
     return (
       deepGet(this._inverseRelationships, [
         recordIdentity.type,
         recordIdentity.id
-      ]) || []
+      ]) ?? []
     );
   }
 

--- a/packages/@orbit/record-cache/test/support/example-sync-record-cache.ts
+++ b/packages/@orbit/record-cache/test/support/example-sync-record-cache.ts
@@ -81,13 +81,28 @@ export class ExampleSyncRecordCache extends SyncRecordCache {
   }
 
   getInverseRelationshipsSync(
+    recordIdentityOrIdentities: RecordIdentity | RecordIdentity[]
+  ): RecordRelationshipIdentity[] {
+    if (Array.isArray(recordIdentityOrIdentities)) {
+      let inverseRelationships: RecordRelationshipIdentity[] = [];
+      recordIdentityOrIdentities.forEach((record) => {
+        let rirs = this._getInverseRelationships(record);
+        Array.prototype.push.apply(inverseRelationships, rirs);
+      });
+      return inverseRelationships;
+    } else {
+      return this._getInverseRelationships(recordIdentityOrIdentities);
+    }
+  }
+
+  _getInverseRelationships(
     recordIdentity: RecordIdentity
   ): RecordRelationshipIdentity[] {
     return (
       deepGet(this._inverseRelationships, [
         recordIdentity.type,
         recordIdentity.id
-      ]) || []
+      ]) ?? []
     );
   }
 

--- a/packages/@orbit/record-cache/test/sync-record-cache-update-test.ts
+++ b/packages/@orbit/record-cache/test/sync-record-cache-update-test.ts
@@ -18,1801 +18,1980 @@ QUnit.dump.maxDepth = 7;
 module('SyncRecordCache', function (hooks) {
   let schema: RecordSchema, keyMap: RecordKeyMap;
 
-  hooks.beforeEach(function () {
-    schema = createSchemaWithRemoteKey();
-    keyMap = new RecordKeyMap();
-  });
+  [true, false].forEach((useBuffer) => {
+    module(`useBuffer: ${useBuffer}`, function (hooks) {
+      // All caches in this module share these transform options
+      const defaultTransformOptions = { useBuffer };
 
-  test('#update sets data and #records retrieves it', function (assert) {
-    assert.expect(4);
-
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    const earth: Record = {
-      type: 'planet',
-      id: '1',
-      attributes: { name: 'Earth' },
-      keys: { remoteId: 'a' }
-    };
-
-    cache.on('patch', (operation, data) => {
-      assert.deepEqual(operation, {
-        op: 'addRecord',
-        record: earth
+      hooks.beforeEach(function () {
+        schema = createSchemaWithRemoteKey();
+        keyMap = new RecordKeyMap();
       });
-      assert.deepEqual(data, earth);
-    });
 
-    cache.update((t) => t.addRecord(earth));
+      test('#update sets data and #records retrieves it', function (assert) {
+        assert.expect(4);
 
-    assert.strictEqual(
-      cache.getRecordSync({ type: 'planet', id: '1' }),
-      earth,
-      'objects strictly match'
-    );
-    assert.equal(
-      keyMap.keyToId('planet', 'remoteId', 'a'),
-      '1',
-      'key has been mapped'
-    );
-  });
+        const cache = new ExampleSyncRecordCache({
+          schema,
+          keyMap,
+          defaultTransformOptions
+        });
 
-  test('#update can replace records', function (assert) {
-    assert.expect(5);
-
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    const earth: Record = {
-      type: 'planet',
-      id: '1',
-      attributes: { name: 'Earth' },
-      keys: { remoteId: 'a' }
-    };
-
-    cache.on('patch', (operation, data) => {
-      assert.deepEqual(operation, {
-        op: 'updateRecord',
-        record: earth
-      });
-      assert.deepEqual(data, earth);
-    });
-
-    cache.update((t) => t.updateRecord(earth));
-
-    assert.deepEqual(
-      cache.getRecordSync({ type: 'planet', id: '1' }),
-      earth,
-      'objects deeply match'
-    );
-    assert.notStrictEqual(
-      cache.getRecordSync({ type: 'planet', id: '1' }),
-      earth,
-      'objects do not strictly match'
-    );
-    assert.equal(
-      keyMap.keyToId('planet', 'remoteId', 'a'),
-      '1',
-      'key has been mapped'
-    );
-  });
-
-  test('#update can replace keys', function (assert) {
-    assert.expect(4);
-
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    const earth: Record = { type: 'planet', id: '1' };
-
-    cache.on('patch', (operation, data) => {
-      assert.deepEqual(operation, {
-        op: 'replaceKey',
-        record: earth,
-        key: 'remoteId',
-        value: 'a'
-      });
-      assert.deepEqual(data, {
-        type: 'planet',
-        id: '1',
-        keys: { remoteId: 'a' }
-      });
-    });
-
-    cache.update((t) => t.replaceKey(earth, 'remoteId', 'a'));
-
-    assert.deepEqual(
-      cache.getRecordSync({ type: 'planet', id: '1' }),
-      { type: 'planet', id: '1', keys: { remoteId: 'a' } },
-      'records match'
-    );
-    assert.equal(
-      keyMap.keyToId('planet', 'remoteId', 'a'),
-      '1',
-      'key has been mapped'
-    );
-  });
-
-  test('#update updates the cache and returns primary data', function (assert) {
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    let p1 = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
-    let p2 = { type: 'planet', id: '2' };
-
-    let result = cache.update((t) => [t.addRecord(p1), t.removeRecord(p2)]);
-
-    assert.deepEqual(
-      result,
-      [
-        p1,
-        undefined // p2 didn't exist
-      ],
-      'response includes just primary data'
-    );
-  });
-
-  test('#update updates the cache and returns a full response if requested', function (assert) {
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    let p1 = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
-    let p2 = { type: 'planet', id: '2' };
-
-    let result = cache.update((t) => [t.addRecord(p1), t.removeRecord(p2)], {
-      fullResponse: true
-    });
-
-    assert.deepEqual(
-      result,
-      {
-        data: [
-          p1,
-          undefined // p2 didn't exist
-        ],
-        details: {
-          appliedOperations: [{ op: 'addRecord', record: p1 }],
-          inverseOperations: [
-            { op: 'removeRecord', record: { type: 'planet', id: '1' } }
-          ]
-        }
-      },
-      'full response includes data and details'
-    );
-  });
-
-  test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added after', function (assert) {
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    const jupiter: Record = {
-      type: 'planet',
-      id: 'p1',
-      attributes: { name: 'Jupiter' },
-      relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-    };
-    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' } };
-
-    cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
-
-    assert.deepEqual(
-      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-        ?.relationships?.moons.data,
-      [{ type: 'moon', id: 'm1' }],
-      'Io has been assigned to Jupiter'
-    );
-    assert.deepEqual(
-      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)?.relationships
-        ?.planet.data,
-      { type: 'planet', id: 'p1' },
-      'Jupiter has been assigned to Io'
-    );
-  });
-
-  test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added before', function (assert) {
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    const jupiter: Record = {
-      type: 'planet',
-      id: 'p1',
-      attributes: { name: 'Jupiter' },
-      relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-    };
-    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' } };
-
-    cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
-
-    assert.deepEqual(
-      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-        ?.relationships?.moons.data,
-      [{ type: 'moon', id: 'm1' }],
-      'Io has been assigned to Jupiter'
-    );
-    assert.deepEqual(
-      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)?.relationships
-        ?.planet.data,
-      { type: 'planet', id: 'p1' },
-      'Jupiter has been assigned to Io'
-    );
-  });
-
-  test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added after', function (assert) {
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    const io: Record = {
-      type: 'moon',
-      id: 'm1',
-      attributes: { name: 'Io' },
-      relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-    };
-    const jupiter: Record = {
-      type: 'planet',
-      id: 'p1',
-      attributes: { name: 'Jupiter' }
-    };
-
-    cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
-
-    assert.deepEqual(
-      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-        ?.relationships?.moons.data,
-      [{ type: 'moon', id: 'm1' }],
-      'Io has been assigned to Jupiter'
-    );
-    assert.deepEqual(
-      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)?.relationships
-        ?.planet.data,
-      { type: 'planet', id: 'p1' },
-      'Jupiter has been assigned to Io'
-    );
-  });
-
-  test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added before', function (assert) {
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    const io: Record = {
-      type: 'moon',
-      id: 'm1',
-      attributes: { name: 'Io' },
-      relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-    };
-    const jupiter: Record = {
-      type: 'planet',
-      id: 'p1',
-      attributes: { name: 'Jupiter' }
-    };
-
-    cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
-
-    assert.deepEqual(
-      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-        ?.relationships?.moons.data,
-      [{ type: 'moon', id: 'm1' }],
-      'Io has been assigned to Jupiter'
-    );
-    assert.deepEqual(
-      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)?.relationships
-        ?.planet.data,
-      { type: 'planet', id: 'p1' },
-      'Jupiter has been assigned to Io'
-    );
-  });
-
-  test('#update updates inverse hasOne relationship when a record with an empty relationship is added', function (assert) {
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    const io: Record = {
-      type: 'moon',
-      id: 'm1',
-      attributes: { name: 'Io' },
-      relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-    };
-    const jupiter: Record = {
-      type: 'planet',
-      id: 'p1',
-      attributes: { name: 'Jupiter' },
-      relationships: { moons: { data: [] } }
-    };
-
-    cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
-
-    assert.deepEqual(
-      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-        ?.relationships?.moons.data,
-      [],
-      'Jupiter has no moons'
-    );
-    assert.deepEqual(
-      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)?.relationships
-        ?.planet.data,
-      null,
-      'Jupiter has been cleared from Io'
-    );
-  });
-
-  test('#update updates inverse hasMany relationship when a record with an empty relationship is added', function (assert) {
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    const jupiter: Record = {
-      type: 'planet',
-      id: 'p1',
-      attributes: { name: 'Jupiter' },
-      relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-    };
-    const io: Record = {
-      type: 'moon',
-      id: 'm1',
-      attributes: { name: 'Io' },
-      relationships: { planet: { data: null } }
-    };
-
-    cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
-
-    assert.deepEqual(
-      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-        ?.relationships?.moons.data,
-      [],
-      'Io has been cleared from Jupiter'
-    );
-    assert.deepEqual(
-      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)?.relationships
-        ?.planet.data,
-      null,
-      'Io has no planet'
-    );
-  });
-
-  test('#update updates inverse hasMany polymorphic relationship', function (assert) {
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    const sun: Record = {
-      type: 'star',
-      id: 's1',
-      attributes: { name: 'Sun' },
-      relationships: {
-        celestialObjects: {
-          data: [
-            { type: 'planet', id: 'p1' },
-            { type: 'moon', id: 'm1' }
-          ]
-        }
-      }
-    };
-    const jupiter: Record = {
-      type: 'planet',
-      id: 'p1',
-      attributes: { name: 'Jupiter' }
-    };
-    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' } };
-
-    cache.update((t) => [
-      t.updateRecord(sun),
-      t.updateRecord(jupiter),
-      t.updateRecord(io)
-    ]);
-
-    assert.deepEqual(
-      (cache.getRecordSync({ type: 'star', id: 's1' }) as Record)?.relationships
-        ?.celestialObjects.data,
-      [
-        { type: 'planet', id: 'p1' },
-        { type: 'moon', id: 'm1' }
-      ],
-      'Jupiter and Io has been assigned to Sun'
-    );
-    assert.deepEqual(
-      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-        ?.relationships?.star.data,
-      { type: 'star', id: 's1' },
-      'Sun has been assigned to Jupiter'
-    );
-    assert.deepEqual(
-      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)?.relationships
-        ?.star.data,
-      { type: 'star', id: 's1' },
-      'Sun has been assigned to Io'
-    );
-  });
-
-  test('#update updates inverse hasOne polymorphic relationship', function (assert) {
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    const jupiter: Record = {
-      type: 'planet',
-      id: 'p1',
-      attributes: { name: 'Jupiter' },
-      relationships: { star: { data: { type: 'star', id: 's1' } } }
-    };
-    const io: Record = {
-      type: 'moon',
-      id: 'm1',
-      attributes: { name: 'Io' },
-      relationships: { star: { data: { type: 'star', id: 's1' } } }
-    };
-    const sun: Record = { type: 'star', id: 's1', attributes: { name: 'Sun' } };
-
-    cache.update((t) => [
-      t.updateRecord(jupiter),
-      t.updateRecord(io),
-      t.updateRecord(sun)
-    ]);
-
-    assert.deepEqual(
-      (cache.getRecordSync({ type: 'star', id: 's1' }) as Record)?.relationships
-        ?.celestialObjects.data,
-      [
-        { type: 'planet', id: 'p1' },
-        { type: 'moon', id: 'm1' }
-      ],
-      'Jupiter and Io has been assigned to Sun'
-    );
-    assert.deepEqual(
-      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-        ?.relationships?.star.data,
-      { type: 'star', id: 's1' },
-      'Sun has been assigned to Jupiter'
-    );
-    assert.deepEqual(
-      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)?.relationships
-        ?.star.data,
-      { type: 'star', id: 's1' },
-      'Sun has been assigned to Io'
-    );
-  });
-
-  test('#update tracks refs and clears them from hasOne relationships when a referenced record is removed', function (assert) {
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    const jupiter: Record = {
-      type: 'planet',
-      id: 'p1',
-      attributes: { name: 'Jupiter' },
-      relationships: { moons: { data: undefined } }
-    };
-    const io: Record = {
-      type: 'moon',
-      id: 'm1',
-      attributes: { name: 'Io' },
-      relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-    };
-    const europa: Record = {
-      type: 'moon',
-      id: 'm2',
-      attributes: { name: 'Europa' },
-      relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-    };
-
-    cache.update((t) => [
-      t.addRecord(jupiter),
-      t.addRecord(io),
-      t.addRecord(europa)
-    ]);
-
-    assert.deepEqual(
-      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)?.relationships
-        ?.planet.data,
-      { type: 'planet', id: 'p1' },
-      'Jupiter has been assigned to Io'
-    );
-    assert.deepEqual(
-      (cache.getRecordSync({ type: 'moon', id: 'm2' }) as Record)?.relationships
-        ?.planet.data,
-      { type: 'planet', id: 'p1' },
-      'Jupiter has been assigned to Europa'
-    );
-
-    cache.update((t) => t.removeRecord(jupiter));
-
-    assert.equal(
-      cache.getRecordSync({ type: 'planet', id: 'p1' }),
-      undefined,
-      'Jupiter is GONE'
-    );
-
-    assert.equal(
-      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)?.relationships
-        ?.planet.data,
-      undefined,
-      'Jupiter has been cleared from Io'
-    );
-    assert.equal(
-      (cache.getRecordSync({ type: 'moon', id: 'm2' }) as Record)?.relationships
-        ?.planet.data,
-      undefined,
-      'Jupiter has been cleared from Europa'
-    );
-  });
-
-  test('#update tracks refs and clears them from hasMany relationships when a referenced record is removed', function (assert) {
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    const io: Record = {
-      type: 'moon',
-      id: 'm1',
-      attributes: { name: 'Io' },
-      relationships: { planet: { data: null } }
-    };
-    const europa: Record = {
-      type: 'moon',
-      id: 'm2',
-      attributes: { name: 'Europa' },
-      relationships: { planet: { data: null } }
-    };
-    const jupiter: Record = {
-      type: 'planet',
-      id: 'p1',
-      attributes: { name: 'Jupiter' },
-      relationships: {
-        moons: {
-          data: [
-            { type: 'moon', id: 'm1' },
-            { type: 'moon', id: 'm2' }
-          ]
-        }
-      }
-    };
-
-    cache.update((t) => [
-      t.addRecord(io),
-      t.addRecord(europa),
-      t.addRecord(jupiter)
-    ]);
-
-    assert.deepEqual(
-      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-        ?.relationships?.moons.data,
-      [
-        { type: 'moon', id: 'm1' },
-        { type: 'moon', id: 'm2' }
-      ],
-      'Jupiter has been assigned to Io and Europa'
-    );
-    assert.ok(
-      recordsIncludeAll(
-        cache.getRelatedRecordsSync(jupiter, 'moons') as RecordIdentity[],
-        [io, europa]
-      ),
-      'Jupiter has been assigned to Io and Europa'
-    );
-
-    cache.update((t) => t.removeRecord(io));
-
-    assert.equal(
-      cache.getRecordSync({ type: 'moon', id: 'm1' }),
-      null,
-      'Io is GONE'
-    );
-
-    cache.update((t) => t.removeRecord(europa));
-
-    assert.equal(
-      cache.getRecordSync({ type: 'moon', id: 'm2' }),
-      null,
-      'Europa is GONE'
-    );
-
-    assert.deepEqual(
-      cache.getRelatedRecordsSync(
-        { type: 'planet', id: 'p1' },
-        'moons'
-      ) as RecordIdentity[],
-      [],
-      'moons have been cleared from Jupiter'
-    );
-  });
-
-  test("#update adds link to hasMany if record doesn't exist", function (assert) {
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    cache.update((t) =>
-      t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
-        type: 'moon',
-        id: 'm1'
-      })
-    );
-
-    cache.update((t) =>
-      t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
-        type: 'moon',
-        id: 'm1'
-      })
-    );
-
-    assert.deepEqual(
-      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-        ?.relationships?.moons.data,
-      [{ type: 'moon', id: 'm1' }],
-      'relationship was added'
-    );
-  });
-
-  test("#update does not remove hasMany relationship if record doesn't exist", function (assert) {
-    assert.expect(1);
-
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    cache.on('patch', () => {
-      assert.ok(false, 'no operations were applied');
-    });
-
-    cache.update((t) =>
-      t.removeFromRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
-        type: 'moon',
-        id: 'moon1'
-      })
-    );
-
-    assert.equal(
-      cache.getRecordSync({ type: 'planet', id: 'p1' }),
-      undefined,
-      'planet does not exist'
-    );
-  });
-
-  test("#update adds hasOne if record doesn't exist", function (assert) {
-    assert.expect(2);
-
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    const tb = cache.transformBuilder;
-    const replacePlanet = tb.replaceRelatedRecord(
-      { type: 'moon', id: 'moon1' },
-      'planet',
-      { type: 'planet', id: 'p1' }
-    );
-
-    const addToMoons = tb.addToRelatedRecords(
-      { type: 'planet', id: 'p1' },
-      'moons',
-      { type: 'moon', id: 'moon1' }
-    );
-
-    let order = 0;
-    cache.on('patch', (op) => {
-      order++;
-      if (order === 1) {
-        assert.deepEqual(
-          op,
-          replacePlanet.toOperation(),
-          'applied replacePlanet operation'
-        );
-      } else if (order === 2) {
-        assert.deepEqual(
-          op,
-          addToMoons.toOperation(),
-          'applied addToMoons operation'
-        );
-      } else {
-        assert.ok(false, 'too many ops');
-      }
-    });
-
-    cache.update([replacePlanet]);
-  });
-
-  test("#update will add empty hasOne link if record doesn't exist", function (assert) {
-    assert.expect(2);
-
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    const tb = cache.transformBuilder;
-    const clearPlanet = tb.replaceRelatedRecord(
-      { type: 'moon', id: 'moon1' },
-      'planet',
-      null
-    );
-
-    let order = 0;
-    cache.on('patch', (op) => {
-      order++;
-      if (order === 1) {
-        assert.deepEqual(
-          op,
-          clearPlanet.toOperation(),
-          'applied clearPlanet operation'
-        );
-      } else {
-        assert.ok(false, 'too many ops');
-      }
-    });
-
-    cache.update([clearPlanet]);
-
-    assert.ok(true, 'patch applied');
-  });
-
-  test('#update does not add link to hasMany if link already exists', function (assert) {
-    assert.expect(1);
-
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    const jupiter: Record = {
-      id: 'p1',
-      type: 'planet',
-      attributes: { name: 'Jupiter' },
-      relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-    };
-
-    cache.update((t) => t.addRecord(jupiter));
-
-    cache.on('patch', () => {
-      assert.ok(false, 'no operations were applied');
-    });
-
-    cache.update((t) =>
-      t.addToRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'm1' })
-    );
-
-    assert.ok(true, 'patch completed');
-  });
-
-  test("#update does not remove relationship from hasMany if relationship doesn't exist", function (assert) {
-    assert.expect(1);
-
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    const jupiter: Record = {
-      id: 'p1',
-      type: 'planet',
-      attributes: { name: 'Jupiter' }
-    };
-
-    cache.update((t) => t.addRecord(jupiter));
-
-    cache.on('patch', () => {
-      assert.ok(false, 'no operations were applied');
-    });
-
-    cache.update((t) =>
-      t.removeFromRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'm1' })
-    );
-
-    assert.ok(true, 'patch completed');
-  });
-
-  test('#update can add and remove to has-many relationship', function (assert) {
-    assert.expect(2);
-
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    const jupiter: Record = { id: 'jupiter', type: 'planet' };
-    cache.update((t) => t.addRecord(jupiter));
-
-    const callisto: Record = { id: 'callisto', type: 'moon' };
-    cache.update((t) => t.addRecord(callisto));
-
-    cache.update((t) =>
-      t.addToRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'callisto' })
-    );
-
-    assert.ok(
-      recordsInclude(
-        cache.getRelatedRecordsSync(jupiter, 'moons') as RecordIdentity[],
-        callisto
-      ),
-      'moon added'
-    );
-
-    cache.update((t) =>
-      t.removeFromRelatedRecords(jupiter, 'moons', {
-        type: 'moon',
-        id: 'callisto'
-      })
-    );
-
-    assert.notOk(
-      recordsInclude(
-        cache.getRelatedRecordsSync(jupiter, 'moons') as RecordIdentity[],
-        callisto
-      ),
-      'moon removed'
-    );
-  });
-
-  test('#update can add and clear has-one relationship', function (assert) {
-    assert.expect(2);
-
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    const jupiter: Record = { id: 'jupiter', type: 'planet' };
-    cache.update((t) => t.addRecord(jupiter));
-
-    const callisto: Record = { id: 'callisto', type: 'moon' };
-    cache.update((t) => t.addRecord(callisto));
-
-    cache.update((t) =>
-      t.replaceRelatedRecord(callisto, 'planet', {
-        type: 'planet',
-        id: 'jupiter'
-      })
-    );
-
-    assert.ok(
-      equalRecordIdentities(
-        cache.getRelatedRecordSync(callisto, 'planet') as RecordIdentity,
-        jupiter
-      ),
-      'relationship added'
-    );
-
-    cache.update((t) => t.replaceRelatedRecord(callisto, 'planet', null));
-
-    assert.notOk(
-      equalRecordIdentities(
-        cache.getRelatedRecordSync(callisto, 'planet') as RecordIdentity,
-        jupiter
-      ),
-      'relationship cleared'
-    );
-  });
-
-  test('does not replace hasOne if relationship already exists', function (assert) {
-    assert.expect(1);
-
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    const europa: Record = {
-      id: 'm1',
-      type: 'moon',
-      attributes: { name: 'Europa' },
-      relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-    };
-
-    cache.update((t) => t.addRecord(europa));
-
-    cache.on('patch', () => {
-      assert.ok(false, 'no operations were applied');
-    });
-
-    cache.update((t) =>
-      t.replaceRelatedRecord(europa, 'planet', { type: 'planet', id: 'p1' })
-    );
-
-    assert.ok(true, 'patch completed');
-  });
-
-  test("does not remove hasOne if relationship doesn't exist", function (assert) {
-    assert.expect(1);
-
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    const europa: Record = {
-      type: 'moon',
-      id: 'm1',
-      attributes: { name: 'Europa' },
-      relationships: { planet: { data: null } }
-    };
-
-    cache.update((t) => t.addRecord(europa));
-
-    cache.on('patch', () => {
-      assert.ok(false, 'no operations were applied');
-    });
-
-    cache.update((t) => t.replaceRelatedRecord(europa, 'planet', null));
-
-    assert.ok(true, 'patch completed');
-  });
-
-  test('#update removing model with a bi-directional hasOne', function (assert) {
-    assert.expect(5);
-
-    const hasOneSchema = new RecordSchema({
-      models: {
-        one: {
-          relationships: {
-            two: { kind: 'hasOne', type: 'two', inverse: 'one' }
-          }
-        },
-        two: {
-          relationships: {
-            one: { kind: 'hasOne', type: 'one', inverse: 'two' }
-          }
-        }
-      }
-    });
-
-    const cache = new ExampleSyncRecordCache({ schema: hasOneSchema, keyMap });
-
-    cache.update((t) => [
-      t.addRecord({
-        id: '1',
-        type: 'one',
-        relationships: {
-          two: { data: null }
-        }
-      }),
-      t.addRecord({
-        id: '2',
-        type: 'two',
-        relationships: {
-          one: { data: { type: 'one', id: '1' } }
-        }
-      })
-    ]);
-
-    const one = cache.getRecordSync({ type: 'one', id: '1' }) as Record;
-    const two = cache.getRecordSync({ type: 'two', id: '2' }) as Record;
-    assert.ok(one, 'one exists');
-    assert.ok(two, 'two exists');
-    assert.deepEqual(
-      one.relationships?.two.data,
-      { type: 'two', id: '2' },
-      'one links to two'
-    );
-    assert.deepEqual(
-      two.relationships?.one.data,
-      { type: 'one', id: '1' },
-      'two links to one'
-    );
-
-    cache.update((t) => t.removeRecord(two));
-
-    assert.equal(
-      (cache.getRecordSync({ type: 'one', id: '1' }) as Record).relationships
-        ?.two.data,
-      null,
-      'ones link to two got removed'
-    );
-  });
-
-  test('#update removes dependent records in a hasOne relationship', function (assert) {
-    const dependentSchema = new RecordSchema({
-      models: {
-        planet: {
-          relationships: {
-            moons: { kind: 'hasMany', type: 'moon' }
-          }
-        },
-        moon: {
-          relationships: {
-            planet: { kind: 'hasOne', type: 'planet', dependent: 'remove' }
-          }
-        }
-      }
-    });
-
-    const cache = new ExampleSyncRecordCache({
-      schema: dependentSchema,
-      keyMap
-    });
-
-    const jupiter: Record = {
-      type: 'planet',
-      id: 'p1',
-      attributes: { name: 'Jupiter' }
-    };
-    const io: Record = {
-      type: 'moon',
-      id: 'm1',
-      attributes: { name: 'Io' },
-      relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-    };
-    const europa: Record = {
-      type: 'moon',
-      id: 'm2',
-      attributes: { name: 'Europa' },
-      relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-    };
-
-    cache.update((t) => [
-      t.addRecord(jupiter),
-      t.addRecord(io),
-      t.addRecord(europa),
-      t.addToRelatedRecords(jupiter, 'moons', io),
-      t.addToRelatedRecords(jupiter, 'moons', europa)
-    ]);
-
-    cache.update((t) => t.removeRecord(io));
-
-    assert.equal(
-      cache.getRecordsSync('moon').length,
-      1,
-      'Only europa is left in store'
-    );
-    assert.equal(
-      cache.getRecordsSync('planet').length,
-      0,
-      'Jupiter has been removed from the store'
-    );
-  });
-
-  test('#update removes dependent records in a hasMany relationship', function (assert) {
-    const dependentSchema = new RecordSchema({
-      models: {
-        planet: {
-          relationships: {
-            moons: { kind: 'hasMany', type: 'moon', dependent: 'remove' }
-          }
-        },
-        moon: {
-          relationships: {
-            planet: { kind: 'hasOne', type: 'planet' }
-          }
-        }
-      }
-    });
-
-    const cache = new ExampleSyncRecordCache({
-      schema: dependentSchema,
-      keyMap
-    });
-
-    const jupiter: Record = {
-      type: 'planet',
-      id: 'p1',
-      attributes: { name: 'Jupiter' }
-    };
-    const io: Record = {
-      type: 'moon',
-      id: 'm1',
-      attributes: { name: 'Io' },
-      relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-    };
-    const europa: Record = {
-      type: 'moon',
-      id: 'm2',
-      attributes: { name: 'Europa' },
-      relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-    };
-
-    cache.update((t) => [
-      t.updateRecord(jupiter),
-      t.updateRecord(io),
-      t.updateRecord(europa),
-      t.addToRelatedRecords(jupiter, 'moons', io),
-      t.addToRelatedRecords(jupiter, 'moons', europa)
-    ]);
-
-    cache.update((t) => t.removeRecord(jupiter));
-
-    assert.equal(
-      cache.getRecordsSync('planet').length,
-      0,
-      'Jupiter has been removed from the store'
-    );
-    assert.equal(
-      cache.getRecordsSync('moon').length,
-      0,
-      'All of Jupiters moons are removed from the store'
-    );
-  });
-
-  test('#update does not remove non-dependent records', function (assert) {
-    const dependentSchema = new RecordSchema({
-      models: {
-        planet: {
-          relationships: {
-            moons: { kind: 'hasMany', type: 'moon' }
-          }
-        },
-        moon: {
-          relationships: {
-            planet: { kind: 'hasOne', type: 'planet' }
-          }
-        }
-      }
-    });
-
-    const cache = new ExampleSyncRecordCache({
-      schema: dependentSchema,
-      keyMap
-    });
-
-    const jupiter: Record = {
-      type: 'planet',
-      id: 'p1',
-      attributes: { name: 'Jupiter' }
-    };
-    const io: Record = {
-      type: 'moon',
-      id: 'm1',
-      attributes: { name: 'Io' },
-      relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-    };
-    const europa: Record = {
-      type: 'moon',
-      id: 'm2',
-      attributes: { name: 'Europa' },
-      relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
-    };
-
-    cache.update((t) => [
-      t.addRecord(jupiter),
-      t.addRecord(io),
-      t.addRecord(europa),
-      t.addToRelatedRecords(jupiter, 'moons', io),
-      t.addToRelatedRecords(jupiter, 'moons', europa)
-    ]);
-
-    // Since there are no dependent relationships, no other records will be
-    // removed
-    cache.update((t) => t.removeRecord(io));
-
-    assert.equal(
-      cache.getRecordsSync('moon').length,
-      1,
-      'One moon left in store'
-    );
-    assert.equal(
-      cache.getRecordsSync('planet').length,
-      1,
-      'One planet left in store'
-    );
-  });
-
-  test('#update merges records when "replacing" and will not stomp on attributes and relationships that are not replaced', function (assert) {
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-    const tb = cache.transformBuilder;
-
-    cache.update((t) => [
-      t.addRecord({
-        type: 'planet',
-        id: '1',
-        attributes: { name: 'Earth' },
-        relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-      })
-    ]);
-
-    let result = cache.update(
-      (t) => [
-        t.updateRecord({
-          type: 'planet',
-          id: '1',
-          attributes: { classification: 'terrestrial' }
-        })
-      ],
-      { fullResponse: true }
-    );
-
-    assert.deepEqual(
-      cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
-      {
-        type: 'planet',
-        id: '1',
-        attributes: { name: 'Earth', classification: 'terrestrial' },
-        relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-      },
-      'records have been merged'
-    );
-
-    assert.deepEqual(
-      result,
-      {
-        data: {
-          type: 'planet',
-          id: '1',
-          attributes: {
-            name: 'Earth',
-            classification: 'terrestrial'
-          },
-          relationships: {
-            moons: {
-              data: [{ type: 'moon', id: 'm1' }]
-            }
-          }
-        },
-        details: {
-          appliedOperations: [
-            tb
-              .updateRecord({
-                type: 'planet',
-                id: '1',
-                attributes: { classification: 'terrestrial' }
-              })
-              .toOperation()
-          ],
-          inverseOperations: [
-            tb
-              .updateRecord({
-                type: 'planet',
-                id: '1',
-                attributes: { classification: null }
-              })
-              .toOperation()
-          ]
-        }
-      },
-      'full response is correct'
-    );
-  });
-
-  test('#update can replace related records but only if they are different', function (assert) {
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-    const tb = cache.transformBuilder;
-
-    cache.update((t) => [
-      t.addRecord({
-        type: 'planet',
-        id: '1',
-        attributes: { name: 'Earth' },
-        relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-      })
-    ]);
-
-    let result = cache.update(
-      (t) => [
-        t.replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
-          { type: 'moon', id: 'm1' }
-        ])
-      ],
-      { fullResponse: true }
-    );
-
-    assert.deepEqual(
-      result,
-      {
-        data: undefined,
-        details: {
-          appliedOperations: [],
-          inverseOperations: []
-        }
-      },
-      'nothing has changed so there are no appliend or inverse ops'
-    );
-
-    result = cache.update(
-      (t) =>
-        t.replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
-          { type: 'moon', id: 'm2' }
-        ]),
-      { fullResponse: true }
-    );
-
-    assert.deepEqual(
-      cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
-      {
-        type: 'planet',
-        id: '1',
-        attributes: { name: 'Earth' },
-        relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
-      },
-      'relationships have been replaced'
-    );
-
-    assert.deepEqual(
-      result,
-      {
-        data: {
+        const earth: Record = {
           type: 'planet',
           id: '1',
           attributes: { name: 'Earth' },
-          relationships: {
-            moons: { data: [{ type: 'moon', id: 'm2' }] }
-          }
-        },
-        details: {
-          appliedOperations: [
-            tb
-              .replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
-                { type: 'moon', id: 'm2' }
-              ])
-              .toOperation(),
-            tb
-              .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', null)
-              .toOperation(),
-            tb
-              .replaceRelatedRecord({ type: 'moon', id: 'm2' }, 'planet', {
-                type: 'planet',
-                id: '1'
-              })
-              .toOperation()
-          ],
-          inverseOperations: [
-            tb
-              .replaceRelatedRecord({ type: 'moon', id: 'm2' }, 'planet', null)
-              .toOperation(),
-            tb
-              .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
-                type: 'planet',
-                id: '1'
-              })
-              .toOperation(),
-            tb
-              .replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
-                { type: 'moon', id: 'm1' }
-              ])
-              .toOperation()
-          ]
-        }
-      },
-      'full response is correct'
-    );
-  });
+          keys: { remoteId: 'a' }
+        };
 
-  test('#update merges records when "replacing" and _will_ replace specified attributes and relationships', function (assert) {
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-    const tb = cache.transformBuilder;
+        cache.on('patch', (operation, data) => {
+          assert.deepEqual(operation, {
+            op: 'addRecord',
+            record: earth
+          });
+          assert.deepEqual(data, earth);
+        });
 
-    const earth: Record = {
-      type: 'planet',
-      id: '1',
-      attributes: { name: 'Earth' },
-      relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-    };
+        cache.update((t) => t.addRecord(earth));
 
-    const jupiter: Record = {
-      type: 'planet',
-      id: '1',
-      attributes: { name: 'Jupiter', classification: 'terrestrial' },
-      relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
-    };
+        assert.strictEqual(
+          cache.getRecordSync({ type: 'planet', id: '1' }),
+          earth,
+          'objects strictly match'
+        );
+        assert.equal(
+          keyMap.keyToId('planet', 'remoteId', 'a'),
+          '1',
+          'key has been mapped'
+        );
+      });
 
-    let result = cache.update([tb.addRecord(earth)], { fullResponse: true });
+      test('#update can replace records', function (assert) {
+        assert.expect(5);
 
-    assert.deepEqual(
-      result,
-      {
-        data: earth,
-        details: {
-          appliedOperations: [
-            tb.addRecord(earth).toOperation(),
-            tb
-              .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
-                type: 'planet',
-                id: '1'
-              })
-              .toOperation()
-          ],
-          inverseOperations: [
-            tb
-              .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', null)
-              .toOperation(),
-            tb
-              .removeRecord({
-                type: 'planet',
-                id: '1'
-              })
-              .toOperation()
-          ]
-        }
-      },
-      'addRecord full response is correct'
-    );
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    result = cache.update([tb.updateRecord(jupiter)], { fullResponse: true });
-
-    assert.deepEqual(result, {
-      data: jupiter,
-      details: {
-        appliedOperations: [
-          tb.updateRecord(jupiter).toOperation(),
-          tb
-            .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', null)
-            .toOperation(),
-          tb
-            .replaceRelatedRecord({ type: 'moon', id: 'm2' }, 'planet', {
-              type: 'planet',
-              id: '1'
-            })
-            .toOperation()
-        ],
-        inverseOperations: [
-          tb
-            .replaceRelatedRecord({ type: 'moon', id: 'm2' }, 'planet', null)
-            .toOperation(),
-          tb
-            .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
-              type: 'planet',
-              id: '1'
-            })
-            .toOperation(),
-          tb
-            .updateRecord({
-              type: 'planet',
-              id: '1',
-              attributes: { name: 'Earth', classification: null },
-              relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
-            })
-            .toOperation()
-        ]
-      }
-    });
-
-    assert.deepEqual(
-      cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
-      {
-        type: 'planet',
-        id: '1',
-        attributes: { name: 'Jupiter', classification: 'terrestrial' },
-        relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
-      },
-      'records have been merged'
-    );
-  });
-
-  test('#update can update existing record with empty relationship', function (assert) {
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-    const tb = cache.transformBuilder;
-
-    let result = cache.update(
-      (t) => [t.addRecord({ id: '1', type: 'planet' })],
-      { fullResponse: true }
-    );
-
-    assert.deepEqual(
-      result,
-      {
-        data: { id: '1', type: 'planet' },
-        details: {
-          appliedOperations: [
-            tb
-              .addRecord({
-                type: 'planet',
-                id: '1'
-              })
-              .toOperation()
-          ],
-          inverseOperations: [
-            tb
-              .removeRecord({
-                type: 'planet',
-                id: '1'
-              })
-              .toOperation()
-          ]
-        }
-      },
-      'addRecord result is correct'
-    );
-
-    result = cache.update(
-      (t) => [
-        t.updateRecord({
-          id: '1',
+        const earth: Record = {
           type: 'planet',
-          relationships: {
-            moons: { data: [] }
-          }
-        })
-      ],
-      { fullResponse: true }
-    );
-
-    assert.deepEqual(
-      result,
-      {
-        data: {
           id: '1',
-          type: 'planet',
-          relationships: {
-            moons: { data: [] }
-          }
-        },
-        details: {
-          appliedOperations: [
-            tb
-              .updateRecord({
-                id: '1',
-                type: 'planet',
-                relationships: {
-                  moons: { data: [] }
-                }
-              })
-              .toOperation()
-          ],
-          inverseOperations: [
-            tb
-              .updateRecord({
-                id: '1',
-                type: 'planet',
-                relationships: {
-                  moons: { data: [] }
-                }
-              })
-              .toOperation()
-          ]
-        }
-      },
-      'updateRecord result is correct'
-    );
+          attributes: { name: 'Earth' },
+          keys: { remoteId: 'a' }
+        };
 
-    const planet = cache.getRecordSync({ type: 'planet', id: '1' });
-    assert.ok(planet, 'planet exists');
-    assert.deepEqual(
-      planet?.relationships?.moons.data,
-      [],
-      'planet has empty moons relationship'
-    );
-  });
+        cache.on('patch', (operation, data) => {
+          assert.deepEqual(operation, {
+            op: 'updateRecord',
+            record: earth
+          });
+          assert.deepEqual(data, earth);
+        });
 
-  test('#update will not overwrite an existing relationship with a missing relationship', function (assert) {
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-    const tb = cache.transformBuilder;
+        cache.update((t) => t.updateRecord(earth));
 
-    let result = cache.update(
-      (t) => [
-        t.addRecord({
-          id: '1',
-          type: 'planet',
-          relationships: {
-            moons: { data: [{ type: 'moon', id: 'm1' }] }
-          }
-        }),
-        t.updateRecord({
-          id: '1',
-          type: 'planet'
-        })
-      ],
-      { fullResponse: true }
-    );
+        assert.deepEqual(
+          cache.getRecordSync({ type: 'planet', id: '1' }),
+          earth,
+          'objects deeply match'
+        );
+        assert.notStrictEqual(
+          cache.getRecordSync({ type: 'planet', id: '1' }),
+          earth,
+          'objects do not strictly match'
+        );
+        assert.equal(
+          keyMap.keyToId('planet', 'remoteId', 'a'),
+          '1',
+          'key has been mapped'
+        );
+      });
 
-    assert.deepEqual(
-      result,
-      {
-        data: [
-          {
-            id: '1',
+      test('#update can replace keys', function (assert) {
+        assert.expect(4);
+
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        const earth: Record = { type: 'planet', id: '1' };
+
+        cache.on('patch', (operation, data) => {
+          assert.deepEqual(operation, {
+            op: 'replaceKey',
+            record: earth,
+            key: 'remoteId',
+            value: 'a'
+          });
+          assert.deepEqual(data, {
             type: 'planet',
-            relationships: {
-              moons: { data: [{ type: 'moon', id: 'm1' }] }
+            id: '1',
+            keys: { remoteId: 'a' }
+          });
+        });
+
+        cache.update((t) => t.replaceKey(earth, 'remoteId', 'a'));
+
+        assert.deepEqual(
+          cache.getRecordSync({ type: 'planet', id: '1' }),
+          { type: 'planet', id: '1', keys: { remoteId: 'a' } },
+          'records match'
+        );
+        assert.equal(
+          keyMap.keyToId('planet', 'remoteId', 'a'),
+          '1',
+          'key has been mapped'
+        );
+      });
+
+      test('#update updates the cache and returns primary data', function (assert) {
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        let p1 = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
+        let p2 = { type: 'planet', id: '2' };
+
+        let result = cache.update((t) => [t.addRecord(p1), t.removeRecord(p2)]);
+
+        assert.deepEqual(
+          result,
+          [
+            p1,
+            undefined // p2 didn't exist
+          ],
+          'response includes just primary data'
+        );
+      });
+
+      test('#update updates the cache and returns a full response if requested', function (assert) {
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        let p1 = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
+        let p2 = { type: 'planet', id: '2' };
+
+        let result = cache.update(
+          (t) => [t.addRecord(p1), t.removeRecord(p2)],
+          {
+            fullResponse: true
+          }
+        );
+
+        assert.deepEqual(
+          result,
+          {
+            data: [
+              p1,
+              undefined // p2 didn't exist
+            ],
+            details: {
+              appliedOperations: [{ op: 'addRecord', record: p1 }],
+              appliedOperationResults: [p1],
+              inverseOperations: [
+                { op: 'removeRecord', record: { type: 'planet', id: '1' } }
+              ]
             }
           },
-          undefined
-        ],
-        details: {
-          appliedOperations: [
-            tb
-              .addRecord({
+          'full response includes data and details'
+        );
+      });
+
+      test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added after', function (assert) {
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' },
+          relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' }
+        };
+
+        cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.moons.data,
+          [{ type: 'moon', id: 'm1' }],
+          'Io has been assigned to Jupiter'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.planet.data,
+          { type: 'planet', id: 'p1' },
+          'Jupiter has been assigned to Io'
+        );
+      });
+
+      test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added before', function (assert) {
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' },
+          relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' }
+        };
+
+        cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.moons.data,
+          [{ type: 'moon', id: 'm1' }],
+          'Io has been assigned to Jupiter'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.planet.data,
+          { type: 'planet', id: 'p1' },
+          'Jupiter has been assigned to Io'
+        );
+      });
+
+      test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added after', function (assert) {
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' }
+        };
+
+        cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.moons.data,
+          [{ type: 'moon', id: 'm1' }],
+          'Io has been assigned to Jupiter'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.planet.data,
+          { type: 'planet', id: 'p1' },
+          'Jupiter has been assigned to Io'
+        );
+      });
+
+      test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added before', function (assert) {
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' }
+        };
+
+        cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.moons.data,
+          [{ type: 'moon', id: 'm1' }],
+          'Io has been assigned to Jupiter'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.planet.data,
+          { type: 'planet', id: 'p1' },
+          'Jupiter has been assigned to Io'
+        );
+      });
+
+      test('#update updates inverse hasOne relationship when a record with an empty relationship is added', function (assert) {
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' },
+          relationships: { moons: { data: [] } }
+        };
+
+        cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.moons.data,
+          [],
+          'Jupiter has no moons'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.planet.data,
+          null,
+          'Jupiter has been cleared from Io'
+        );
+      });
+
+      test('#update updates inverse hasMany relationship when a record with an empty relationship is added', function (assert) {
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' },
+          relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: null } }
+        };
+
+        cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.moons.data,
+          [],
+          'Io has been cleared from Jupiter'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.planet.data,
+          null,
+          'Io has no planet'
+        );
+      });
+
+      test('#update updates inverse hasMany polymorphic relationship', function (assert) {
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        const sun: Record = {
+          type: 'star',
+          id: 's1',
+          attributes: { name: 'Sun' },
+          relationships: {
+            celestialObjects: {
+              data: [
+                { type: 'planet', id: 'p1' },
+                { type: 'moon', id: 'm1' }
+              ]
+            }
+          }
+        };
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' }
+        };
+
+        cache.update((t) => [
+          t.updateRecord(sun),
+          t.updateRecord(jupiter),
+          t.updateRecord(io)
+        ]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'star', id: 's1' }) as Record)
+            ?.relationships?.celestialObjects.data,
+          [
+            { type: 'planet', id: 'p1' },
+            { type: 'moon', id: 'm1' }
+          ],
+          'Jupiter and Io has been assigned to Sun'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.star.data,
+          { type: 'star', id: 's1' },
+          'Sun has been assigned to Jupiter'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.star.data,
+          { type: 'star', id: 's1' },
+          'Sun has been assigned to Io'
+        );
+      });
+
+      test('#update updates inverse hasOne polymorphic relationship', function (assert) {
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' },
+          relationships: { star: { data: { type: 'star', id: 's1' } } }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { star: { data: { type: 'star', id: 's1' } } }
+        };
+        const sun: Record = {
+          type: 'star',
+          id: 's1',
+          attributes: { name: 'Sun' }
+        };
+
+        cache.update((t) => [
+          t.updateRecord(jupiter),
+          t.updateRecord(io),
+          t.updateRecord(sun)
+        ]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'star', id: 's1' }) as Record)
+            ?.relationships?.celestialObjects.data,
+          [
+            { type: 'planet', id: 'p1' },
+            { type: 'moon', id: 'm1' }
+          ],
+          'Jupiter and Io has been assigned to Sun'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.star.data,
+          { type: 'star', id: 's1' },
+          'Sun has been assigned to Jupiter'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.star.data,
+          { type: 'star', id: 's1' },
+          'Sun has been assigned to Io'
+        );
+      });
+
+      test('#update tracks refs and clears them from hasOne relationships when a referenced record is removed', function (assert) {
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' },
+          relationships: { moons: { data: undefined } }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+        const europa: Record = {
+          type: 'moon',
+          id: 'm2',
+          attributes: { name: 'Europa' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+
+        cache.update((t) => [
+          t.addRecord(jupiter),
+          t.addRecord(io),
+          t.addRecord(europa)
+        ]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.planet.data,
+          { type: 'planet', id: 'p1' },
+          'Jupiter has been assigned to Io'
+        );
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'moon', id: 'm2' }) as Record)
+            ?.relationships?.planet.data,
+          { type: 'planet', id: 'p1' },
+          'Jupiter has been assigned to Europa'
+        );
+
+        cache.update((t) => t.removeRecord(jupiter));
+
+        assert.equal(
+          cache.getRecordSync({ type: 'planet', id: 'p1' }),
+          undefined,
+          'Jupiter is GONE'
+        );
+
+        assert.equal(
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+            ?.relationships?.planet.data,
+          undefined,
+          'Jupiter has been cleared from Io'
+        );
+        assert.equal(
+          (cache.getRecordSync({ type: 'moon', id: 'm2' }) as Record)
+            ?.relationships?.planet.data,
+          undefined,
+          'Jupiter has been cleared from Europa'
+        );
+      });
+
+      test('#update tracks refs and clears them from hasMany relationships when a referenced record is removed', function (assert) {
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: null } }
+        };
+        const europa: Record = {
+          type: 'moon',
+          id: 'm2',
+          attributes: { name: 'Europa' },
+          relationships: { planet: { data: null } }
+        };
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' },
+          relationships: {
+            moons: {
+              data: [
+                { type: 'moon', id: 'm1' },
+                { type: 'moon', id: 'm2' }
+              ]
+            }
+          }
+        };
+
+        cache.update((t) => [
+          t.addRecord(io),
+          t.addRecord(europa),
+          t.addRecord(jupiter)
+        ]);
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.moons.data,
+          [
+            { type: 'moon', id: 'm1' },
+            { type: 'moon', id: 'm2' }
+          ],
+          'Jupiter has been assigned to Io and Europa'
+        );
+        assert.ok(
+          recordsIncludeAll(
+            cache.getRelatedRecordsSync(jupiter, 'moons') as RecordIdentity[],
+            [io, europa]
+          ),
+          'Jupiter has been assigned to Io and Europa'
+        );
+
+        cache.update((t) => t.removeRecord(io));
+
+        assert.equal(
+          cache.getRecordSync({ type: 'moon', id: 'm1' }),
+          null,
+          'Io is GONE'
+        );
+
+        cache.update((t) => t.removeRecord(europa));
+
+        assert.equal(
+          cache.getRecordSync({ type: 'moon', id: 'm2' }),
+          null,
+          'Europa is GONE'
+        );
+
+        assert.deepEqual(
+          cache.getRelatedRecordsSync(
+            { type: 'planet', id: 'p1' },
+            'moons'
+          ) as RecordIdentity[],
+          [],
+          'moons have been cleared from Jupiter'
+        );
+      });
+
+      test("#update adds link to hasMany if record doesn't exist", function (assert) {
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        cache.update((t) =>
+          t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+            type: 'moon',
+            id: 'm1'
+          })
+        );
+
+        cache.update((t) =>
+          t.addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+            type: 'moon',
+            id: 'm1'
+          })
+        );
+
+        assert.deepEqual(
+          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+            ?.relationships?.moons.data,
+          [{ type: 'moon', id: 'm1' }],
+          'relationship was added'
+        );
+      });
+
+      test("#update does not remove hasMany relationship if record doesn't exist", function (assert) {
+        assert.expect(1);
+
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        cache.on('patch', () => {
+          assert.ok(false, 'no operations were applied');
+        });
+
+        cache.update((t) =>
+          t.removeFromRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+            type: 'moon',
+            id: 'moon1'
+          })
+        );
+
+        assert.equal(
+          cache.getRecordSync({ type: 'planet', id: 'p1' }),
+          undefined,
+          'planet does not exist'
+        );
+      });
+
+      test("#update adds hasOne if record doesn't exist", function (assert) {
+        assert.expect(2);
+
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        const tb = cache.transformBuilder;
+        const replacePlanet = tb.replaceRelatedRecord(
+          { type: 'moon', id: 'moon1' },
+          'planet',
+          { type: 'planet', id: 'p1' }
+        );
+
+        const addToMoons = tb.addToRelatedRecords(
+          { type: 'planet', id: 'p1' },
+          'moons',
+          { type: 'moon', id: 'moon1' }
+        );
+
+        let order = 0;
+        cache.on('patch', (op) => {
+          order++;
+          if (order === 1) {
+            assert.deepEqual(
+              op,
+              replacePlanet.toOperation(),
+              'applied replacePlanet operation'
+            );
+          } else if (order === 2) {
+            assert.deepEqual(
+              op,
+              addToMoons.toOperation(),
+              'applied addToMoons operation'
+            );
+          } else {
+            assert.ok(false, 'too many ops');
+          }
+        });
+
+        cache.update([replacePlanet]);
+      });
+
+      test("#update will add empty hasOne link if record doesn't exist", function (assert) {
+        assert.expect(2);
+
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        const tb = cache.transformBuilder;
+        const clearPlanet = tb.replaceRelatedRecord(
+          { type: 'moon', id: 'moon1' },
+          'planet',
+          null
+        );
+
+        let order = 0;
+        cache.on('patch', (op) => {
+          order++;
+          if (order === 1) {
+            assert.deepEqual(
+              op,
+              clearPlanet.toOperation(),
+              'applied clearPlanet operation'
+            );
+          } else {
+            assert.ok(false, 'too many ops');
+          }
+        });
+
+        cache.update([clearPlanet]);
+
+        assert.ok(true, 'patch applied');
+      });
+
+      test('#update does not add link to hasMany if link already exists', function (assert) {
+        assert.expect(1);
+
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        const jupiter: Record = {
+          id: 'p1',
+          type: 'planet',
+          attributes: { name: 'Jupiter' },
+          relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+        };
+
+        cache.update((t) => t.addRecord(jupiter));
+
+        cache.on('patch', () => {
+          assert.ok(false, 'no operations were applied');
+        });
+
+        cache.update((t) =>
+          t.addToRelatedRecords(jupiter, 'moons', { type: 'moon', id: 'm1' })
+        );
+
+        assert.ok(true, 'patch completed');
+      });
+
+      test("#update does not remove relationship from hasMany if relationship doesn't exist", function (assert) {
+        assert.expect(1);
+
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        const jupiter: Record = {
+          id: 'p1',
+          type: 'planet',
+          attributes: { name: 'Jupiter' }
+        };
+
+        cache.update((t) => t.addRecord(jupiter));
+
+        cache.on('patch', () => {
+          assert.ok(false, 'no operations were applied');
+        });
+
+        cache.update((t) =>
+          t.removeFromRelatedRecords(jupiter, 'moons', {
+            type: 'moon',
+            id: 'm1'
+          })
+        );
+
+        assert.ok(true, 'patch completed');
+      });
+
+      test('#update can add and remove to has-many relationship', function (assert) {
+        assert.expect(2);
+
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        const jupiter: Record = { id: 'jupiter', type: 'planet' };
+        cache.update((t) => t.addRecord(jupiter));
+
+        const callisto: Record = { id: 'callisto', type: 'moon' };
+        cache.update((t) => t.addRecord(callisto));
+
+        cache.update((t) =>
+          t.addToRelatedRecords(jupiter, 'moons', {
+            type: 'moon',
+            id: 'callisto'
+          })
+        );
+
+        assert.ok(
+          recordsInclude(
+            cache.getRelatedRecordsSync(jupiter, 'moons') as RecordIdentity[],
+            callisto
+          ),
+          'moon added'
+        );
+
+        cache.update((t) =>
+          t.removeFromRelatedRecords(jupiter, 'moons', {
+            type: 'moon',
+            id: 'callisto'
+          })
+        );
+
+        assert.notOk(
+          recordsInclude(
+            cache.getRelatedRecordsSync(jupiter, 'moons') as RecordIdentity[],
+            callisto
+          ),
+          'moon removed'
+        );
+      });
+
+      test('#update can add and clear has-one relationship', function (assert) {
+        assert.expect(2);
+
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        const jupiter: Record = { id: 'jupiter', type: 'planet' };
+        cache.update((t) => t.addRecord(jupiter));
+
+        const callisto: Record = { id: 'callisto', type: 'moon' };
+        cache.update((t) => t.addRecord(callisto));
+
+        cache.update((t) =>
+          t.replaceRelatedRecord(callisto, 'planet', {
+            type: 'planet',
+            id: 'jupiter'
+          })
+        );
+
+        assert.ok(
+          equalRecordIdentities(
+            cache.getRelatedRecordSync(callisto, 'planet') as RecordIdentity,
+            jupiter
+          ),
+          'relationship added'
+        );
+
+        cache.update((t) => t.replaceRelatedRecord(callisto, 'planet', null));
+
+        assert.notOk(
+          equalRecordIdentities(
+            cache.getRelatedRecordSync(callisto, 'planet') as RecordIdentity,
+            jupiter
+          ),
+          'relationship cleared'
+        );
+      });
+
+      test('does not replace hasOne if relationship already exists', function (assert) {
+        assert.expect(1);
+
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        const europa: Record = {
+          id: 'm1',
+          type: 'moon',
+          attributes: { name: 'Europa' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+
+        cache.update((t) => t.addRecord(europa));
+
+        cache.on('patch', () => {
+          assert.ok(false, 'no operations were applied');
+        });
+
+        cache.update((t) =>
+          t.replaceRelatedRecord(europa, 'planet', { type: 'planet', id: 'p1' })
+        );
+
+        assert.ok(true, 'patch completed');
+      });
+
+      test("does not remove hasOne if relationship doesn't exist", function (assert) {
+        assert.expect(1);
+
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        const europa: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Europa' },
+          relationships: { planet: { data: null } }
+        };
+
+        cache.update((t) => t.addRecord(europa));
+
+        cache.on('patch', () => {
+          assert.ok(false, 'no operations were applied');
+        });
+
+        cache.update((t) => t.replaceRelatedRecord(europa, 'planet', null));
+
+        assert.ok(true, 'patch completed');
+      });
+
+      test('#update removing model with a bi-directional hasOne', function (assert) {
+        assert.expect(5);
+
+        const hasOneSchema = new RecordSchema({
+          models: {
+            one: {
+              relationships: {
+                two: { kind: 'hasOne', type: 'two', inverse: 'one' }
+              }
+            },
+            two: {
+              relationships: {
+                one: { kind: 'hasOne', type: 'one', inverse: 'two' }
+              }
+            }
+          }
+        });
+
+        const cache = new ExampleSyncRecordCache({
+          schema: hasOneSchema,
+          keyMap
+        });
+
+        cache.update((t) => [
+          t.addRecord({
+            id: '1',
+            type: 'one',
+            relationships: {
+              two: { data: null }
+            }
+          }),
+          t.addRecord({
+            id: '2',
+            type: 'two',
+            relationships: {
+              one: { data: { type: 'one', id: '1' } }
+            }
+          })
+        ]);
+
+        const one = cache.getRecordSync({ type: 'one', id: '1' }) as Record;
+        const two = cache.getRecordSync({ type: 'two', id: '2' }) as Record;
+        assert.ok(one, 'one exists');
+        assert.ok(two, 'two exists');
+        assert.deepEqual(
+          one.relationships?.two.data,
+          { type: 'two', id: '2' },
+          'one links to two'
+        );
+        assert.deepEqual(
+          two.relationships?.one.data,
+          { type: 'one', id: '1' },
+          'two links to one'
+        );
+
+        cache.update((t) => t.removeRecord(two));
+
+        assert.equal(
+          (cache.getRecordSync({ type: 'one', id: '1' }) as Record)
+            .relationships?.two.data,
+          null,
+          'ones link to two got removed'
+        );
+      });
+
+      test('#update removes dependent records in a hasOne relationship', function (assert) {
+        const dependentSchema = new RecordSchema({
+          models: {
+            planet: {
+              relationships: {
+                moons: { kind: 'hasMany', type: 'moon' }
+              }
+            },
+            moon: {
+              relationships: {
+                planet: { kind: 'hasOne', type: 'planet', dependent: 'remove' }
+              }
+            }
+          }
+        });
+
+        const cache = new ExampleSyncRecordCache({
+          schema: dependentSchema,
+          keyMap
+        });
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+        const europa: Record = {
+          type: 'moon',
+          id: 'm2',
+          attributes: { name: 'Europa' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+
+        cache.update((t) => [
+          t.addRecord(jupiter),
+          t.addRecord(io),
+          t.addRecord(europa),
+          t.addToRelatedRecords(jupiter, 'moons', io),
+          t.addToRelatedRecords(jupiter, 'moons', europa)
+        ]);
+
+        cache.update((t) => t.removeRecord(io));
+
+        assert.equal(
+          cache.getRecordsSync('moon').length,
+          1,
+          'Only europa is left in store'
+        );
+        assert.equal(
+          cache.getRecordsSync('planet').length,
+          0,
+          'Jupiter has been removed from the store'
+        );
+      });
+
+      test('#update removes dependent records in a hasMany relationship', function (assert) {
+        const dependentSchema = new RecordSchema({
+          models: {
+            planet: {
+              relationships: {
+                moons: { kind: 'hasMany', type: 'moon', dependent: 'remove' }
+              }
+            },
+            moon: {
+              relationships: {
+                planet: { kind: 'hasOne', type: 'planet' }
+              }
+            }
+          }
+        });
+
+        const cache = new ExampleSyncRecordCache({
+          schema: dependentSchema,
+          keyMap
+        });
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+        const europa: Record = {
+          type: 'moon',
+          id: 'm2',
+          attributes: { name: 'Europa' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+
+        cache.update((t) => [
+          t.updateRecord(jupiter),
+          t.updateRecord(io),
+          t.updateRecord(europa),
+          t.addToRelatedRecords(jupiter, 'moons', io),
+          t.addToRelatedRecords(jupiter, 'moons', europa)
+        ]);
+
+        cache.update((t) => t.removeRecord(jupiter));
+
+        assert.equal(
+          cache.getRecordsSync('planet').length,
+          0,
+          'Jupiter has been removed from the store'
+        );
+        assert.equal(
+          cache.getRecordsSync('moon').length,
+          0,
+          'All of Jupiters moons are removed from the store'
+        );
+      });
+
+      test('#update does not remove non-dependent records', function (assert) {
+        const dependentSchema = new RecordSchema({
+          models: {
+            planet: {
+              relationships: {
+                moons: { kind: 'hasMany', type: 'moon' }
+              }
+            },
+            moon: {
+              relationships: {
+                planet: { kind: 'hasOne', type: 'planet' }
+              }
+            }
+          }
+        });
+
+        const cache = new ExampleSyncRecordCache({
+          schema: dependentSchema,
+          keyMap
+        });
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: 'p1',
+          attributes: { name: 'Jupiter' }
+        };
+        const io: Record = {
+          type: 'moon',
+          id: 'm1',
+          attributes: { name: 'Io' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+        const europa: Record = {
+          type: 'moon',
+          id: 'm2',
+          attributes: { name: 'Europa' },
+          relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+        };
+
+        cache.update((t) => [
+          t.addRecord(jupiter),
+          t.addRecord(io),
+          t.addRecord(europa),
+          t.addToRelatedRecords(jupiter, 'moons', io),
+          t.addToRelatedRecords(jupiter, 'moons', europa)
+        ]);
+
+        // Since there are no dependent relationships, no other records will be
+        // removed
+        cache.update((t) => t.removeRecord(io));
+
+        assert.equal(
+          cache.getRecordsSync('moon').length,
+          1,
+          'One moon left in store'
+        );
+        assert.equal(
+          cache.getRecordsSync('planet').length,
+          1,
+          'One planet left in store'
+        );
+      });
+
+      test('#update merges records when "replacing" and will not stomp on attributes and relationships that are not replaced', function (assert) {
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+        const tb = cache.transformBuilder;
+
+        cache.update((t) => [
+          t.addRecord({
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Earth' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+          })
+        ]);
+
+        let result = cache.update(
+          (t) => [
+            t.updateRecord({
+              type: 'planet',
+              id: '1',
+              attributes: { classification: 'terrestrial' }
+            })
+          ],
+          { fullResponse: true }
+        );
+
+        assert.deepEqual(
+          cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
+          {
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Earth', classification: 'terrestrial' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+          },
+          'records have been merged'
+        );
+
+        assert.deepEqual(
+          result,
+          {
+            data: {
+              type: 'planet',
+              id: '1',
+              attributes: {
+                name: 'Earth',
+                classification: 'terrestrial'
+              },
+              relationships: {
+                moons: {
+                  data: [{ type: 'moon', id: 'm1' }]
+                }
+              }
+            },
+            details: {
+              appliedOperations: [
+                tb
+                  .updateRecord({
+                    type: 'planet',
+                    id: '1',
+                    attributes: { classification: 'terrestrial' }
+                  })
+                  .toOperation()
+              ],
+              appliedOperationResults: [
+                {
+                  type: 'planet',
+                  id: '1',
+                  attributes: {
+                    name: 'Earth',
+                    classification: 'terrestrial'
+                  },
+                  relationships: {
+                    moons: {
+                      data: [{ type: 'moon', id: 'm1' }]
+                    }
+                  }
+                }
+              ],
+              inverseOperations: [
+                tb
+                  .updateRecord({
+                    type: 'planet',
+                    id: '1',
+                    attributes: { classification: null }
+                  })
+                  .toOperation()
+              ]
+            }
+          },
+          'full response is correct'
+        );
+      });
+
+      test('#update can replace related records but only if they are different', function (assert) {
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+        const tb = cache.transformBuilder;
+
+        cache.update((t) => [
+          t.addRecord({
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Earth' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+          })
+        ]);
+
+        let result = cache.update(
+          (t) => [
+            t.replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
+              { type: 'moon', id: 'm1' }
+            ])
+          ],
+          { fullResponse: true }
+        );
+
+        assert.deepEqual(
+          result,
+          {
+            data: undefined,
+            details: {
+              appliedOperations: [],
+              appliedOperationResults: [],
+              inverseOperations: []
+            }
+          },
+          'nothing has changed so there are no appliend or inverse ops'
+        );
+
+        result = cache.update(
+          (t) =>
+            t.replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
+              { type: 'moon', id: 'm2' }
+            ]),
+          { fullResponse: true }
+        );
+
+        assert.deepEqual(
+          cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
+          {
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Earth' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
+          },
+          'relationships have been replaced'
+        );
+
+        assert.deepEqual(
+          result,
+          {
+            data: {
+              type: 'planet',
+              id: '1',
+              attributes: { name: 'Earth' },
+              relationships: {
+                moons: { data: [{ type: 'moon', id: 'm2' }] }
+              }
+            },
+            details: {
+              appliedOperations: [
+                tb
+                  .replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
+                    { type: 'moon', id: 'm2' }
+                  ])
+                  .toOperation(),
+                tb
+                  .replaceRelatedRecord(
+                    { type: 'moon', id: 'm1' },
+                    'planet',
+                    null
+                  )
+                  .toOperation(),
+                tb
+                  .replaceRelatedRecord({ type: 'moon', id: 'm2' }, 'planet', {
+                    type: 'planet',
+                    id: '1'
+                  })
+                  .toOperation()
+              ],
+              appliedOperationResults: [
+                {
+                  type: 'planet',
+                  id: '1',
+                  attributes: { name: 'Earth' },
+                  relationships: {
+                    moons: { data: [{ type: 'moon', id: 'm2' }] }
+                  }
+                },
+                {
+                  type: 'moon',
+                  id: 'm1',
+                  relationships: {
+                    planet: { data: null }
+                  }
+                },
+                {
+                  type: 'moon',
+                  id: 'm2',
+                  relationships: {
+                    planet: { data: { type: 'planet', id: '1' } }
+                  }
+                }
+              ],
+              inverseOperations: [
+                tb
+                  .replaceRelatedRecord(
+                    { type: 'moon', id: 'm2' },
+                    'planet',
+                    null
+                  )
+                  .toOperation(),
+                tb
+                  .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
+                    type: 'planet',
+                    id: '1'
+                  })
+                  .toOperation(),
+                tb
+                  .replaceRelatedRecords({ type: 'planet', id: '1' }, 'moons', [
+                    { type: 'moon', id: 'm1' }
+                  ])
+                  .toOperation()
+              ]
+            }
+          },
+          'full response is correct'
+        );
+      });
+
+      test('#update merges records when "replacing" and _will_ replace specified attributes and relationships', function (assert) {
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+        const tb = cache.transformBuilder;
+
+        const earth: Record = {
+          type: 'planet',
+          id: '1',
+          attributes: { name: 'Earth' },
+          relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
+        };
+
+        const jupiter: Record = {
+          type: 'planet',
+          id: '1',
+          attributes: { name: 'Jupiter', classification: 'terrestrial' },
+          relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
+        };
+
+        let result = cache.update([tb.addRecord(earth)], {
+          fullResponse: true
+        });
+
+        assert.deepEqual(
+          result,
+          {
+            data: earth,
+            details: {
+              appliedOperations: [
+                tb.addRecord(earth).toOperation(),
+                tb
+                  .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
+                    type: 'planet',
+                    id: '1'
+                  })
+                  .toOperation()
+              ],
+              appliedOperationResults: [
+                {
+                  type: 'planet',
+                  id: '1',
+                  attributes: { name: 'Earth' },
+                  relationships: {
+                    moons: { data: [{ type: 'moon', id: 'm1' }] }
+                  }
+                },
+                {
+                  type: 'moon',
+                  id: 'm1',
+                  relationships: {
+                    planet: { data: { type: 'planet', id: '1' } }
+                  }
+                }
+              ],
+              inverseOperations: [
+                tb
+                  .replaceRelatedRecord(
+                    { type: 'moon', id: 'm1' },
+                    'planet',
+                    null
+                  )
+                  .toOperation(),
+                tb
+                  .removeRecord({
+                    type: 'planet',
+                    id: '1'
+                  })
+                  .toOperation()
+              ]
+            }
+          },
+          'addRecord full response is correct'
+        );
+
+        result = cache.update([tb.updateRecord(jupiter)], {
+          fullResponse: true
+        });
+
+        assert.deepEqual(result, {
+          data: jupiter,
+          details: {
+            appliedOperations: [
+              tb.updateRecord(jupiter).toOperation(),
+              tb
+                .replaceRelatedRecord(
+                  { type: 'moon', id: 'm1' },
+                  'planet',
+                  null
+                )
+                .toOperation(),
+              tb
+                .replaceRelatedRecord({ type: 'moon', id: 'm2' }, 'planet', {
+                  type: 'planet',
+                  id: '1'
+                })
+                .toOperation()
+            ],
+            appliedOperationResults: [
+              jupiter,
+              {
+                type: 'moon',
+                id: 'm1',
+                relationships: {
+                  planet: { data: null }
+                }
+              },
+              {
+                type: 'moon',
+                id: 'm2',
+                relationships: {
+                  planet: { data: { type: 'planet', id: '1' } }
+                }
+              }
+            ],
+            inverseOperations: [
+              tb
+                .replaceRelatedRecord(
+                  { type: 'moon', id: 'm2' },
+                  'planet',
+                  null
+                )
+                .toOperation(),
+              tb
+                .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
+                  type: 'planet',
+                  id: '1'
+                })
+                .toOperation(),
+              tb
+                .updateRecord({
+                  type: 'planet',
+                  id: '1',
+                  attributes: { name: 'Earth', classification: null },
+                  relationships: {
+                    moons: { data: [{ type: 'moon', id: 'm1' }] }
+                  }
+                })
+                .toOperation()
+            ]
+          }
+        });
+
+        assert.deepEqual(
+          cache.query((q) => q.findRecord({ type: 'planet', id: '1' })),
+          {
+            type: 'planet',
+            id: '1',
+            attributes: { name: 'Jupiter', classification: 'terrestrial' },
+            relationships: { moons: { data: [{ type: 'moon', id: 'm2' }] } }
+          },
+          'records have been merged'
+        );
+      });
+
+      test('#update can update existing record with empty relationship', function (assert) {
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+        const tb = cache.transformBuilder;
+
+        let result = cache.update(
+          (t) => [t.addRecord({ id: '1', type: 'planet' })],
+          { fullResponse: true }
+        );
+
+        assert.deepEqual(
+          result,
+          {
+            data: { id: '1', type: 'planet' },
+            details: {
+              appliedOperations: [
+                tb
+                  .addRecord({
+                    type: 'planet',
+                    id: '1'
+                  })
+                  .toOperation()
+              ],
+              appliedOperationResults: [
+                {
+                  id: '1',
+                  type: 'planet'
+                }
+              ],
+              inverseOperations: [
+                tb
+                  .removeRecord({
+                    type: 'planet',
+                    id: '1'
+                  })
+                  .toOperation()
+              ]
+            }
+          },
+          'addRecord result is correct'
+        );
+
+        result = cache.update(
+          (t) => [
+            t.updateRecord({
+              id: '1',
+              type: 'planet',
+              relationships: {
+                moons: { data: [] }
+              }
+            })
+          ],
+          { fullResponse: true }
+        );
+
+        assert.deepEqual(
+          result,
+          {
+            data: {
+              id: '1',
+              type: 'planet',
+              relationships: {
+                moons: { data: [] }
+              }
+            },
+            details: {
+              appliedOperations: [
+                tb
+                  .updateRecord({
+                    id: '1',
+                    type: 'planet',
+                    relationships: {
+                      moons: { data: [] }
+                    }
+                  })
+                  .toOperation()
+              ],
+              appliedOperationResults: [
+                {
+                  id: '1',
+                  type: 'planet',
+                  relationships: {
+                    moons: { data: [] }
+                  }
+                }
+              ],
+              inverseOperations: [
+                tb
+                  .updateRecord({
+                    id: '1',
+                    type: 'planet',
+                    relationships: {
+                      moons: { data: [] }
+                    }
+                  })
+                  .toOperation()
+              ]
+            }
+          },
+          'updateRecord result is correct'
+        );
+
+        const planet = cache.getRecordSync({ type: 'planet', id: '1' });
+        assert.ok(planet, 'planet exists');
+        assert.deepEqual(
+          planet?.relationships?.moons.data,
+          [],
+          'planet has empty moons relationship'
+        );
+      });
+
+      test('#update will not overwrite an existing relationship with a missing relationship', function (assert) {
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+        const tb = cache.transformBuilder;
+
+        let result = cache.update(
+          (t) => [
+            t.addRecord({
+              id: '1',
+              type: 'planet',
+              relationships: {
+                moons: { data: [{ type: 'moon', id: 'm1' }] }
+              }
+            }),
+            t.updateRecord({
+              id: '1',
+              type: 'planet'
+            })
+          ],
+          { fullResponse: true }
+        );
+
+        assert.deepEqual(
+          result,
+          {
+            data: [
+              {
                 id: '1',
                 type: 'planet',
                 relationships: {
                   moons: { data: [{ type: 'moon', id: 'm1' }] }
                 }
-              })
-              .toOperation(),
-            tb
-              .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
-                id: '1',
-                type: 'planet'
-              })
-              .toOperation()
-          ],
-          inverseOperations: [
-            tb
-              .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', null)
-              .toOperation(),
-            tb
-              .removeRecord({
-                id: '1',
-                type: 'planet'
-              })
-              .toOperation()
-          ]
-        }
-      },
-      'update full response is correct'
-    );
+              },
+              undefined
+            ],
+            details: {
+              appliedOperations: [
+                tb
+                  .addRecord({
+                    id: '1',
+                    type: 'planet',
+                    relationships: {
+                      moons: { data: [{ type: 'moon', id: 'm1' }] }
+                    }
+                  })
+                  .toOperation(),
+                tb
+                  .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
+                    id: '1',
+                    type: 'planet'
+                  })
+                  .toOperation()
+              ],
+              appliedOperationResults: [
+                {
+                  id: '1',
+                  type: 'planet',
+                  relationships: {
+                    moons: { data: [{ type: 'moon', id: 'm1' }] }
+                  }
+                },
+                {
+                  type: 'moon',
+                  id: 'm1',
+                  relationships: {
+                    planet: { data: { id: '1', type: 'planet' } }
+                  }
+                }
+              ],
+              inverseOperations: [
+                tb
+                  .replaceRelatedRecord(
+                    { type: 'moon', id: 'm1' },
+                    'planet',
+                    null
+                  )
+                  .toOperation(),
+                tb
+                  .removeRecord({
+                    id: '1',
+                    type: 'planet'
+                  })
+                  .toOperation()
+              ]
+            }
+          },
+          'update full response is correct'
+        );
 
-    const planet = cache.getRecordSync({ type: 'planet', id: '1' });
-    assert.ok(planet, 'planet exists');
-    assert.deepEqual(
-      planet?.relationships?.moons.data,
-      [{ type: 'moon', id: 'm1' }],
-      'planet has a moons relationship'
-    );
-  });
+        const planet = cache.getRecordSync({ type: 'planet', id: '1' });
+        assert.ok(planet, 'planet exists');
+        assert.deepEqual(
+          planet?.relationships?.moons.data,
+          [{ type: 'moon', id: 'm1' }],
+          'planet has a moons relationship'
+        );
+      });
 
-  test('#update allows replaceRelatedRecord to be called on a relationship with no inverse and to be followed up by removing the replaced record', function (assert) {
-    assert.expect(2);
+      test('#update allows replaceRelatedRecord to be called on a relationship with no inverse and to be followed up by removing the replaced record', function (assert) {
+        assert.expect(2);
 
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const star1 = {
-      id: 'star1',
-      type: 'star',
-      attributes: { name: 'sun1' }
-    };
+        const star1 = {
+          id: 'star1',
+          type: 'star',
+          attributes: { name: 'sun1' }
+        };
 
-    const star2 = {
-      id: 'star2',
-      type: 'star',
-      attributes: { name: 'sun2' }
-    };
+        const star2 = {
+          id: 'star2',
+          type: 'star',
+          attributes: { name: 'sun2' }
+        };
 
-    const home = {
-      id: 'home',
-      type: 'planetarySystem',
-      attributes: { name: 'Home' },
-      relationships: {
-        star: {
-          data: { id: 'star1', type: 'star' }
-        }
-      }
-    };
+        const home = {
+          id: 'home',
+          type: 'planetarySystem',
+          attributes: { name: 'Home' },
+          relationships: {
+            star: {
+              data: { id: 'star1', type: 'star' }
+            }
+          }
+        };
 
-    cache.update((t) => [
-      t.addRecord(star1),
-      t.addRecord(star2),
-      t.addRecord(home)
-    ]);
+        cache.update((t) => [
+          t.addRecord(star1),
+          t.addRecord(star2),
+          t.addRecord(home)
+        ]);
 
-    let latestHome = cache.getRecordSync({
-      id: 'home',
-      type: 'planetarySystem'
-    });
-    assert.deepEqual(
-      (latestHome?.relationships?.star.data as Record).id,
-      star1.id,
-      'The original related record is in place.'
-    );
-
-    cache.update((t) => [
-      t.replaceRelatedRecord(
-        {
+        let latestHome = cache.getRecordSync({
           id: 'home',
           type: 'planetarySystem'
-        },
-        'star',
-        star2
-      ),
-      t.removeRecord(star1)
-    ]);
+        });
+        assert.deepEqual(
+          (latestHome?.relationships?.star.data as Record).id,
+          star1.id,
+          'The original related record is in place.'
+        );
 
-    latestHome = cache.getRecordSync({
-      id: 'home',
-      type: 'planetarySystem'
+        cache.update((t) => [
+          t.replaceRelatedRecord(
+            {
+              id: 'home',
+              type: 'planetarySystem'
+            },
+            'star',
+            star2
+          ),
+          t.removeRecord(star1)
+        ]);
+
+        latestHome = cache.getRecordSync({
+          id: 'home',
+          type: 'planetarySystem'
+        });
+
+        assert.deepEqual(
+          (latestHome?.relationships?.star.data as Record).id,
+          star2.id,
+          'The related record was replaced.'
+        );
+      });
+
+      test("#update - updateRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        const earth: Record = {
+          type: 'planet',
+          id: '1',
+          attributes: { name: 'Earth' },
+          keys: { remoteId: 'a' }
+        };
+
+        assert.throws(
+          () =>
+            cache.update((t) =>
+              t.updateRecord(earth).options({
+                raiseNotFoundExceptions: true
+              })
+            ),
+          RecordNotFoundException
+        );
+      });
+
+      test("#update - removeRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        const earth: Record = {
+          type: 'planet',
+          id: '1'
+        };
+
+        assert.throws(
+          () =>
+            cache.update((t) =>
+              t.removeRecord(earth).options({
+                raiseNotFoundExceptions: true
+              })
+            ),
+          RecordNotFoundException
+        );
+      });
+
+      test("#update - replaceKey - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        const earth: Record = {
+          type: 'planet',
+          id: '1',
+          attributes: { name: 'Earth' },
+          keys: { remoteId: 'a' }
+        };
+
+        assert.throws(
+          () =>
+            cache.update((t) =>
+              t.replaceKey(earth, 'remoteId', 'b').options({
+                raiseNotFoundExceptions: true
+              })
+            ),
+          RecordNotFoundException
+        );
+      });
+
+      test("#update - replaceAttribute - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        const earth: Record = {
+          type: 'planet',
+          id: '1',
+          attributes: { name: 'Earth' },
+          keys: { remoteId: 'a' }
+        };
+
+        assert.throws(
+          () =>
+            cache.update((t) =>
+              t.replaceAttribute(earth, 'name', 'Mother Earth').options({
+                raiseNotFoundExceptions: true
+              })
+            ),
+          RecordNotFoundException
+        );
+      });
+
+      test("#update - addToRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        assert.throws(
+          () =>
+            cache.update((t) =>
+              t
+                .addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
+                  type: 'moon',
+                  id: 'm1'
+                })
+                .options({
+                  raiseNotFoundExceptions: true
+                })
+            ),
+          RecordNotFoundException
+        );
+      });
+
+      test("#update - removeFromRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        assert.throws(
+          () =>
+            cache.update((t) =>
+              t
+                .removeFromRelatedRecords(
+                  { type: 'planet', id: 'p1' },
+                  'moons',
+                  {
+                    type: 'moon',
+                    id: 'm1'
+                  }
+                )
+                .options({
+                  raiseNotFoundExceptions: true
+                })
+            ),
+          RecordNotFoundException
+        );
+      });
+
+      test("#update - replaceRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        assert.throws(
+          () =>
+            cache.update((t) =>
+              t
+                .replaceRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', [
+                  {
+                    type: 'moon',
+                    id: 'm1'
+                  }
+                ])
+                .options({
+                  raiseNotFoundExceptions: true
+                })
+            ),
+          RecordNotFoundException
+        );
+      });
+
+      test("#update - replaceRelatedRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
+        const cache = new ExampleSyncRecordCache({ schema, keyMap });
+
+        assert.throws(
+          () =>
+            cache.update((t) =>
+              t
+                .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
+                  type: 'planet',
+                  id: 'p1'
+                })
+                .options({
+                  raiseNotFoundExceptions: true
+                })
+            ),
+          RecordNotFoundException
+        );
+      });
     });
-
-    assert.deepEqual(
-      (latestHome?.relationships?.star.data as Record).id,
-      star2.id,
-      'The related record was replaced.'
-    );
-  });
-
-  test("#update - updateRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    const earth: Record = {
-      type: 'planet',
-      id: '1',
-      attributes: { name: 'Earth' },
-      keys: { remoteId: 'a' }
-    };
-
-    assert.throws(
-      () =>
-        cache.update((t) =>
-          t.updateRecord(earth).options({
-            raiseNotFoundExceptions: true
-          })
-        ),
-      RecordNotFoundException
-    );
-  });
-
-  test("#update - removeRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    const earth: Record = {
-      type: 'planet',
-      id: '1'
-    };
-
-    assert.throws(
-      () =>
-        cache.update((t) =>
-          t.removeRecord(earth).options({
-            raiseNotFoundExceptions: true
-          })
-        ),
-      RecordNotFoundException
-    );
-  });
-
-  test("#update - replaceKey - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    const earth: Record = {
-      type: 'planet',
-      id: '1',
-      attributes: { name: 'Earth' },
-      keys: { remoteId: 'a' }
-    };
-
-    assert.throws(
-      () =>
-        cache.update((t) =>
-          t.replaceKey(earth, 'remoteId', 'b').options({
-            raiseNotFoundExceptions: true
-          })
-        ),
-      RecordNotFoundException
-    );
-  });
-
-  test("#update - replaceAttribute - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    const earth: Record = {
-      type: 'planet',
-      id: '1',
-      attributes: { name: 'Earth' },
-      keys: { remoteId: 'a' }
-    };
-
-    assert.throws(
-      () =>
-        cache.update((t) =>
-          t.replaceAttribute(earth, 'name', 'Mother Earth').options({
-            raiseNotFoundExceptions: true
-          })
-        ),
-      RecordNotFoundException
-    );
-  });
-
-  test("#update - addToRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    assert.throws(
-      () =>
-        cache.update((t) =>
-          t
-            .addToRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
-              type: 'moon',
-              id: 'm1'
-            })
-            .options({
-              raiseNotFoundExceptions: true
-            })
-        ),
-      RecordNotFoundException
-    );
-  });
-
-  test("#update - removeFromRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    assert.throws(
-      () =>
-        cache.update((t) =>
-          t
-            .removeFromRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', {
-              type: 'moon',
-              id: 'm1'
-            })
-            .options({
-              raiseNotFoundExceptions: true
-            })
-        ),
-      RecordNotFoundException
-    );
-  });
-
-  test("#update - replaceRelatedRecords - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    assert.throws(
-      () =>
-        cache.update((t) =>
-          t
-            .replaceRelatedRecords({ type: 'planet', id: 'p1' }, 'moons', [
-              {
-                type: 'moon',
-                id: 'm1'
-              }
-            ])
-            .options({
-              raiseNotFoundExceptions: true
-            })
-        ),
-      RecordNotFoundException
-    );
-  });
-
-  test("#update - replaceRelatedRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
-    const cache = new ExampleSyncRecordCache({ schema, keyMap });
-
-    assert.throws(
-      () =>
-        cache.update((t) =>
-          t
-            .replaceRelatedRecord({ type: 'moon', id: 'm1' }, 'planet', {
-              type: 'planet',
-              id: 'p1'
-            })
-            .options({
-              raiseNotFoundExceptions: true
-            })
-        ),
-      RecordNotFoundException
-    );
   });
 });

--- a/packages/@orbit/records/src/record.ts
+++ b/packages/@orbit/records/src/record.ts
@@ -95,6 +95,21 @@ export function uniqueRecordIdentities(
   ).map((id) => deserializeRecordIdentity(id));
 }
 
+export function dedupeRecordIdentities(
+  recordIdentities: RecordIdentity[]
+): RecordIdentity[] {
+  let dict: Dict<true> = {};
+  let deduped: RecordIdentity[] = [];
+  recordIdentities.forEach((ri) => {
+    const sri = serializeRecordIdentity(ri);
+    if (dict[sri] === undefined) {
+      deduped.push(ri);
+      dict[sri] = true;
+    }
+  });
+  return deduped;
+}
+
 export function recordsInclude(
   records: RecordIdentity[],
   match: RecordIdentity

--- a/packages/@orbit/records/test/record-test.ts
+++ b/packages/@orbit/records/test/record-test.ts
@@ -7,7 +7,8 @@ import {
   recordsIncludeAll,
   deserializeRecordIdentity,
   serializeRecordIdentity,
-  mergeRecords
+  mergeRecords,
+  dedupeRecordIdentities
 } from '../src/record';
 
 const { module, test } = QUnit;
@@ -153,6 +154,30 @@ module('Record', function () {
       ),
       [],
       'unequal sets 2'
+    );
+  });
+
+  test('`dedupeRecordIdentities` returns a deduped array of record identities', function (assert) {
+    assert.deepEqual(dedupeRecordIdentities([]), [], 'empty sets are equal');
+    assert.deepEqual(
+      dedupeRecordIdentities([{ type: 'planet', id: 'p1' }]),
+      [{ type: 'planet', id: 'p1' }],
+      'equal sets with one member'
+    );
+    assert.deepEqual(
+      dedupeRecordIdentities([
+        { type: 'moon', id: 'm1' },
+        { type: 'planet', id: 'p1' },
+        { type: 'moon', id: 'm1' },
+        { type: 'moon', id: 'm2' },
+        { type: 'planet', id: 'p1' }
+      ]),
+      [
+        { type: 'moon', id: 'm1' },
+        { type: 'planet', id: 'p1' },
+        { type: 'moon', id: 'm2' }
+      ],
+      'equal sets with two members out of order'
     );
   });
 


### PR DESCRIPTION
As mentioned in #821, this PR introduces a new `RecordTransformBuffer` for applying updates to caches in a more atomic and performant manner.

The `RecordTransformBuffer` acts as a synchronous memory cache that is populated, tracks changes as an update is applied, and then returns a corresponding changeset that includes all the changes that can be applied at once to another source.

This buffered approach addresses the IndexedDB performance issues mentioned in #798 and also will be useful for local storage updates.

Using a buffer to apply changes will initially be opt-in, via the `useBuffer` option. Sources can also set this option for all transforms via `source.defaultTransformOptions = { useBuffer: true }`.

--- 

_Note: perf benchmarks will be added with a separate PR._