### PR TITLE
Fix IndexedDBCache getInverseRelationshipsAsync

### DIFF
--- a/packages/@orbit/indexeddb/src/indexeddb-cache.ts
+++ b/packages/@orbit/indexeddb/src/indexeddb-cache.ts
@@ -149,6 +149,9 @@ export class IndexedDBCache extends AsyncRecordCache {
     objectStore.createIndex('recordIdentity', 'recordIdentity', {
       unique: false
     });
+    objectStore.createIndex('relatedIdentity', 'relatedIdentity', {
+      unique: false
+    });
   }
 
   /**
@@ -418,7 +421,7 @@ export class IndexedDBCache extends AsyncRecordCache {
       const keyRange = Orbit.globals.IDBKeyRange.only(
         serializeRecordIdentity(recordIdentity)
       );
-      const request = objectStore.index('recordIdentity').openCursor(keyRange);
+      const request = objectStore.index('relatedIdentity').openCursor(keyRange);
 
       request.onsuccess = (event: any) => {
         const cursor = event.target.result;

--- a/packages/@orbit/indexeddb/test/indexeddb-cache-test.ts
+++ b/packages/@orbit/indexeddb/test/indexeddb-cache-test.ts
@@ -127,11 +127,14 @@ module('IndexedDBCache', function (hooks) {
     assert.deepEqual(await cache.getRecordsAsync([jupiter, io, europa]), []);
   });
 
-  test('sets/gets inverse relationships', async function (assert) {
+  test('sets/gets inverse relationships for a single record', async function (assert) {
     const jupiter = { type: 'planet', id: 'jupiter' };
     const io = { type: 'moon', id: 'io' };
     const europa = { type: 'moon', id: 'europa' };
     const callisto = { type: 'moon', id: 'callisto' };
+
+    const earth = { type: 'planet', id: 'earth' };
+    const earthMoon = { type: 'moon', id: 'earthMoon' };
 
     assert.deepEqual(
       await cache.getInverseRelationshipsAsync(jupiter),
@@ -140,29 +143,43 @@ module('IndexedDBCache', function (hooks) {
     );
 
     await cache.addInverseRelationshipsAsync([
-      { record: jupiter, relationship: 'moons', relatedRecord: io },
-      { record: jupiter, relationship: 'moons', relatedRecord: europa },
-      { record: jupiter, relationship: 'moons', relatedRecord: callisto }
+      { record: callisto, relationship: 'planet', relatedRecord: jupiter },
+      { record: earthMoon, relationship: 'planet', relatedRecord: earth },
+      { record: europa, relationship: 'planet', relatedRecord: jupiter },
+      { record: io, relationship: 'planet', relatedRecord: jupiter }
     ]);
 
     assert.deepEqual(
       await cache.getInverseRelationshipsAsync(jupiter),
       [
-        { record: jupiter, relationship: 'moons', relatedRecord: callisto },
-        { record: jupiter, relationship: 'moons', relatedRecord: europa },
-        { record: jupiter, relationship: 'moons', relatedRecord: io }
+        { record: callisto, relationship: 'planet', relatedRecord: jupiter },
+        { record: europa, relationship: 'planet', relatedRecord: jupiter },
+        { record: io, relationship: 'planet', relatedRecord: jupiter }
       ],
       'inverse relationships have been added'
     );
 
+    assert.deepEqual(
+      await cache.getInverseRelationshipsAsync(earth),
+      [{ record: earthMoon, relationship: 'planet', relatedRecord: earth }],
+      'inverse relationships have been added'
+    );
+
     await cache.removeInverseRelationshipsAsync([
-      { record: jupiter, relationship: 'moons', relatedRecord: io },
-      { record: jupiter, relationship: 'moons', relatedRecord: europa },
-      { record: jupiter, relationship: 'moons', relatedRecord: callisto }
+      { record: callisto, relationship: 'planet', relatedRecord: jupiter },
+      { record: earthMoon, relationship: 'planet', relatedRecord: earth },
+      { record: europa, relationship: 'planet', relatedRecord: jupiter },
+      { record: io, relationship: 'planet', relatedRecord: jupiter }
     ]);
 
     assert.deepEqual(
       await cache.getInverseRelationshipsAsync(jupiter),
+      [],
+      'inverse relationships have been removed'
+    );
+
+    assert.deepEqual(
+      await cache.getInverseRelationshipsAsync(earth),
       [],
       'inverse relationships have been removed'
     );


### PR DESCRIPTION
This fixes an issue with `IndexedDBCache#getInverseRelationshipsAsync` in which
the wrong index was being used to lookup items in the object store that
maintains inverse relationships (`__inverseRels__`).

This bug could result in the inability of the `AsyncCacheIntegrityProcessor` to
properly remove relationships when records themselves are removed.

The correct index, `relatedIdentity`, also needs to be added. This will need to be
handled for pre-existing databases with an IndexedDB migration.