### PR TITLE
Backport PR 823 to v0.16

### DIFF
--- a/packages/@orbit/indexeddb/src/cache.ts
+++ b/packages/@orbit/indexeddb/src/cache.ts
@@ -165,6 +165,9 @@ export default class IndexedDBCache extends AsyncRecordCache {
     objectStore.createIndex('recordIdentity', 'recordIdentity', {
       unique: false
     });
+    objectStore.createIndex('relatedIdentity', 'relatedIdentity', {
+      unique: false
+    });
   }
 
   /**
@@ -464,7 +467,20 @@ export default class IndexedDBCache extends AsyncRecordCache {
       const keyRange = Orbit.globals.IDBKeyRange.only(
         serializeRecordIdentity(recordIdentity)
       );
-      const request = objectStore.index('recordIdentity').openCursor(keyRange);
+
+      let index;
+      try {
+        index = objectStore.index('relatedIdentity');
+      } catch (e) {
+        console.error(
+          `[@orbit/indexeddb] The 'relatedIdentity' index is missing from the ${INVERSE_RELS} object store in IndexedDB. ` +
+            'Please add this index using a DB migration as described in https://github.com/orbitjs/orbit/pull/825'
+        );
+        resolve([]);
+        return;
+      }
+
+      const request = index.openCursor(keyRange);
 
       request.onerror = function(/* event */) {
         // console.error('error - getRecords', request.error);

--- a/packages/@orbit/indexeddb/src/source.ts
+++ b/packages/@orbit/indexeddb/src/source.ts
@@ -66,7 +66,9 @@ export default class IndexedDBSource extends Source
 
     super(settings);
 
-    let cacheSettings: IndexedDBCacheSettings = settings.cacheSettings || {};
+    let cacheSettings: IndexedDBCacheSettings = settings.cacheSettings || {
+      schema: settings.schema
+    };
     cacheSettings.schema = settings.schema;
     cacheSettings.keyMap = settings.keyMap;
     cacheSettings.queryBuilder =

--- a/packages/@orbit/indexeddb/test/cache-test.ts
+++ b/packages/@orbit/indexeddb/test/cache-test.ts
@@ -130,11 +130,14 @@ module('Cache', function(hooks) {
     assert.deepEqual(await cache.getRecordsAsync([jupiter, io, europa]), []);
   });
 
-  test('sets/gets inverse relationships', async function(assert) {
+  test('sets/gets inverse relationships for a single record', async function(assert) {
     const jupiter = { type: 'planet', id: 'jupiter' };
     const io = { type: 'moon', id: 'io' };
     const europa = { type: 'moon', id: 'europa' };
     const callisto = { type: 'moon', id: 'callisto' };
+
+    const earth = { type: 'planet', id: 'earth' };
+    const earthMoon = { type: 'moon', id: 'earthMoon' };
 
     await cache.openDB();
 
@@ -145,29 +148,43 @@ module('Cache', function(hooks) {
     );
 
     await cache.addInverseRelationshipsAsync([
-      { record: jupiter, relationship: 'moons', relatedRecord: io },
-      { record: jupiter, relationship: 'moons', relatedRecord: europa },
-      { record: jupiter, relationship: 'moons', relatedRecord: callisto }
+      { record: callisto, relationship: 'planet', relatedRecord: jupiter },
+      { record: earthMoon, relationship: 'planet', relatedRecord: earth },
+      { record: europa, relationship: 'planet', relatedRecord: jupiter },
+      { record: io, relationship: 'planet', relatedRecord: jupiter }
     ]);
 
     assert.deepEqual(
       await cache.getInverseRelationshipsAsync(jupiter),
       [
-        { record: jupiter, relationship: 'moons', relatedRecord: callisto },
-        { record: jupiter, relationship: 'moons', relatedRecord: europa },
-        { record: jupiter, relationship: 'moons', relatedRecord: io }
+        { record: callisto, relationship: 'planet', relatedRecord: jupiter },
+        { record: europa, relationship: 'planet', relatedRecord: jupiter },
+        { record: io, relationship: 'planet', relatedRecord: jupiter }
       ],
       'inverse relationships have been added'
     );
 
+    assert.deepEqual(
+      await cache.getInverseRelationshipsAsync(earth),
+      [{ record: earthMoon, relationship: 'planet', relatedRecord: earth }],
+      'inverse relationships have been added'
+    );
+
     await cache.removeInverseRelationshipsAsync([
-      { record: jupiter, relationship: 'moons', relatedRecord: io },
-      { record: jupiter, relationship: 'moons', relatedRecord: europa },
-      { record: jupiter, relationship: 'moons', relatedRecord: callisto }
+      { record: callisto, relationship: 'planet', relatedRecord: jupiter },
+      { record: earthMoon, relationship: 'planet', relatedRecord: earth },
+      { record: europa, relationship: 'planet', relatedRecord: jupiter },
+      { record: io, relationship: 'planet', relatedRecord: jupiter }
     ]);
 
     assert.deepEqual(
       await cache.getInverseRelationshipsAsync(jupiter),
+      [],
+      'inverse relationships have been removed'
+    );
+
+    assert.deepEqual(
+      await cache.getInverseRelationshipsAsync(earth),
       [],
       'inverse relationships have been removed'
     );

--- a/packages/@orbit/indexeddb/test/cache-test.ts
+++ b/packages/@orbit/indexeddb/test/cache-test.ts
@@ -1014,4 +1014,130 @@ module('Cache', function(hooks) {
       'key has been mapped'
     );
   });
+
+  test('#patch tracks refs and clears them from hasOne relationships when a referenced record is removed', async function(assert) {
+    const jupiter: Record = {
+      type: 'planet',
+      id: 'p1',
+      attributes: { name: 'Jupiter' },
+      relationships: { moons: { data: undefined } }
+    };
+    const io: Record = {
+      type: 'moon',
+      id: 'm1',
+      attributes: { name: 'Io' },
+      relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+    };
+    const europa: Record = {
+      type: 'moon',
+      id: 'm2',
+      attributes: { name: 'Europa' },
+      relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
+    };
+
+    await cache.patch(t => [
+      t.addRecord(jupiter),
+      t.addRecord(io),
+      t.addRecord(europa)
+    ]);
+
+    assert.deepEqual(
+      ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+        .relationships.planet.data,
+      { type: 'planet', id: 'p1' },
+      'Jupiter has been assigned to Io'
+    );
+    assert.deepEqual(
+      ((await cache.getRecordAsync({ type: 'moon', id: 'm2' })) as Record)
+        .relationships.planet.data,
+      { type: 'planet', id: 'p1' },
+      'Jupiter has been assigned to Europa'
+    );
+
+    await cache.patch(t => t.removeRecord(jupiter));
+
+    assert.equal(
+      await cache.getRecordAsync({ type: 'planet', id: 'p1' }),
+      undefined,
+      'Jupiter is GONE'
+    );
+
+    assert.equal(
+      ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
+        .relationships.planet.data,
+      undefined,
+      'Jupiter has been cleared from Io'
+    );
+    assert.equal(
+      ((await cache.getRecordAsync({ type: 'moon', id: 'm2' })) as Record)
+        .relationships.planet.data,
+      undefined,
+      'Jupiter has been cleared from Europa'
+    );
+  });
+
+  test('#patch tracks refs and clears them from hasMany relationships when a referenced record is removed', async function(assert) {
+    const io: Record = {
+      type: 'moon',
+      id: 'm1',
+      attributes: { name: 'Io' },
+      relationships: { planet: { data: null } }
+    };
+    const europa: Record = {
+      type: 'moon',
+      id: 'm2',
+      attributes: { name: 'Europa' },
+      relationships: { planet: { data: null } }
+    };
+    const jupiter: Record = {
+      type: 'planet',
+      id: 'p1',
+      attributes: { name: 'Jupiter' },
+      relationships: {
+        moons: {
+          data: [{ type: 'moon', id: 'm1' }, { type: 'moon', id: 'm2' }]
+        }
+      }
+    };
+
+    await cache.patch(t => [
+      t.addRecord(io),
+      t.addRecord(europa),
+      t.addRecord(jupiter)
+    ]);
+
+    assert.deepEqual(
+      ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
+        .relationships.moons.data,
+      [{ type: 'moon', id: 'm1' }, { type: 'moon', id: 'm2' }],
+      'Jupiter has been assigned to Io and Europa'
+    );
+    assert.deepEqual(
+      await cache.getRelatedRecordsAsync(jupiter, 'moons'),
+      [{ type: 'moon', id: 'm1' }, { type: 'moon', id: 'm2' }],
+      'Jupiter has been assigned to Io and Europa'
+    );
+
+    await cache.patch(t => t.removeRecord(io));
+
+    assert.equal(
+      await cache.getRecordAsync({ type: 'moon', id: 'm1' }),
+      null,
+      'Io is GONE'
+    );
+
+    await cache.patch(t => t.removeRecord(europa));
+
+    assert.equal(
+      await cache.getRecordAsync({ type: 'moon', id: 'm2' }),
+      null,
+      'Europa is GONE'
+    );
+
+    assert.deepEqual(
+      await cache.getRelatedRecordsAsync({ type: 'planet', id: 'p1' }, 'moons'),
+      [],
+      'moons have been cleared from Jupiter'
+    );
+  });
 });


### PR DESCRIPTION
:boom: **Important: Action is needed to correct the integrity of any pre-existing `@orbit/indexeddb` databases. See below.** :boom:

_Note: This issue has been written specifically for @orbit/indexeddb v0.16. If you're using v0.17 or later, see #823._

This PR fixes an issue with `IndexedDBCache#getInverseRelationshipsAsync` in which the wrong index was being used to lookup items in the object store that maintains inverse relationships (`__inverseRels__`). This issue may have prevented the `AsyncCacheIntegrityProcessor` from properly removing relationships when records were removed. Therefore, it's possible that your cache may contain extra "dead" relationships (i.e. relationships to records that have been removed).

This PR adds the missing index, `relatedIdentity`, to the object store `__inverseRels__` when it is _created_. Therefore, any new IndexedDB databases should now properly track inverse relationships.

### Recreating / migrating pre-existing databases

If your application has any pre-existing IndexedDB databases "in the wild", you'll need to take steps to update them.  The steps you take really depend why / how you're using this source in your app. If you're just using it as a temporary offline buffer, you may choose to just drop and recreate the database. However, if your IndexedDB source is the "source of truth" for some of your application's data, you'll want to upgrade the database and validate its data.

In order to perform an upgrade, take the following steps:

1. Increase the [`version`](https://github.com/orbitjs/orbit/blob/release-0-16/packages/%40orbit/data/src/schema.ts#L43) of your `Schema`.
2. Override the [`migrateDB`](https://github.com/orbitjs/orbit/blob/release-0-16/packages/%40orbit/indexeddb/src/cache.ts#L173-L180) method for your cache instance. If `event.newVersion` equals your new schema version, either recreate the `__inverseRels__` object store by calling `createInverseRelationshipStore` or modify the existing one to add the `relatedIdentity` index.
3. Optionally validate your data relationships and the contents of `__inverseRels__` within `migrateDB`, pruning any references to non-existent records.
4. Test everything carefully of course.

Please comment here or reach out on [gitter](https://gitter.im/orbitjs/orbit.js) if you have questions or problems.
