### PR TITLE
Allow record-cache-based sources to define a custom `cacheClass`

### DIFF
--- a/packages/@orbit/indexeddb/src/indexeddb-cache.ts
+++ b/packages/@orbit/indexeddb/src/indexeddb-cache.ts
@@ -30,6 +30,10 @@ export interface IndexedDBCacheSettings extends AsyncRecordCacheSettings {
   namespace?: string;
 }
 
+export interface IndexedDBCacheClass {
+  new (settings: IndexedDBCacheSettings): IndexedDBCache;
+}
+
 /**
  * A cache used to access records in an IndexedDB database.
  *

--- a/packages/@orbit/indexeddb/src/indexeddb-source.ts
+++ b/packages/@orbit/indexeddb/src/indexeddb-source.ts
@@ -30,13 +30,18 @@ import {
   RecordUpdatable,
   UpdateRecordOperation
 } from '@orbit/records';
-import { IndexedDBCache, IndexedDBCacheSettings } from './indexeddb-cache';
+import {
+  IndexedDBCache,
+  IndexedDBCacheClass,
+  IndexedDBCacheSettings
+} from './indexeddb-cache';
 import { supportsIndexedDB } from './lib/indexeddb';
 
 const { assert } = Orbit;
 
 export interface IndexedDBSourceSettings extends RecordSourceSettings {
   namespace?: string;
+  cacheClass?: IndexedDBCacheClass;
   cacheSettings?: Partial<IndexedDBCacheSettings>;
 }
 
@@ -73,7 +78,7 @@ export class IndexedDBSource extends RecordSource {
 
     super(settings);
 
-    let cacheSettings: Partial<IndexedDBCacheSettings> =
+    const cacheSettings: Partial<IndexedDBCacheSettings> =
       settings.cacheSettings ?? {};
     cacheSettings.schema = settings.schema;
     cacheSettings.keyMap = settings.keyMap;
@@ -87,7 +92,9 @@ export class IndexedDBSource extends RecordSource {
     cacheSettings.defaultTransformOptions =
       cacheSettings.defaultTransformOptions ?? settings.defaultTransformOptions;
 
-    this._cache = new IndexedDBCache(cacheSettings as IndexedDBCacheSettings);
+    const cacheClass = settings.cacheClass ?? IndexedDBCache;
+    this._cache = new cacheClass(cacheSettings as IndexedDBCacheSettings);
+
     if (autoActivate) {
       this.activate();
     }

--- a/packages/@orbit/indexeddb/test/indexeddb-source-test.ts
+++ b/packages/@orbit/indexeddb/test/indexeddb-source-test.ts
@@ -5,6 +5,7 @@ import {
   RecordKeyMap,
   RecordSchema
 } from '@orbit/records';
+import { IndexedDBCache } from '../src';
 import { IndexedDBSource } from '../src/indexeddb-source';
 import { getRecordFromIndexedDB } from './support/indexeddb';
 
@@ -73,6 +74,22 @@ module('IndexedDBSource', function (hooks) {
       source.cache.dbName,
       'orbit',
       '`dbName` is `orbit` by default'
+    );
+  });
+
+  test('can be assigned a custom `cacheClass`', function (assert) {
+    class CustomCache extends IndexedDBCache {
+      custom = true;
+    }
+
+    source = new IndexedDBSource({
+      schema,
+      autoActivate: false,
+      cacheClass: CustomCache
+    });
+    assert.ok(
+      (source.cache as CustomCache).custom,
+      'custom cacheClass has been instantiated'
     );
   });
 

--- a/packages/@orbit/local-storage/src/local-storage-cache.ts
+++ b/packages/@orbit/local-storage/src/local-storage-cache.ts
@@ -12,6 +12,10 @@ export interface LocalStorageCacheSettings extends SyncRecordCacheSettings {
   namespace?: string;
 }
 
+export interface LocalStorageCacheClass {
+  new (settings: LocalStorageCacheSettings): LocalStorageCache;
+}
+
 /**
  * A cache used to access records in local storage.
  *

--- a/packages/@orbit/local-storage/src/local-storage-source.ts
+++ b/packages/@orbit/local-storage/src/local-storage-source.ts
@@ -35,6 +35,7 @@ import {
 import { supportsLocalStorage } from './lib/local-storage';
 import {
   LocalStorageCache,
+  LocalStorageCacheClass,
   LocalStorageCacheSettings
 } from './local-storage-cache';
 
@@ -43,6 +44,7 @@ const { assert } = Orbit;
 export interface LocalStorageSourceSettings extends RecordSourceSettings {
   delimiter?: string;
   namespace?: string;
+  cacheClass?: LocalStorageCacheClass;
   cacheSettings?: Partial<LocalStorageCacheSettings>;
 }
 
@@ -95,9 +97,8 @@ export class LocalStorageSource extends RecordSource {
     cacheSettings.namespace = cacheSettings.namespace ?? settings.namespace;
     cacheSettings.delimiter = cacheSettings.delimiter ?? settings.delimiter;
 
-    this._cache = new LocalStorageCache(
-      cacheSettings as LocalStorageCacheSettings
-    );
+    const cacheClass = settings.cacheClass ?? LocalStorageCache;
+    this._cache = new cacheClass(cacheSettings as LocalStorageCacheSettings);
   }
 
   get cache(): LocalStorageCache {

--- a/packages/@orbit/local-storage/test/local-storage-source-test.ts
+++ b/packages/@orbit/local-storage/test/local-storage-source-test.ts
@@ -7,13 +7,12 @@ import { buildTransform } from '@orbit/data';
 import {
   AddRecordOperation,
   Record,
-  RecordIdentity,
   RecordSchema,
   RecordSource,
-  RecordKeyMap,
-  RecordTransform
+  RecordKeyMap
 } from '@orbit/records';
 import { LocalStorageSource } from '../src/local-storage-source';
+import { LocalStorageCache } from '../src/local-storage-cache';
 
 const { module, test } = QUnit;
 
@@ -68,6 +67,22 @@ module('LocalStorageSource', function (hooks) {
   test('is assigned a default namespace and delimiter', function (assert) {
     assert.equal(source.namespace, 'orbit', 'namespace is `orbit` by default');
     assert.equal(source.delimiter, '/', 'delimiter is `/` by default');
+  });
+
+  test('can be assigned a custom `cacheClass`', function (assert) {
+    class CustomCache extends LocalStorageCache {
+      custom = true;
+    }
+
+    source = new LocalStorageSource({
+      schema,
+      autoActivate: false,
+      cacheClass: CustomCache
+    });
+    assert.ok(
+      (source.cache as CustomCache).custom,
+      'custom cacheClass has been instantiated'
+    );
   });
 
   test('shares its `transformBuilder` and `queryBuilder` with its cache', function (assert) {

--- a/packages/@orbit/memory/src/memory-cache.ts
+++ b/packages/@orbit/memory/src/memory-cache.ts
@@ -11,6 +11,10 @@ export interface MemoryCacheSettings extends SyncRecordCacheSettings {
   base?: MemoryCache;
 }
 
+export interface MemoryCacheClass {
+  new (settings: MemoryCacheSettings): MemoryCache;
+}
+
 /**
  * A cache used to access records in memory.
  *

--- a/packages/@orbit/memory/src/memory-source.ts
+++ b/packages/@orbit/memory/src/memory-source.ts
@@ -26,10 +26,15 @@ import {
 } from '@orbit/data';
 import { ResponseHints } from '@orbit/data';
 import { Dict } from '@orbit/utils';
-import { MemoryCache, MemoryCacheSettings } from './memory-cache';
+import {
+  MemoryCache,
+  MemoryCacheClass,
+  MemoryCacheSettings
+} from './memory-cache';
 
 export interface MemorySourceSettings extends RecordSourceSettings {
   base?: MemorySource;
+  cacheClass?: MemoryCacheClass;
   cacheSettings?: Partial<MemoryCacheSettings>;
 }
 
@@ -87,7 +92,8 @@ export class MemorySource extends RecordSource {
       cacheSettings.base = this._base.cache;
     }
 
-    this._cache = new MemoryCache(cacheSettings as MemoryCacheSettings);
+    const cacheClass = settings.cacheClass ?? MemoryCache;
+    this._cache = new cacheClass(cacheSettings as MemoryCacheSettings);
   }
 
   get cache(): MemoryCache {

--- a/packages/@orbit/memory/test/memory-source-test.ts
+++ b/packages/@orbit/memory/test/memory-source-test.ts
@@ -14,6 +14,7 @@ import {
   RecordTransformBuilder
 } from '@orbit/records';
 import { clone } from '@orbit/utils';
+import { MemoryCache } from '../src/memory-cache';
 import { MemorySource } from '../src/memory-source';
 
 const { module, test } = QUnit;
@@ -98,6 +99,22 @@ module('MemorySource', function (hooks) {
 
     assert.ok(source.cache, 'cache exists');
     assert.equal(source.cache.processors.length, 2, 'cache has 2 processors');
+  });
+
+  test('can be assigned a custom `cacheClass`', function (assert) {
+    class CustomCache extends MemoryCache {
+      custom = true;
+    }
+
+    const source = new MemorySource({
+      schema,
+      autoActivate: false,
+      cacheClass: CustomCache
+    });
+    assert.ok(
+      (source.cache as CustomCache).custom,
+      'custom cacheClass has been instantiated'
+    );
   });
 
   test('shares its `transformBuilder` and `queryBuilder` with its cache', function (assert) {


### PR DESCRIPTION
All record-cache-based sources (memory, indexeddb, and local storage) now allow a `cacheClass` setting to be passed on construction. This allows for customization of cache behavior that may not be plausible via the other cache-related setting: `cacheSettings`.