### PR TITLE
Deprecate Record interface in favor of InitializedRecord

### DIFF
--- a/packages/@orbit/indexeddb/src/indexeddb-cache.ts
+++ b/packages/@orbit/indexeddb/src/indexeddb-cache.ts
@@ -2,7 +2,7 @@ import { Orbit } from '@orbit/core';
 import {
   serializeRecordIdentity,
   deserializeRecordIdentity,
-  Record,
+  InitializedRecord,
   RecordIdentity
 } from '@orbit/records';
 import {
@@ -210,7 +210,9 @@ export class IndexedDBCache extends AsyncRecordCache {
     });
   }
 
-  getRecordAsync(record: RecordIdentity): Promise<Record | undefined> {
+  getRecordAsync(
+    record: RecordIdentity
+  ): Promise<InitializedRecord | undefined> {
     return new Promise((resolve, reject) => {
       if (!this._db) return reject(DB_NOT_OPEN);
 
@@ -236,7 +238,7 @@ export class IndexedDBCache extends AsyncRecordCache {
 
   getRecordsAsync(
     typeOrIdentities?: string | RecordIdentity[]
-  ): Promise<Record[]> {
+  ): Promise<InitializedRecord[]> {
     if (!this._db) return Promise.reject(DB_NOT_OPEN);
 
     if (typeOrIdentities === undefined) {
@@ -247,7 +249,7 @@ export class IndexedDBCache extends AsyncRecordCache {
       return new Promise((resolve, reject) => {
         if (!this._db) return reject(DB_NOT_OPEN);
 
-        const records: Record[] = [];
+        const records: InitializedRecord[] = [];
         const transaction = this._db.transaction([type]);
         const objectStore = transaction.objectStore(type);
         const request = objectStore.openCursor();
@@ -270,7 +272,7 @@ export class IndexedDBCache extends AsyncRecordCache {
       });
     } else {
       const identities: RecordIdentity[] = typeOrIdentities;
-      const records: Record[] = [];
+      const records: InitializedRecord[] = [];
 
       if (identities.length > 0) {
         const types: string[] = [];
@@ -307,7 +309,7 @@ export class IndexedDBCache extends AsyncRecordCache {
     }
   }
 
-  setRecordAsync(record: Record): Promise<void> {
+  setRecordAsync(record: InitializedRecord): Promise<void> {
     if (!this._db) return Promise.reject(DB_NOT_OPEN);
 
     const transaction = this._db.transaction([record.type], 'readwrite');
@@ -325,7 +327,7 @@ export class IndexedDBCache extends AsyncRecordCache {
     });
   }
 
-  setRecordsAsync(records: Record[]): Promise<void> {
+  setRecordsAsync(records: InitializedRecord[]): Promise<void> {
     if (!this._db) return Promise.reject(DB_NOT_OPEN);
 
     if (records.length > 0) {
@@ -364,7 +366,7 @@ export class IndexedDBCache extends AsyncRecordCache {
 
   removeRecordAsync(
     recordIdentity: RecordIdentity
-  ): Promise<Record | undefined> {
+  ): Promise<InitializedRecord | undefined> {
     return new Promise((resolve, reject) => {
       if (!this._db) return reject(DB_NOT_OPEN);
 
@@ -380,7 +382,7 @@ export class IndexedDBCache extends AsyncRecordCache {
     });
   }
 
-  removeRecordsAsync(records: RecordIdentity[]): Promise<Record[]> {
+  removeRecordsAsync(records: RecordIdentity[]): Promise<InitializedRecord[]> {
     if (!this._db) return Promise.reject(DB_NOT_OPEN);
 
     if (records.length > 0) {
@@ -530,7 +532,7 @@ export class IndexedDBCache extends AsyncRecordCache {
   // Protected methods
   /////////////////////////////////////////////////////////////////////////////
 
-  protected async _getAllRecords(): Promise<Record[]> {
+  protected async _getAllRecords(): Promise<InitializedRecord[]> {
     if (!this._db) return Promise.reject(DB_NOT_OPEN);
 
     const types = Object.keys(this.schema.models);
@@ -539,7 +541,7 @@ export class IndexedDBCache extends AsyncRecordCache {
       types.map((type) => this.getRecordsAsync(type))
     );
 
-    const allRecords: Record[] = [];
+    const allRecords: InitializedRecord[] = [];
     recordsets.forEach((records) =>
       Array.prototype.push.apply(allRecords, records)
     );

--- a/packages/@orbit/indexeddb/test/indexeddb-cache-test.ts
+++ b/packages/@orbit/indexeddb/test/indexeddb-cache-test.ts
@@ -1,5 +1,5 @@
 import { getRecordFromIndexedDB } from './support/indexeddb';
-import { Record, RecordSchema, RecordKeyMap } from '@orbit/records';
+import { InitializedRecord, RecordSchema, RecordKeyMap } from '@orbit/records';
 import { IndexedDBCache } from '../src/indexeddb-cache';
 
 const { module, test } = QUnit;
@@ -235,7 +235,7 @@ module('IndexedDBCache', function (hooks) {
   test('#update - addRecord', async function (assert) {
     assert.expect(2);
 
-    let planet: Record = {
+    let planet: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -265,7 +265,7 @@ module('IndexedDBCache', function (hooks) {
   test('#update - updateRecord', async function (assert) {
     assert.expect(2);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -281,7 +281,7 @@ module('IndexedDBCache', function (hooks) {
       }
     };
 
-    let updates: Record = {
+    let updates: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -294,7 +294,7 @@ module('IndexedDBCache', function (hooks) {
       }
     };
 
-    let expected: Record = {
+    let expected: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -352,7 +352,7 @@ module('IndexedDBCache', function (hooks) {
   test('#update - removeRecord', async function (assert) {
     assert.expect(1);
 
-    let planet: Record = {
+    let planet: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -389,7 +389,7 @@ module('IndexedDBCache', function (hooks) {
   test('#update - replaceKey', async function (assert) {
     assert.expect(2);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -398,7 +398,7 @@ module('IndexedDBCache', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -428,7 +428,7 @@ module('IndexedDBCache', function (hooks) {
   test('#update - replaceKey - when base record does not exist', async function (assert) {
     assert.expect(2);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -455,7 +455,7 @@ module('IndexedDBCache', function (hooks) {
   test('#update - replaceAttribute', async function (assert) {
     assert.expect(1);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -464,7 +464,7 @@ module('IndexedDBCache', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -486,7 +486,7 @@ module('IndexedDBCache', function (hooks) {
   test('#update - replaceAttribute - when base record does not exist', async function (assert) {
     assert.expect(1);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -507,7 +507,7 @@ module('IndexedDBCache', function (hooks) {
   test('#update - addToRelatedRecords', async function (assert) {
     assert.expect(1);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -521,7 +521,7 @@ module('IndexedDBCache', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -549,7 +549,7 @@ module('IndexedDBCache', function (hooks) {
   test('#update - addToRelatedRecords - when base record does not exist', async function (assert) {
     assert.expect(1);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -575,7 +575,7 @@ module('IndexedDBCache', function (hooks) {
   test('#update - removeFromRelatedRecords', async function (assert) {
     assert.expect(1);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -592,7 +592,7 @@ module('IndexedDBCache', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -623,7 +623,7 @@ module('IndexedDBCache', function (hooks) {
   test('#update - removeFromRelatedRecords - when base record does not exist', async function (assert) {
     assert.expect(1);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -649,7 +649,7 @@ module('IndexedDBCache', function (hooks) {
   test('#update - replaceRelatedRecords', async function (assert) {
     assert.expect(1);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -663,7 +663,7 @@ module('IndexedDBCache', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -697,7 +697,7 @@ module('IndexedDBCache', function (hooks) {
   test('#update - replaceRelatedRecords - when base record does not exist', async function (assert) {
     assert.expect(1);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -726,7 +726,7 @@ module('IndexedDBCache', function (hooks) {
   test('#update - replaceRelatedRecord - with record', async function (assert) {
     assert.expect(1);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -740,7 +740,7 @@ module('IndexedDBCache', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -771,7 +771,7 @@ module('IndexedDBCache', function (hooks) {
   test('#update - replaceRelatedRecord - with record - when base record does not exist', async function (assert) {
     assert.expect(1);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -797,7 +797,7 @@ module('IndexedDBCache', function (hooks) {
   test('#update - replaceRelatedRecord - with null', async function (assert) {
     assert.expect(1);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -811,7 +811,7 @@ module('IndexedDBCache', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -839,7 +839,7 @@ module('IndexedDBCache', function (hooks) {
   test('#update - replaceRelatedRecord - with null - when base record does not exist', async function (assert) {
     assert.expect(1);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -866,7 +866,7 @@ module('IndexedDBCache', function (hooks) {
   test('#query - all records', async function (assert) {
     assert.expect(4);
 
-    let earth: Record = {
+    let earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       keys: {
@@ -878,7 +878,7 @@ module('IndexedDBCache', function (hooks) {
       }
     };
 
-    let jupiter: Record = {
+    let jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -890,7 +890,7 @@ module('IndexedDBCache', function (hooks) {
       }
     };
 
-    let io: Record = {
+    let io: InitializedRecord = {
       type: 'moon',
       id: 'io',
       keys: {
@@ -937,7 +937,7 @@ module('IndexedDBCache', function (hooks) {
   test('#query - records of one type', async function (assert) {
     assert.expect(1);
 
-    let earth: Record = {
+    let earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -946,7 +946,7 @@ module('IndexedDBCache', function (hooks) {
       }
     };
 
-    let jupiter: Record = {
+    let jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -955,7 +955,7 @@ module('IndexedDBCache', function (hooks) {
       }
     };
 
-    let io: Record = {
+    let io: InitializedRecord = {
       type: 'moon',
       id: 'io',
       attributes: {
@@ -976,7 +976,7 @@ module('IndexedDBCache', function (hooks) {
   test('#query - records by identity', async function (assert) {
     assert.expect(1);
 
-    let earth: Record = {
+    let earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -985,7 +985,7 @@ module('IndexedDBCache', function (hooks) {
       }
     };
 
-    let jupiter: Record = {
+    let jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -994,7 +994,7 @@ module('IndexedDBCache', function (hooks) {
       }
     };
 
-    let io: Record = {
+    let io: InitializedRecord = {
       type: 'moon',
       id: 'io',
       attributes: {
@@ -1017,7 +1017,7 @@ module('IndexedDBCache', function (hooks) {
   test('#query - a specific record', async function (assert) {
     assert.expect(2);
 
-    let earth: Record = {
+    let earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -1026,7 +1026,7 @@ module('IndexedDBCache', function (hooks) {
       }
     };
 
-    let jupiter: Record = {
+    let jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -1038,7 +1038,7 @@ module('IndexedDBCache', function (hooks) {
       }
     };
 
-    let io: Record = {
+    let io: InitializedRecord = {
       type: 'moon',
       id: 'io',
       attributes: {
@@ -1067,19 +1067,19 @@ module('IndexedDBCache', function (hooks) {
   });
 
   test('#update tracks refs and clears them from hasOne relationships when a referenced record is removed', async function (assert) {
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' },
       relationships: { moons: { data: undefined } }
     };
-    const io: Record = {
+    const io: InitializedRecord = {
       type: 'moon',
       id: 'm1',
       attributes: { name: 'Io' },
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
-    const europa: Record = {
+    const europa: InitializedRecord = {
       type: 'moon',
       id: 'm2',
       attributes: { name: 'Europa' },
@@ -1093,14 +1093,18 @@ module('IndexedDBCache', function (hooks) {
     ]);
 
     assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-        ?.relationships?.planet.data,
+      ((await cache.getRecordAsync({
+        type: 'moon',
+        id: 'm1'
+      })) as InitializedRecord)?.relationships?.planet.data,
       { type: 'planet', id: 'p1' },
       'Jupiter has been assigned to Io'
     );
     assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm2' })) as Record)
-        ?.relationships?.planet.data,
+      ((await cache.getRecordAsync({
+        type: 'moon',
+        id: 'm2'
+      })) as InitializedRecord)?.relationships?.planet.data,
       { type: 'planet', id: 'p1' },
       'Jupiter has been assigned to Europa'
     );
@@ -1114,33 +1118,37 @@ module('IndexedDBCache', function (hooks) {
     );
 
     assert.equal(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-        ?.relationships?.planet.data,
+      ((await cache.getRecordAsync({
+        type: 'moon',
+        id: 'm1'
+      })) as InitializedRecord)?.relationships?.planet.data,
       undefined,
       'Jupiter has been cleared from Io'
     );
     assert.equal(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm2' })) as Record)
-        ?.relationships?.planet.data,
+      ((await cache.getRecordAsync({
+        type: 'moon',
+        id: 'm2'
+      })) as InitializedRecord)?.relationships?.planet.data,
       undefined,
       'Jupiter has been cleared from Europa'
     );
   });
 
   test('#update tracks refs and clears them from hasMany relationships when a referenced record is removed', async function (assert) {
-    const io: Record = {
+    const io: InitializedRecord = {
       type: 'moon',
       id: 'm1',
       attributes: { name: 'Io' },
       relationships: { planet: { data: null } }
     };
-    const europa: Record = {
+    const europa: InitializedRecord = {
       type: 'moon',
       id: 'm2',
       attributes: { name: 'Europa' },
       relationships: { planet: { data: null } }
     };
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' },
@@ -1161,8 +1169,10 @@ module('IndexedDBCache', function (hooks) {
     ]);
 
     assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-        ?.relationships?.moons.data,
+      ((await cache.getRecordAsync({
+        type: 'planet',
+        id: 'p1'
+      })) as InitializedRecord)?.relationships?.moons.data,
       [
         { type: 'moon', id: 'm1' },
         { type: 'moon', id: 'm2' }

--- a/packages/@orbit/indexeddb/test/indexeddb-cache-update-test.ts
+++ b/packages/@orbit/indexeddb/test/indexeddb-cache-update-test.ts
@@ -1,7 +1,7 @@
 import {
   equalRecordIdentities,
   RecordKeyMap,
-  Record,
+  InitializedRecord,
   RecordIdentity,
   recordsInclude,
   recordsIncludeAll,
@@ -49,7 +49,7 @@ module('IndexedDBCache - update', function (hooks) {
         test('#update sets data and #records retrieves it', async function (assert) {
           assert.expect(4);
 
-          const earth: Record = {
+          const earth: InitializedRecord = {
             type: 'planet',
             id: '1',
             attributes: { name: 'Earth' },
@@ -81,7 +81,7 @@ module('IndexedDBCache - update', function (hooks) {
         test('#update can replace records', async function (assert) {
           assert.expect(5);
 
-          const earth: Record = {
+          const earth: InitializedRecord = {
             type: 'planet',
             id: '1',
             attributes: { name: 'Earth' },
@@ -118,7 +118,7 @@ module('IndexedDBCache - update', function (hooks) {
         test('#update can replace keys', async function (assert) {
           assert.expect(4);
 
-          const earth: Record = { type: 'planet', id: '1' };
+          const earth: InitializedRecord = { type: 'planet', id: '1' };
 
           cache.on('patch', (operation, data) => {
             assert.deepEqual(operation, {
@@ -198,13 +198,13 @@ module('IndexedDBCache - update', function (hooks) {
         });
 
         test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added after', async function (assert) {
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: 'p1',
             attributes: { name: 'Jupiter' },
             relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
           };
-          const io: Record = {
+          const io: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Io' }
@@ -219,26 +219,28 @@ module('IndexedDBCache - update', function (hooks) {
             ((await cache.getRecordAsync({
               type: 'planet',
               id: 'p1'
-            })) as Record)?.relationships?.moons.data,
+            })) as InitializedRecord)?.relationships?.moons.data,
             [{ type: 'moon', id: 'm1' }],
             'Io has been assigned to Jupiter'
           );
           assert.deepEqual(
-            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-              ?.relationships?.planet.data,
+            ((await cache.getRecordAsync({
+              type: 'moon',
+              id: 'm1'
+            })) as InitializedRecord)?.relationships?.planet.data,
             { type: 'planet', id: 'p1' },
             'Jupiter has been assigned to Io'
           );
         });
 
         test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added before', async function (assert) {
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: 'p1',
             attributes: { name: 'Jupiter' },
             relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
           };
-          const io: Record = {
+          const io: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Io' }
@@ -253,26 +255,28 @@ module('IndexedDBCache - update', function (hooks) {
             ((await cache.getRecordAsync({
               type: 'planet',
               id: 'p1'
-            })) as Record)?.relationships?.moons.data,
+            })) as InitializedRecord)?.relationships?.moons.data,
             [{ type: 'moon', id: 'm1' }],
             'Io has been assigned to Jupiter'
           );
           assert.deepEqual(
-            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-              ?.relationships?.planet.data,
+            ((await cache.getRecordAsync({
+              type: 'moon',
+              id: 'm1'
+            })) as InitializedRecord)?.relationships?.planet.data,
             { type: 'planet', id: 'p1' },
             'Jupiter has been assigned to Io'
           );
         });
 
         test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added after', async function (assert) {
-          const io: Record = {
+          const io: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Io' },
             relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
           };
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: 'p1',
             attributes: { name: 'Jupiter' }
@@ -287,26 +291,28 @@ module('IndexedDBCache - update', function (hooks) {
             ((await cache.getRecordAsync({
               type: 'planet',
               id: 'p1'
-            })) as Record)?.relationships?.moons.data,
+            })) as InitializedRecord)?.relationships?.moons.data,
             [{ type: 'moon', id: 'm1' }],
             'Io has been assigned to Jupiter'
           );
           assert.deepEqual(
-            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-              ?.relationships?.planet.data,
+            ((await cache.getRecordAsync({
+              type: 'moon',
+              id: 'm1'
+            })) as InitializedRecord)?.relationships?.planet.data,
             { type: 'planet', id: 'p1' },
             'Jupiter has been assigned to Io'
           );
         });
 
         test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added before', async function (assert) {
-          const io: Record = {
+          const io: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Io' },
             relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
           };
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: 'p1',
             attributes: { name: 'Jupiter' }
@@ -321,26 +327,28 @@ module('IndexedDBCache - update', function (hooks) {
             ((await cache.getRecordAsync({
               type: 'planet',
               id: 'p1'
-            })) as Record)?.relationships?.moons.data,
+            })) as InitializedRecord)?.relationships?.moons.data,
             [{ type: 'moon', id: 'm1' }],
             'Io has been assigned to Jupiter'
           );
           assert.deepEqual(
-            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-              ?.relationships?.planet.data,
+            ((await cache.getRecordAsync({
+              type: 'moon',
+              id: 'm1'
+            })) as InitializedRecord)?.relationships?.planet.data,
             { type: 'planet', id: 'p1' },
             'Jupiter has been assigned to Io'
           );
         });
 
         test('#update updates inverse hasOne relationship when a record with an empty relationship is added', async function (assert) {
-          const io: Record = {
+          const io: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Io' },
             relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
           };
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: 'p1',
             attributes: { name: 'Jupiter' },
@@ -356,26 +364,28 @@ module('IndexedDBCache - update', function (hooks) {
             ((await cache.getRecordAsync({
               type: 'planet',
               id: 'p1'
-            })) as Record)?.relationships?.moons.data,
+            })) as InitializedRecord)?.relationships?.moons.data,
             [],
             'Jupiter has no moons'
           );
           assert.deepEqual(
-            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-              ?.relationships?.planet.data,
+            ((await cache.getRecordAsync({
+              type: 'moon',
+              id: 'm1'
+            })) as InitializedRecord)?.relationships?.planet.data,
             null,
             'Jupiter has been cleared from Io'
           );
         });
 
         test('#update updates inverse hasMany relationship when a record with an empty relationship is added', async function (assert) {
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: 'p1',
             attributes: { name: 'Jupiter' },
             relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
           };
-          const io: Record = {
+          const io: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Io' },
@@ -391,20 +401,22 @@ module('IndexedDBCache - update', function (hooks) {
             ((await cache.getRecordAsync({
               type: 'planet',
               id: 'p1'
-            })) as Record)?.relationships?.moons.data,
+            })) as InitializedRecord)?.relationships?.moons.data,
             [],
             'Io has been cleared from Jupiter'
           );
           assert.deepEqual(
-            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-              ?.relationships?.planet.data,
+            ((await cache.getRecordAsync({
+              type: 'moon',
+              id: 'm1'
+            })) as InitializedRecord)?.relationships?.planet.data,
             null,
             'Io has no planet'
           );
         });
 
         test('#update updates inverse hasMany polymorphic relationship', async function (assert) {
-          const sun: Record = {
+          const sun: InitializedRecord = {
             type: 'star',
             id: 's1',
             attributes: { name: 'Sun' },
@@ -417,12 +429,12 @@ module('IndexedDBCache - update', function (hooks) {
               }
             }
           };
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: 'p1',
             attributes: { name: 'Jupiter' }
           };
-          const io: Record = {
+          const io: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Io' }
@@ -435,8 +447,10 @@ module('IndexedDBCache - update', function (hooks) {
           ]);
 
           assert.deepEqual(
-            ((await cache.getRecordAsync({ type: 'star', id: 's1' })) as Record)
-              ?.relationships?.celestialObjects.data,
+            ((await cache.getRecordAsync({
+              type: 'star',
+              id: 's1'
+            })) as InitializedRecord)?.relationships?.celestialObjects.data,
             [
               { type: 'planet', id: 'p1' },
               { type: 'moon', id: 'm1' }
@@ -447,32 +461,34 @@ module('IndexedDBCache - update', function (hooks) {
             ((await cache.getRecordAsync({
               type: 'planet',
               id: 'p1'
-            })) as Record)?.relationships?.star.data,
+            })) as InitializedRecord)?.relationships?.star.data,
             { type: 'star', id: 's1' },
             'Sun has been assigned to Jupiter'
           );
           assert.deepEqual(
-            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-              ?.relationships?.star.data,
+            ((await cache.getRecordAsync({
+              type: 'moon',
+              id: 'm1'
+            })) as InitializedRecord)?.relationships?.star.data,
             { type: 'star', id: 's1' },
             'Sun has been assigned to Io'
           );
         });
 
         test('#update updates inverse hasOne polymorphic relationship', async function (assert) {
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: 'p1',
             attributes: { name: 'Jupiter' },
             relationships: { star: { data: { type: 'star', id: 's1' } } }
           };
-          const io: Record = {
+          const io: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Io' },
             relationships: { star: { data: { type: 'star', id: 's1' } } }
           };
-          const sun: Record = {
+          const sun: InitializedRecord = {
             type: 'star',
             id: 's1',
             attributes: { name: 'Sun' }
@@ -485,8 +501,10 @@ module('IndexedDBCache - update', function (hooks) {
           ]);
 
           assert.deepEqual(
-            ((await cache.getRecordAsync({ type: 'star', id: 's1' })) as Record)
-              ?.relationships?.celestialObjects.data,
+            ((await cache.getRecordAsync({
+              type: 'star',
+              id: 's1'
+            })) as InitializedRecord)?.relationships?.celestialObjects.data,
             [
               { type: 'planet', id: 'p1' },
               { type: 'moon', id: 'm1' }
@@ -497,32 +515,34 @@ module('IndexedDBCache - update', function (hooks) {
             ((await cache.getRecordAsync({
               type: 'planet',
               id: 'p1'
-            })) as Record)?.relationships?.star.data,
+            })) as InitializedRecord)?.relationships?.star.data,
             { type: 'star', id: 's1' },
             'Sun has been assigned to Jupiter'
           );
           assert.deepEqual(
-            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-              ?.relationships?.star.data,
+            ((await cache.getRecordAsync({
+              type: 'moon',
+              id: 'm1'
+            })) as InitializedRecord)?.relationships?.star.data,
             { type: 'star', id: 's1' },
             'Sun has been assigned to Io'
           );
         });
 
         test('#update tracks refs and clears them from hasOne relationships when a referenced record is removed', async function (assert) {
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: 'p1',
             attributes: { name: 'Jupiter' },
             relationships: { moons: { data: undefined } }
           };
-          const io: Record = {
+          const io: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Io' },
             relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
           };
-          const europa: Record = {
+          const europa: InitializedRecord = {
             type: 'moon',
             id: 'm2',
             attributes: { name: 'Europa' },
@@ -536,14 +556,18 @@ module('IndexedDBCache - update', function (hooks) {
           ]);
 
           assert.deepEqual(
-            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-              ?.relationships?.planet.data,
+            ((await cache.getRecordAsync({
+              type: 'moon',
+              id: 'm1'
+            })) as InitializedRecord)?.relationships?.planet.data,
             { type: 'planet', id: 'p1' },
             'Jupiter has been assigned to Io'
           );
           assert.deepEqual(
-            ((await cache.getRecordAsync({ type: 'moon', id: 'm2' })) as Record)
-              ?.relationships?.planet.data,
+            ((await cache.getRecordAsync({
+              type: 'moon',
+              id: 'm2'
+            })) as InitializedRecord)?.relationships?.planet.data,
             { type: 'planet', id: 'p1' },
             'Jupiter has been assigned to Europa'
           );
@@ -557,33 +581,37 @@ module('IndexedDBCache - update', function (hooks) {
           );
 
           assert.equal(
-            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-              ?.relationships?.planet.data,
+            ((await cache.getRecordAsync({
+              type: 'moon',
+              id: 'm1'
+            })) as InitializedRecord)?.relationships?.planet.data,
             undefined,
             'Jupiter has been cleared from Io'
           );
           assert.equal(
-            ((await cache.getRecordAsync({ type: 'moon', id: 'm2' })) as Record)
-              ?.relationships?.planet.data,
+            ((await cache.getRecordAsync({
+              type: 'moon',
+              id: 'm2'
+            })) as InitializedRecord)?.relationships?.planet.data,
             undefined,
             'Jupiter has been cleared from Europa'
           );
         });
 
         test('#update tracks refs and clears them from hasMany relationships when a referenced record is removed', async function (assert) {
-          const io: Record = {
+          const io: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Io' },
             relationships: { planet: { data: null } }
           };
-          const europa: Record = {
+          const europa: InitializedRecord = {
             type: 'moon',
             id: 'm2',
             attributes: { name: 'Europa' },
             relationships: { planet: { data: null } }
           };
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: 'p1',
             attributes: { name: 'Jupiter' },
@@ -607,7 +635,7 @@ module('IndexedDBCache - update', function (hooks) {
             ((await cache.getRecordAsync({
               type: 'planet',
               id: 'p1'
-            })) as Record)?.relationships?.moons.data,
+            })) as InitializedRecord)?.relationships?.moons.data,
             [
               { type: 'moon', id: 'm1' },
               { type: 'moon', id: 'm2' }
@@ -670,7 +698,7 @@ module('IndexedDBCache - update', function (hooks) {
             ((await cache.getRecordAsync({
               type: 'planet',
               id: 'p1'
-            })) as Record)?.relationships?.moons.data,
+            })) as InitializedRecord)?.relationships?.moons.data,
             [{ type: 'moon', id: 'm1' }],
             'relationship was added'
           );
@@ -768,7 +796,7 @@ module('IndexedDBCache - update', function (hooks) {
         test('#update does not add link to hasMany if link already exists', async function (assert) {
           assert.expect(1);
 
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             id: 'p1',
             type: 'planet',
             attributes: { name: 'Jupiter' },
@@ -791,7 +819,7 @@ module('IndexedDBCache - update', function (hooks) {
         test("#update does not remove relationship from hasMany if relationship doesn't exist", async function (assert) {
           assert.expect(1);
 
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             id: 'p1',
             type: 'planet',
             attributes: { name: 'Jupiter' }
@@ -816,10 +844,10 @@ module('IndexedDBCache - update', function (hooks) {
         test('#update can add and remove to has-many relationship', async function (assert) {
           assert.expect(2);
 
-          const jupiter: Record = { id: 'jupiter', type: 'planet' };
+          const jupiter: InitializedRecord = { id: 'jupiter', type: 'planet' };
           await cache.update((t) => t.addRecord(jupiter));
 
-          const callisto: Record = { id: 'callisto', type: 'moon' };
+          const callisto: InitializedRecord = { id: 'callisto', type: 'moon' };
           await cache.update((t) => t.addRecord(callisto));
 
           await cache.update((t) =>
@@ -862,10 +890,10 @@ module('IndexedDBCache - update', function (hooks) {
         test('#update can add and clear has-one relationship', async function (assert) {
           assert.expect(2);
 
-          const jupiter: Record = { id: 'jupiter', type: 'planet' };
+          const jupiter: InitializedRecord = { id: 'jupiter', type: 'planet' };
           await cache.update((t) => t.addRecord(jupiter));
 
-          const callisto: Record = { id: 'callisto', type: 'moon' };
+          const callisto: InitializedRecord = { id: 'callisto', type: 'moon' };
           await cache.update((t) => t.addRecord(callisto));
 
           await cache.update((t) =>
@@ -905,7 +933,7 @@ module('IndexedDBCache - update', function (hooks) {
         test('does not replace hasOne if relationship already exists', async function (assert) {
           assert.expect(1);
 
-          const europa: Record = {
+          const europa: InitializedRecord = {
             id: 'm1',
             type: 'moon',
             attributes: { name: 'Europa' },
@@ -931,7 +959,7 @@ module('IndexedDBCache - update', function (hooks) {
         test("does not remove hasOne if relationship doesn't exist", async function (assert) {
           assert.expect(1);
 
-          const europa: Record = {
+          const europa: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Europa' },
@@ -1191,14 +1219,14 @@ module('IndexedDBCache - update', function (hooks) {
         test('#update merges records when "replacing" and _will_ replace specified attributes and relationships', async function (assert) {
           const tb = cache.transformBuilder;
 
-          const earth: Record = {
+          const earth: InitializedRecord = {
             type: 'planet',
             id: '1',
             attributes: { name: 'Earth' },
             relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
           };
 
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: '1',
             attributes: { name: 'Jupiter', classification: 'terrestrial' },
@@ -1596,7 +1624,7 @@ module('IndexedDBCache - update', function (hooks) {
             type: 'planetarySystem'
           });
           assert.deepEqual(
-            (latestHome?.relationships?.star.data as Record).id,
+            (latestHome?.relationships?.star.data as InitializedRecord).id,
             star1.id,
             'The original related record is in place.'
           );
@@ -1619,14 +1647,14 @@ module('IndexedDBCache - update', function (hooks) {
           });
 
           assert.deepEqual(
-            (latestHome?.relationships?.star.data as Record).id,
+            (latestHome?.relationships?.star.data as InitializedRecord).id,
             star2.id,
             'The related record was replaced.'
           );
         });
 
         test("#update - updateRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
-          const earth: Record = {
+          const earth: InitializedRecord = {
             type: 'planet',
             id: '1',
             attributes: { name: 'Earth' },
@@ -1645,7 +1673,7 @@ module('IndexedDBCache - update', function (hooks) {
         });
 
         test("#update - removeRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
-          const earth: Record = {
+          const earth: InitializedRecord = {
             type: 'planet',
             id: '1'
           };
@@ -1662,7 +1690,7 @@ module('IndexedDBCache - update', function (hooks) {
         });
 
         test("#update - replaceKey - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
-          const earth: Record = {
+          const earth: InitializedRecord = {
             type: 'planet',
             id: '1',
             attributes: { name: 'Earth' },
@@ -1681,7 +1709,7 @@ module('IndexedDBCache - update', function (hooks) {
         });
 
         test("#update - replaceAttribute - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
-          const earth: Record = {
+          const earth: InitializedRecord = {
             type: 'planet',
             id: '1',
             attributes: { name: 'Earth' },
@@ -1828,11 +1856,11 @@ module('IndexedDBCache - update', function (hooks) {
           const one = (await cache.getRecordAsync({
             type: 'one',
             id: '1'
-          })) as Record;
+          })) as InitializedRecord;
           const two = (await cache.getRecordAsync({
             type: 'two',
             id: '2'
-          })) as Record;
+          })) as InitializedRecord;
           assert.ok(one, 'one exists');
           assert.ok(two, 'two exists');
           assert.deepEqual(
@@ -1849,8 +1877,10 @@ module('IndexedDBCache - update', function (hooks) {
           await cache.update((t) => t.removeRecord(two));
 
           assert.equal(
-            ((await cache.getRecordAsync({ type: 'one', id: '1' })) as Record)
-              .relationships?.two.data,
+            ((await cache.getRecordAsync({
+              type: 'one',
+              id: '1'
+            })) as InitializedRecord).relationships?.two.data,
             null,
             'ones link to two got removed'
           );
@@ -1883,18 +1913,18 @@ module('IndexedDBCache - update', function (hooks) {
           });
           await cache.openDB();
 
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: 'p1',
             attributes: { name: 'Jupiter' }
           };
-          const io: Record = {
+          const io: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Io' },
             relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
           };
-          const europa: Record = {
+          const europa: InitializedRecord = {
             type: 'moon',
             id: 'm2',
             attributes: { name: 'Europa' },
@@ -1946,18 +1976,18 @@ module('IndexedDBCache - update', function (hooks) {
           });
           await cache.openDB();
 
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: 'p1',
             attributes: { name: 'Jupiter' }
           };
-          const io: Record = {
+          const io: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Io' },
             relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
           };
-          const europa: Record = {
+          const europa: InitializedRecord = {
             type: 'moon',
             id: 'm2',
             attributes: { name: 'Europa' },
@@ -2009,18 +2039,18 @@ module('IndexedDBCache - update', function (hooks) {
           });
           await cache.openDB();
 
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: 'p1',
             attributes: { name: 'Jupiter' }
           };
-          const io: Record = {
+          const io: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Io' },
             relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
           };
-          const europa: Record = {
+          const europa: InitializedRecord = {
             type: 'moon',
             id: 'm2',
             attributes: { name: 'Europa' },

--- a/packages/@orbit/indexeddb/test/indexeddb-source-pullable-test.ts
+++ b/packages/@orbit/indexeddb/test/indexeddb-source-pullable-test.ts
@@ -1,6 +1,6 @@
 import {
   AddRecordOperation,
-  Record,
+  InitializedRecord,
   RecordKeyMap,
   RecordSchema,
   RecordTransform
@@ -70,7 +70,7 @@ module('IndexedDBSource - pullable', function (hooks) {
   test('#pull - all records', async function (assert) {
     assert.expect(5);
 
-    let earth: Record = {
+    let earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       keys: {
@@ -82,7 +82,7 @@ module('IndexedDBSource - pullable', function (hooks) {
       }
     };
 
-    let jupiter: Record = {
+    let jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -94,7 +94,7 @@ module('IndexedDBSource - pullable', function (hooks) {
       }
     };
 
-    let io: Record = {
+    let io: InitializedRecord = {
       type: 'moon',
       id: 'io',
       keys: {
@@ -144,7 +144,7 @@ module('IndexedDBSource - pullable', function (hooks) {
   test('#pull - records of one type', async function (assert) {
     assert.expect(4);
 
-    let earth: Record = {
+    let earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -153,7 +153,7 @@ module('IndexedDBSource - pullable', function (hooks) {
       }
     };
 
-    let jupiter: Record = {
+    let jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -162,7 +162,7 @@ module('IndexedDBSource - pullable', function (hooks) {
       }
     };
 
-    let io: Record = {
+    let io: InitializedRecord = {
       type: 'moon',
       id: 'io',
       attributes: {
@@ -202,7 +202,7 @@ module('IndexedDBSource - pullable', function (hooks) {
   test('#pull - specific records', async function (assert) {
     assert.expect(4);
 
-    let earth: Record = {
+    let earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -211,7 +211,7 @@ module('IndexedDBSource - pullable', function (hooks) {
       }
     };
 
-    let jupiter: Record = {
+    let jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -220,7 +220,7 @@ module('IndexedDBSource - pullable', function (hooks) {
       }
     };
 
-    let io: Record = {
+    let io: InitializedRecord = {
       type: 'moon',
       id: 'io',
       attributes: {
@@ -260,7 +260,7 @@ module('IndexedDBSource - pullable', function (hooks) {
   test('#pull - a specific record', async function (assert) {
     assert.expect(4);
 
-    let earth: Record = {
+    let earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -269,7 +269,7 @@ module('IndexedDBSource - pullable', function (hooks) {
       }
     };
 
-    let jupiter: Record = {
+    let jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -281,7 +281,7 @@ module('IndexedDBSource - pullable', function (hooks) {
       }
     };
 
-    let io: Record = {
+    let io: InitializedRecord = {
       type: 'moon',
       id: 'io',
       attributes: {

--- a/packages/@orbit/indexeddb/test/indexeddb-source-pushable-test.ts
+++ b/packages/@orbit/indexeddb/test/indexeddb-source-pushable-test.ts
@@ -1,7 +1,7 @@
 import { buildTransform } from '@orbit/data';
 import {
   AddRecordOperation,
-  Record,
+  InitializedRecord,
   RecordIdentity,
   RecordKeyMap,
   RecordSchema,
@@ -73,7 +73,7 @@ module('IndexedDBSource - pushable', function (hooks) {
   test('#push - addRecord', async function (assert) {
     assert.expect(3);
 
-    let planet: Record = {
+    let planet: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -108,7 +108,7 @@ module('IndexedDBSource - pushable', function (hooks) {
   test('#push - addRecord - with beforePush listener that syncs transform', async function (assert) {
     assert.expect(4);
 
-    let planet: Record = {
+    let planet: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -148,7 +148,7 @@ module('IndexedDBSource - pushable', function (hooks) {
   test('#push - updateRecord', async function (assert) {
     assert.expect(2);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -164,7 +164,7 @@ module('IndexedDBSource - pushable', function (hooks) {
       }
     };
 
-    let updates: Record = {
+    let updates: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -177,7 +177,7 @@ module('IndexedDBSource - pushable', function (hooks) {
       }
     };
 
-    let expected: Record = {
+    let expected: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -214,7 +214,7 @@ module('IndexedDBSource - pushable', function (hooks) {
   test('#push - updateRecord - when record does not exist', async function (assert) {
     assert.expect(1);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -235,7 +235,7 @@ module('IndexedDBSource - pushable', function (hooks) {
   test('#push - removeRecord', async function (assert) {
     assert.expect(1);
 
-    let planet: Record = {
+    let planet: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -258,7 +258,7 @@ module('IndexedDBSource - pushable', function (hooks) {
 
     let moon1 = { type: 'moon', id: 'moon1' };
     let moon2 = { type: 'moon', id: 'moon2' };
-    let planet: Record = {
+    let planet: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -291,7 +291,7 @@ module('IndexedDBSource - pushable', function (hooks) {
   test('#push - removeRecord - when record does not exist', async function (assert) {
     assert.expect(1);
 
-    let planet: Record = {
+    let planet: InitializedRecord = {
       type: 'planet',
       id: 'jupiter'
     };
@@ -307,7 +307,7 @@ module('IndexedDBSource - pushable', function (hooks) {
   test('#push - replaceKey', async function (assert) {
     assert.expect(2);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -316,7 +316,7 @@ module('IndexedDBSource - pushable', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -346,7 +346,7 @@ module('IndexedDBSource - pushable', function (hooks) {
   test('#push - replaceKey - when base record does not exist', async function (assert) {
     assert.expect(2);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -373,7 +373,7 @@ module('IndexedDBSource - pushable', function (hooks) {
   test('#push - replaceAttribute', async function (assert) {
     assert.expect(1);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -382,7 +382,7 @@ module('IndexedDBSource - pushable', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -404,7 +404,7 @@ module('IndexedDBSource - pushable', function (hooks) {
   test('#push - replaceAttribute - when base record does not exist', async function (assert) {
     assert.expect(1);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -425,7 +425,7 @@ module('IndexedDBSource - pushable', function (hooks) {
   test('#push - addToRelatedRecords', async function (assert) {
     assert.expect(1);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -439,7 +439,7 @@ module('IndexedDBSource - pushable', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -467,7 +467,7 @@ module('IndexedDBSource - pushable', function (hooks) {
   test('#push - addToRelatedRecords - when base record does not exist', async function (assert) {
     assert.expect(1);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -493,7 +493,7 @@ module('IndexedDBSource - pushable', function (hooks) {
   test('#push - removeFromRelatedRecords', async function (assert) {
     assert.expect(1);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -510,7 +510,7 @@ module('IndexedDBSource - pushable', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -541,7 +541,7 @@ module('IndexedDBSource - pushable', function (hooks) {
   test('#push - removeFromRelatedRecords - when base record does not exist', async function (assert) {
     assert.expect(1);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -567,7 +567,7 @@ module('IndexedDBSource - pushable', function (hooks) {
   test('#push - replaceRelatedRecords', async function (assert) {
     assert.expect(1);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -581,7 +581,7 @@ module('IndexedDBSource - pushable', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -615,7 +615,7 @@ module('IndexedDBSource - pushable', function (hooks) {
   test('#push - replaceRelatedRecords - when base record does not exist', async function (assert) {
     assert.expect(1);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -644,7 +644,7 @@ module('IndexedDBSource - pushable', function (hooks) {
   test('#push - replaceRelatedRecord - with record', async function (assert) {
     assert.expect(1);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -658,7 +658,7 @@ module('IndexedDBSource - pushable', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -689,7 +689,7 @@ module('IndexedDBSource - pushable', function (hooks) {
   test('#push - replaceRelatedRecord - with record - when base record does not exist', async function (assert) {
     assert.expect(1);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -715,7 +715,7 @@ module('IndexedDBSource - pushable', function (hooks) {
   test('#push - replaceRelatedRecord - with null', async function (assert) {
     assert.expect(1);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -729,7 +729,7 @@ module('IndexedDBSource - pushable', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -757,7 +757,7 @@ module('IndexedDBSource - pushable', function (hooks) {
   test('#push - replaceRelatedRecord - with null - when base record does not exist', async function (assert) {
     assert.expect(1);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -789,7 +789,7 @@ module('IndexedDBSource - pushable', function (hooks) {
       id: 'ss'
     };
 
-    let earth: Record = {
+    let earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -803,7 +803,7 @@ module('IndexedDBSource - pushable', function (hooks) {
       }
     };
 
-    let jupiter: Record = {
+    let jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -817,7 +817,7 @@ module('IndexedDBSource - pushable', function (hooks) {
       }
     };
 
-    let io: Record = {
+    let io: InitializedRecord = {
       type: 'moon',
       id: 'io',
       attributes: {

--- a/packages/@orbit/indexeddb/test/indexeddb-source-queryable-test.ts
+++ b/packages/@orbit/indexeddb/test/indexeddb-source-queryable-test.ts
@@ -1,6 +1,6 @@
 import { Orbit } from '@orbit/core';
 import {
-  Record,
+  InitializedRecord,
   RecordKeyMap,
   RecordQuery,
   RecordSchema
@@ -207,14 +207,14 @@ module('IndexedDBSource - queryable', function (hooks) {
   });
 
   test('#query - can query with multiple expressions', async function (assert) {
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
         name: 'Jupiter'
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {

--- a/packages/@orbit/indexeddb/test/indexeddb-source-test.ts
+++ b/packages/@orbit/indexeddb/test/indexeddb-source-test.ts
@@ -1,7 +1,7 @@
 import { buildTransform } from '@orbit/data';
 import {
   AddRecordOperation,
-  Record,
+  InitializedRecord,
   RecordKeyMap,
   RecordSchema
 } from '@orbit/records';
@@ -236,7 +236,7 @@ module('IndexedDBSource', function (hooks) {
     test('data persists across re-instantiating source', async function (assert) {
       assert.expect(2);
 
-      let planet: Record = {
+      let planet: InitializedRecord = {
         type: 'planet',
         id: 'jupiter',
         keys: {
@@ -270,7 +270,7 @@ module('IndexedDBSource', function (hooks) {
     test('#sync - addRecord', async function (assert) {
       assert.expect(3);
 
-      let planet: Record = {
+      let planet: InitializedRecord = {
         type: 'planet',
         id: 'jupiter',
         keys: {

--- a/packages/@orbit/indexeddb/test/indexeddb-source-updatable-test.ts
+++ b/packages/@orbit/indexeddb/test/indexeddb-source-updatable-test.ts
@@ -1,7 +1,7 @@
 import { Orbit } from '@orbit/core';
 import { FullResponse, ResponseHints } from '@orbit/data';
 import {
-  Record,
+  InitializedRecord,
   RecordKeyMap,
   RecordOperation,
   RecordSchema,
@@ -85,7 +85,7 @@ module('IndexedDBSource - updatable', function (hooks) {
   test("#update - transforms the source's cache", async function (assert) {
     assert.expect(4);
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'jupiter',
       type: 'planet',
       attributes: { name: 'Jupiter', classification: 'gas giant' }
@@ -134,13 +134,13 @@ module('IndexedDBSource - updatable', function (hooks) {
   test('#update - can perform multiple operations and return the results', async function (assert) {
     assert.expect(3);
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: { name: 'Jupiter', classification: 'gas giant' }
     };
 
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: { name: 'Earth', classification: 'terrestrial' }
@@ -206,7 +206,7 @@ module('IndexedDBSource - updatable', function (hooks) {
       type: 'planetarySystem'
     });
     assert.deepEqual(
-      (latestHome?.relationships?.star.data as Record).id,
+      (latestHome?.relationships?.star.data as InitializedRecord).id,
       star1.id,
       'The original related record is in place.'
     );
@@ -221,7 +221,7 @@ module('IndexedDBSource - updatable', function (hooks) {
       type: 'planetarySystem'
     });
     assert.deepEqual(
-      (latestHome?.relationships?.star.data as Record).id,
+      (latestHome?.relationships?.star.data as InitializedRecord).id,
       star2.id,
       'The related record was replaced.'
     );

--- a/packages/@orbit/indexeddb/test/support/indexeddb.ts
+++ b/packages/@orbit/indexeddb/test/support/indexeddb.ts
@@ -1,15 +1,15 @@
 import { IndexedDBCache } from '../../src/index';
-import { Record } from '@orbit/records';
+import { InitializedRecord } from '@orbit/records';
 
 export async function getRecordFromIndexedDB(
   cache: IndexedDBCache,
-  record: Record
-): Promise<Record> {
+  record: InitializedRecord
+): Promise<InitializedRecord> {
   const db = await cache.openDB();
   const transaction = db.transaction([record.type]);
   const objectStore = transaction.objectStore(record.type);
 
-  return new Promise((resolve: (record: Record) => void, reject) => {
+  return new Promise((resolve: (record: InitializedRecord) => void, reject) => {
     const request = objectStore.get(record.id);
 
     request.onerror = function (/* event */) {
@@ -19,7 +19,7 @@ export async function getRecordFromIndexedDB(
 
     request.onsuccess = function (/* event */) {
       // console.log('success - getRecord', request.result);
-      resolve(request.result as Record);
+      resolve(request.result as InitializedRecord);
     };
   });
 }

--- a/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
@@ -7,7 +7,7 @@ import {
 } from '@orbit/data';
 import {
   RecordKeyMap,
-  Record,
+  InitializedRecord,
   RecordSchema,
   RecordQueryExpression,
   RecordTransform,
@@ -227,7 +227,7 @@ export class JSONAPIRequestProcessor {
   operationsFromDeserializedDocument(
     deserialized: RecordDocument
   ): RecordOperation[] {
-    const records: Record[] = [];
+    const records: InitializedRecord[] = [];
     Array.prototype.push.apply(records, toArray(deserialized.data));
 
     if (deserialized.included) {

--- a/packages/@orbit/jsonapi/src/jsonapi-serializer.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-serializer.ts
@@ -3,7 +3,7 @@ import Orbit, { Assertion } from '@orbit/core';
 import {
   RecordSchema,
   RecordKeyMap,
-  Record,
+  InitializedRecord,
   RecordIdentity,
   RecordOperation,
   ModelDefinition
@@ -37,8 +37,8 @@ import { JSONAPIResourceFieldSerializer } from './serializers/jsonapi-resource-f
 const { deprecate } = Orbit;
 
 export interface JSONAPISerializationOptions {
-  primaryRecord?: Record;
-  primaryRecords?: Record[];
+  primaryRecord?: InitializedRecord;
+  primaryRecords?: InitializedRecord[];
 }
 
 export interface JSONAPISerializerSettings {
@@ -193,8 +193,8 @@ export class JSONAPISerializer
 
     return {
       data: Array.isArray(data)
-        ? this.serializeRecords(data as Record[])
-        : this.serializeRecord(data as Record)
+        ? this.serializeRecords(data as InitializedRecord[])
+        : this.serializeRecord(data as InitializedRecord)
     };
   }
 
@@ -220,11 +220,11 @@ export class JSONAPISerializer
     return this.atomicOperationSerializer.serialize(operation);
   }
 
-  serializeRecords(records: Record[]): Resource[] {
+  serializeRecords(records: InitializedRecord[]): Resource[] {
     return records.map((record) => this.serializeRecord(record));
   }
 
-  serializeRecord(record: Record): Resource {
+  serializeRecord(record: InitializedRecord): Resource {
     const resource: Resource = {
       type: this.resourceType(record.type)
     };
@@ -237,7 +237,7 @@ export class JSONAPISerializer
     return resource;
   }
 
-  serializeIdentity(record: Record): ResourceIdentity {
+  serializeIdentity(record: InitializedRecord): ResourceIdentity {
     return {
       type: this.resourceType(record.type),
       id: this.resourceId(record.type, record.id)
@@ -258,7 +258,7 @@ export class JSONAPISerializer
 
   serializeAttributes(
     resource: Resource,
-    record: Record,
+    record: InitializedRecord,
     model: ModelDefinition
   ): void {
     if (record.attributes) {
@@ -270,7 +270,7 @@ export class JSONAPISerializer
 
   serializeAttribute(
     resource: Resource,
-    record: Record,
+    record: InitializedRecord,
     attr: string,
     model: ModelDefinition
   ): void {
@@ -298,7 +298,7 @@ export class JSONAPISerializer
 
   serializeRelationships(
     resource: Resource,
-    record: Record,
+    record: InitializedRecord,
     model: ModelDefinition
   ): void {
     if (record.relationships) {
@@ -310,7 +310,7 @@ export class JSONAPISerializer
 
   serializeRelationship(
     resource: Resource,
-    record: Record,
+    record: InitializedRecord,
     relationship: string,
     model: ModelDefinition
   ): void {
@@ -427,9 +427,9 @@ export class JSONAPISerializer
 
   deserializeResourceIdentity(
     resource: Resource,
-    primaryRecord?: Record
-  ): Record {
-    let record: Record;
+    primaryRecord?: InitializedRecord
+  ): InitializedRecord {
+    let record: InitializedRecord;
     const type: string = this.recordType(resource.type);
     const resourceKey = this.resourceKey(type);
 
@@ -475,7 +475,10 @@ export class JSONAPISerializer
     return record;
   }
 
-  deserializeResource(resource: Resource, primaryRecord?: Record): Record {
+  deserializeResource(
+    resource: Resource,
+    primaryRecord?: InitializedRecord
+  ): InitializedRecord {
     const record = this.deserializeResourceIdentity(resource, primaryRecord);
     const model: ModelDefinition = this._schema.getModel(record.type);
 
@@ -488,7 +491,7 @@ export class JSONAPISerializer
   }
 
   deserializeAttributes(
-    record: Record,
+    record: InitializedRecord,
     resource: Resource,
     model: ModelDefinition
   ): void {
@@ -506,7 +509,7 @@ export class JSONAPISerializer
   }
 
   deserializeAttribute(
-    record: Record,
+    record: InitializedRecord,
     attr: string,
     value: unknown,
     model: ModelDefinition
@@ -526,7 +529,7 @@ export class JSONAPISerializer
   }
 
   deserializeRelationships(
-    record: Record,
+    record: InitializedRecord,
     resource: Resource,
     model: ModelDefinition
   ): void {
@@ -544,7 +547,7 @@ export class JSONAPISerializer
   }
 
   deserializeRelationship(
-    record: Record,
+    record: InitializedRecord,
     relationship: string,
     value: ResourceRelationship,
     /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
@@ -580,7 +583,7 @@ export class JSONAPISerializer
   }
 
   deserializeLinks(
-    record: Record,
+    record: InitializedRecord,
     resource: Resource,
     /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
     model: ModelDefinition
@@ -591,7 +594,7 @@ export class JSONAPISerializer
   }
 
   deserializeMeta(
-    record: Record,
+    record: InitializedRecord,
     resource: Resource,
     /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
     model: ModelDefinition

--- a/packages/@orbit/jsonapi/src/lib/query-requests.ts
+++ b/packages/@orbit/jsonapi/src/lib/query-requests.ts
@@ -8,7 +8,7 @@ import {
   FindRecords,
   FindRelatedRecord,
   FindRelatedRecords,
-  Record,
+  RecordIdentity,
   RecordQueryExpression,
   cloneRecordIdentity,
   RecordOperation,
@@ -33,7 +33,7 @@ export interface QueryRequest {
 
 export interface FindRecordRequest extends QueryRequest {
   op: 'findRecord';
-  record: Record;
+  record: RecordIdentity;
 }
 
 export interface FindRecordsRequest extends QueryRequest {
@@ -43,13 +43,13 @@ export interface FindRecordsRequest extends QueryRequest {
 
 export interface FindRelatedRecordRequest extends QueryRequest {
   op: 'findRelatedRecord';
-  record: Record;
+  record: RecordIdentity;
   relationship: string;
 }
 
 export interface FindRelatedRecordsRequest extends QueryRequest {
   op: 'findRelatedRecords';
-  record: Record;
+  record: RecordIdentity;
   relationship: string;
 }
 
@@ -314,7 +314,7 @@ export const QueryRequestProcessors: Dict<QueryRequestProcessor> = {
         JSONAPISerializers.ResourceDocument
       ) as JSONAPIDocumentSerializer;
       const recordDoc = serializer.deserialize(document) as RecordDocument;
-      const relatedRecords = recordDoc.data as Record[];
+      const relatedRecords = recordDoc.data as RecordIdentity[];
       const operations = requestProcessor.operationsFromDeserializedDocument(
         recordDoc
       );

--- a/packages/@orbit/jsonapi/src/lib/transform-requests.ts
+++ b/packages/@orbit/jsonapi/src/lib/transform-requests.ts
@@ -3,7 +3,7 @@ import {
   cloneRecordIdentity,
   equalRecordIdentities,
   recordDiffs,
-  Record,
+  InitializedRecord,
   RecordIdentity,
   RecordOperation,
   AddRecordOperation,
@@ -39,7 +39,7 @@ export interface TransformRecordRelationshipRequest
 
 export interface AddRecordRequest extends BaseTransformRecordRequest {
   op: 'addRecord';
-  record: Record;
+  record: InitializedRecord;
 }
 
 export interface RemoveRecordRequest extends BaseTransformRecordRequest {
@@ -48,7 +48,7 @@ export interface RemoveRecordRequest extends BaseTransformRecordRequest {
 
 export interface UpdateRecordRequest extends BaseTransformRecordRequest {
   op: 'updateRecord';
-  record: Record;
+  record: InitializedRecord;
 }
 
 export interface AddToRelatedRecordsRequest
@@ -527,11 +527,11 @@ function replaceRecordHasMany(
 }
 
 function handleChanges(
-  record: Record,
+  record: InitializedRecord,
   recordDoc: RecordDocument,
   details: JSONAPIResponse
 ): TransformRequestProcessorResponse {
-  let updatedRecord: Record = recordDoc.data as Record;
+  let updatedRecord: InitializedRecord = recordDoc.data as InitializedRecord;
   let transforms: RecordTransform[] = [];
   let updateOps = recordDiffs(record, updatedRecord);
   if (updateOps.length > 0) {

--- a/packages/@orbit/jsonapi/src/record-document.ts
+++ b/packages/@orbit/jsonapi/src/record-document.ts
@@ -1,9 +1,9 @@
 import { Dict } from '@orbit/utils';
-import { Link, Record } from '@orbit/records';
+import { Link, InitializedRecord } from '@orbit/records';
 
 export interface RecordDocument {
-  data: Record | Record[] | null;
-  included?: Record[];
+  data: InitializedRecord | InitializedRecord[] | null;
+  included?: InitializedRecord[];
   links?: Dict<Link>;
   meta?: Dict<unknown>;
 }

--- a/packages/@orbit/jsonapi/src/resource-operations.ts
+++ b/packages/@orbit/jsonapi/src/resource-operations.ts
@@ -1,6 +1,6 @@
 import { Resource } from './resource-document';
 import { Dict } from '@orbit/utils';
-import { Link, RecordOperation, Record } from '@orbit/records';
+import { Link, RecordOperation, InitializedRecord } from '@orbit/records';
 
 export interface ResourceAtomicOperation {
   op: 'get' | 'add' | 'update' | 'remove';
@@ -101,7 +101,7 @@ export interface RecordOperationsDocument {
 }
 
 export interface RecordResultsDocument {
-  results: Record[];
+  results: InitializedRecord[];
   links?: Dict<Link>;
   meta?: Dict<unknown>;
 }

--- a/packages/@orbit/jsonapi/src/serializers/jsonapi-atomic-results-document-serializer.ts
+++ b/packages/@orbit/jsonapi/src/serializers/jsonapi-atomic-results-document-serializer.ts
@@ -1,4 +1,4 @@
-import { Record } from '@orbit/records';
+import { InitializedRecord } from '@orbit/records';
 import {
   RecordResultsDocument,
   ResourceAtomicResultsDocument
@@ -23,7 +23,7 @@ export class JSONAPIAtomicResultsDocumentSerializer extends JSONAPIBaseSerialize
     return result;
   }
 
-  serializeResults(results: Record[]): Resource[] {
+  serializeResults(results: InitializedRecord[]): Resource[] {
     return results.map((record) => this.resourceSerializer.serialize(record));
   }
 
@@ -50,7 +50,7 @@ export class JSONAPIAtomicResultsDocumentSerializer extends JSONAPIBaseSerialize
     return result;
   }
 
-  deserializeAtomicResults(results: Resource[]): Record[] {
+  deserializeAtomicResults(results: Resource[]): InitializedRecord[] {
     return results.map((resource) =>
       this.resourceSerializer.deserialize(resource)
     );

--- a/packages/@orbit/jsonapi/src/serializers/jsonapi-document-serializer.ts
+++ b/packages/@orbit/jsonapi/src/serializers/jsonapi-document-serializer.ts
@@ -1,11 +1,11 @@
-import { Record } from '@orbit/records';
+import { InitializedRecord } from '@orbit/records';
 import { Resource, ResourceDocument } from '../resource-document';
 import { RecordDocument } from '../record-document';
 import { JSONAPIBaseSerializer } from './jsonapi-base-serializer';
 
 export interface JSONAPIDocumentDeserializationOptions {
-  primaryRecord?: Record;
-  primaryRecords?: Record[];
+  primaryRecord?: InitializedRecord;
+  primaryRecords?: InitializedRecord[];
 }
 
 export class JSONAPIDocumentSerializer extends JSONAPIBaseSerializer<
@@ -17,8 +17,8 @@ export class JSONAPIDocumentSerializer extends JSONAPIBaseSerializer<
   serialize(document: RecordDocument): ResourceDocument {
     let resDocument: ResourceDocument = {
       data: Array.isArray(document.data)
-        ? this.serializeRecords(document.data as Record[])
-        : this.serializeRecord(document.data as Record)
+        ? this.serializeRecords(document.data as InitializedRecord[])
+        : this.serializeRecord(document.data as InitializedRecord)
     };
 
     this.serializeLinks(document, resDocument);
@@ -65,11 +65,11 @@ export class JSONAPIDocumentSerializer extends JSONAPIBaseSerializer<
     return result;
   }
 
-  protected serializeRecords(records: Record[]): Resource[] {
+  protected serializeRecords(records: InitializedRecord[]): Resource[] {
     return records.map((record) => this.serializeRecord(record));
   }
 
-  protected serializeRecord(record: Record): Resource {
+  protected serializeRecord(record: InitializedRecord): Resource {
     return this.resourceSerializer.serialize(record);
   }
 
@@ -87,8 +87,8 @@ export class JSONAPIDocumentSerializer extends JSONAPIBaseSerializer<
 
   protected deserializeResources(
     resources: Resource[],
-    primaryRecords?: Record[]
-  ): Record[] {
+    primaryRecords?: InitializedRecord[]
+  ): InitializedRecord[] {
     if (primaryRecords) {
       return resources.map((entry, i) => {
         return this.deserializeResource(entry, primaryRecords[i]);
@@ -100,8 +100,8 @@ export class JSONAPIDocumentSerializer extends JSONAPIBaseSerializer<
 
   protected deserializeResource(
     resource: Resource,
-    primaryRecord?: Record
-  ): Record {
+    primaryRecord?: InitializedRecord
+  ): InitializedRecord {
     if (primaryRecord) {
       return this.resourceSerializer.deserialize(resource, { primaryRecord });
     } else {

--- a/packages/@orbit/jsonapi/src/serializers/jsonapi-resource-identity-serializer.ts
+++ b/packages/@orbit/jsonapi/src/serializers/jsonapi-resource-identity-serializer.ts
@@ -1,5 +1,5 @@
 import Orbit, { Assertion } from '@orbit/core';
-import { Record, RecordSchema, RecordKeyMap } from '@orbit/records';
+import { InitializedRecord, RecordSchema, RecordKeyMap } from '@orbit/records';
 import { Dict } from '@orbit/utils';
 import { Resource } from '../resource-document';
 import { JSONAPIBaseSerializer } from './jsonapi-base-serializer';
@@ -8,7 +8,7 @@ import { SerializerForFn } from '@orbit/serializers';
 const { assert } = Orbit;
 
 export interface JSONAPIResourceIdentityDeserializationOptions {
-  primaryRecord?: Record;
+  primaryRecord?: InitializedRecord;
   includeKeys?: boolean;
 }
 
@@ -21,7 +21,7 @@ export interface JSONAPIResourceIdentitySerializerSettings {
 }
 
 export class JSONAPIResourceIdentitySerializer extends JSONAPIBaseSerializer<
-  Record,
+  InitializedRecord,
   Resource,
   unknown,
   JSONAPIResourceIdentityDeserializationOptions
@@ -77,7 +77,7 @@ export class JSONAPIResourceIdentitySerializer extends JSONAPIBaseSerializer<
     this._getCustomResourceKey = getResourceKey;
   }
 
-  serialize(recordIdentity: Record): Resource {
+  serialize(recordIdentity: InitializedRecord): Resource {
     const { type, id } = recordIdentity;
     const resourceKey = this.getResourceKey(type);
     const resourceType = this.typeSerializer.serialize(type) as string;
@@ -99,7 +99,7 @@ export class JSONAPIResourceIdentitySerializer extends JSONAPIBaseSerializer<
   deserialize(
     resource: Resource,
     customOptions?: JSONAPIResourceIdentityDeserializationOptions
-  ): Record {
+  ): InitializedRecord {
     const options = this.buildDeserializationOptions(customOptions);
     const type = this.typeSerializer.deserialize(resource.type) as string;
     const resourceKey = this.getResourceKey(type);
@@ -132,7 +132,7 @@ export class JSONAPIResourceIdentitySerializer extends JSONAPIBaseSerializer<
           (primaryRecord && primaryRecord.id) || this.schema.generateId(type);
       }
 
-      const record: Record = { type, id };
+      const record: InitializedRecord = { type, id };
 
       if (keys) {
         if (options.includeKeys) {

--- a/packages/@orbit/jsonapi/src/serializers/jsonapi-resource-serializer.ts
+++ b/packages/@orbit/jsonapi/src/serializers/jsonapi-resource-serializer.ts
@@ -1,17 +1,21 @@
 import { deepSet } from '@orbit/utils';
 import { Assertion } from '@orbit/core';
-import { Record, RecordIdentity, ModelDefinition } from '@orbit/records';
+import {
+  InitializedRecord,
+  RecordIdentity,
+  ModelDefinition
+} from '@orbit/records';
 import { Resource, ResourceIdentity } from '../resource-document';
 import { JSONAPIBaseSerializer } from './jsonapi-base-serializer';
 import { JSONAPIResourceIdentityDeserializationOptions } from './jsonapi-resource-identity-serializer';
 
 export class JSONAPIResourceSerializer extends JSONAPIBaseSerializer<
-  Record,
+  InitializedRecord,
   Resource,
   unknown,
   JSONAPIResourceIdentityDeserializationOptions
 > {
-  serialize(record: Record): Resource {
+  serialize(record: InitializedRecord): Resource {
     const resource: Resource = this.identitySerializer.serialize(record);
     const model: ModelDefinition = this.schema.getModel(record.type);
 
@@ -26,10 +30,10 @@ export class JSONAPIResourceSerializer extends JSONAPIBaseSerializer<
   deserialize(
     resource: Resource,
     customOptions?: JSONAPIResourceIdentityDeserializationOptions
-  ): Record {
+  ): InitializedRecord {
     const options = this.buildDeserializationOptions(customOptions);
     options.includeKeys = true;
-    const record: Record = this.identitySerializer.deserialize(
+    const record: InitializedRecord = this.identitySerializer.deserialize(
       resource as ResourceIdentity,
       options
     );
@@ -45,7 +49,7 @@ export class JSONAPIResourceSerializer extends JSONAPIBaseSerializer<
 
   protected serializeAttributes(
     resource: Resource,
-    record: Record,
+    record: InitializedRecord,
     model: ModelDefinition
   ): void {
     if (record.attributes) {
@@ -57,7 +61,7 @@ export class JSONAPIResourceSerializer extends JSONAPIBaseSerializer<
 
   protected serializeAttribute(
     resource: Resource,
-    record: Record,
+    record: InitializedRecord,
     field: string,
     model: ModelDefinition
   ): void {
@@ -98,7 +102,7 @@ export class JSONAPIResourceSerializer extends JSONAPIBaseSerializer<
 
   protected serializeRelationships(
     resource: Resource,
-    record: Record,
+    record: InitializedRecord,
     model: ModelDefinition
   ): void {
     if (record.relationships) {
@@ -110,7 +114,7 @@ export class JSONAPIResourceSerializer extends JSONAPIBaseSerializer<
 
   protected serializeRelationship(
     resource: Resource,
-    record: Record,
+    record: InitializedRecord,
     field: string,
     model: ModelDefinition
   ): void {
@@ -149,19 +153,19 @@ export class JSONAPIResourceSerializer extends JSONAPIBaseSerializer<
   /* eslint-disable @typescript-eslint/no-unused-vars */
   protected serializeLinks(
     resource: Resource,
-    record: Record,
+    record: InitializedRecord,
     model: ModelDefinition
   ): void {}
 
   protected serializeMeta(
     resource: Resource,
-    record: Record,
+    record: InitializedRecord,
     model: ModelDefinition
   ): void {}
   /* eslint-enable @typescript-eslint/no-unused-vars */
 
   protected deserializeAttributes(
-    record: Record,
+    record: InitializedRecord,
     resource: Resource,
     model: ModelDefinition
   ): void {
@@ -173,7 +177,7 @@ export class JSONAPIResourceSerializer extends JSONAPIBaseSerializer<
   }
 
   protected deserializeAttribute(
-    record: Record,
+    record: InitializedRecord,
     resource: Resource,
     resField: string,
     model: ModelDefinition
@@ -214,7 +218,7 @@ export class JSONAPIResourceSerializer extends JSONAPIBaseSerializer<
   }
 
   protected deserializeRelationships(
-    record: Record,
+    record: InitializedRecord,
     resource: Resource,
     model: ModelDefinition
   ): void {
@@ -226,7 +230,7 @@ export class JSONAPIResourceSerializer extends JSONAPIBaseSerializer<
   }
 
   protected deserializeRelationship(
-    record: Record,
+    record: InitializedRecord,
     resource: Resource,
     resField: string,
     model: ModelDefinition
@@ -279,7 +283,7 @@ export class JSONAPIResourceSerializer extends JSONAPIBaseSerializer<
   }
 
   protected deserializeLinks(
-    record: Record,
+    record: InitializedRecord,
     resource: Resource,
     /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
     model: ModelDefinition
@@ -290,7 +294,7 @@ export class JSONAPIResourceSerializer extends JSONAPIBaseSerializer<
   }
 
   protected deserializeMeta(
-    record: Record,
+    record: InitializedRecord,
     resource: Resource,
     /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
     model: ModelDefinition

--- a/packages/@orbit/jsonapi/test/jsonapi-serializer-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-serializer-test.ts
@@ -2,7 +2,7 @@ import { Dict } from '@orbit/utils';
 import {
   RecordKeyMap,
   ModelDefinition,
-  Record,
+  InitializedRecord,
   RecordSchema
 } from '@orbit/records';
 import { JSONAPISerializer } from '../src/jsonapi-serializer';
@@ -493,7 +493,7 @@ module('JSONAPISerializer', function (hooks) {
             }
           }
         });
-        let planet = result.data as Record;
+        let planet = result.data as InitializedRecord;
         assert.deepEqual(result, {
           data: {
             type: 'planet',
@@ -550,7 +550,7 @@ module('JSONAPISerializer', function (hooks) {
             }
           }
         });
-        let planet = result.data as Record;
+        let planet = result.data as InitializedRecord;
         assert.deepEqual(result, {
           data: {
             type: 'planet',
@@ -614,7 +614,7 @@ module('JSONAPISerializer', function (hooks) {
             }
           }
         });
-        let planet = result.data as Record;
+        let planet = result.data as InitializedRecord;
         assert.deepEqual(result, {
           data: {
             type: 'planet',
@@ -675,7 +675,7 @@ module('JSONAPISerializer', function (hooks) {
             }
           }
         });
-        let planet = result.data as Record;
+        let planet = result.data as InitializedRecord;
         assert.deepEqual(result, {
           data: {
             type: 'planet',
@@ -735,7 +735,7 @@ module('JSONAPISerializer', function (hooks) {
             }
           }
         });
-        let planet = result.data as Record;
+        let planet = result.data as InitializedRecord;
         assert.deepEqual(result, {
           data: {
             type: 'planet',
@@ -1075,7 +1075,7 @@ module('JSONAPISerializer', function (hooks) {
           id: '123'
         }
       });
-      let record = result.data as Record;
+      let record = result.data as InitializedRecord;
 
       assert.deepEqual(
         record,
@@ -1094,7 +1094,7 @@ module('JSONAPISerializer', function (hooks) {
       let localRecord = {
         id: '1a2b3c',
         type: 'planet'
-      } as Record;
+      } as InitializedRecord;
 
       let result = serializer.deserialize(
         {
@@ -1161,9 +1161,9 @@ module('JSONAPISerializer', function (hooks) {
         ]
       });
 
-      let planet = result.data as Record;
-      let moon = result.included?.[0] as Record;
-      let solarSystem = result.included?.[1] as Record;
+      let planet = result.data as InitializedRecord;
+      let moon = result.included?.[0] as InitializedRecord;
+      let solarSystem = result.included?.[1] as InitializedRecord;
 
       assert.deepEqual(
         result,
@@ -1240,7 +1240,7 @@ module('JSONAPISerializer', function (hooks) {
           { type: 'planets', id: '234' }
         ]
       });
-      let records = result.data as Record[];
+      let records = result.data as InitializedRecord[];
 
       assert.deepEqual(
         records,
@@ -1261,7 +1261,10 @@ module('JSONAPISerializer', function (hooks) {
     });
 
     test('#deserialize - can deserialize an array of records and associate them with local records', function (assert) {
-      let localRecords = [{ id: '1a2b3c' }, { id: '4d5e6f' }] as Record[];
+      let localRecords = [
+        { id: '1a2b3c' },
+        { id: '4d5e6f' }
+      ] as InitializedRecord[];
       let result = serializer.deserialize(
         {
           data: [
@@ -1273,7 +1276,7 @@ module('JSONAPISerializer', function (hooks) {
           primaryRecords: localRecords
         }
       );
-      let records = result.data as Record[];
+      let records = result.data as InitializedRecord[];
 
       assert.deepEqual(
         records,

--- a/packages/@orbit/jsonapi/test/jsonapi-source-pullable-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-pullable-test.ts
@@ -1,7 +1,7 @@
 import { NetworkError } from '@orbit/data';
 import {
   RecordKeyMap,
-  Record,
+  InitializedRecord,
   RecordIdentity,
   RecordOperation,
   ReplaceRelatedRecordOperation,
@@ -64,7 +64,7 @@ module('JSONAPISource - pullable', function (hooks) {
         attributes: { name: 'Jupiter', classification: 'gas giant' }
       };
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
       });
@@ -104,7 +104,7 @@ module('JSONAPISource - pullable', function (hooks) {
     test('#pull - record (with a 304 response)', async function (assert) {
       assert.expect(3);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
       });
@@ -134,7 +134,7 @@ module('JSONAPISource - pullable', function (hooks) {
         relationships: { moons: { data: [] } }
       };
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
       });
@@ -167,7 +167,7 @@ module('JSONAPISource - pullable', function (hooks) {
         relationships: { moons: { data: [] } }
       };
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
       });
@@ -201,7 +201,7 @@ module('JSONAPISource - pullable', function (hooks) {
     test('#pull - fetch can reject with a NetworkError', async function (assert) {
       assert.expect(2);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
       });
@@ -229,7 +229,7 @@ module('JSONAPISource - pullable', function (hooks) {
         relationships: { moons: { data: [] } }
       };
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
       });
@@ -827,7 +827,7 @@ module('JSONAPISource - pullable', function (hooks) {
       const solarSystem = resourceSerializer.deserialize({
         type: 'solarSystem',
         id: 'sun'
-      }) as Record;
+      }) as InitializedRecord;
 
       const data: Resource[] = [
         {
@@ -890,7 +890,7 @@ module('JSONAPISource - pullable', function (hooks) {
       const solarSystem = resourceSerializer.deserialize({
         type: 'solarSystem',
         id: 'sun'
-      }) as Record;
+      }) as InitializedRecord;
 
       const data: Resource[] = [
         {
@@ -947,7 +947,7 @@ module('JSONAPISource - pullable', function (hooks) {
       const solarSystem = resourceSerializer.deserialize({
         type: 'solarSystem',
         id: 'sun'
-      }) as Record;
+      }) as InitializedRecord;
 
       const data: Resource[] = [
         {
@@ -1003,7 +1003,7 @@ module('JSONAPISource - pullable', function (hooks) {
       const solarSystem = resourceSerializer.deserialize({
         type: 'solarSystem',
         id: 'sun'
-      }) as Record;
+      }) as InitializedRecord;
 
       const data: Resource[] = [
         {
@@ -1090,7 +1090,7 @@ module('JSONAPISource - pullable', function (hooks) {
       const solarSystem = resourceSerializer.deserialize({
         type: 'solarSystem',
         id: 'sun'
-      }) as Record;
+      }) as InitializedRecord;
 
       const data: Resource[] = [
         {
@@ -1155,7 +1155,7 @@ module('JSONAPISource - pullable', function (hooks) {
       const solarSystem = resourceSerializer.deserialize({
         type: 'solarSystem',
         id: 'sun'
-      }) as Record;
+      }) as InitializedRecord;
 
       const data: Resource[] = [
         {
@@ -1220,7 +1220,7 @@ module('JSONAPISource - pullable', function (hooks) {
       const solarSystem = resourceSerializer.deserialize({
         type: 'solarSystem',
         id: 'sun'
-      }) as Record;
+      }) as InitializedRecord;
 
       const data: Resource[] = [
         {
@@ -1285,7 +1285,7 @@ module('JSONAPISource - pullable', function (hooks) {
       const solarSystem = resourceSerializer.deserialize({
         type: 'solarSystem',
         id: 'sun'
-      }) as Record;
+      }) as InitializedRecord;
 
       const data: Resource[] = [
         {
@@ -1366,7 +1366,7 @@ module('JSONAPISource - pullable', function (hooks) {
       const solarSystem = resourceSerializer.deserialize({
         type: 'solarSystem',
         id: 'sun'
-      }) as Record;
+      }) as InitializedRecord;
 
       const data: Resource[] = [
         {
@@ -1489,7 +1489,7 @@ module('JSONAPISource - pullable', function (hooks) {
       const planetRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: 'jupiter'
-      }) as Record;
+      }) as InitializedRecord;
 
       const data: Resource = {
         type: 'solarSystem',
@@ -1545,10 +1545,10 @@ module('JSONAPISource - pullable', function (hooks) {
     test('#pull - relatedRecords', async function (assert) {
       assert.expect(9);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: 'jupiter'
-      }) as Record;
+      }) as InitializedRecord;
 
       let data = [
         {

--- a/packages/@orbit/jsonapi/test/jsonapi-source-pushable-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-pushable-test.ts
@@ -7,7 +7,7 @@ import {
 import {
   AddRecordOperation,
   RecordKeyMap,
-  Record,
+  InitializedRecord,
   RecordOperation,
   ReplaceKeyOperation,
   RecordSchema,
@@ -60,10 +60,10 @@ module('JSONAPISource - pushable', function (hooks) {
 
       let transformCount = 0;
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         attributes: { name: 'Jupiter', classification: 'gas giant' }
-      }) as Record;
+      }) as InitializedRecord;
 
       const addPlanetOp: AddRecordOperation = {
         op: 'addRecord',
@@ -155,7 +155,7 @@ module('JSONAPISource - pushable', function (hooks) {
       const planet = resourceSerializer.deserialize({
         type: 'planet',
         attributes: { name: 'Jupiter', classification: 'gas giant' }
-      }) as Record;
+      }) as InitializedRecord;
 
       const t = buildTransform({
         op: 'addRecord',
@@ -180,7 +180,7 @@ module('JSONAPISource - pushable', function (hooks) {
       const planet = resourceSerializer.deserialize({
         type: 'planet',
         attributes: { name: 'Jupiter', classification: 'gas giant' }
-      }) as Record;
+      }) as InitializedRecord;
 
       const addPlanetOp: AddRecordOperation = {
         op: 'addRecord',
@@ -296,10 +296,10 @@ module('JSONAPISource - pushable', function (hooks) {
     test('#push - options can be passed in at the root level or source-specific level', async function (assert) {
       assert.expect(1);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         attributes: { name: 'Jupiter', classification: 'gas giant' }
-      }) as Record;
+      }) as InitializedRecord;
 
       fetchStub.withArgs('/planets?include=moons').returns(
         jsonapiResponse(201, {
@@ -333,7 +333,7 @@ module('JSONAPISource - pushable', function (hooks) {
 
       let transformCount = 0;
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345',
         attributes: {
@@ -413,14 +413,14 @@ module('JSONAPISource - pushable', function (hooks) {
     test('#push - can replace a single attribute', async function (assert) {
       assert.expect(5);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345',
         attributes: {
           name: 'Jupiter',
           classification: 'gas giant'
         }
-      }) as Record;
+      }) as InitializedRecord;
 
       fetchStub.withArgs('/planets/12345').returns(jsonapiResponse(204));
 
@@ -459,7 +459,7 @@ module('JSONAPISource - pushable', function (hooks) {
     test('#push - can accept remote changes', async function (assert) {
       assert.expect(2);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345',
         attributes: {
@@ -499,10 +499,10 @@ module('JSONAPISource - pushable', function (hooks) {
     test('#push - can delete records', async function (assert) {
       assert.expect(4);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
-      }) as Record;
+      }) as InitializedRecord;
 
       fetchStub.withArgs('/planets/12345').returns(jsonapiResponse(200));
 
@@ -525,15 +525,15 @@ module('JSONAPISource - pushable', function (hooks) {
     test('#push - can add a hasMany relationship with POST', async function (assert) {
       assert.expect(5);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
-      }) as Record;
+      }) as InitializedRecord;
 
       let moon = resourceSerializer.deserialize({
         type: 'moon',
         id: '987'
-      }) as Record;
+      }) as InitializedRecord;
 
       fetchStub
         .withArgs('/planets/12345/relationships/moons')
@@ -563,15 +563,15 @@ module('JSONAPISource - pushable', function (hooks) {
     test('#push - can remove a relationship with DELETE', async function (assert) {
       assert.expect(4);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
-      }) as Record;
+      }) as InitializedRecord;
 
       let moon = resourceSerializer.deserialize({
         type: 'moon',
         id: '987'
-      }) as Record;
+      }) as InitializedRecord;
 
       fetchStub
         .withArgs('/planets/12345/relationships/moons')
@@ -598,15 +598,15 @@ module('JSONAPISource - pushable', function (hooks) {
     test('#push - can update a hasOne relationship with PATCH', async function (assert) {
       assert.expect(5);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
-      }) as Record;
+      }) as InitializedRecord;
 
       let moon = resourceSerializer.deserialize({
         type: 'moon',
         id: '987'
-      }) as Record;
+      }) as InitializedRecord;
 
       fetchStub.withArgs('/moons/987').returns(jsonapiResponse(200));
 
@@ -647,12 +647,12 @@ module('JSONAPISource - pushable', function (hooks) {
         type: 'planet',
         id: 'jupiter',
         attributes: { name: 'Jupiter', classification: 'gas giant' }
-      } as Record;
+      } as InitializedRecord;
 
       let moon = resourceSerializer.deserialize({
         type: 'moon',
         id: '987'
-      }) as Record;
+      }) as InitializedRecord;
 
       fetchStub.withArgs('/planets').returns(
         jsonapiResponse(201, {
@@ -705,7 +705,7 @@ module('JSONAPISource - pushable', function (hooks) {
       let moon = resourceSerializer.deserialize({
         type: 'moon',
         id: '987'
-      }) as Record;
+      }) as InitializedRecord;
 
       fetchStub.withArgs('/moons/987').returns(jsonapiResponse(200));
 
@@ -740,15 +740,15 @@ module('JSONAPISource - pushable', function (hooks) {
     test('#push - can replace a hasMany relationship with PATCH', async function (assert) {
       assert.expect(5);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
-      }) as Record;
+      }) as InitializedRecord;
 
       let moon = resourceSerializer.deserialize({
         type: 'moon',
         id: '987'
-      }) as Record;
+      }) as InitializedRecord;
 
       fetchStub.withArgs('/planets/12345').returns(jsonapiResponse(200));
 
@@ -788,11 +788,11 @@ module('JSONAPISource - pushable', function (hooks) {
       let planet1 = resourceSerializer.deserialize({
         type: 'planet',
         id: '1'
-      }) as Record;
+      }) as InitializedRecord;
       let planet2 = resourceSerializer.deserialize({
         type: 'planet',
         id: '2'
-      }) as Record;
+      }) as InitializedRecord;
 
       fetchStub.withArgs('/planets/1').returns(jsonapiResponse(200));
 
@@ -836,11 +836,11 @@ module('JSONAPISource - pushable', function (hooks) {
       let planet1 = resourceSerializer.deserialize({
         type: 'planet',
         id: '1'
-      }) as Record;
+      }) as InitializedRecord;
       let planet2 = resourceSerializer.deserialize({
         type: 'planet',
         id: '2'
-      }) as Record;
+      }) as InitializedRecord;
 
       source.maxRequestsPerTransform = 1;
 
@@ -860,14 +860,14 @@ module('JSONAPISource - pushable', function (hooks) {
     test('#push - request can timeout', async function (assert) {
       assert.expect(2);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345',
         attributes: {
           name: 'Jupiter',
           classification: 'gas giant'
         }
-      }) as Record;
+      }) as InitializedRecord;
 
       // 10ms timeout
       source.requestProcessor.defaultFetchSettings.timeout = 10;
@@ -890,14 +890,14 @@ module('JSONAPISource - pushable', function (hooks) {
     test('#push - allowed timeout can be specified per-request', async function (assert) {
       assert.expect(2);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345',
         attributes: {
           name: 'Jupiter',
           classification: 'gas giant'
         }
-      }) as Record;
+      }) as InitializedRecord;
 
       const options = {
         sources: {
@@ -928,14 +928,14 @@ module('JSONAPISource - pushable', function (hooks) {
     test('#push - fetch can reject with a NetworkError', async function (assert) {
       assert.expect(2);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345',
         attributes: {
           name: 'Jupiter',
           classification: 'gas giant'
         }
-      }) as Record;
+      }) as InitializedRecord;
 
       fetchStub.withArgs('/planets/12345').returns(Promise.reject(':('));
 
@@ -953,14 +953,14 @@ module('JSONAPISource - pushable', function (hooks) {
     test('#push - response can trigger a ClientError', async function (assert) {
       assert.expect(3);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345',
         attributes: {
           name: 'Jupiter',
           classification: 'gas giant'
         }
-      }) as Record;
+      }) as InitializedRecord;
 
       let errors = [
         {
@@ -997,7 +997,7 @@ module('JSONAPISource - pushable', function (hooks) {
 
       let transformCount = 0;
 
-      const planet: Record = {
+      const planet: InitializedRecord = {
         type: 'planet',
         id: 'jupiter',
         attributes: { name: 'Jupiter', classification: 'gas giant' }
@@ -1070,13 +1070,13 @@ module('JSONAPISource - pushable', function (hooks) {
         type: 'planet',
         id: 'p1',
         attributes: { name: 'Jupiter' }
-      } as Record;
+      } as InitializedRecord;
 
       let moon1 = {
         type: 'moon',
         id: 'm1',
         attributes: { name: 'Io' }
-      } as Record;
+      } as InitializedRecord;
 
       fetchStub.withArgs('/planets').returns(
         jsonapiResponse(201, {
@@ -1143,7 +1143,9 @@ module('JSONAPISource - pushable', function (hooks) {
         attributes: { name: 'Jupiter' }
       };
 
-      const planet = resourceSerializer.deserialize(planetResource) as Record;
+      const planet = resourceSerializer.deserialize(
+        planetResource
+      ) as InitializedRecord;
 
       fetchStub.withArgs('/custom/path/here').returns(
         jsonapiResponse(201, {

--- a/packages/@orbit/jsonapi/test/jsonapi-source-queryable-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-queryable-test.ts
@@ -1,7 +1,7 @@
 import { NetworkError, QueryNotAllowed } from '@orbit/data';
 import {
   RecordKeyMap,
-  Record,
+  InitializedRecord,
   RecordIdentity,
   RecordSchema,
   RecordNotFoundException
@@ -60,7 +60,7 @@ module('JSONAPISource - queryable', function (hooks) {
         attributes: { name: 'Jupiter', classification: 'gas giant' }
       };
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
       });
@@ -77,7 +77,7 @@ module('JSONAPISource - queryable', function (hooks) {
         !Array.isArray(record),
         'only a single primary record returned'
       );
-      assert.equal((record as Record).attributes?.name, 'Jupiter');
+      assert.equal((record as InitializedRecord).attributes?.name, 'Jupiter');
 
       assert.equal(fetchStub.callCount, 1, 'fetch called once');
       assert.equal(
@@ -96,7 +96,7 @@ module('JSONAPISource - queryable', function (hooks) {
         attributes: { name: 'Jupiter', classification: 'gas giant' }
       };
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
       });
@@ -111,7 +111,7 @@ module('JSONAPISource - queryable', function (hooks) {
       );
 
       assert.ok(!Array.isArray(data), 'only a single primary record returned');
-      assert.equal((data as Record).attributes?.name, 'Jupiter');
+      assert.equal((data as InitializedRecord).attributes?.name, 'Jupiter');
 
       assert.equal(details?.[0].response.status, 200);
 
@@ -128,7 +128,7 @@ module('JSONAPISource - queryable', function (hooks) {
     test('#query - record (304 response)', async function (assert) {
       assert.expect(3);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
       });
@@ -161,7 +161,7 @@ module('JSONAPISource - queryable', function (hooks) {
       const planet1 = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
-      }) as Record;
+      }) as InitializedRecord;
 
       const data2: Resource = {
         type: 'planet',
@@ -172,7 +172,7 @@ module('JSONAPISource - queryable', function (hooks) {
       const planet2 = resourceSerializer.deserialize({
         type: 'planet',
         id: '1234'
-      }) as Record;
+      }) as InitializedRecord;
 
       fetchStub
         .withArgs('/planets/12345')
@@ -184,7 +184,7 @@ module('JSONAPISource - queryable', function (hooks) {
       let records = (await source.query((q) => [
         q.findRecord({ type: 'planet', id: planet1.id }),
         q.findRecord({ type: 'planet', id: planet2.id })
-      ])) as Record[];
+      ])) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'multiple primary records returned');
       assert.equal(records[0].attributes?.name, 'Jupiter');
@@ -215,7 +215,7 @@ module('JSONAPISource - queryable', function (hooks) {
       const planet1 = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
-      }) as Record;
+      }) as InitializedRecord;
 
       const data2: Resource = {
         type: 'planet',
@@ -226,7 +226,7 @@ module('JSONAPISource - queryable', function (hooks) {
       const planet2 = resourceSerializer.deserialize({
         type: 'planet',
         id: '1234'
-      }) as Record;
+      }) as InitializedRecord;
 
       fetchStub
         .withArgs('/planets/12345')
@@ -242,7 +242,7 @@ module('JSONAPISource - queryable', function (hooks) {
         ],
         { fullResponse: true }
       );
-      let records = data as Record[];
+      let records = data as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'multiple primary records returned');
       assert.equal(records[0].attributes?.name, 'Jupiter');
@@ -279,7 +279,7 @@ module('JSONAPISource - queryable', function (hooks) {
       };
       let responseDoc = { data, meta };
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
       });
@@ -318,7 +318,7 @@ module('JSONAPISource - queryable', function (hooks) {
       const planet1 = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
-      }) as Record;
+      }) as InitializedRecord;
 
       const data2: Resource = {
         type: 'planet',
@@ -329,7 +329,7 @@ module('JSONAPISource - queryable', function (hooks) {
       const planet2 = resourceSerializer.deserialize({
         type: 'planet',
         id: '1234'
-      }) as Record;
+      }) as InitializedRecord;
 
       fetchStub
         .withArgs('/planets/12345')
@@ -362,7 +362,7 @@ module('JSONAPISource - queryable', function (hooks) {
         relationships: { moons: { data: [] } }
       };
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
       });
@@ -395,7 +395,7 @@ module('JSONAPISource - queryable', function (hooks) {
         relationships: { moons: { data: [] } }
       };
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
       });
@@ -429,7 +429,7 @@ module('JSONAPISource - queryable', function (hooks) {
     test('#query - fetch can reject with a NetworkError', async function (assert) {
       assert.expect(2);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
       });
@@ -457,7 +457,7 @@ module('JSONAPISource - queryable', function (hooks) {
         relationships: { moons: { data: [] } }
       };
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
       });
@@ -497,7 +497,7 @@ module('JSONAPISource - queryable', function (hooks) {
         relationships: { moons: { data: [] } }
       };
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
       });
@@ -539,7 +539,7 @@ module('JSONAPISource - queryable', function (hooks) {
 
       let records = (await source.query((q) =>
         q.findRecords('planet')
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
@@ -576,7 +576,7 @@ module('JSONAPISource - queryable', function (hooks) {
     test('#query - record (404 response) - returns undefined by default', async function (assert) {
       assert.expect(3);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
       });
@@ -600,7 +600,7 @@ module('JSONAPISource - queryable', function (hooks) {
     test("#query - record (404 response) - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
       assert.expect(1);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
       });
@@ -637,7 +637,7 @@ module('JSONAPISource - queryable', function (hooks) {
 
       let records = (await source.query((q) =>
         q.findRecords('planet').filter({ attribute: 'lengthOfDay', value: 24 })
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 1, 'one objects in data returned');
@@ -677,7 +677,7 @@ module('JSONAPISource - queryable', function (hooks) {
           relation: 'planet',
           record: { id: 'earth', type: 'planet' }
         })
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 1, 'one objects in data returned');
@@ -740,7 +740,7 @@ module('JSONAPISource - queryable', function (hooks) {
             { id: 'mars', type: 'planet' }
           ]
         })
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
@@ -793,7 +793,7 @@ module('JSONAPISource - queryable', function (hooks) {
           ],
           op: 'equal'
         })
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 1, 'one objects in data returned');
@@ -834,7 +834,7 @@ module('JSONAPISource - queryable', function (hooks) {
 
       let records = (await source.query((q) =>
         q.findRecords('planet').sort('name')
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
@@ -875,7 +875,7 @@ module('JSONAPISource - queryable', function (hooks) {
 
       let records = (await source.query((q) =>
         q.findRecords('planet').sort('-name')
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
@@ -928,7 +928,7 @@ module('JSONAPISource - queryable', function (hooks) {
 
       let records = (await source.query((q) =>
         q.findRecords('planet').sort('lengthOfDay', 'name')
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
@@ -973,7 +973,7 @@ module('JSONAPISource - queryable', function (hooks) {
 
       let records = (await source.query((q) =>
         q.findRecords('planet').page({ offset: 1, limit: 10 })
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
@@ -996,7 +996,7 @@ module('JSONAPISource - queryable', function (hooks) {
       const solarSystem = resourceSerializer.deserialize({
         type: 'solarSystem',
         id: 'sun'
-      }) as Record;
+      }) as InitializedRecord;
 
       const data: Resource[] = [
         {
@@ -1029,7 +1029,7 @@ module('JSONAPISource - queryable', function (hooks) {
         q
           .findRelatedRecords(solarSystem, 'planets')
           .filter({ attribute: 'lengthOfDay', value: 24 })
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 1, 'one objects in data returned');
@@ -1052,7 +1052,7 @@ module('JSONAPISource - queryable', function (hooks) {
       const solarSystem = resourceSerializer.deserialize({
         type: 'solarSystem',
         id: 'sun'
-      }) as Record;
+      }) as InitializedRecord;
 
       const data: Resource[] = [
         {
@@ -1078,7 +1078,7 @@ module('JSONAPISource - queryable', function (hooks) {
           relation: 'planet',
           record: { id: 'earth', type: 'planet' }
         })
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 1, 'one objects in data returned');
@@ -1101,7 +1101,7 @@ module('JSONAPISource - queryable', function (hooks) {
       const solarSystem = resourceSerializer.deserialize({
         type: 'solarSystem',
         id: 'sun'
-      }) as Record;
+      }) as InitializedRecord;
 
       const data: Resource[] = [
         {
@@ -1146,7 +1146,7 @@ module('JSONAPISource - queryable', function (hooks) {
             { id: 'mars', type: 'planet' }
           ]
         })
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
@@ -1169,7 +1169,7 @@ module('JSONAPISource - queryable', function (hooks) {
       const solarSystem = resourceSerializer.deserialize({
         type: 'solarSystem',
         id: 'sun'
-      }) as Record;
+      }) as InitializedRecord;
 
       const data: Resource[] = [
         {
@@ -1204,7 +1204,7 @@ module('JSONAPISource - queryable', function (hooks) {
           ],
           op: 'equal'
         })
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 1, 'one objects in data returned');
@@ -1227,7 +1227,7 @@ module('JSONAPISource - queryable', function (hooks) {
       const solarSystem = resourceSerializer.deserialize({
         type: 'solarSystem',
         id: 'sun'
-      }) as Record;
+      }) as InitializedRecord;
 
       const data: Resource[] = [
         {
@@ -1250,7 +1250,7 @@ module('JSONAPISource - queryable', function (hooks) {
 
       let records = (await source.query((q) =>
         q.findRelatedRecords(solarSystem, 'planets').sort('name')
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
@@ -1273,7 +1273,7 @@ module('JSONAPISource - queryable', function (hooks) {
       const solarSystem = resourceSerializer.deserialize({
         type: 'solarSystem',
         id: 'sun'
-      }) as Record;
+      }) as InitializedRecord;
 
       const data: Resource[] = [
         {
@@ -1296,7 +1296,7 @@ module('JSONAPISource - queryable', function (hooks) {
 
       let records = (await source.query((q) =>
         q.findRelatedRecords(solarSystem, 'planets').sort('-name')
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
@@ -1319,7 +1319,7 @@ module('JSONAPISource - queryable', function (hooks) {
       const solarSystem = resourceSerializer.deserialize({
         type: 'solarSystem',
         id: 'sun'
-      }) as Record;
+      }) as InitializedRecord;
 
       const data: Resource[] = [
         {
@@ -1358,7 +1358,7 @@ module('JSONAPISource - queryable', function (hooks) {
 
       let records = (await source.query((q) =>
         q.findRelatedRecords(solarSystem, 'planets').sort('lengthOfDay', 'name')
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
@@ -1381,7 +1381,7 @@ module('JSONAPISource - queryable', function (hooks) {
       const solarSystem = resourceSerializer.deserialize({
         type: 'solarSystem',
         id: 'sun'
-      }) as Record;
+      }) as InitializedRecord;
 
       const data: Resource[] = [
         {
@@ -1410,7 +1410,7 @@ module('JSONAPISource - queryable', function (hooks) {
         q
           .findRelatedRecords(solarSystem, 'planets')
           .page({ offset: 1, limit: 10 })
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
@@ -1437,7 +1437,7 @@ module('JSONAPISource - queryable', function (hooks) {
       const earth = resourceSerializer.deserialize({
         type: 'planet',
         id: 'earth'
-      }) as Record;
+      }) as InitializedRecord;
 
       let records = await source.query((q) =>
         q.findRelatedRecord({ type: 'planet', id: earth.id }, 'solarSystem')
@@ -1463,7 +1463,7 @@ module('JSONAPISource - queryable', function (hooks) {
       const earth = resourceSerializer.deserialize({
         type: 'planet',
         id: 'earth'
-      }) as Record;
+      }) as InitializedRecord;
 
       let records = await source.query((q) =>
         q.findRelatedRecord({ type: 'planet', id: earth.id }, 'solarSystem')
@@ -1485,7 +1485,7 @@ module('JSONAPISource - queryable', function (hooks) {
       const earth = resourceSerializer.deserialize({
         type: 'planet',
         id: 'earth'
-      }) as Record;
+      }) as InitializedRecord;
 
       fetchStub
         .withArgs('/planets/earth/solar-system')
@@ -1515,7 +1515,7 @@ module('JSONAPISource - queryable', function (hooks) {
       const solarSystem = resourceSerializer.deserialize({
         type: 'solarSystem',
         id: 'sun'
-      }) as Record;
+      }) as InitializedRecord;
 
       let records = await source.query((q) =>
         q.findRelatedRecords(
@@ -1544,7 +1544,7 @@ module('JSONAPISource - queryable', function (hooks) {
       const solarSystem = resourceSerializer.deserialize({
         type: 'solarSystem',
         id: 'sun'
-      }) as Record;
+      }) as InitializedRecord;
 
       let records = await source.query((q) =>
         q.findRelatedRecords(
@@ -1573,7 +1573,7 @@ module('JSONAPISource - queryable', function (hooks) {
       const solarSystem = resourceSerializer.deserialize({
         type: 'solarSystem',
         id: 'sun'
-      }) as Record;
+      }) as InitializedRecord;
 
       try {
         await source.query(
@@ -1641,7 +1641,7 @@ module('JSONAPISource - queryable', function (hooks) {
       let records = (await source.query(
         (q) => q.findRecords('planet'),
         options
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(
         Array.isArray(records),
@@ -1723,10 +1723,10 @@ module('JSONAPISource - queryable', function (hooks) {
     test('#query - relatedRecords', async function (assert) {
       assert.expect(5);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: 'jupiter'
-      }) as Record;
+      }) as InitializedRecord;
 
       let data = [
         {
@@ -1744,7 +1744,7 @@ module('JSONAPISource - queryable', function (hooks) {
 
       let records = (await source.query((q) =>
         q.findRelatedRecords(planet, 'moons')
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 1, 'one objects in data returned');
@@ -1852,7 +1852,7 @@ module('JSONAPISource - queryable', function (hooks) {
       let [planets, moons] = (await source.query((q) => [
         q.findRecords('planet'),
         q.findRecords('moon')
-      ])) as Record[][];
+      ])) as InitializedRecord[][];
 
       const endTime = new Date().getTime();
       const elapsedTime = endTime - startTime;
@@ -1931,7 +1931,7 @@ module('JSONAPISource - queryable', function (hooks) {
       let [planets, moons] = (await source.query(
         (q) => [q.findRecords('planet'), q.findRecords('moon')],
         { parallelRequests: false }
-      )) as Record[][];
+      )) as InitializedRecord[][];
 
       const endTime = new Date().getTime();
       const elapsedTime = endTime - startTime;
@@ -1971,7 +1971,9 @@ module('JSONAPISource - queryable', function (hooks) {
         attributes: { name: 'Jupiter' }
       };
 
-      const planet = resourceSerializer.deserialize(planetResource) as Record;
+      const planet = resourceSerializer.deserialize(
+        planetResource
+      ) as InitializedRecord;
 
       fetchStub.withArgs('/custom/path/here').returns(
         jsonapiResponse(200, {

--- a/packages/@orbit/jsonapi/test/jsonapi-source-updatable-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-updatable-test.ts
@@ -1,7 +1,7 @@
 import { ClientError, NetworkError, TransformNotAllowed } from '@orbit/data';
 import {
   RecordKeyMap,
-  Record,
+  InitializedRecord,
   RecordOperation,
   ReplaceKeyOperation,
   RecordSchema,
@@ -55,7 +55,7 @@ module('JSONAPISource - updatable', function (hooks) {
 
       let transformCount = 0;
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         attributes: { name: 'Jupiter', classification: 'gas giant' }
       });
@@ -143,7 +143,7 @@ module('JSONAPISource - updatable', function (hooks) {
 
       let transformCount = 0;
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         attributes: { name: 'Jupiter', classification: 'gas giant' }
       });
@@ -264,7 +264,7 @@ module('JSONAPISource - updatable', function (hooks) {
 
       let transformCount = 0;
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345',
         attributes: {
@@ -344,7 +344,7 @@ module('JSONAPISource - updatable', function (hooks) {
     test('#update - can replace a single attribute', async function (assert) {
       assert.expect(5);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345',
         attributes: {
@@ -390,7 +390,7 @@ module('JSONAPISource - updatable', function (hooks) {
     test('#update - can accept remote changes', async function (assert) {
       assert.expect(3);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345',
         attributes: {
@@ -445,7 +445,7 @@ module('JSONAPISource - updatable', function (hooks) {
     test('#update - can delete records', async function (assert) {
       assert.expect(4);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
       });
@@ -471,15 +471,15 @@ module('JSONAPISource - updatable', function (hooks) {
     test('#update - can add a hasMany relationship with POST', async function (assert) {
       assert.expect(5);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
-      }) as Record;
+      }) as InitializedRecord;
 
       let moon = resourceSerializer.deserialize({
         type: 'moon',
         id: '987'
-      }) as Record;
+      }) as InitializedRecord;
 
       fetchStub
         .withArgs('/planets/12345/relationships/moons')
@@ -509,12 +509,12 @@ module('JSONAPISource - updatable', function (hooks) {
     test('#update - can remove a relationship with DELETE', async function (assert) {
       assert.expect(4);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
       });
 
-      const moon: Record = resourceSerializer.deserialize({
+      const moon: InitializedRecord = resourceSerializer.deserialize({
         type: 'moon',
         id: '987'
       });
@@ -544,12 +544,12 @@ module('JSONAPISource - updatable', function (hooks) {
     test('#update - can update a hasOne relationship with PATCH', async function (assert) {
       assert.expect(5);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
       });
 
-      const moon: Record = resourceSerializer.deserialize({
+      const moon: InitializedRecord = resourceSerializer.deserialize({
         type: 'moon',
         id: '987'
       });
@@ -600,7 +600,7 @@ module('JSONAPISource - updatable', function (hooks) {
       let moon = resourceSerializer.deserialize({
         type: 'moon',
         id: '987'
-      }) as Record;
+      }) as InitializedRecord;
 
       fetchStub.withArgs('/planets').returns(
         jsonapiResponse(201, {
@@ -653,7 +653,7 @@ module('JSONAPISource - updatable', function (hooks) {
       let moon = resourceSerializer.deserialize({
         type: 'moon',
         id: '987'
-      }) as Record;
+      }) as InitializedRecord;
 
       fetchStub.withArgs('/moons/987').returns(jsonapiResponse(200));
 
@@ -688,15 +688,15 @@ module('JSONAPISource - updatable', function (hooks) {
     test('#update - can replace a hasMany relationship with PATCH', async function (assert) {
       assert.expect(5);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345'
-      }) as Record;
+      }) as InitializedRecord;
 
       let moon = resourceSerializer.deserialize({
         type: 'moon',
         id: '987'
-      }) as Record;
+      }) as InitializedRecord;
 
       fetchStub.withArgs('/planets/12345').returns(jsonapiResponse(200));
 
@@ -736,11 +736,11 @@ module('JSONAPISource - updatable', function (hooks) {
       let planet1 = resourceSerializer.deserialize({
         type: 'planet',
         id: '1'
-      }) as Record;
+      }) as InitializedRecord;
       let planet2 = resourceSerializer.deserialize({
         type: 'planet',
         id: '2'
-      }) as Record;
+      }) as InitializedRecord;
 
       fetchStub.withArgs('/planets/1').returns(jsonapiResponse(200));
 
@@ -784,11 +784,11 @@ module('JSONAPISource - updatable', function (hooks) {
       let planet1 = resourceSerializer.deserialize({
         type: 'planet',
         id: '1'
-      }) as Record;
+      }) as InitializedRecord;
       let planet2 = resourceSerializer.deserialize({
         type: 'planet',
         id: '2'
-      }) as Record;
+      }) as InitializedRecord;
 
       source.maxRequestsPerTransform = 1;
 
@@ -811,11 +811,11 @@ module('JSONAPISource - updatable', function (hooks) {
       let planet1 = resourceSerializer.deserialize({
         type: 'planet',
         id: '1'
-      }) as Record;
+      }) as InitializedRecord;
       let planet2 = resourceSerializer.deserialize({
         type: 'planet',
         id: '2'
-      }) as Record;
+      }) as InitializedRecord;
 
       source.defaultTransformOptions = {
         maxRequests: 1
@@ -837,14 +837,14 @@ module('JSONAPISource - updatable', function (hooks) {
     test('#update - request can timeout', async function (assert) {
       assert.expect(2);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345',
         attributes: {
           name: 'Jupiter',
           classification: 'gas giant'
         }
-      }) as Record;
+      }) as InitializedRecord;
 
       // 10ms timeout
       source.requestProcessor.defaultFetchSettings.timeout = 10;
@@ -867,14 +867,14 @@ module('JSONAPISource - updatable', function (hooks) {
     test('#update - allowed timeout can be specified per-request', async function (assert) {
       assert.expect(2);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345',
         attributes: {
           name: 'Jupiter',
           classification: 'gas giant'
         }
-      }) as Record;
+      }) as InitializedRecord;
 
       const options = {
         sources: {
@@ -905,14 +905,14 @@ module('JSONAPISource - updatable', function (hooks) {
     test('#update - fetch can reject with a NetworkError', async function (assert) {
       assert.expect(2);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345',
         attributes: {
           name: 'Jupiter',
           classification: 'gas giant'
         }
-      }) as Record;
+      }) as InitializedRecord;
 
       fetchStub.withArgs('/planets/12345').returns(Promise.reject(':('));
 
@@ -930,14 +930,14 @@ module('JSONAPISource - updatable', function (hooks) {
     test('#update - response can trigger a ClientError', async function (assert) {
       assert.expect(3);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planet',
         id: '12345',
         attributes: {
           name: 'Jupiter',
           classification: 'gas giant'
         }
-      }) as Record;
+      }) as InitializedRecord;
 
       let errors = [
         {
@@ -979,7 +979,7 @@ module('JSONAPISource - updatable', function (hooks) {
         type: 'planet',
         id: 'p1',
         attributes: { name: 'Jupiter' }
-      } as Record;
+      } as InitializedRecord;
 
       fetchStub.withArgs('/planets').returns(
         jsonapiResponse(201, {
@@ -1024,13 +1024,13 @@ module('JSONAPISource - updatable', function (hooks) {
     test('#update - can add multiple records in series (by default)', async function (assert) {
       assert.expect(10);
 
-      const planet1: Record = {
+      const planet1: InitializedRecord = {
         type: 'planet',
         id: 'p1',
         attributes: { name: 'Jupiter' }
       };
 
-      const moon1: Record = {
+      const moon1: InitializedRecord = {
         type: 'moon',
         id: 'm1',
         attributes: { name: 'Io' }
@@ -1063,7 +1063,7 @@ module('JSONAPISource - updatable', function (hooks) {
       let [planet, moon] = (await source.update((t) => [
         t.addRecord(planet1),
         t.addRecord(moon1)
-      ])) as Record[];
+      ])) as InitializedRecord[];
 
       const endTime = new Date().getTime();
       const elapsedTime = endTime - startTime;
@@ -1120,13 +1120,13 @@ module('JSONAPISource - updatable', function (hooks) {
     test('#update - can add multiple records in parallel (via `parallelRequests: true` option)', async function (assert) {
       assert.expect(10);
 
-      const planet1: Record = {
+      const planet1: InitializedRecord = {
         type: 'planet',
         id: 'p1',
         attributes: { name: 'Jupiter' }
       };
 
-      const moon1: Record = {
+      const moon1: InitializedRecord = {
         type: 'moon',
         id: 'm1',
         attributes: { name: 'Io' }
@@ -1161,7 +1161,7 @@ module('JSONAPISource - updatable', function (hooks) {
         {
           parallelRequests: true
         }
-      )) as Record[];
+      )) as InitializedRecord[];
 
       const endTime = new Date().getTime();
       const elapsedTime = endTime - startTime;

--- a/packages/@orbit/jsonapi/test/jsonapi-source-with-legacy-serializer-settings-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-with-legacy-serializer-settings-test.ts
@@ -7,7 +7,7 @@ import {
 import {
   AddRecordOperation,
   RecordKeyMap,
-  Record,
+  InitializedRecord,
   RecordIdentity,
   UpdateRecordOperation,
   RecordSchema,
@@ -17,8 +17,7 @@ import {
   RecordOperation,
   ReplaceRelatedRecordOperation,
   ReplaceRelatedRecordsOperation,
-  RecordTransform,
-  RecordTransformBuilder
+  RecordTransform
 } from '@orbit/records';
 import { jsonapiResponse } from './support/jsonapi';
 import { JSONAPISource } from '../src/jsonapi-source';
@@ -220,7 +219,7 @@ module('JSONAPISource with legacy serialization settings', function () {
 
       let transformCount = 0;
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         attributes: { name: 'Jupiter', classification: 'gas giant' }
       });
@@ -312,10 +311,10 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#push - will not issue fetch if beforePush listener logs transform', async function (assert) {
       assert.expect(2);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         attributes: { name: 'Jupiter', classification: 'gas giant' }
-      }) as Record;
+      }) as InitializedRecord;
 
       const t = buildTransform({
         op: 'addRecord',
@@ -337,7 +336,7 @@ module('JSONAPISource with legacy serialization settings', function () {
 
       let transformCount = 0;
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         attributes: { name: 'Jupiter', classification: 'gas giant' }
       });
@@ -456,10 +455,10 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#push - options can be passed in at the root level or source-specific level', async function (assert) {
       assert.expect(1);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         attributes: { name: 'Jupiter', classification: 'gas giant' }
-      }) as Record;
+      }) as InitializedRecord;
 
       fetchStub.withArgs('/planets?include=moons').returns(
         jsonapiResponse(201, {
@@ -493,7 +492,7 @@ module('JSONAPISource with legacy serialization settings', function () {
 
       let transformCount = 0;
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345',
         attributes: {
@@ -573,7 +572,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#push - can replace a single attribute', async function (assert) {
       assert.expect(5);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345',
         attributes: {
@@ -619,7 +618,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#push - can accept remote changes', async function (assert) {
       assert.expect(2);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345',
         attributes: {
@@ -658,7 +657,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#push - can delete records', async function (assert) {
       assert.expect(4);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345'
       });
@@ -684,12 +683,12 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#push - can add a hasMany relationship with POST', async function (assert) {
       assert.expect(5);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345'
       });
 
-      const moon: Record = resourceSerializer.deserialize({
+      const moon: InitializedRecord = resourceSerializer.deserialize({
         type: 'moons',
         id: '987'
       });
@@ -722,12 +721,12 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#push - can remove a relationship with DELETE', async function (assert) {
       assert.expect(4);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345'
       });
 
-      const moon: Record = resourceSerializer.deserialize({
+      const moon: InitializedRecord = resourceSerializer.deserialize({
         type: 'moons',
         id: '987'
       });
@@ -757,12 +756,12 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#push - can update a hasOne relationship with PATCH', async function (assert) {
       assert.expect(5);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345'
       });
 
-      const moon: Record = resourceSerializer.deserialize({
+      const moon: InitializedRecord = resourceSerializer.deserialize({
         type: 'moons',
         id: '987'
       });
@@ -806,9 +805,9 @@ module('JSONAPISource with legacy serialization settings', function () {
         type: 'planet',
         id: 'jupiter',
         attributes: { name: 'Jupiter', classification: 'gas giant' }
-      } as Record;
+      } as InitializedRecord;
 
-      const moon: Record = resourceSerializer.deserialize({
+      const moon: InitializedRecord = resourceSerializer.deserialize({
         type: 'moons',
         id: '987'
       });
@@ -861,7 +860,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#push - can clear a hasOne relationship with PATCH', async function (assert) {
       assert.expect(5);
 
-      const moon: Record = resourceSerializer.deserialize({
+      const moon: InitializedRecord = resourceSerializer.deserialize({
         type: 'moons',
         id: '987'
       });
@@ -899,12 +898,12 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#push - can replace a hasMany relationship with PATCH', async function (assert) {
       assert.expect(5);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345'
       });
 
-      const moon: Record = resourceSerializer.deserialize({
+      const moon: InitializedRecord = resourceSerializer.deserialize({
         type: 'moons',
         id: '987'
       });
@@ -944,12 +943,12 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#push - a single transform can result in multiple requests', async function (assert) {
       assert.expect(6);
 
-      const planet1: Record = resourceSerializer.deserialize({
+      const planet1: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '1'
       });
 
-      const planet2: Record = resourceSerializer.deserialize({
+      const planet2: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '2'
       });
@@ -993,12 +992,12 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#push - source can limit the number of allowed requests per transform with `maxRequestsPerTransform`', async function (assert) {
       assert.expect(1);
 
-      const planet1: Record = resourceSerializer.deserialize({
+      const planet1: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '1'
       });
 
-      const planet2: Record = resourceSerializer.deserialize({
+      const planet2: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '2'
       });
@@ -1021,14 +1020,14 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#push - request can timeout', async function (assert) {
       assert.expect(2);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345',
         attributes: {
           name: 'Jupiter',
           classification: 'gas giant'
         }
-      }) as Record;
+      }) as InitializedRecord;
 
       // 10ms timeout
       source.requestProcessor.defaultFetchSettings.timeout = 10;
@@ -1051,14 +1050,14 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#push - allowed timeout can be specified per-request', async function (assert) {
       assert.expect(2);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345',
         attributes: {
           name: 'Jupiter',
           classification: 'gas giant'
         }
-      }) as Record;
+      }) as InitializedRecord;
 
       const options = {
         sources: {
@@ -1089,14 +1088,14 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#push - fetch can reject with a NetworkError', async function (assert) {
       assert.expect(2);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345',
         attributes: {
           name: 'Jupiter',
           classification: 'gas giant'
         }
-      }) as Record;
+      }) as InitializedRecord;
 
       fetchStub.withArgs('/planets/12345').returns(Promise.reject(':('));
 
@@ -1114,14 +1113,14 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#push - response can trigger a ClientError', async function (assert) {
       assert.expect(3);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345',
         attributes: {
           name: 'Jupiter',
           classification: 'gas giant'
         }
-      }) as Record;
+      }) as InitializedRecord;
 
       let errors = [
         {
@@ -1151,7 +1150,7 @@ module('JSONAPISource with legacy serialization settings', function () {
 
       let transformCount = 0;
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         attributes: { name: 'Jupiter', classification: 'gas giant' }
       });
@@ -1239,7 +1238,7 @@ module('JSONAPISource with legacy serialization settings', function () {
 
       let transformCount = 0;
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         attributes: { name: 'Jupiter', classification: 'gas giant' }
       });
@@ -1360,14 +1359,14 @@ module('JSONAPISource with legacy serialization settings', function () {
 
       let transformCount = 0;
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345',
         attributes: {
           name: 'Jupiter',
           classification: 'gas giant'
         }
-      }) as Record;
+      }) as InitializedRecord;
 
       const replacePlanetOp: UpdateRecordOperation = {
         op: 'updateRecord',
@@ -1440,7 +1439,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#update - can replace a single attribute', async function (assert) {
       assert.expect(5);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345',
         attributes: {
@@ -1486,7 +1485,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#update - can accept remote changes', async function (assert) {
       assert.expect(3);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345',
         attributes: {
@@ -1541,7 +1540,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#update - can delete records', async function (assert) {
       assert.expect(4);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345'
       });
@@ -1567,12 +1566,12 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#update - can add a hasMany relationship with POST', async function (assert) {
       assert.expect(5);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345'
       });
 
-      const moon: Record = resourceSerializer.deserialize({
+      const moon: InitializedRecord = resourceSerializer.deserialize({
         type: 'moons',
         id: '987'
       });
@@ -1605,12 +1604,12 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#update - can remove a relationship with DELETE', async function (assert) {
       assert.expect(4);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345'
       });
 
-      const moon: Record = resourceSerializer.deserialize({
+      const moon: InitializedRecord = resourceSerializer.deserialize({
         type: 'moons',
         id: '987'
       });
@@ -1640,12 +1639,12 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#update - can update a hasOne relationship with PATCH', async function (assert) {
       assert.expect(5);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345'
       });
 
-      const moon: Record = resourceSerializer.deserialize({
+      const moon: InitializedRecord = resourceSerializer.deserialize({
         type: 'moons',
         id: '987'
       });
@@ -1693,7 +1692,7 @@ module('JSONAPISource with legacy serialization settings', function () {
         attributes: { name: 'Jupiter', classification: 'gas giant' }
       };
 
-      const moon: Record = resourceSerializer.deserialize({
+      const moon: InitializedRecord = resourceSerializer.deserialize({
         type: 'moons',
         id: '987'
       });
@@ -1746,7 +1745,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#update - can clear a hasOne relationship with PATCH', async function (assert) {
       assert.expect(5);
 
-      const moon: Record = resourceSerializer.deserialize({
+      const moon: InitializedRecord = resourceSerializer.deserialize({
         type: 'moons',
         id: '987'
       });
@@ -1784,12 +1783,12 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#update - can replace a hasMany relationship with PATCH', async function (assert) {
       assert.expect(5);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345'
       });
 
-      const moon: Record = resourceSerializer.deserialize({
+      const moon: InitializedRecord = resourceSerializer.deserialize({
         type: 'moons',
         id: '987'
       });
@@ -1829,12 +1828,12 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#update - a single transform can result in multiple requests', async function (assert) {
       assert.expect(6);
 
-      let planet1: Record = resourceSerializer.deserialize({
+      let planet1: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '1'
       });
 
-      let planet2: Record = resourceSerializer.deserialize({
+      let planet2: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '2'
       });
@@ -1878,12 +1877,12 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#update - source can limit the number of allowed requests per transform with `maxRequestsPerTransform`', async function (assert) {
       assert.expect(1);
 
-      const planet1: Record = resourceSerializer.deserialize({
+      const planet1: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '1'
       });
 
-      const planet2: Record = resourceSerializer.deserialize({
+      const planet2: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '2'
       });
@@ -1906,14 +1905,14 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#update - request can timeout', async function (assert) {
       assert.expect(2);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345',
         attributes: {
           name: 'Jupiter',
           classification: 'gas giant'
         }
-      }) as Record;
+      }) as InitializedRecord;
 
       // 10ms timeout
       source.requestProcessor.defaultFetchSettings.timeout = 10;
@@ -1936,14 +1935,14 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#update - allowed timeout can be specified per-request', async function (assert) {
       assert.expect(2);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345',
         attributes: {
           name: 'Jupiter',
           classification: 'gas giant'
         }
-      }) as Record;
+      }) as InitializedRecord;
 
       const options = {
         sources: {
@@ -1974,7 +1973,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#update - fetch can reject with a NetworkError', async function (assert) {
       assert.expect(2);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345',
         attributes: {
@@ -1999,7 +1998,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#update - response can trigger a ClientError', async function (assert) {
       assert.expect(3);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345',
         attributes: {
@@ -2040,7 +2039,7 @@ module('JSONAPISource with legacy serialization settings', function () {
         attributes: { name: 'Jupiter', classification: 'gas giant' }
       };
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345'
       });
@@ -2080,7 +2079,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#pull - record (with a 304 response)', async function (assert) {
       assert.expect(3);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345'
       });
@@ -2110,7 +2109,7 @@ module('JSONAPISource with legacy serialization settings', function () {
         relationships: { moons: { data: [] } }
       };
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345'
       });
@@ -2143,7 +2142,7 @@ module('JSONAPISource with legacy serialization settings', function () {
         relationships: { moons: { data: [] } }
       };
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345'
       });
@@ -2177,7 +2176,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#pull - fetch can reject with a NetworkError', async function (assert) {
       assert.expect(2);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345'
       });
@@ -2205,7 +2204,7 @@ module('JSONAPISource with legacy serialization settings', function () {
         relationships: { moons: { data: [] } }
       };
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345'
       });
@@ -2800,7 +2799,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#pull - related records with attribute filter', async function (assert) {
       assert.expect(6);
 
-      const solarSystem: Record = resourceSerializer.deserialize({
+      const solarSystem: InitializedRecord = resourceSerializer.deserialize({
         type: 'solar-systems',
         id: 'sun'
       });
@@ -2863,7 +2862,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#pull - related records with attribute filters', async function (assert) {
       assert.expect(6);
 
-      const solarSystem: Record = resourceSerializer.deserialize({
+      const solarSystem: InitializedRecord = resourceSerializer.deserialize({
         type: 'solar-systems',
         id: 'sun'
       });
@@ -2920,7 +2919,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#pull - records with relatedRecord filter (single value)', async function (assert) {
       assert.expect(6);
 
-      const solarSystem: Record = resourceSerializer.deserialize({
+      const solarSystem: InitializedRecord = resourceSerializer.deserialize({
         type: 'solar-systems',
         id: 'sun'
       });
@@ -2976,7 +2975,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#pull - records with relatedRecord filter (multiple values)', async function (assert) {
       assert.expect(6);
 
-      const solarSystem: Record = resourceSerializer.deserialize({
+      const solarSystem: InitializedRecord = resourceSerializer.deserialize({
         type: 'solar-systems',
         id: 'sun'
       });
@@ -3063,7 +3062,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#pull - records with relatedRecords filter', async function (assert) {
       assert.expect(6);
 
-      const solarSystem: Record = resourceSerializer.deserialize({
+      const solarSystem: InitializedRecord = resourceSerializer.deserialize({
         type: 'solar-systems',
         id: 'sun'
       });
@@ -3128,7 +3127,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#pull - records with sort by an attribute in ascending order', async function (assert) {
       assert.expect(6);
 
-      const solarSystem: Record = resourceSerializer.deserialize({
+      const solarSystem: InitializedRecord = resourceSerializer.deserialize({
         type: 'solar-systems',
         id: 'sun'
       });
@@ -3193,7 +3192,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#pull - records with sort by an attribute in descending order', async function (assert) {
       assert.expect(6);
 
-      const solarSystem: Record = resourceSerializer.deserialize({
+      const solarSystem: InitializedRecord = resourceSerializer.deserialize({
         type: 'solar-systems',
         id: 'sun'
       });
@@ -3258,7 +3257,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#pull - records with sort by multiple fields', async function (assert) {
       assert.expect(6);
 
-      const solarSystem: Record = resourceSerializer.deserialize({
+      const solarSystem: InitializedRecord = resourceSerializer.deserialize({
         type: 'solar-systems',
         id: 'sun'
       });
@@ -3339,7 +3338,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#pull - records with pagination', async function (assert) {
       assert.expect(6);
 
-      const solarSystem: Record = resourceSerializer.deserialize({
+      const solarSystem: InitializedRecord = resourceSerializer.deserialize({
         type: 'solar-systems',
         id: 'sun'
       });
@@ -3465,7 +3464,7 @@ module('JSONAPISource with legacy serialization settings', function () {
       const planetRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: 'jupiter'
-      }) as Record;
+      }) as InitializedRecord;
 
       const data: Resource = {
         type: 'solar-systems',
@@ -3521,10 +3520,10 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#pull - relatedRecords', async function (assert) {
       assert.expect(9);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: 'jupiter'
-      }) as Record;
+      }) as InitializedRecord;
 
       let data = [
         {
@@ -3619,7 +3618,7 @@ module('JSONAPISource with legacy serialization settings', function () {
         attributes: { name: 'Jupiter', classification: 'gas giant' }
       };
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345'
       });
@@ -3636,7 +3635,7 @@ module('JSONAPISource with legacy serialization settings', function () {
         !Array.isArray(record),
         'only a single primary record returned'
       );
-      assert.equal((record as Record).attributes?.name, 'Jupiter');
+      assert.equal((record as InitializedRecord).attributes?.name, 'Jupiter');
 
       assert.equal(fetchStub.callCount, 1, 'fetch called once');
       assert.equal(
@@ -3649,7 +3648,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#query - record (304 response)', async function (assert) {
       assert.expect(3);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345'
       });
@@ -3682,7 +3681,7 @@ module('JSONAPISource with legacy serialization settings', function () {
       const planet1 = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345'
-      }) as Record;
+      }) as InitializedRecord;
 
       const data2: Resource = {
         type: 'planets',
@@ -3693,7 +3692,7 @@ module('JSONAPISource with legacy serialization settings', function () {
       const planet2 = resourceSerializer.deserialize({
         type: 'planets',
         id: '1234'
-      }) as Record;
+      }) as InitializedRecord;
 
       fetchStub
         .withArgs('/planets/12345')
@@ -3705,11 +3704,14 @@ module('JSONAPISource with legacy serialization settings', function () {
       let records = (await source.query((q) => [
         q.findRecord({ type: 'planet', id: planet1.id }),
         q.findRecord({ type: 'planet', id: planet2.id })
-      ])) as Record[];
+      ])) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'multiple primary records returned');
-      assert.equal((records[0] as Record).attributes?.name, 'Jupiter');
-      assert.equal((records[1] as Record).attributes?.name, 'Earth');
+      assert.equal(
+        (records[0] as InitializedRecord).attributes?.name,
+        'Jupiter'
+      );
+      assert.equal((records[1] as InitializedRecord).attributes?.name, 'Earth');
 
       assert.equal(fetchStub.callCount, 2, 'fetch called once');
       assert.equal(
@@ -3737,7 +3739,7 @@ module('JSONAPISource with legacy serialization settings', function () {
       };
       let responseDoc = { data, meta };
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345'
       });
@@ -3774,7 +3776,7 @@ module('JSONAPISource with legacy serialization settings', function () {
         relationships: { moons: { data: [] } }
       };
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345'
       });
@@ -3807,7 +3809,7 @@ module('JSONAPISource with legacy serialization settings', function () {
         relationships: { moons: { data: [] } }
       };
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345'
       });
@@ -3841,7 +3843,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#query - fetch can reject with a NetworkError', async function (assert) {
       assert.expect(2);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345'
       });
@@ -3869,7 +3871,7 @@ module('JSONAPISource with legacy serialization settings', function () {
         relationships: { moons: { data: [] } }
       };
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345'
       });
@@ -3909,7 +3911,7 @@ module('JSONAPISource with legacy serialization settings', function () {
         relationships: { moons: { data: [] } }
       };
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: '12345'
       });
@@ -3951,7 +3953,7 @@ module('JSONAPISource with legacy serialization settings', function () {
 
       let records = (await source.query((q) =>
         q.findRecords('planet')
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
@@ -4005,7 +4007,7 @@ module('JSONAPISource with legacy serialization settings', function () {
 
       let records = (await source.query((q) =>
         q.findRecords('planet').filter({ attribute: 'lengthOfDay', value: 24 })
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 1, 'one objects in data returned');
@@ -4045,7 +4047,7 @@ module('JSONAPISource with legacy serialization settings', function () {
           relation: 'planet',
           record: { id: 'earth', type: 'planets' }
         })
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 1, 'one objects in data returned');
@@ -4108,7 +4110,7 @@ module('JSONAPISource with legacy serialization settings', function () {
             { id: 'mars', type: 'planets' }
           ]
         })
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
@@ -4161,7 +4163,7 @@ module('JSONAPISource with legacy serialization settings', function () {
           ],
           op: 'equal'
         })
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 1, 'one objects in data returned');
@@ -4202,7 +4204,7 @@ module('JSONAPISource with legacy serialization settings', function () {
 
       let records = (await source.query((q) =>
         q.findRecords('planet').sort('name')
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
@@ -4243,7 +4245,7 @@ module('JSONAPISource with legacy serialization settings', function () {
 
       let records = (await source.query((q) =>
         q.findRecords('planet').sort('-name')
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
@@ -4296,7 +4298,7 @@ module('JSONAPISource with legacy serialization settings', function () {
 
       let records = (await source.query((q) =>
         q.findRecords('planet').sort('lengthOfDay', 'name')
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
@@ -4341,7 +4343,7 @@ module('JSONAPISource with legacy serialization settings', function () {
 
       let records = (await source.query((q) =>
         q.findRecords('planet').page({ offset: 1, limit: 10 })
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
@@ -4361,7 +4363,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#query - related records with attribute filter', async function (assert) {
       assert.expect(5);
 
-      const solarSystem: Record = resourceSerializer.deserialize({
+      const solarSystem: InitializedRecord = resourceSerializer.deserialize({
         type: 'solar-systems',
         id: 'sun'
       });
@@ -4397,7 +4399,7 @@ module('JSONAPISource with legacy serialization settings', function () {
         q
           .findRelatedRecords(solarSystem, 'planets')
           .filter({ attribute: 'lengthOfDay', value: 24 })
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 1, 'one objects in data returned');
@@ -4417,7 +4419,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#query - related records with relatedRecord filter (single value)', async function (assert) {
       assert.expect(5);
 
-      const solarSystem: Record = resourceSerializer.deserialize({
+      const solarSystem: InitializedRecord = resourceSerializer.deserialize({
         type: 'solar-systems',
         id: 'sun'
       });
@@ -4446,7 +4448,7 @@ module('JSONAPISource with legacy serialization settings', function () {
           relation: 'planet',
           record: { id: 'earth', type: 'planets' }
         })
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 1, 'one objects in data returned');
@@ -4466,7 +4468,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#query - related records with relatedRecord filter (multiple values)', async function (assert) {
       assert.expect(5);
 
-      const solarSystem: Record = resourceSerializer.deserialize({
+      const solarSystem: InitializedRecord = resourceSerializer.deserialize({
         type: 'solar-systems',
         id: 'sun'
       });
@@ -4514,7 +4516,7 @@ module('JSONAPISource with legacy serialization settings', function () {
             { id: 'mars', type: 'planets' }
           ]
         })
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
@@ -4534,7 +4536,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#query - related records with relatedRecords filter', async function (assert) {
       assert.expect(5);
 
-      const solarSystem: Record = resourceSerializer.deserialize({
+      const solarSystem: InitializedRecord = resourceSerializer.deserialize({
         type: 'solar-systems',
         id: 'sun'
       });
@@ -4572,7 +4574,7 @@ module('JSONAPISource with legacy serialization settings', function () {
           ],
           op: 'equal'
         })
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 1, 'one objects in data returned');
@@ -4592,7 +4594,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#query - related records with sort by an attribute in ascending order', async function (assert) {
       assert.expect(5);
 
-      const solarSystem: Record = resourceSerializer.deserialize({
+      const solarSystem: InitializedRecord = resourceSerializer.deserialize({
         type: 'solar-systems',
         id: 'sun'
       });
@@ -4618,7 +4620,7 @@ module('JSONAPISource with legacy serialization settings', function () {
 
       let records = (await source.query((q) =>
         q.findRelatedRecords(solarSystem, 'planets').sort('name')
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
@@ -4638,7 +4640,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#query - related records with sort by an attribute in descending order', async function (assert) {
       assert.expect(5);
 
-      const solarSystem: Record = resourceSerializer.deserialize({
+      const solarSystem: InitializedRecord = resourceSerializer.deserialize({
         type: 'solar-systems',
         id: 'sun'
       });
@@ -4664,7 +4666,7 @@ module('JSONAPISource with legacy serialization settings', function () {
 
       let records = (await source.query((q) =>
         q.findRelatedRecords(solarSystem, 'planets').sort('-name')
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
@@ -4684,7 +4686,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#query - related records with sort by multiple fields', async function (assert) {
       assert.expect(5);
 
-      const solarSystem: Record = resourceSerializer.deserialize({
+      const solarSystem: InitializedRecord = resourceSerializer.deserialize({
         type: 'solar-systems',
         id: 'sun'
       });
@@ -4726,7 +4728,7 @@ module('JSONAPISource with legacy serialization settings', function () {
 
       let records = (await source.query((q) =>
         q.findRelatedRecords(solarSystem, 'planets').sort('lengthOfDay', 'name')
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
@@ -4746,7 +4748,7 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#query - related records with pagination', async function (assert) {
       assert.expect(5);
 
-      const solarSystem: Record = resourceSerializer.deserialize({
+      const solarSystem: InitializedRecord = resourceSerializer.deserialize({
         type: 'solar-systems',
         id: 'sun'
       });
@@ -4778,7 +4780,7 @@ module('JSONAPISource with legacy serialization settings', function () {
         q
           .findRelatedRecords(solarSystem, 'planets')
           .page({ offset: 1, limit: 10 })
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 3, 'three objects in data returned');
@@ -4805,7 +4807,7 @@ module('JSONAPISource with legacy serialization settings', function () {
       const earth = resourceSerializer.deserialize({
         type: 'planets',
         id: 'earth'
-      }) as Record;
+      }) as InitializedRecord;
 
       let records = await source.query((q) =>
         q.findRelatedRecord({ type: 'planet', id: earth.id }, 'solarSystem')
@@ -4828,7 +4830,7 @@ module('JSONAPISource with legacy serialization settings', function () {
         .withArgs('/solar-systems/sun/planets')
         .returns(jsonapiResponse(304));
 
-      const solarSystem: Record = resourceSerializer.deserialize({
+      const solarSystem: InitializedRecord = resourceSerializer.deserialize({
         type: 'solar-systems',
         id: 'sun'
       });
@@ -4902,7 +4904,7 @@ module('JSONAPISource with legacy serialization settings', function () {
       let records = (await source.query(
         (q) => q.findRecords('planet'),
         options
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(
         Array.isArray(records),
@@ -4984,10 +4986,10 @@ module('JSONAPISource with legacy serialization settings', function () {
     test('#query - relatedRecords', async function (assert) {
       assert.expect(5);
 
-      const planet: Record = resourceSerializer.deserialize({
+      const planet: InitializedRecord = resourceSerializer.deserialize({
         type: 'planets',
         id: 'jupiter'
-      }) as Record;
+      }) as InitializedRecord;
 
       let data = [
         {
@@ -5005,7 +5007,7 @@ module('JSONAPISource with legacy serialization settings', function () {
 
       let records = (await source.query((q) =>
         q.findRelatedRecords(planet, 'moons')
-      )) as Record[];
+      )) as InitializedRecord[];
 
       assert.ok(Array.isArray(records), 'returned an array of data');
       assert.equal(records.length, 1, 'one objects in data returned');
@@ -5095,7 +5097,7 @@ module('JSONAPISource with legacy serialization settings', function () {
 
       let transformCount = 0;
 
-      const planet: Record = {
+      const planet: InitializedRecord = {
         type: 'planet',
         id: 'jupiter',
         attributes: { name: 'Jupiter', classification: 'gas giant' }
@@ -5170,7 +5172,9 @@ module('JSONAPISource with legacy serialization settings', function () {
         attributes: { name: 'Jupiter' }
       };
 
-      const planet = resourceSerializer.deserialize(planetResource) as Record;
+      const planet = resourceSerializer.deserialize(
+        planetResource
+      ) as InitializedRecord;
 
       fetchStub.withArgs('/custom/path/here').returns(
         jsonapiResponse(201, {
@@ -5296,7 +5300,9 @@ module('JSONAPISource with legacy serialization settings', function () {
         attributes: { name: 'Jupiter' }
       };
 
-      const planet = resourceSerializer.deserialize(planetResource) as Record;
+      const planet = resourceSerializer.deserialize(
+        planetResource
+      ) as InitializedRecord;
 
       fetchStub.withArgs('/custom/path/here').returns(
         jsonapiResponse(200, {

--- a/packages/@orbit/jsonapi/test/serializers/jsonapi-document-serializer-test.ts
+++ b/packages/@orbit/jsonapi/test/serializers/jsonapi-document-serializer-test.ts
@@ -2,7 +2,7 @@ import { Dict } from '@orbit/utils';
 import {
   RecordKeyMap,
   ModelDefinition,
-  Record,
+  InitializedRecord,
   RecordSchema
 } from '@orbit/records';
 import { JSONAPIDocumentSerializer } from '../../src/serializers/jsonapi-document-serializer';
@@ -270,7 +270,7 @@ module('JSONAPIDocumentSerializer', function (hooks) {
             }
           }
         });
-        let planet = result.data as Record;
+        let planet = result.data as InitializedRecord;
         assert.deepEqual(result, {
           data: {
             type: 'planet',
@@ -327,7 +327,7 @@ module('JSONAPIDocumentSerializer', function (hooks) {
             }
           }
         });
-        let planet = result.data as Record;
+        let planet = result.data as InitializedRecord;
         assert.deepEqual(result, {
           data: {
             type: 'planet',
@@ -391,7 +391,7 @@ module('JSONAPIDocumentSerializer', function (hooks) {
             }
           }
         });
-        let planet = result.data as Record;
+        let planet = result.data as InitializedRecord;
         assert.deepEqual(result, {
           data: {
             type: 'planet',
@@ -452,7 +452,7 @@ module('JSONAPIDocumentSerializer', function (hooks) {
             }
           }
         });
-        let planet = result.data as Record;
+        let planet = result.data as InitializedRecord;
         assert.deepEqual(result, {
           data: {
             type: 'planet',
@@ -512,7 +512,7 @@ module('JSONAPIDocumentSerializer', function (hooks) {
             }
           }
         });
-        let planet = result.data as Record;
+        let planet = result.data as InitializedRecord;
         assert.deepEqual(result, {
           data: {
             type: 'planet',
@@ -983,7 +983,7 @@ module('JSONAPIDocumentSerializer', function (hooks) {
           id: '123'
         }
       });
-      let record = result.data as Record;
+      let record = result.data as InitializedRecord;
 
       assert.deepEqual(
         record,
@@ -1002,7 +1002,7 @@ module('JSONAPIDocumentSerializer', function (hooks) {
       let localRecord = {
         id: '1a2b3c',
         type: 'planet'
-      } as Record;
+      } as InitializedRecord;
 
       let result = serializer.deserialize(
         {
@@ -1069,9 +1069,9 @@ module('JSONAPIDocumentSerializer', function (hooks) {
         ]
       });
 
-      let planet = result.data as Record;
-      let moon = result?.included?.[0] as Record;
-      let solarSystem = result?.included?.[1] as Record;
+      let planet = result.data as InitializedRecord;
+      let moon = result?.included?.[0] as InitializedRecord;
+      let solarSystem = result?.included?.[1] as InitializedRecord;
 
       assert.deepEqual(
         result,
@@ -1148,7 +1148,7 @@ module('JSONAPIDocumentSerializer', function (hooks) {
           { type: 'planet', id: '234' }
         ]
       });
-      let records = result.data as Record[];
+      let records = result.data as InitializedRecord[];
 
       assert.deepEqual(
         records,
@@ -1169,7 +1169,10 @@ module('JSONAPIDocumentSerializer', function (hooks) {
     });
 
     test('#deserialize - can deserialize an array of records and associate them with local records', function (assert) {
-      let localRecords = [{ id: '1a2b3c' }, { id: '4d5e6f' }] as Record[];
+      let localRecords = [
+        { id: '1a2b3c' },
+        { id: '4d5e6f' }
+      ] as InitializedRecord[];
       let result = serializer.deserialize(
         {
           data: [
@@ -1181,7 +1184,7 @@ module('JSONAPIDocumentSerializer', function (hooks) {
           primaryRecords: localRecords
         }
       );
-      let records = result.data as Record[];
+      let records = result.data as InitializedRecord[];
 
       assert.deepEqual(
         records,

--- a/packages/@orbit/jsonapi/test/serializers/jsonapi-resource-identity-serializer-test.ts
+++ b/packages/@orbit/jsonapi/test/serializers/jsonapi-resource-identity-serializer-test.ts
@@ -2,7 +2,7 @@ import { Dict } from '@orbit/utils';
 import {
   RecordKeyMap,
   ModelDefinition,
-  Record,
+  InitializedRecord,
   RecordSchema
 } from '@orbit/records';
 import { JSONAPIResourceIdentitySerializer } from '../../src/serializers/jsonapi-resource-identity-serializer';
@@ -254,7 +254,7 @@ module('JSONAPIResourceIdentitySerializer', function (hooks) {
       let localRecord = {
         id: '1a2b3c',
         type: 'planet'
-      } as Record;
+      } as InitializedRecord;
 
       assert.deepEqual(
         serializer.deserialize(

--- a/packages/@orbit/jsonapi/test/serializers/jsonapi-resource-serializer-test.ts
+++ b/packages/@orbit/jsonapi/test/serializers/jsonapi-resource-serializer-test.ts
@@ -2,7 +2,7 @@ import { Dict } from '@orbit/utils';
 import {
   RecordKeyMap,
   ModelDefinition,
-  Record,
+  InitializedRecord,
   RecordSchema
 } from '@orbit/records';
 import { JSONAPIResourceSerializer } from '../../src/serializers/jsonapi-resource-serializer';
@@ -922,7 +922,7 @@ module('JSONAPIResourceSerializer', function (hooks) {
       let localRecord = {
         id: '1a2b3c',
         type: 'planet'
-      } as Record;
+      } as InitializedRecord;
 
       let record = serializer.deserialize(
         {

--- a/packages/@orbit/local-storage/src/local-storage-cache.ts
+++ b/packages/@orbit/local-storage/src/local-storage-cache.ts
@@ -1,6 +1,10 @@
 /* eslint-disable valid-jsdoc */
 import { Orbit } from '@orbit/core';
-import { Record, RecordIdentity, equalRecordIdentities } from '@orbit/records';
+import {
+  InitializedRecord,
+  RecordIdentity,
+  equalRecordIdentities
+} from '@orbit/records';
 import {
   RecordRelationshipIdentity,
   SyncRecordCache,
@@ -40,22 +44,22 @@ export class LocalStorageCache extends SyncRecordCache {
     return this._delimiter;
   }
 
-  getKeyForRecord(record: RecordIdentity | Record): string {
+  getKeyForRecord(record: RecordIdentity | InitializedRecord): string {
     return [this.namespace, record.type, record.id].join(this.delimiter);
   }
 
-  getKeyForRecordInverses(record: RecordIdentity | Record): string {
+  getKeyForRecordInverses(record: RecordIdentity | InitializedRecord): string {
     return [this.namespace, 'inverseRels', record.type, record.id].join(
       this.delimiter
     );
   }
 
-  getRecordSync(identity: RecordIdentity): Record | undefined {
+  getRecordSync(identity: RecordIdentity): InitializedRecord | undefined {
     const key = this.getKeyForRecord(identity);
     const item: string | undefined = Orbit.globals.localStorage.getItem(key);
 
     if (item) {
-      const record: Record = JSON.parse(item);
+      const record: InitializedRecord = JSON.parse(item);
 
       if (this._keyMap) {
         this._keyMap.pushRecord(record);
@@ -67,8 +71,10 @@ export class LocalStorageCache extends SyncRecordCache {
     return undefined;
   }
 
-  getRecordsSync(typeOrIdentities?: string | RecordIdentity[]): Record[] {
-    const records: Record[] = [];
+  getRecordsSync(
+    typeOrIdentities?: string | RecordIdentity[]
+  ): InitializedRecord[] {
+    const records: InitializedRecord[] = [];
 
     if (
       typeOrIdentities === undefined ||
@@ -111,7 +117,7 @@ export class LocalStorageCache extends SyncRecordCache {
     return records;
   }
 
-  setRecordSync(record: Record): void {
+  setRecordSync(record: InitializedRecord): void {
     const key = this.getKeyForRecord(record);
 
     if (this._keyMap) {
@@ -121,13 +127,15 @@ export class LocalStorageCache extends SyncRecordCache {
     Orbit.globals.localStorage.setItem(key, JSON.stringify(record));
   }
 
-  setRecordsSync(records: Record[]): void {
+  setRecordsSync(records: InitializedRecord[]): void {
     for (let record of records) {
       this.setRecordSync(record);
     }
   }
 
-  removeRecordSync(recordIdentity: RecordIdentity): Record | undefined {
+  removeRecordSync(
+    recordIdentity: RecordIdentity
+  ): InitializedRecord | undefined {
     const record = this.getRecordSync(recordIdentity);
     if (record) {
       const key = this.getKeyForRecord(record);
@@ -138,7 +146,7 @@ export class LocalStorageCache extends SyncRecordCache {
     }
   }
 
-  removeRecordsSync(recordIdentities: RecordIdentity[]): Record[] {
+  removeRecordsSync(recordIdentities: RecordIdentity[]): InitializedRecord[] {
     const records = [];
     for (let recordIdentity of recordIdentities) {
       let record = this.getRecordSync(recordIdentity);

--- a/packages/@orbit/local-storage/src/local-storage-source.ts
+++ b/packages/@orbit/local-storage/src/local-storage-source.ts
@@ -13,7 +13,7 @@ import {
   ResponseHints
 } from '@orbit/data';
 import {
-  Record,
+  InitializedRecord,
   RecordIdentity,
   RecordOperation,
   UpdateRecordOperation,
@@ -137,7 +137,7 @@ export class LocalStorageSource extends RecordSource {
     this._defaultTransformOptions = this.cache.defaultTransformOptions = options;
   }
 
-  getKeyForRecord(record: RecordIdentity | Record): string {
+  getKeyForRecord(record: RecordIdentity | InitializedRecord): string {
     return this._cache.getKeyForRecord(record);
   }
 

--- a/packages/@orbit/local-storage/test/local-storage-cache-test.ts
+++ b/packages/@orbit/local-storage/test/local-storage-cache-test.ts
@@ -1,5 +1,5 @@
 import { getRecordFromLocalStorage } from './support/local-storage';
-import { Record, RecordSchema, RecordKeyMap } from '@orbit/records';
+import { InitializedRecord, RecordSchema, RecordKeyMap } from '@orbit/records';
 import { LocalStorageCache } from '../src/local-storage-cache';
 
 const { module, test } = QUnit;
@@ -230,7 +230,7 @@ module('LocalStorageCache', function (hooks) {
   test('#update - addRecord', function (assert) {
     assert.expect(2);
 
-    let planet: Record = {
+    let planet: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -260,7 +260,7 @@ module('LocalStorageCache', function (hooks) {
   test('#update - updateRecord', function (assert) {
     assert.expect(2);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -276,7 +276,7 @@ module('LocalStorageCache', function (hooks) {
       }
     };
 
-    let updates: Record = {
+    let updates: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -289,7 +289,7 @@ module('LocalStorageCache', function (hooks) {
       }
     };
 
-    let expected: Record = {
+    let expected: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -347,7 +347,7 @@ module('LocalStorageCache', function (hooks) {
   test('#update - removeRecord', function (assert) {
     assert.expect(1);
 
-    let planet: Record = {
+    let planet: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -384,7 +384,7 @@ module('LocalStorageCache', function (hooks) {
   test('#update - replaceKey', function (assert) {
     assert.expect(2);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -393,7 +393,7 @@ module('LocalStorageCache', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -423,7 +423,7 @@ module('LocalStorageCache', function (hooks) {
   test('#update - replaceKey - when base record does not exist', function (assert) {
     assert.expect(2);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -450,7 +450,7 @@ module('LocalStorageCache', function (hooks) {
   test('#update - replaceAttribute', function (assert) {
     assert.expect(1);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -459,7 +459,7 @@ module('LocalStorageCache', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -481,7 +481,7 @@ module('LocalStorageCache', function (hooks) {
   test('#update - replaceAttribute - when base record does not exist', function (assert) {
     assert.expect(1);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -502,7 +502,7 @@ module('LocalStorageCache', function (hooks) {
   test('#update - addToRelatedRecords', function (assert) {
     assert.expect(1);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -516,7 +516,7 @@ module('LocalStorageCache', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -544,7 +544,7 @@ module('LocalStorageCache', function (hooks) {
   test('#update - addToRelatedRecords - when base record does not exist', function (assert) {
     assert.expect(1);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -570,7 +570,7 @@ module('LocalStorageCache', function (hooks) {
   test('#update - removeFromRelatedRecords', function (assert) {
     assert.expect(1);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -587,7 +587,7 @@ module('LocalStorageCache', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -618,7 +618,7 @@ module('LocalStorageCache', function (hooks) {
   test('#update - removeFromRelatedRecords - when base record does not exist', function (assert) {
     assert.expect(1);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -644,7 +644,7 @@ module('LocalStorageCache', function (hooks) {
   test('#update - replaceRelatedRecords', function (assert) {
     assert.expect(1);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -658,7 +658,7 @@ module('LocalStorageCache', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -692,7 +692,7 @@ module('LocalStorageCache', function (hooks) {
   test('#update - replaceRelatedRecords - when base record does not exist', function (assert) {
     assert.expect(1);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -721,7 +721,7 @@ module('LocalStorageCache', function (hooks) {
   test('#update - replaceRelatedRecord - with record', function (assert) {
     assert.expect(1);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -735,7 +735,7 @@ module('LocalStorageCache', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -766,7 +766,7 @@ module('LocalStorageCache', function (hooks) {
   test('#update - replaceRelatedRecord - with record - when base record does not exist', function (assert) {
     assert.expect(1);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -792,7 +792,7 @@ module('LocalStorageCache', function (hooks) {
   test('#update - replaceRelatedRecord - with null', function (assert) {
     assert.expect(1);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -806,7 +806,7 @@ module('LocalStorageCache', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -832,7 +832,7 @@ module('LocalStorageCache', function (hooks) {
   test('#update - replaceRelatedRecord - with null - when base record does not exist', function (assert) {
     assert.expect(1);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -857,7 +857,7 @@ module('LocalStorageCache', function (hooks) {
   });
 
   test('#query - all records', function (assert) {
-    let earth: Record = {
+    let earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       keys: {
@@ -869,7 +869,7 @@ module('LocalStorageCache', function (hooks) {
       }
     };
 
-    let jupiter: Record = {
+    let jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -881,7 +881,7 @@ module('LocalStorageCache', function (hooks) {
       }
     };
 
-    let io: Record = {
+    let io: InitializedRecord = {
       type: 'moon',
       id: 'io',
       keys: {
@@ -901,7 +901,7 @@ module('LocalStorageCache', function (hooks) {
     // reset keyMap to verify that querying records also adds keys
     keyMap.reset();
 
-    const records = cache.query<Record[]>((q) => q.findRecords());
+    const records = cache.query<InitializedRecord[]>((q) => q.findRecords());
     assert.deepEqual(
       records.map((r) => r.id).sort(),
       ['earth', 'io', 'jupiter'],
@@ -928,7 +928,7 @@ module('LocalStorageCache', function (hooks) {
   test('#query - records of one type', function (assert) {
     assert.expect(1);
 
-    let earth: Record = {
+    let earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -937,7 +937,7 @@ module('LocalStorageCache', function (hooks) {
       }
     };
 
-    let jupiter: Record = {
+    let jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -946,7 +946,7 @@ module('LocalStorageCache', function (hooks) {
       }
     };
 
-    let io: Record = {
+    let io: InitializedRecord = {
       type: 'moon',
       id: 'io',
       attributes: {
@@ -967,7 +967,7 @@ module('LocalStorageCache', function (hooks) {
   test('#query - records by identity', function (assert) {
     assert.expect(1);
 
-    let earth: Record = {
+    let earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -976,7 +976,7 @@ module('LocalStorageCache', function (hooks) {
       }
     };
 
-    let jupiter: Record = {
+    let jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -985,7 +985,7 @@ module('LocalStorageCache', function (hooks) {
       }
     };
 
-    let io: Record = {
+    let io: InitializedRecord = {
       type: 'moon',
       id: 'io',
       attributes: {
@@ -1008,7 +1008,7 @@ module('LocalStorageCache', function (hooks) {
   test('#query - a specific record', function (assert) {
     assert.expect(2);
 
-    let earth: Record = {
+    let earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -1017,7 +1017,7 @@ module('LocalStorageCache', function (hooks) {
       }
     };
 
-    let jupiter: Record = {
+    let jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -1029,7 +1029,7 @@ module('LocalStorageCache', function (hooks) {
       }
     };
 
-    let io: Record = {
+    let io: InitializedRecord = {
       type: 'moon',
       id: 'io',
       attributes: {

--- a/packages/@orbit/local-storage/test/local-storage-cache-update-test.ts
+++ b/packages/@orbit/local-storage/test/local-storage-cache-update-test.ts
@@ -1,7 +1,7 @@
 import {
   equalRecordIdentities,
   RecordKeyMap,
-  Record,
+  InitializedRecord,
   RecordIdentity,
   recordsInclude,
   recordsIncludeAll,
@@ -41,7 +41,7 @@ module('LocalStorageCache - update', function (hooks) {
           defaultTransformOptions
         });
 
-        const earth: Record = {
+        const earth: InitializedRecord = {
           type: 'planet',
           id: '1',
           attributes: { name: 'Earth' },
@@ -75,7 +75,7 @@ module('LocalStorageCache - update', function (hooks) {
 
         cache = new LocalStorageCache({ schema, keyMap });
 
-        const earth: Record = {
+        const earth: InitializedRecord = {
           type: 'planet',
           id: '1',
           attributes: { name: 'Earth' },
@@ -114,7 +114,7 @@ module('LocalStorageCache - update', function (hooks) {
 
         cache = new LocalStorageCache({ schema, keyMap });
 
-        const earth: Record = { type: 'planet', id: '1' };
+        const earth: InitializedRecord = { type: 'planet', id: '1' };
 
         cache.on('patch', (operation, data) => {
           assert.deepEqual(operation, {
@@ -197,13 +197,13 @@ module('LocalStorageCache - update', function (hooks) {
       test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added after', function (assert) {
         cache = new LocalStorageCache({ schema, keyMap });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' },
           relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' }
@@ -212,13 +212,15 @@ module('LocalStorageCache - update', function (hooks) {
         cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.moons.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.moons.data,
           [{ type: 'moon', id: 'm1' }],
           'Io has been assigned to Jupiter'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.planet.data,
           { type: 'planet', id: 'p1' },
           'Jupiter has been assigned to Io'
@@ -228,13 +230,13 @@ module('LocalStorageCache - update', function (hooks) {
       test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added before', function (assert) {
         cache = new LocalStorageCache({ schema, keyMap });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' },
           relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' }
@@ -243,13 +245,15 @@ module('LocalStorageCache - update', function (hooks) {
         cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.moons.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.moons.data,
           [{ type: 'moon', id: 'm1' }],
           'Io has been assigned to Jupiter'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.planet.data,
           { type: 'planet', id: 'p1' },
           'Jupiter has been assigned to Io'
@@ -259,13 +263,13 @@ module('LocalStorageCache - update', function (hooks) {
       test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added after', function (assert) {
         cache = new LocalStorageCache({ schema, keyMap });
 
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
         };
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' }
@@ -274,13 +278,15 @@ module('LocalStorageCache - update', function (hooks) {
         cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.moons.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.moons.data,
           [{ type: 'moon', id: 'm1' }],
           'Io has been assigned to Jupiter'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.planet.data,
           { type: 'planet', id: 'p1' },
           'Jupiter has been assigned to Io'
@@ -290,13 +296,13 @@ module('LocalStorageCache - update', function (hooks) {
       test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added before', function (assert) {
         cache = new LocalStorageCache({ schema, keyMap });
 
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
         };
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' }
@@ -305,13 +311,15 @@ module('LocalStorageCache - update', function (hooks) {
         cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.moons.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.moons.data,
           [{ type: 'moon', id: 'm1' }],
           'Io has been assigned to Jupiter'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.planet.data,
           { type: 'planet', id: 'p1' },
           'Jupiter has been assigned to Io'
@@ -321,13 +329,13 @@ module('LocalStorageCache - update', function (hooks) {
       test('#update updates inverse hasOne relationship when a record with an empty relationship is added', function (assert) {
         cache = new LocalStorageCache({ schema, keyMap });
 
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
         };
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' },
@@ -337,13 +345,15 @@ module('LocalStorageCache - update', function (hooks) {
         cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.moons.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.moons.data,
           [],
           'Jupiter has no moons'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.planet.data,
           null,
           'Jupiter has been cleared from Io'
@@ -353,13 +363,13 @@ module('LocalStorageCache - update', function (hooks) {
       test('#update updates inverse hasMany relationship when a record with an empty relationship is added', function (assert) {
         cache = new LocalStorageCache({ schema, keyMap });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' },
           relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
@@ -369,13 +379,15 @@ module('LocalStorageCache - update', function (hooks) {
         cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.moons.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.moons.data,
           [],
           'Io has been cleared from Jupiter'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.planet.data,
           null,
           'Io has no planet'
@@ -385,7 +397,7 @@ module('LocalStorageCache - update', function (hooks) {
       test('#update updates inverse hasMany polymorphic relationship', function (assert) {
         cache = new LocalStorageCache({ schema, keyMap });
 
-        const sun: Record = {
+        const sun: InitializedRecord = {
           type: 'star',
           id: 's1',
           attributes: { name: 'Sun' },
@@ -398,12 +410,12 @@ module('LocalStorageCache - update', function (hooks) {
             }
           }
         };
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' }
@@ -416,7 +428,7 @@ module('LocalStorageCache - update', function (hooks) {
         ]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'star', id: 's1' }) as Record)
+          (cache.getRecordSync({ type: 'star', id: 's1' }) as InitializedRecord)
             ?.relationships?.celestialObjects.data,
           [
             { type: 'planet', id: 'p1' },
@@ -425,13 +437,15 @@ module('LocalStorageCache - update', function (hooks) {
           'Jupiter and Io has been assigned to Sun'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.star.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.star.data,
           { type: 'star', id: 's1' },
           'Sun has been assigned to Jupiter'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.star.data,
           { type: 'star', id: 's1' },
           'Sun has been assigned to Io'
@@ -441,19 +455,19 @@ module('LocalStorageCache - update', function (hooks) {
       test('#update updates inverse hasOne polymorphic relationship', function (assert) {
         cache = new LocalStorageCache({ schema, keyMap });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' },
           relationships: { star: { data: { type: 'star', id: 's1' } } }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { star: { data: { type: 'star', id: 's1' } } }
         };
-        const sun: Record = {
+        const sun: InitializedRecord = {
           type: 'star',
           id: 's1',
           attributes: { name: 'Sun' }
@@ -466,7 +480,7 @@ module('LocalStorageCache - update', function (hooks) {
         ]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'star', id: 's1' }) as Record)
+          (cache.getRecordSync({ type: 'star', id: 's1' }) as InitializedRecord)
             ?.relationships?.celestialObjects.data,
           [
             { type: 'planet', id: 'p1' },
@@ -475,13 +489,15 @@ module('LocalStorageCache - update', function (hooks) {
           'Jupiter and Io has been assigned to Sun'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.star.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.star.data,
           { type: 'star', id: 's1' },
           'Sun has been assigned to Jupiter'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.star.data,
           { type: 'star', id: 's1' },
           'Sun has been assigned to Io'
@@ -491,19 +507,19 @@ module('LocalStorageCache - update', function (hooks) {
       test('#update tracks refs and clears them from hasOne relationships when a referenced record is removed', function (assert) {
         cache = new LocalStorageCache({ schema, keyMap });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' },
           relationships: { moons: { data: undefined } }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
         };
-        const europa: Record = {
+        const europa: InitializedRecord = {
           type: 'moon',
           id: 'm2',
           attributes: { name: 'Europa' },
@@ -517,13 +533,13 @@ module('LocalStorageCache - update', function (hooks) {
         ]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.planet.data,
           { type: 'planet', id: 'p1' },
           'Jupiter has been assigned to Io'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm2' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm2' }) as InitializedRecord)
             ?.relationships?.planet.data,
           { type: 'planet', id: 'p1' },
           'Jupiter has been assigned to Europa'
@@ -538,13 +554,13 @@ module('LocalStorageCache - update', function (hooks) {
         );
 
         assert.equal(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.planet.data,
           undefined,
           'Jupiter has been cleared from Io'
         );
         assert.equal(
-          (cache.getRecordSync({ type: 'moon', id: 'm2' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm2' }) as InitializedRecord)
             ?.relationships?.planet.data,
           undefined,
           'Jupiter has been cleared from Europa'
@@ -554,19 +570,19 @@ module('LocalStorageCache - update', function (hooks) {
       test('#update tracks refs and clears them from hasMany relationships when a referenced record is removed', function (assert) {
         cache = new LocalStorageCache({ schema, keyMap });
 
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { planet: { data: null } }
         };
-        const europa: Record = {
+        const europa: InitializedRecord = {
           type: 'moon',
           id: 'm2',
           attributes: { name: 'Europa' },
           relationships: { planet: { data: null } }
         };
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' },
@@ -587,8 +603,10 @@ module('LocalStorageCache - update', function (hooks) {
         ]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.moons.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.moons.data,
           [
             { type: 'moon', id: 'm1' },
             { type: 'moon', id: 'm2' }
@@ -647,8 +665,10 @@ module('LocalStorageCache - update', function (hooks) {
         );
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.moons.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.moons.data,
           [{ type: 'moon', id: 'm1' }],
           'relationship was added'
         );
@@ -754,7 +774,7 @@ module('LocalStorageCache - update', function (hooks) {
 
         cache = new LocalStorageCache({ schema, keyMap });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           id: 'p1',
           type: 'planet',
           attributes: { name: 'Jupiter' },
@@ -779,7 +799,7 @@ module('LocalStorageCache - update', function (hooks) {
 
         cache = new LocalStorageCache({ schema, keyMap });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           id: 'p1',
           type: 'planet',
           attributes: { name: 'Jupiter' }
@@ -806,10 +826,10 @@ module('LocalStorageCache - update', function (hooks) {
 
         cache = new LocalStorageCache({ schema, keyMap });
 
-        const jupiter: Record = { id: 'jupiter', type: 'planet' };
+        const jupiter: InitializedRecord = { id: 'jupiter', type: 'planet' };
         cache.update((t) => t.addRecord(jupiter));
 
-        const callisto: Record = { id: 'callisto', type: 'moon' };
+        const callisto: InitializedRecord = { id: 'callisto', type: 'moon' };
         cache.update((t) => t.addRecord(callisto));
 
         cache.update((t) =>
@@ -848,10 +868,10 @@ module('LocalStorageCache - update', function (hooks) {
 
         cache = new LocalStorageCache({ schema, keyMap });
 
-        const jupiter: Record = { id: 'jupiter', type: 'planet' };
+        const jupiter: InitializedRecord = { id: 'jupiter', type: 'planet' };
         cache.update((t) => t.addRecord(jupiter));
 
-        const callisto: Record = { id: 'callisto', type: 'moon' };
+        const callisto: InitializedRecord = { id: 'callisto', type: 'moon' };
         cache.update((t) => t.addRecord(callisto));
 
         cache.update((t) =>
@@ -885,7 +905,7 @@ module('LocalStorageCache - update', function (hooks) {
 
         cache = new LocalStorageCache({ schema, keyMap });
 
-        const europa: Record = {
+        const europa: InitializedRecord = {
           id: 'm1',
           type: 'moon',
           attributes: { name: 'Europa' },
@@ -910,7 +930,7 @@ module('LocalStorageCache - update', function (hooks) {
 
         cache = new LocalStorageCache({ schema, keyMap });
 
-        const europa: Record = {
+        const europa: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Europa' },
@@ -968,8 +988,14 @@ module('LocalStorageCache - update', function (hooks) {
           })
         ]);
 
-        const one = cache.getRecordSync({ type: 'one', id: '1' }) as Record;
-        const two = cache.getRecordSync({ type: 'two', id: '2' }) as Record;
+        const one = cache.getRecordSync({
+          type: 'one',
+          id: '1'
+        }) as InitializedRecord;
+        const two = cache.getRecordSync({
+          type: 'two',
+          id: '2'
+        }) as InitializedRecord;
         assert.ok(one, 'one exists');
         assert.ok(two, 'two exists');
         assert.deepEqual(
@@ -986,7 +1012,7 @@ module('LocalStorageCache - update', function (hooks) {
         cache.update((t) => t.removeRecord(two));
 
         assert.equal(
-          (cache.getRecordSync({ type: 'one', id: '1' }) as Record)
+          (cache.getRecordSync({ type: 'one', id: '1' }) as InitializedRecord)
             .relationships?.two.data,
           null,
           'ones link to two got removed'
@@ -1014,18 +1040,18 @@ module('LocalStorageCache - update', function (hooks) {
           keyMap
         });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
         };
-        const europa: Record = {
+        const europa: InitializedRecord = {
           type: 'moon',
           id: 'm2',
           attributes: { name: 'Europa' },
@@ -1075,18 +1101,18 @@ module('LocalStorageCache - update', function (hooks) {
           keyMap
         });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
         };
-        const europa: Record = {
+        const europa: InitializedRecord = {
           type: 'moon',
           id: 'm2',
           attributes: { name: 'Europa' },
@@ -1136,18 +1162,18 @@ module('LocalStorageCache - update', function (hooks) {
           keyMap
         });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
         };
-        const europa: Record = {
+        const europa: InitializedRecord = {
           type: 'moon',
           id: 'm2',
           attributes: { name: 'Europa' },
@@ -1409,14 +1435,14 @@ module('LocalStorageCache - update', function (hooks) {
         cache = new LocalStorageCache({ schema, keyMap });
         const tb = cache.transformBuilder;
 
-        const earth: Record = {
+        const earth: InitializedRecord = {
           type: 'planet',
           id: '1',
           attributes: { name: 'Earth' },
           relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
         };
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: '1',
           attributes: { name: 'Jupiter', classification: 'terrestrial' },
@@ -1804,7 +1830,7 @@ module('LocalStorageCache - update', function (hooks) {
           type: 'planetarySystem'
         });
         assert.deepEqual(
-          (latestHome?.relationships?.star.data as Record).id,
+          (latestHome?.relationships?.star.data as InitializedRecord).id,
           star1.id,
           'The original related record is in place.'
         );
@@ -1827,7 +1853,7 @@ module('LocalStorageCache - update', function (hooks) {
         });
 
         assert.deepEqual(
-          (latestHome?.relationships?.star.data as Record).id,
+          (latestHome?.relationships?.star.data as InitializedRecord).id,
           star2.id,
           'The related record was replaced.'
         );
@@ -1836,7 +1862,7 @@ module('LocalStorageCache - update', function (hooks) {
       test("#update - updateRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
         cache = new LocalStorageCache({ schema, keyMap });
 
-        const earth: Record = {
+        const earth: InitializedRecord = {
           type: 'planet',
           id: '1',
           attributes: { name: 'Earth' },
@@ -1857,7 +1883,7 @@ module('LocalStorageCache - update', function (hooks) {
       test("#update - removeRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
         cache = new LocalStorageCache({ schema, keyMap });
 
-        const earth: Record = {
+        const earth: InitializedRecord = {
           type: 'planet',
           id: '1'
         };
@@ -1876,7 +1902,7 @@ module('LocalStorageCache - update', function (hooks) {
       test("#update - replaceKey - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
         cache = new LocalStorageCache({ schema, keyMap });
 
-        const earth: Record = {
+        const earth: InitializedRecord = {
           type: 'planet',
           id: '1',
           attributes: { name: 'Earth' },
@@ -1897,7 +1923,7 @@ module('LocalStorageCache - update', function (hooks) {
       test("#update - replaceAttribute - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
         cache = new LocalStorageCache({ schema, keyMap });
 
-        const earth: Record = {
+        const earth: InitializedRecord = {
           type: 'planet',
           id: '1',
           attributes: { name: 'Earth' },

--- a/packages/@orbit/local-storage/test/local-storage-source-pullable-test.ts
+++ b/packages/@orbit/local-storage/test/local-storage-source-pullable-test.ts
@@ -1,7 +1,7 @@
 import { Orbit } from '@orbit/core';
 import {
   AddRecordOperation,
-  Record,
+  InitializedRecord,
   RecordKeyMap,
   RecordSchema,
   RecordTransform
@@ -188,7 +188,7 @@ module('LocalStorageSource - pullable', function (hooks) {
   test('#pull - specific records', async function (assert) {
     assert.expect(4);
 
-    let earth: Record = {
+    let earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -197,7 +197,7 @@ module('LocalStorageSource - pullable', function (hooks) {
       }
     };
 
-    let jupiter: Record = {
+    let jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -206,7 +206,7 @@ module('LocalStorageSource - pullable', function (hooks) {
       }
     };
 
-    let io: Record = {
+    let io: InitializedRecord = {
       type: 'moon',
       id: 'io',
       attributes: {

--- a/packages/@orbit/local-storage/test/local-storage-source-pushable-test.ts
+++ b/packages/@orbit/local-storage/test/local-storage-source-pushable-test.ts
@@ -2,7 +2,7 @@ import { Orbit } from '@orbit/core';
 import { buildTransform } from '@orbit/data';
 import {
   AddRecordOperation,
-  Record,
+  InitializedRecord,
   RecordIdentity,
   RecordKeyMap,
   RecordSchema,
@@ -92,7 +92,7 @@ module('LocalStorageSource - pushable', function (hooks) {
   test('#push - addRecord - with beforePush listener that syncs transform', async function (assert) {
     assert.expect(4);
 
-    let planet: Record = {
+    let planet: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -132,7 +132,7 @@ module('LocalStorageSource - pushable', function (hooks) {
   test('#push - updateRecord', async function (assert) {
     assert.expect(2);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -199,7 +199,7 @@ module('LocalStorageSource - pushable', function (hooks) {
   test('#push - updateRecord - when record does not exist', async function (assert) {
     assert.expect(1);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -245,7 +245,7 @@ module('LocalStorageSource - pushable', function (hooks) {
 
     let moon1 = { type: 'moon', id: 'moon1' };
     let moon2 = { type: 'moon', id: 'moon2' };
-    let planet: Record = {
+    let planet: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -295,7 +295,7 @@ module('LocalStorageSource - pushable', function (hooks) {
   test('#push - replaceKey', async function (assert) {
     assert.expect(2);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -304,7 +304,7 @@ module('LocalStorageSource - pushable', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -334,7 +334,7 @@ module('LocalStorageSource - pushable', function (hooks) {
   test('#push - replaceKey - when base record does not exist', async function (assert) {
     assert.expect(2);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -361,7 +361,7 @@ module('LocalStorageSource - pushable', function (hooks) {
   test('#push - replaceAttribute', async function (assert) {
     assert.expect(1);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -370,7 +370,7 @@ module('LocalStorageSource - pushable', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -393,7 +393,7 @@ module('LocalStorageSource - pushable', function (hooks) {
   test('#push - replaceAttribute - when base record does not exist', async function (assert) {
     assert.expect(1);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -415,7 +415,7 @@ module('LocalStorageSource - pushable', function (hooks) {
   test('#push - addToRelatedRecords', async function (assert) {
     assert.expect(1);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -429,7 +429,7 @@ module('LocalStorageSource - pushable', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -458,7 +458,7 @@ module('LocalStorageSource - pushable', function (hooks) {
   test('#push - addToRelatedRecords - when base record does not exist', async function (assert) {
     assert.expect(1);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -485,7 +485,7 @@ module('LocalStorageSource - pushable', function (hooks) {
   test('#push - removeFromRelatedRecords', async function (assert) {
     assert.expect(1);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -502,7 +502,7 @@ module('LocalStorageSource - pushable', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -534,7 +534,7 @@ module('LocalStorageSource - pushable', function (hooks) {
   test('#push - removeFromRelatedRecords - when base record does not exist', async function (assert) {
     assert.expect(1);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -561,7 +561,7 @@ module('LocalStorageSource - pushable', function (hooks) {
   test('#push - replaceRelatedRecords', async function (assert) {
     assert.expect(1);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -575,7 +575,7 @@ module('LocalStorageSource - pushable', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -610,7 +610,7 @@ module('LocalStorageSource - pushable', function (hooks) {
   test('#push - replaceRelatedRecords - when base record does not exist', async function (assert) {
     assert.expect(1);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -640,7 +640,7 @@ module('LocalStorageSource - pushable', function (hooks) {
   test('#push - replaceRelatedRecord - with record', async function (assert) {
     assert.expect(1);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -654,7 +654,7 @@ module('LocalStorageSource - pushable', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -686,7 +686,7 @@ module('LocalStorageSource - pushable', function (hooks) {
   test('#push - replaceRelatedRecord - with record - when base record does not exist', async function (assert) {
     assert.expect(1);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -712,7 +712,7 @@ module('LocalStorageSource - pushable', function (hooks) {
   test('#push - replaceRelatedRecord - with null', async function (assert) {
     assert.expect(1);
 
-    let original: Record = {
+    let original: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -726,7 +726,7 @@ module('LocalStorageSource - pushable', function (hooks) {
       }
     };
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -754,7 +754,7 @@ module('LocalStorageSource - pushable', function (hooks) {
   test('#push - replaceRelatedRecord - with null - when base record does not exist', async function (assert) {
     assert.expect(1);
 
-    let revised: Record = {
+    let revised: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       relationships: {

--- a/packages/@orbit/local-storage/test/local-storage-source-queryable-test.ts
+++ b/packages/@orbit/local-storage/test/local-storage-source-queryable-test.ts
@@ -1,6 +1,6 @@
 import { Orbit } from '@orbit/core';
 import {
-  Record,
+  InitializedRecord,
   RecordKeyMap,
   RecordQuery,
   RecordSchema
@@ -218,14 +218,14 @@ module('LocalStorageSource - queryable', function (hooks) {
 
   test('#query - can query with multiple expressions', async function (assert) {
     const source = new LocalStorageSource({ schema, keyMap });
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
         name: 'Jupiter'
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {

--- a/packages/@orbit/local-storage/test/local-storage-source-test.ts
+++ b/packages/@orbit/local-storage/test/local-storage-source-test.ts
@@ -6,7 +6,7 @@ import { Orbit } from '@orbit/core';
 import { buildTransform } from '@orbit/data';
 import {
   AddRecordOperation,
-  Record,
+  InitializedRecord,
   RecordSchema,
   RecordSource,
   RecordKeyMap
@@ -173,7 +173,7 @@ module('LocalStorageSource', function (hooks) {
   test('data persists across re-instantiating source', async function (assert) {
     assert.expect(2);
 
-    let planet: Record = {
+    let planet: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       keys: {

--- a/packages/@orbit/local-storage/test/local-storage-source-updatable-test.ts
+++ b/packages/@orbit/local-storage/test/local-storage-source-updatable-test.ts
@@ -1,7 +1,7 @@
 import { Orbit } from '@orbit/core';
 import { FullResponse, ResponseHints } from '@orbit/data';
 import {
-  Record,
+  InitializedRecord,
   RecordKeyMap,
   RecordOperation,
   RecordSchema,
@@ -81,7 +81,7 @@ module('LocalStorageSource - updatable', function (hooks) {
 
     const source = new LocalStorageSource({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'jupiter',
       type: 'planet',
       attributes: { name: 'Jupiter', classification: 'gas giant' }
@@ -136,13 +136,13 @@ module('LocalStorageSource - updatable', function (hooks) {
 
     const source = new LocalStorageSource({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: { name: 'Jupiter', classification: 'gas giant' }
     };
 
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: { name: 'Earth', classification: 'terrestrial' }
@@ -210,7 +210,7 @@ module('LocalStorageSource - updatable', function (hooks) {
       type: 'planetarySystem'
     });
     assert.deepEqual(
-      (latestHome?.relationships?.star.data as Record).id,
+      (latestHome?.relationships?.star.data as InitializedRecord).id,
       star1.id,
       'The original related record is in place.'
     );
@@ -225,7 +225,7 @@ module('LocalStorageSource - updatable', function (hooks) {
       type: 'planetarySystem'
     });
     assert.deepEqual(
-      (latestHome?.relationships?.star.data as Record).id,
+      (latestHome?.relationships?.star.data as InitializedRecord).id,
       star2.id,
       'The related record was replaced.'
     );

--- a/packages/@orbit/local-storage/test/support/local-storage.ts
+++ b/packages/@orbit/local-storage/test/support/local-storage.ts
@@ -1,12 +1,12 @@
 import { Orbit } from '@orbit/core';
-import { Record } from '@orbit/records';
+import { InitializedRecord } from '@orbit/records';
 import { LocalStorageSource } from '../../src/local-storage-source';
 import { LocalStorageCache } from '../../src/local-storage-cache';
 
 export function getRecordFromLocalStorage(
   source: LocalStorageSource | LocalStorageCache,
-  record: Record
-): Record {
+  record: InitializedRecord
+): InitializedRecord {
   const recordKey = [source.namespace, record.type, record.id].join(
     source.delimiter
   );

--- a/packages/@orbit/memory/src/memory-cache.ts
+++ b/packages/@orbit/memory/src/memory-cache.ts
@@ -1,5 +1,9 @@
 import { clone, Dict } from '@orbit/utils';
-import { Record, RecordIdentity, equalRecordIdentities } from '@orbit/records';
+import {
+  InitializedRecord,
+  RecordIdentity,
+  equalRecordIdentities
+} from '@orbit/records';
 import {
   RecordRelationshipIdentity,
   SyncRecordCache,
@@ -22,7 +26,7 @@ export interface MemoryCacheClass {
  * efficiently.
  */
 export class MemoryCache extends SyncRecordCache {
-  protected _records!: Dict<ImmutableMap<string, Record>>;
+  protected _records!: Dict<ImmutableMap<string, InitializedRecord>>;
   protected _inverseRelationships!: Dict<
     ImmutableMap<string, RecordRelationshipIdentity[]>
   >;
@@ -33,14 +37,16 @@ export class MemoryCache extends SyncRecordCache {
     this.reset(settings.base);
   }
 
-  getRecordSync(identity: RecordIdentity): Record | undefined {
+  getRecordSync(identity: RecordIdentity): InitializedRecord | undefined {
     return this._records[identity.type].get(identity.id);
   }
 
-  getRecordsSync(typeOrIdentities?: string | RecordIdentity[]): Record[] {
+  getRecordsSync(
+    typeOrIdentities?: string | RecordIdentity[]
+  ): InitializedRecord[] {
     if (typeOrIdentities === undefined) {
       const types = Object.keys(this.schema.models);
-      const records: Record[] = [];
+      const records: InitializedRecord[] = [];
       types.forEach((type) =>
         Array.prototype.push.apply(
           records,
@@ -52,7 +58,7 @@ export class MemoryCache extends SyncRecordCache {
       const type: string = typeOrIdentities;
       return Array.from(this._records[type].values());
     } else {
-      const records: Record[] = [];
+      const records: InitializedRecord[] = [];
       const identities: RecordIdentity[] = typeOrIdentities;
       for (let identity of identities) {
         let record = this.getRecordSync(identity);
@@ -64,11 +70,11 @@ export class MemoryCache extends SyncRecordCache {
     }
   }
 
-  setRecordSync(record: Record): void {
+  setRecordSync(record: InitializedRecord): void {
     this._records[record.type].set(record.id, record);
   }
 
-  setRecordsSync(records: Record[]): void {
+  setRecordsSync(records: InitializedRecord[]): void {
     let typedMap: any = {};
     for (let record of records) {
       typedMap[record.type] = typedMap[record.type] || [];
@@ -79,7 +85,9 @@ export class MemoryCache extends SyncRecordCache {
     }
   }
 
-  removeRecordSync(recordIdentity: RecordIdentity): Record | undefined {
+  removeRecordSync(
+    recordIdentity: RecordIdentity
+  ): InitializedRecord | undefined {
     const recordMap = this._records[recordIdentity.type];
     const record = recordMap.get(recordIdentity.id);
     if (record) {
@@ -90,7 +98,7 @@ export class MemoryCache extends SyncRecordCache {
     }
   }
 
-  removeRecordsSync(recordIdentities: RecordIdentity[]): Record[] {
+  removeRecordsSync(recordIdentities: RecordIdentity[]): InitializedRecord[] {
     const records = [];
     const typedIds: any = {};
     for (let recordIdentity of recordIdentities) {
@@ -181,7 +189,9 @@ export class MemoryCache extends SyncRecordCache {
     Object.keys(this._schema.models).forEach((type) => {
       let baseRecords = base && base._records[type];
 
-      this._records[type] = new ImmutableMap<string, Record>(baseRecords);
+      this._records[type] = new ImmutableMap<string, InitializedRecord>(
+        baseRecords
+      );
     });
 
     this._resetInverseRelationships(base);
@@ -197,7 +207,7 @@ export class MemoryCache extends SyncRecordCache {
   upgrade(): void {
     Object.keys(this._schema.models).forEach((type) => {
       if (!this._records[type]) {
-        this._records[type] = new ImmutableMap<string, Record>();
+        this._records[type] = new ImmutableMap<string, InitializedRecord>();
       }
     });
 

--- a/packages/@orbit/memory/test/memory-cache-test.ts
+++ b/packages/@orbit/memory/test/memory-cache-test.ts
@@ -1,6 +1,6 @@
 import {
   RecordKeyMap,
-  Record,
+  InitializedRecord,
   RecordNotFoundException,
   RecordSchema,
   equalRecordIdentities,
@@ -69,7 +69,7 @@ module('MemoryCache', function (hooks) {
 
     let cache = new MemoryCache({ schema, keyMap });
 
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: '1',
       attributes: { name: 'Earth' },
@@ -103,7 +103,7 @@ module('MemoryCache', function (hooks) {
 
     let cache = new MemoryCache({ schema, keyMap });
 
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: '1',
       attributes: { name: 'Earth' },
@@ -142,7 +142,7 @@ module('MemoryCache', function (hooks) {
 
     let cache = new MemoryCache({ schema, keyMap });
 
-    const earth: Record = { type: 'planet', id: '1' };
+    const earth: InitializedRecord = { type: 'planet', id: '1' };
 
     cache.on('patch', (operation, data) => {
       assert.deepEqual(operation, {
@@ -480,7 +480,7 @@ module('MemoryCache', function (hooks) {
   test('#update tracks refs and clears them from hasOne relationships when a referenced record is removed', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' },
@@ -492,7 +492,7 @@ module('MemoryCache', function (hooks) {
       attributes: { name: 'Io' },
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
-    const europa: Record = {
+    const europa: InitializedRecord = {
       type: 'moon',
       id: 'm2',
       attributes: { name: 'Europa' },
@@ -543,19 +543,19 @@ module('MemoryCache', function (hooks) {
   test('#update tracks refs and clears them from hasMany relationships when a referenced record is removed', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 
-    const io: Record = {
+    const io: InitializedRecord = {
       type: 'moon',
       id: 'm1',
       attributes: { name: 'Io' },
       relationships: { planet: { data: null } }
     };
-    const europa: Record = {
+    const europa: InitializedRecord = {
       type: 'moon',
       id: 'm2',
       attributes: { name: 'Europa' },
       relationships: { planet: { data: null } }
     };
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' },
@@ -732,7 +732,7 @@ module('MemoryCache', function (hooks) {
 
     let cache = new MemoryCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'p1',
       type: 'planet',
       attributes: { name: 'Jupiter' },
@@ -757,7 +757,7 @@ module('MemoryCache', function (hooks) {
 
     let cache = new MemoryCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'p1',
       type: 'planet',
       attributes: { name: 'Jupiter' }
@@ -781,7 +781,7 @@ module('MemoryCache', function (hooks) {
 
     let cache = new MemoryCache({ schema, keyMap });
 
-    const jupiter: Record = { id: 'jupiter', type: 'planet' };
+    const jupiter: InitializedRecord = { id: 'jupiter', type: 'planet' };
     cache.update((t) => t.addRecord(jupiter));
 
     const callisto = { id: 'callisto', type: 'moon' };
@@ -820,7 +820,7 @@ module('MemoryCache', function (hooks) {
 
     let cache = new MemoryCache({ schema, keyMap });
 
-    const jupiter: Record = { id: 'jupiter', type: 'planet' };
+    const jupiter: InitializedRecord = { id: 'jupiter', type: 'planet' };
     cache.update((t) => t.addRecord(jupiter));
 
     const callisto = { id: 'callisto', type: 'moon' };
@@ -857,7 +857,7 @@ module('MemoryCache', function (hooks) {
 
     let cache = new MemoryCache({ schema, keyMap });
 
-    const europa: Record = {
+    const europa: InitializedRecord = {
       id: 'm1',
       type: 'moon',
       attributes: { name: 'Europa' },
@@ -882,7 +882,7 @@ module('MemoryCache', function (hooks) {
 
     let cache = new MemoryCache({ schema, keyMap });
 
-    const europa: Record = {
+    const europa: InitializedRecord = {
       type: 'moon',
       id: 'm1',
       attributes: { name: 'Europa' },
@@ -937,8 +937,14 @@ module('MemoryCache', function (hooks) {
       })
     ]);
 
-    const one = cache.getRecordSync({ type: 'one', id: '1' }) as Record;
-    const two = cache.getRecordSync({ type: 'two', id: '2' }) as Record;
+    const one = cache.getRecordSync({
+      type: 'one',
+      id: '1'
+    }) as InitializedRecord;
+    const two = cache.getRecordSync({
+      type: 'two',
+      id: '2'
+    }) as InitializedRecord;
     assert.ok(one, 'one exists');
     assert.ok(two, 'two exists');
     assert.deepEqual(
@@ -1405,7 +1411,7 @@ module('MemoryCache', function (hooks) {
       assert,
       cache.query((q) =>
         q.findRecords('planet').filter({ attribute: 'name', value: 'Jupiter' })
-      ) as Record[],
+      ) as InitializedRecord[],
       [jupiter]
     );
   });
@@ -1466,7 +1472,7 @@ module('MemoryCache', function (hooks) {
       cache.query((q) => {
         let tmp = q.findRecords('planet');
         return tmp.filter({ attribute: 'sequence', value: 2, op: 'gt' });
-      }) as Record[],
+      }) as InitializedRecord[],
       [earth, jupiter]
     );
     arrayMembershipMatches(
@@ -1474,7 +1480,7 @@ module('MemoryCache', function (hooks) {
       cache.query((q) => {
         let tmp = q.findRecords('planet');
         return tmp.filter({ attribute: 'sequence', value: 2, op: 'gte' });
-      }) as Record[],
+      }) as InitializedRecord[],
       [venus, earth, jupiter]
     );
     arrayMembershipMatches(
@@ -1482,7 +1488,7 @@ module('MemoryCache', function (hooks) {
       cache.query((q) => {
         let tmp = q.findRecords('planet');
         return tmp.filter({ attribute: 'sequence', value: 2, op: 'lt' });
-      }) as Record[],
+      }) as InitializedRecord[],
       [mercury]
     );
     arrayMembershipMatches(
@@ -1490,7 +1496,7 @@ module('MemoryCache', function (hooks) {
       cache.query((q) => {
         let tmp = q.findRecords('planet');
         return tmp.filter({ attribute: 'sequence', value: 2, op: 'lte' });
-      }) as Record[],
+      }) as InitializedRecord[],
       [venus, mercury]
     );
   });
@@ -1619,7 +1625,7 @@ module('MemoryCache', function (hooks) {
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [theMoon], op: 'equal' })
-      ) as Record[],
+      ) as InitializedRecord[],
       [earth]
     );
     arrayMembershipMatches(
@@ -1628,7 +1634,7 @@ module('MemoryCache', function (hooks) {
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [phobos], op: 'equal' })
-      ) as Record[],
+      ) as InitializedRecord[],
       []
     );
     arrayMembershipMatches(
@@ -1637,7 +1643,7 @@ module('MemoryCache', function (hooks) {
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [phobos], op: 'all' })
-      ) as Record[],
+      ) as InitializedRecord[],
       [mars]
     );
     arrayMembershipMatches(
@@ -1646,7 +1652,7 @@ module('MemoryCache', function (hooks) {
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [phobos, callisto], op: 'all' })
-      ) as Record[],
+      ) as InitializedRecord[],
       []
     );
     arrayMembershipMatches(
@@ -1657,7 +1663,7 @@ module('MemoryCache', function (hooks) {
           records: [phobos, callisto],
           op: 'some'
         })
-      ) as Record[],
+      ) as InitializedRecord[],
       [mars, jupiter]
     );
     arrayMembershipMatches(
@@ -1666,7 +1672,7 @@ module('MemoryCache', function (hooks) {
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [titan], op: 'some' })
-      ) as Record[],
+      ) as InitializedRecord[],
       []
     );
     arrayMembershipMatches(
@@ -1675,7 +1681,7 @@ module('MemoryCache', function (hooks) {
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [ganymede], op: 'none' })
-      ) as Record[],
+      ) as InitializedRecord[],
       [earth, mars]
     );
   });
@@ -1802,21 +1808,21 @@ module('MemoryCache', function (hooks) {
       assert,
       cache.query((q) =>
         q.findRecords('moon').filter({ relation: 'planet', record: earth })
-      ) as Record[],
+      ) as InitializedRecord[],
       [theMoon]
     );
     arrayMembershipMatches(
       assert,
       cache.query((q) =>
         q.findRecords('moon').filter({ relation: 'planet', record: jupiter })
-      ) as Record[],
+      ) as InitializedRecord[],
       [europa, ganymede, callisto]
     );
     arrayMembershipMatches(
       assert,
       cache.query((q) =>
         q.findRecords('moon').filter({ relation: 'planet', record: mercury })
-      ) as Record[],
+      ) as InitializedRecord[],
       []
     );
     arrayMembershipMatches(
@@ -1825,7 +1831,7 @@ module('MemoryCache', function (hooks) {
         q
           .findRecords('moon')
           .filter({ relation: 'planet', record: [earth, mars] })
-      ) as Record[],
+      ) as InitializedRecord[],
       [theMoon, phobos, deimos]
     );
   });
@@ -1886,7 +1892,7 @@ module('MemoryCache', function (hooks) {
             { attribute: 'atmosphere', value: true },
             { attribute: 'classification', value: 'terrestrial' }
           )
-      ) as Record[],
+      ) as InitializedRecord[],
       [earth, venus]
     );
   });
@@ -1939,7 +1945,7 @@ module('MemoryCache', function (hooks) {
             { attribute: 'atmosphere', value: true },
             { attribute: 'classification', value: 'terrestrial' }
           )
-      ) as Record[],
+      ) as InitializedRecord[],
       [earth, venus]
     );
   });
@@ -2214,7 +2220,7 @@ module('MemoryCache', function (hooks) {
   test('#query - findRecord - finds record', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'jupiter',
       type: 'planet',
       attributes: { name: 'Jupiter' },
@@ -2255,7 +2261,7 @@ module('MemoryCache', function (hooks) {
   test('#query - findRecords - records by type', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'jupiter',
       type: 'planet',
       attributes: { name: 'Jupiter' },
@@ -2282,7 +2288,7 @@ module('MemoryCache', function (hooks) {
 
     let cache = new MemoryCache({ schema, keyMap });
 
-    let earth: Record = {
+    let earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -2291,7 +2297,7 @@ module('MemoryCache', function (hooks) {
       }
     };
 
-    let jupiter: Record = {
+    let jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -2300,7 +2306,7 @@ module('MemoryCache', function (hooks) {
       }
     };
 
-    let io: Record = {
+    let io: InitializedRecord = {
       type: 'moon',
       id: 'io',
       attributes: {
@@ -2323,13 +2329,13 @@ module('MemoryCache', function (hooks) {
   test('#query - page - can paginate records by offset and limit', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'jupiter',
       type: 'planet',
       attributes: { name: 'Jupiter' }
     };
 
-    const earth: Record = {
+    const earth: InitializedRecord = {
       id: 'earth',
       type: 'planet',
       attributes: { name: 'Earth' }
@@ -2379,7 +2385,7 @@ module('MemoryCache', function (hooks) {
 
     let cache = new MemoryCache({ schema, keyMap });
 
-    let earth: Record = {
+    let earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       keys: {
@@ -2391,7 +2397,7 @@ module('MemoryCache', function (hooks) {
       }
     };
 
-    let jupiter: Record = {
+    let jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       keys: {
@@ -2403,7 +2409,7 @@ module('MemoryCache', function (hooks) {
       }
     };
 
-    let io: Record = {
+    let io: InitializedRecord = {
       type: 'moon',
       id: 'io',
       keys: {
@@ -2447,7 +2453,7 @@ module('MemoryCache', function (hooks) {
   test('#query - findRelatedRecords', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'jupiter',
       type: 'planet',
       attributes: { name: 'Jupiter' },
@@ -2474,7 +2480,7 @@ module('MemoryCache', function (hooks) {
   test('#query - findRelatedRecord', function (assert) {
     let cache = new MemoryCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'jupiter',
       type: 'planet',
       attributes: { name: 'Jupiter' },

--- a/packages/@orbit/memory/test/memory-cache-update-test.ts
+++ b/packages/@orbit/memory/test/memory-cache-update-test.ts
@@ -1,7 +1,7 @@
 import {
   equalRecordIdentities,
   RecordKeyMap,
-  Record,
+  InitializedRecord,
   RecordIdentity,
   recordsInclude,
   recordsIncludeAll,
@@ -37,7 +37,7 @@ module('MemoryCache - update', function (hooks) {
           defaultTransformOptions
         });
 
-        const earth: Record = {
+        const earth: InitializedRecord = {
           type: 'planet',
           id: '1',
           attributes: { name: 'Earth' },
@@ -71,7 +71,7 @@ module('MemoryCache - update', function (hooks) {
 
         const cache = new MemoryCache({ schema, keyMap });
 
-        const earth: Record = {
+        const earth: InitializedRecord = {
           type: 'planet',
           id: '1',
           attributes: { name: 'Earth' },
@@ -110,7 +110,7 @@ module('MemoryCache - update', function (hooks) {
 
         const cache = new MemoryCache({ schema, keyMap });
 
-        const earth: Record = { type: 'planet', id: '1' };
+        const earth: InitializedRecord = { type: 'planet', id: '1' };
 
         cache.on('patch', (operation, data) => {
           assert.deepEqual(operation, {
@@ -193,13 +193,13 @@ module('MemoryCache - update', function (hooks) {
       test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added after', function (assert) {
         const cache = new MemoryCache({ schema, keyMap });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' },
           relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' }
@@ -208,13 +208,15 @@ module('MemoryCache - update', function (hooks) {
         cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.moons.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.moons.data,
           [{ type: 'moon', id: 'm1' }],
           'Io has been assigned to Jupiter'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.planet.data,
           { type: 'planet', id: 'p1' },
           'Jupiter has been assigned to Io'
@@ -224,13 +226,13 @@ module('MemoryCache - update', function (hooks) {
       test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added before', function (assert) {
         const cache = new MemoryCache({ schema, keyMap });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' },
           relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' }
@@ -239,13 +241,15 @@ module('MemoryCache - update', function (hooks) {
         cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.moons.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.moons.data,
           [{ type: 'moon', id: 'm1' }],
           'Io has been assigned to Jupiter'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.planet.data,
           { type: 'planet', id: 'p1' },
           'Jupiter has been assigned to Io'
@@ -255,13 +259,13 @@ module('MemoryCache - update', function (hooks) {
       test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added after', function (assert) {
         const cache = new MemoryCache({ schema, keyMap });
 
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
         };
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' }
@@ -270,13 +274,15 @@ module('MemoryCache - update', function (hooks) {
         cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.moons.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.moons.data,
           [{ type: 'moon', id: 'm1' }],
           'Io has been assigned to Jupiter'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.planet.data,
           { type: 'planet', id: 'p1' },
           'Jupiter has been assigned to Io'
@@ -286,13 +292,13 @@ module('MemoryCache - update', function (hooks) {
       test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added before', function (assert) {
         const cache = new MemoryCache({ schema, keyMap });
 
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
         };
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' }
@@ -301,13 +307,15 @@ module('MemoryCache - update', function (hooks) {
         cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.moons.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.moons.data,
           [{ type: 'moon', id: 'm1' }],
           'Io has been assigned to Jupiter'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.planet.data,
           { type: 'planet', id: 'p1' },
           'Jupiter has been assigned to Io'
@@ -317,13 +325,13 @@ module('MemoryCache - update', function (hooks) {
       test('#update updates inverse hasOne relationship when a record with an empty relationship is added', function (assert) {
         const cache = new MemoryCache({ schema, keyMap });
 
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
         };
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' },
@@ -333,13 +341,15 @@ module('MemoryCache - update', function (hooks) {
         cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.moons.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.moons.data,
           [],
           'Jupiter has no moons'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.planet.data,
           null,
           'Jupiter has been cleared from Io'
@@ -349,13 +359,13 @@ module('MemoryCache - update', function (hooks) {
       test('#update updates inverse hasMany relationship when a record with an empty relationship is added', function (assert) {
         const cache = new MemoryCache({ schema, keyMap });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' },
           relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
@@ -365,13 +375,15 @@ module('MemoryCache - update', function (hooks) {
         cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.moons.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.moons.data,
           [],
           'Io has been cleared from Jupiter'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.planet.data,
           null,
           'Io has no planet'
@@ -381,7 +393,7 @@ module('MemoryCache - update', function (hooks) {
       test('#update updates inverse hasMany polymorphic relationship', function (assert) {
         const cache = new MemoryCache({ schema, keyMap });
 
-        const sun: Record = {
+        const sun: InitializedRecord = {
           type: 'star',
           id: 's1',
           attributes: { name: 'Sun' },
@@ -394,12 +406,12 @@ module('MemoryCache - update', function (hooks) {
             }
           }
         };
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' }
@@ -412,7 +424,7 @@ module('MemoryCache - update', function (hooks) {
         ]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'star', id: 's1' }) as Record)
+          (cache.getRecordSync({ type: 'star', id: 's1' }) as InitializedRecord)
             ?.relationships?.celestialObjects.data,
           [
             { type: 'planet', id: 'p1' },
@@ -421,13 +433,15 @@ module('MemoryCache - update', function (hooks) {
           'Jupiter and Io has been assigned to Sun'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.star.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.star.data,
           { type: 'star', id: 's1' },
           'Sun has been assigned to Jupiter'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.star.data,
           { type: 'star', id: 's1' },
           'Sun has been assigned to Io'
@@ -437,19 +451,19 @@ module('MemoryCache - update', function (hooks) {
       test('#update updates inverse hasOne polymorphic relationship', function (assert) {
         const cache = new MemoryCache({ schema, keyMap });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' },
           relationships: { star: { data: { type: 'star', id: 's1' } } }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { star: { data: { type: 'star', id: 's1' } } }
         };
-        const sun: Record = {
+        const sun: InitializedRecord = {
           type: 'star',
           id: 's1',
           attributes: { name: 'Sun' }
@@ -462,7 +476,7 @@ module('MemoryCache - update', function (hooks) {
         ]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'star', id: 's1' }) as Record)
+          (cache.getRecordSync({ type: 'star', id: 's1' }) as InitializedRecord)
             ?.relationships?.celestialObjects.data,
           [
             { type: 'planet', id: 'p1' },
@@ -471,13 +485,15 @@ module('MemoryCache - update', function (hooks) {
           'Jupiter and Io has been assigned to Sun'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.star.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.star.data,
           { type: 'star', id: 's1' },
           'Sun has been assigned to Jupiter'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.star.data,
           { type: 'star', id: 's1' },
           'Sun has been assigned to Io'
@@ -487,19 +503,19 @@ module('MemoryCache - update', function (hooks) {
       test('#update tracks refs and clears them from hasOne relationships when a referenced record is removed', function (assert) {
         const cache = new MemoryCache({ schema, keyMap });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' },
           relationships: { moons: { data: undefined } }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
         };
-        const europa: Record = {
+        const europa: InitializedRecord = {
           type: 'moon',
           id: 'm2',
           attributes: { name: 'Europa' },
@@ -513,13 +529,13 @@ module('MemoryCache - update', function (hooks) {
         ]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.planet.data,
           { type: 'planet', id: 'p1' },
           'Jupiter has been assigned to Io'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm2' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm2' }) as InitializedRecord)
             ?.relationships?.planet.data,
           { type: 'planet', id: 'p1' },
           'Jupiter has been assigned to Europa'
@@ -534,13 +550,13 @@ module('MemoryCache - update', function (hooks) {
         );
 
         assert.equal(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.planet.data,
           undefined,
           'Jupiter has been cleared from Io'
         );
         assert.equal(
-          (cache.getRecordSync({ type: 'moon', id: 'm2' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm2' }) as InitializedRecord)
             ?.relationships?.planet.data,
           undefined,
           'Jupiter has been cleared from Europa'
@@ -550,19 +566,19 @@ module('MemoryCache - update', function (hooks) {
       test('#update tracks refs and clears them from hasMany relationships when a referenced record is removed', function (assert) {
         const cache = new MemoryCache({ schema, keyMap });
 
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { planet: { data: null } }
         };
-        const europa: Record = {
+        const europa: InitializedRecord = {
           type: 'moon',
           id: 'm2',
           attributes: { name: 'Europa' },
           relationships: { planet: { data: null } }
         };
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' },
@@ -583,8 +599,10 @@ module('MemoryCache - update', function (hooks) {
         ]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.moons.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.moons.data,
           [
             { type: 'moon', id: 'm1' },
             { type: 'moon', id: 'm2' }
@@ -643,8 +661,10 @@ module('MemoryCache - update', function (hooks) {
         );
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.moons.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.moons.data,
           [{ type: 'moon', id: 'm1' }],
           'relationship was added'
         );
@@ -750,7 +770,7 @@ module('MemoryCache - update', function (hooks) {
 
         const cache = new MemoryCache({ schema, keyMap });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           id: 'p1',
           type: 'planet',
           attributes: { name: 'Jupiter' },
@@ -775,7 +795,7 @@ module('MemoryCache - update', function (hooks) {
 
         const cache = new MemoryCache({ schema, keyMap });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           id: 'p1',
           type: 'planet',
           attributes: { name: 'Jupiter' }
@@ -802,10 +822,10 @@ module('MemoryCache - update', function (hooks) {
 
         const cache = new MemoryCache({ schema, keyMap });
 
-        const jupiter: Record = { id: 'jupiter', type: 'planet' };
+        const jupiter: InitializedRecord = { id: 'jupiter', type: 'planet' };
         cache.update((t) => t.addRecord(jupiter));
 
-        const callisto: Record = { id: 'callisto', type: 'moon' };
+        const callisto: InitializedRecord = { id: 'callisto', type: 'moon' };
         cache.update((t) => t.addRecord(callisto));
 
         cache.update((t) =>
@@ -844,10 +864,10 @@ module('MemoryCache - update', function (hooks) {
 
         const cache = new MemoryCache({ schema, keyMap });
 
-        const jupiter: Record = { id: 'jupiter', type: 'planet' };
+        const jupiter: InitializedRecord = { id: 'jupiter', type: 'planet' };
         cache.update((t) => t.addRecord(jupiter));
 
-        const callisto: Record = { id: 'callisto', type: 'moon' };
+        const callisto: InitializedRecord = { id: 'callisto', type: 'moon' };
         cache.update((t) => t.addRecord(callisto));
 
         cache.update((t) =>
@@ -881,7 +901,7 @@ module('MemoryCache - update', function (hooks) {
 
         const cache = new MemoryCache({ schema, keyMap });
 
-        const europa: Record = {
+        const europa: InitializedRecord = {
           id: 'm1',
           type: 'moon',
           attributes: { name: 'Europa' },
@@ -906,7 +926,7 @@ module('MemoryCache - update', function (hooks) {
 
         const cache = new MemoryCache({ schema, keyMap });
 
-        const europa: Record = {
+        const europa: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Europa' },
@@ -964,8 +984,14 @@ module('MemoryCache - update', function (hooks) {
           })
         ]);
 
-        const one = cache.getRecordSync({ type: 'one', id: '1' }) as Record;
-        const two = cache.getRecordSync({ type: 'two', id: '2' }) as Record;
+        const one = cache.getRecordSync({
+          type: 'one',
+          id: '1'
+        }) as InitializedRecord;
+        const two = cache.getRecordSync({
+          type: 'two',
+          id: '2'
+        }) as InitializedRecord;
         assert.ok(one, 'one exists');
         assert.ok(two, 'two exists');
         assert.deepEqual(
@@ -982,7 +1008,7 @@ module('MemoryCache - update', function (hooks) {
         cache.update((t) => t.removeRecord(two));
 
         assert.equal(
-          (cache.getRecordSync({ type: 'one', id: '1' }) as Record)
+          (cache.getRecordSync({ type: 'one', id: '1' }) as InitializedRecord)
             .relationships?.two.data,
           null,
           'ones link to two got removed'
@@ -1010,18 +1036,18 @@ module('MemoryCache - update', function (hooks) {
           keyMap
         });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
         };
-        const europa: Record = {
+        const europa: InitializedRecord = {
           type: 'moon',
           id: 'm2',
           attributes: { name: 'Europa' },
@@ -1071,18 +1097,18 @@ module('MemoryCache - update', function (hooks) {
           keyMap
         });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
         };
-        const europa: Record = {
+        const europa: InitializedRecord = {
           type: 'moon',
           id: 'm2',
           attributes: { name: 'Europa' },
@@ -1132,18 +1158,18 @@ module('MemoryCache - update', function (hooks) {
           keyMap
         });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
         };
-        const europa: Record = {
+        const europa: InitializedRecord = {
           type: 'moon',
           id: 'm2',
           attributes: { name: 'Europa' },
@@ -1405,14 +1431,14 @@ module('MemoryCache - update', function (hooks) {
         const cache = new MemoryCache({ schema, keyMap });
         const tb = cache.transformBuilder;
 
-        const earth: Record = {
+        const earth: InitializedRecord = {
           type: 'planet',
           id: '1',
           attributes: { name: 'Earth' },
           relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
         };
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: '1',
           attributes: { name: 'Jupiter', classification: 'terrestrial' },
@@ -1800,7 +1826,7 @@ module('MemoryCache - update', function (hooks) {
           type: 'planetarySystem'
         });
         assert.deepEqual(
-          (latestHome?.relationships?.star.data as Record).id,
+          (latestHome?.relationships?.star.data as InitializedRecord).id,
           star1.id,
           'The original related record is in place.'
         );
@@ -1823,7 +1849,7 @@ module('MemoryCache - update', function (hooks) {
         });
 
         assert.deepEqual(
-          (latestHome?.relationships?.star.data as Record).id,
+          (latestHome?.relationships?.star.data as InitializedRecord).id,
           star2.id,
           'The related record was replaced.'
         );
@@ -1832,7 +1858,7 @@ module('MemoryCache - update', function (hooks) {
       test("#update - updateRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
         const cache = new MemoryCache({ schema, keyMap });
 
-        const earth: Record = {
+        const earth: InitializedRecord = {
           type: 'planet',
           id: '1',
           attributes: { name: 'Earth' },
@@ -1853,7 +1879,7 @@ module('MemoryCache - update', function (hooks) {
       test("#update - removeRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
         const cache = new MemoryCache({ schema, keyMap });
 
-        const earth: Record = {
+        const earth: InitializedRecord = {
           type: 'planet',
           id: '1'
         };
@@ -1872,7 +1898,7 @@ module('MemoryCache - update', function (hooks) {
       test("#update - replaceKey - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
         const cache = new MemoryCache({ schema, keyMap });
 
-        const earth: Record = {
+        const earth: InitializedRecord = {
           type: 'planet',
           id: '1',
           attributes: { name: 'Earth' },
@@ -1893,7 +1919,7 @@ module('MemoryCache - update', function (hooks) {
       test("#update - replaceAttribute - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
         const cache = new MemoryCache({ schema, keyMap });
 
-        const earth: Record = {
+        const earth: InitializedRecord = {
           type: 'planet',
           id: '1',
           attributes: { name: 'Earth' },

--- a/packages/@orbit/memory/test/memory-source-queryable-test.ts
+++ b/packages/@orbit/memory/test/memory-source-queryable-test.ts
@@ -1,5 +1,5 @@
 import {
-  Record,
+  InitializedRecord,
   RecordKeyMap,
   RecordQuery,
   RecordSchema,
@@ -212,14 +212,14 @@ module('MemorySource - queryable', function (hooks) {
 
   test('#query - can query with multiple expressions', async function (assert) {
     const source = new MemorySource({ schema, keyMap });
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
         name: 'Jupiter'
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {

--- a/packages/@orbit/memory/test/memory-source-test.ts
+++ b/packages/@orbit/memory/test/memory-source-test.ts
@@ -5,7 +5,7 @@ import {
 } from '@orbit/record-cache';
 import {
   cloneRecordIdentity as identity,
-  Record,
+  InitializedRecord,
   RecordKeyMap,
   RecordOperation,
   RecordSchema,
@@ -395,7 +395,7 @@ module('MemorySource', function (hooks) {
   test('#fork - creates a new source that starts with the same schema, keyMap, and cache contents as the base source', async function (assert) {
     const source = new MemorySource({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter-id',
       attributes: { name: 'Jupiter', classification: 'gas giant' }
@@ -443,7 +443,7 @@ module('MemorySource', function (hooks) {
   test('#merge - merges transforms from a forked source back into a base source', async function (assert) {
     const source = new MemorySource({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter-id',
       attributes: { name: 'Jupiter', classification: 'gas giant' }
@@ -473,7 +473,7 @@ module('MemorySource', function (hooks) {
 
     const source = new MemorySource({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter-id',
       attributes: { name: 'Jupiter', classification: 'gas giant' }
@@ -516,7 +516,7 @@ module('MemorySource', function (hooks) {
   test('#rebase - record ends up in child source', async function (assert) {
     assert.expect(3);
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter-id',
       attributes: { name: 'Jupiter', classification: 'gas giant' }
@@ -611,7 +611,7 @@ module('MemorySource', function (hooks) {
 
     const source = new MemorySource({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter-id',
       attributes: { name: 'Jupiter', classification: 'gas giant' }
@@ -667,7 +667,7 @@ module('MemorySource', function (hooks) {
     assert.expect(22);
 
     const source = new MemorySource({ schema, keyMap });
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter-id',
       attributes: { name: 'Jupiter', classification: 'gas giant' }

--- a/packages/@orbit/memory/test/memory-source-updatable-test.ts
+++ b/packages/@orbit/memory/test/memory-source-updatable-test.ts
@@ -1,6 +1,6 @@
 import { FullResponse, ResponseHints } from '@orbit/data';
 import {
-  Record,
+  InitializedRecord,
   RecordKeyMap,
   RecordOperation,
   RecordSchema,
@@ -75,7 +75,7 @@ module('MemorySource - updatable', function (hooks) {
 
     const source = new MemorySource({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'jupiter',
       type: 'planet',
       attributes: { name: 'Jupiter', classification: 'gas giant' }
@@ -130,13 +130,13 @@ module('MemorySource - updatable', function (hooks) {
 
     const source = new MemorySource({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: { name: 'Jupiter', classification: 'gas giant' }
     };
 
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: { name: 'Earth', classification: 'terrestrial' }
@@ -204,7 +204,7 @@ module('MemorySource - updatable', function (hooks) {
       type: 'planetarySystem'
     });
     assert.deepEqual(
-      (latestHome?.relationships?.star.data as Record).id,
+      (latestHome?.relationships?.star.data as InitializedRecord).id,
       star1.id,
       'The original related record is in place.'
     );
@@ -219,7 +219,7 @@ module('MemorySource - updatable', function (hooks) {
       type: 'planetarySystem'
     });
     assert.deepEqual(
-      (latestHome?.relationships?.star.data as Record).id,
+      (latestHome?.relationships?.star.data as InitializedRecord).id,
       star2.id,
       'The related record was replaced.'
     );

--- a/packages/@orbit/record-cache/src/async-record-cache.ts
+++ b/packages/@orbit/record-cache/src/async-record-cache.ts
@@ -10,7 +10,7 @@ import {
   RequestOptions
 } from '@orbit/data';
 import {
-  Record,
+  InitializedRecord,
   RecordOperation,
   RecordIdentity,
   RecordOperationTerm,
@@ -147,23 +147,23 @@ export abstract class AsyncRecordCache<
   // Abstract methods for getting records and relationships
   abstract getRecordAsync(
     recordIdentity: RecordIdentity
-  ): Promise<Record | undefined>;
+  ): Promise<InitializedRecord | undefined>;
   abstract getRecordsAsync(
     typeOrIdentities?: string | RecordIdentity[]
-  ): Promise<Record[]>;
+  ): Promise<InitializedRecord[]>;
   abstract getInverseRelationshipsAsync(
     recordIdentityOrIdentities: RecordIdentity | RecordIdentity[]
   ): Promise<RecordRelationshipIdentity[]>;
 
   // Abstract methods for setting records and relationships
-  abstract setRecordAsync(record: Record): Promise<void>;
-  abstract setRecordsAsync(records: Record[]): Promise<void>;
+  abstract setRecordAsync(record: InitializedRecord): Promise<void>;
+  abstract setRecordsAsync(records: InitializedRecord[]): Promise<void>;
   abstract removeRecordAsync(
     recordIdentity: RecordIdentity
-  ): Promise<Record | undefined>;
+  ): Promise<InitializedRecord | undefined>;
   abstract removeRecordsAsync(
     recordIdentities: RecordIdentity[]
-  ): Promise<Record[]>;
+  ): Promise<InitializedRecord[]>;
   abstract addInverseRelationshipsAsync(
     relationships: RecordRelationshipIdentity[]
   ): Promise<void>;

--- a/packages/@orbit/record-cache/src/live-query/record-change.ts
+++ b/packages/@orbit/record-cache/src/live-query/record-change.ts
@@ -1,5 +1,5 @@
 import {
-  Record,
+  InitializedRecord,
   cloneRecordIdentity,
   RecordIdentity,
   RecordOperation
@@ -17,7 +17,7 @@ export interface RecordChange extends RecordIdentity {
 export function recordOperationChange(
   operation: RecordOperation
 ): RecordChange {
-  const record = operation.record as Record;
+  const record = operation.record as InitializedRecord;
   const change: RecordChange = {
     ...cloneRecordIdentity(record),
     remove: false,

--- a/packages/@orbit/record-cache/src/operation-processors/async-cache-integrity-processor.ts
+++ b/packages/@orbit/record-cache/src/operation-processors/async-cache-integrity-processor.ts
@@ -1,4 +1,8 @@
-import { Record, RecordIdentity, RecordOperation } from '@orbit/records';
+import {
+  InitializedRecord,
+  RecordIdentity,
+  RecordOperation
+} from '@orbit/records';
 import { AsyncOperationProcessor } from '../async-operation-processor';
 import {
   getInverseRelationship,
@@ -135,7 +139,9 @@ export class AsyncCacheIntegrityProcessor extends AsyncOperationProcessor {
     }
   }
 
-  protected async addAllInverseRelationships(record: Record): Promise<void> {
+  protected async addAllInverseRelationships(
+    record: InitializedRecord
+  ): Promise<void> {
     let inverseRelationships = getAllInverseRelationships(
       this.accessor.schema,
       record

--- a/packages/@orbit/record-cache/src/operation-processors/async-schema-validation-processor.ts
+++ b/packages/@orbit/record-cache/src/operation-processors/async-schema-validation-processor.ts
@@ -1,5 +1,5 @@
 import {
-  Record,
+  InitializedRecord,
   RecordIdentity,
   RecordOperation,
   IncorrectRelatedRecordType
@@ -62,11 +62,11 @@ export class AsyncSchemaValidationProcessor extends AsyncOperationProcessor {
     }
   }
 
-  protected _recordAdded(record: Record): void {
+  protected _recordAdded(record: InitializedRecord): void {
     this._validateRecord(record);
   }
 
-  protected _recordReplaced(record: Record): void {
+  protected _recordReplaced(record: InitializedRecord): void {
     this._validateRecord(record);
   }
 
@@ -127,7 +127,7 @@ export class AsyncSchemaValidationProcessor extends AsyncOperationProcessor {
     }
   }
 
-  protected _validateRecord(record: Record): void {
+  protected _validateRecord(record: InitializedRecord): void {
     this._validateRecordIdentity(record);
   }
 
@@ -136,7 +136,7 @@ export class AsyncSchemaValidationProcessor extends AsyncOperationProcessor {
   }
 
   protected _validateRelationship(
-    record: Record,
+    record: InitializedRecord,
     relationship: string,
     relatedRecord: RecordIdentity
   ): void {

--- a/packages/@orbit/record-cache/src/operation-processors/sync-cache-integrity-processor.ts
+++ b/packages/@orbit/record-cache/src/operation-processors/sync-cache-integrity-processor.ts
@@ -1,4 +1,8 @@
-import { Record, RecordIdentity, RecordOperation } from '@orbit/records';
+import {
+  InitializedRecord,
+  RecordIdentity,
+  RecordOperation
+} from '@orbit/records';
 import { SyncOperationProcessor } from '../sync-operation-processor';
 import {
   getInverseRelationship,
@@ -135,7 +139,7 @@ export class SyncCacheIntegrityProcessor extends SyncOperationProcessor {
     }
   }
 
-  protected addAllInverseRelationships(record: Record): void {
+  protected addAllInverseRelationships(record: InitializedRecord): void {
     let inverseRelationships = getAllInverseRelationships(
       this.accessor.schema,
       record

--- a/packages/@orbit/record-cache/src/operation-processors/sync-schema-validation-processor.ts
+++ b/packages/@orbit/record-cache/src/operation-processors/sync-schema-validation-processor.ts
@@ -1,5 +1,5 @@
 import {
-  Record,
+  InitializedRecord,
   RecordIdentity,
   RecordOperation,
   IncorrectRelatedRecordType
@@ -62,11 +62,11 @@ export class SyncSchemaValidationProcessor extends SyncOperationProcessor {
     }
   }
 
-  protected _recordAdded(record: Record): void {
+  protected _recordAdded(record: InitializedRecord): void {
     this._validateRecord(record);
   }
 
-  protected _recordReplaced(record: Record): void {
+  protected _recordReplaced(record: InitializedRecord): void {
     this._validateRecord(record);
   }
 
@@ -127,7 +127,7 @@ export class SyncSchemaValidationProcessor extends SyncOperationProcessor {
     }
   }
 
-  protected _validateRecord(record: Record): void {
+  protected _validateRecord(record: InitializedRecord): void {
     this._validateRecordIdentity(record);
   }
 
@@ -136,7 +136,7 @@ export class SyncSchemaValidationProcessor extends SyncOperationProcessor {
   }
 
   protected _validateRelationship(
-    record: Record,
+    record: InitializedRecord,
     relationship: string,
     relatedRecord: RecordIdentity
   ): void {

--- a/packages/@orbit/record-cache/src/operation-processors/utils/cache-integrity-utils.ts
+++ b/packages/@orbit/record-cache/src/operation-processors/utils/cache-integrity-utils.ts
@@ -1,6 +1,6 @@
 import {
   cloneRecordIdentity,
-  Record,
+  InitializedRecord,
   RecordIdentity,
   RecordOperation,
   RecordSchema
@@ -49,7 +49,7 @@ export function getInverseRelationships(
 
 export function getAllInverseRelationships(
   schema: RecordSchema,
-  record: Record
+  record: InitializedRecord
 ): RecordRelationshipIdentity[] {
   const recordIdentity = cloneRecordIdentity(record);
   const inverseRelationships: RecordRelationshipIdentity[] = [];

--- a/packages/@orbit/record-cache/src/operation-processors/utils/schema-consistency-utils.ts
+++ b/packages/@orbit/record-cache/src/operation-processors/utils/schema-consistency-utils.ts
@@ -3,7 +3,7 @@ import {
   cloneRecordIdentity,
   equalRecordIdentities,
   uniqueRecordIdentities,
-  Record,
+  InitializedRecord,
   RecordIdentity,
   RecordOperation,
   RelationshipDefinition,
@@ -13,7 +13,7 @@ import { getRelationshipDef } from './schema-utils';
 
 export function recordAdded(
   schema: RecordSchema,
-  record: Record
+  record: InitializedRecord
 ): RecordOperation[] {
   const ops: RecordOperation[] = [];
 
@@ -178,7 +178,7 @@ export function relatedRecordsReplaced(
 
 export function recordRemoved(
   schema: RecordSchema,
-  record?: Record
+  record?: InitializedRecord
 ): RecordOperation[] {
   const ops: RecordOperation[] = [];
 
@@ -215,8 +215,8 @@ export function recordRemoved(
 
 export function recordUpdated(
   schema: RecordSchema,
-  record: Record,
-  currentRecord?: Record
+  record: InitializedRecord,
+  currentRecord?: InitializedRecord
 ): RecordOperation[] {
   const ops: RecordOperation[] = [];
 

--- a/packages/@orbit/record-cache/src/operators/async-inverse-transform-operators.ts
+++ b/packages/@orbit/record-cache/src/operators/async-inverse-transform-operators.ts
@@ -1,6 +1,6 @@
 import { Dict, deepGet, deepSet, eq } from '@orbit/utils';
 import {
-  Record,
+  InitializedRecord,
   RecordOperation,
   AddRecordOperation,
   AddToRelatedRecordsOperation,
@@ -62,7 +62,7 @@ export const AsyncInverseTransformOperators: Dict<AsyncInverseTransformOperator>
   ): Promise<RecordOperation | undefined> {
     const op = operation as UpdateRecordOperation;
     const currentRecord = await cache.getRecordAsync(op.record);
-    const replacement: Record = op.record;
+    const replacement: InitializedRecord = op.record;
     const { type, id } = replacement;
 
     if (currentRecord) {

--- a/packages/@orbit/record-cache/src/operators/async-query-operators.ts
+++ b/packages/@orbit/record-cache/src/operators/async-query-operators.ts
@@ -9,7 +9,7 @@ import {
   FindRelatedRecords,
   SortSpecifier,
   AttributeSortSpecifier,
-  Record,
+  InitializedRecord,
   RecordIdentity,
   RecordQueryExpressionResult,
   RecordQuery
@@ -47,7 +47,7 @@ export const AsyncQueryOperators: Dict<AsyncQueryOperator> = {
     cache: AsyncRecordCache,
     query: RecordQuery,
     expression: RecordQueryExpression
-  ): Promise<Record[]> {
+  ): Promise<InitializedRecord[]> {
     const exp = expression as FindRecords;
     let results = await cache.getRecordsAsync(exp.records || exp.type);
     if (exp.filter) {
@@ -66,7 +66,7 @@ export const AsyncQueryOperators: Dict<AsyncQueryOperator> = {
     cache: AsyncRecordCache,
     query: RecordQuery,
     expression: RecordQueryExpression
-  ): Promise<Record[] | undefined> {
+  ): Promise<InitializedRecord[] | undefined> {
     const exp = expression as FindRelatedRecords;
     const { record, relationship } = exp;
     const relatedIds = await cache.getRelatedRecordsAsync(record, relationship);
@@ -100,7 +100,7 @@ export const AsyncQueryOperators: Dict<AsyncQueryOperator> = {
     cache: AsyncRecordCache,
     query: RecordQuery,
     expression: RecordQueryExpression
-  ): Promise<Record | null | undefined> {
+  ): Promise<InitializedRecord | null | undefined> {
     const exp = expression as FindRelatedRecord;
     const { record, relationship } = exp;
     const relatedId = await cache.getRelatedRecordAsync(record, relationship);
@@ -122,7 +122,7 @@ export const AsyncQueryOperators: Dict<AsyncQueryOperator> = {
   }
 };
 
-function filterRecords(records: Record[], filters: any[]) {
+function filterRecords(records: InitializedRecord[], filters: any[]) {
   return records.filter((record) => {
     for (let i = 0, l = filters.length; i < l; i++) {
       if (!applyFilter(record, filters[i])) {
@@ -133,7 +133,7 @@ function filterRecords(records: Record[], filters: any[]) {
   });
 }
 
-function applyFilter(record: Record, filter: any): boolean {
+function applyFilter(record: InitializedRecord, filter: any): boolean {
   if (filter.kind === 'attribute') {
     let actual = deepGet(record, ['attributes', filter.attribute]);
     if (actual === undefined) {
@@ -221,7 +221,10 @@ function applyFilter(record: Record, filter: any): boolean {
   return false;
 }
 
-function sortRecords(records: Record[], sortSpecifiers: SortSpecifier[]) {
+function sortRecords(
+  records: InitializedRecord[],
+  sortSpecifiers: SortSpecifier[]
+): InitializedRecord[] {
   const comparisonValues = new Map();
 
   records.forEach((record) => {
@@ -264,7 +267,10 @@ function sortRecords(records: Record[], sortSpecifiers: SortSpecifier[]) {
   });
 }
 
-function paginateRecords(records: Record[], paginationOptions: any) {
+function paginateRecords(
+  records: InitializedRecord[],
+  paginationOptions: any
+): InitializedRecord[] {
   if (paginationOptions.limit !== undefined) {
     let offset =
       paginationOptions.offset === undefined ? 0 : paginationOptions.offset;

--- a/packages/@orbit/record-cache/src/operators/async-transform-operators.ts
+++ b/packages/@orbit/record-cache/src/operators/async-transform-operators.ts
@@ -15,7 +15,7 @@ import {
   RemoveFromRelatedRecordsOperation,
   ReplaceRelatedRecordsOperation,
   ReplaceRelatedRecordOperation,
-  Record,
+  InitializedRecord,
   recordsInclude,
   RecordTransform,
   RecordNotFoundException
@@ -99,7 +99,7 @@ export const AsyncTransformOperators: Dict<AsyncTransformOperator> = {
   ): Promise<RecordOperationResult> {
     const op = operation as ReplaceKeyOperation;
     const currentRecord = await cache.getRecordAsync(op.record);
-    let record: Record;
+    let record: InitializedRecord;
 
     if (currentRecord) {
       record = clone(currentRecord);
@@ -129,7 +129,7 @@ export const AsyncTransformOperators: Dict<AsyncTransformOperator> = {
   ): Promise<RecordOperationResult> {
     const op = operation as ReplaceAttributeOperation;
     const currentRecord = await cache.getRecordAsync(op.record);
-    let record: Record;
+    let record: InitializedRecord;
 
     if (currentRecord) {
       record = clone(currentRecord);
@@ -156,7 +156,7 @@ export const AsyncTransformOperators: Dict<AsyncTransformOperator> = {
     const op = operation as AddToRelatedRecordsOperation;
     const { relationship, relatedRecord } = op;
     const currentRecord = await cache.getRecordAsync(op.record);
-    let record: Record;
+    let record: InitializedRecord;
 
     if (currentRecord) {
       record = clone(currentRecord);
@@ -190,7 +190,7 @@ export const AsyncTransformOperators: Dict<AsyncTransformOperator> = {
     const op = operation as RemoveFromRelatedRecordsOperation;
     const currentRecord = await cache.getRecordAsync(op.record);
     const { relationship, relatedRecord } = op;
-    let record: Record;
+    let record: InitializedRecord;
 
     if (currentRecord) {
       record = clone(currentRecord);
@@ -231,7 +231,7 @@ export const AsyncTransformOperators: Dict<AsyncTransformOperator> = {
     const op = operation as ReplaceRelatedRecordsOperation;
     const currentRecord = await cache.getRecordAsync(op.record);
     const { relationship, relatedRecords } = op;
-    let record: Record;
+    let record: InitializedRecord;
 
     if (currentRecord) {
       record = clone(currentRecord);
@@ -261,7 +261,7 @@ export const AsyncTransformOperators: Dict<AsyncTransformOperator> = {
     const op = operation as ReplaceRelatedRecordOperation;
     const currentRecord = await cache.getRecordAsync(op.record);
     const { relationship, relatedRecord } = op;
-    let record: Record;
+    let record: InitializedRecord;
 
     if (currentRecord) {
       record = clone(currentRecord);

--- a/packages/@orbit/record-cache/src/operators/sync-inverse-transform-operators.ts
+++ b/packages/@orbit/record-cache/src/operators/sync-inverse-transform-operators.ts
@@ -1,6 +1,6 @@
 import { Dict, deepGet, deepSet, eq } from '@orbit/utils';
 import {
-  Record,
+  InitializedRecord,
   RecordOperation,
   AddRecordOperation,
   AddToRelatedRecordsOperation,
@@ -62,7 +62,7 @@ export const SyncInverseTransformOperators: Dict<SyncInverseTransformOperator> =
   ): RecordOperation | undefined {
     const op = operation as UpdateRecordOperation;
     const currentRecord = cache.getRecordSync(op.record);
-    const replacement: Record = op.record;
+    const replacement: InitializedRecord = op.record;
     const { type, id } = replacement;
 
     if (currentRecord) {

--- a/packages/@orbit/record-cache/src/operators/sync-query-operators.ts
+++ b/packages/@orbit/record-cache/src/operators/sync-query-operators.ts
@@ -9,7 +9,7 @@ import {
   FindRelatedRecords,
   SortSpecifier,
   AttributeSortSpecifier,
-  Record,
+  InitializedRecord,
   RecordIdentity,
   RecordQueryExpressionResult,
   RecordQuery
@@ -29,7 +29,7 @@ export const SyncQueryOperators: Dict<SyncQueryOperator> = {
     cache: SyncRecordCache,
     query: RecordQuery,
     expression: RecordQueryExpression
-  ): Record | undefined {
+  ): InitializedRecord | undefined {
     const { record } = expression as FindRecord;
     const currentRecord = cache.getRecordSync(record);
 
@@ -47,7 +47,7 @@ export const SyncQueryOperators: Dict<SyncQueryOperator> = {
     cache: SyncRecordCache,
     query: RecordQuery,
     expression: RecordQueryExpression
-  ): Record[] {
+  ): InitializedRecord[] {
     let exp = expression as FindRecords;
     let results = cache.getRecordsSync(exp.records || exp.type);
     if (exp.filter) {
@@ -66,7 +66,7 @@ export const SyncQueryOperators: Dict<SyncQueryOperator> = {
     cache: SyncRecordCache,
     query: RecordQuery,
     expression: RecordQueryExpression
-  ): Record[] | undefined {
+  ): InitializedRecord[] | undefined {
     const exp = expression as FindRelatedRecords;
     const { record, relationship } = exp;
     const relatedIds = cache.getRelatedRecordsSync(record, relationship);
@@ -100,7 +100,7 @@ export const SyncQueryOperators: Dict<SyncQueryOperator> = {
     cache: SyncRecordCache,
     query: RecordQuery,
     expression: RecordQueryExpression
-  ): Record | null | undefined {
+  ): InitializedRecord | null | undefined {
     const exp = expression as FindRelatedRecord;
     const { record, relationship } = exp;
     const relatedId = cache.getRelatedRecordSync(record, relationship);
@@ -122,7 +122,7 @@ export const SyncQueryOperators: Dict<SyncQueryOperator> = {
   }
 };
 
-function filterRecords(records: Record[], filters: any[]) {
+function filterRecords(records: InitializedRecord[], filters: any[]) {
   return records.filter((record) => {
     for (let i = 0, l = filters.length; i < l; i++) {
       if (!applyFilter(record, filters[i])) {
@@ -133,7 +133,7 @@ function filterRecords(records: Record[], filters: any[]) {
   });
 }
 
-function applyFilter(record: Record, filter: any): boolean {
+function applyFilter(record: InitializedRecord, filter: any): boolean {
   if (filter.kind === 'attribute') {
     let actual = deepGet(record, ['attributes', filter.attribute]);
     if (actual === undefined) {
@@ -221,7 +221,10 @@ function applyFilter(record: Record, filter: any): boolean {
   return false;
 }
 
-function sortRecords(records: Record[], sortSpecifiers: SortSpecifier[]) {
+function sortRecords(
+  records: InitializedRecord[],
+  sortSpecifiers: SortSpecifier[]
+): InitializedRecord[] {
   const comparisonValues = new Map();
 
   records.forEach((record) => {
@@ -264,7 +267,10 @@ function sortRecords(records: Record[], sortSpecifiers: SortSpecifier[]) {
   });
 }
 
-function paginateRecords(records: Record[], paginationOptions: any) {
+function paginateRecords(
+  records: InitializedRecord[],
+  paginationOptions: any
+): InitializedRecord[] {
   if (paginationOptions.limit !== undefined) {
     let offset =
       paginationOptions.offset === undefined ? 0 : paginationOptions.offset;

--- a/packages/@orbit/record-cache/src/operators/sync-transform-operators.ts
+++ b/packages/@orbit/record-cache/src/operators/sync-transform-operators.ts
@@ -15,7 +15,7 @@ import {
   RemoveFromRelatedRecordsOperation,
   ReplaceRelatedRecordsOperation,
   ReplaceRelatedRecordOperation,
-  Record,
+  InitializedRecord,
   recordsInclude,
   RecordTransform,
   RecordNotFoundException
@@ -99,7 +99,7 @@ export const SyncTransformOperators: Dict<SyncTransformOperator> = {
   ): RecordOperationResult {
     const op = operation as ReplaceKeyOperation;
     const currentRecord = cache.getRecordSync(op.record);
-    let record: Record;
+    let record: InitializedRecord;
 
     if (currentRecord) {
       record = clone(currentRecord);
@@ -129,7 +129,7 @@ export const SyncTransformOperators: Dict<SyncTransformOperator> = {
   ): RecordOperationResult {
     const op = operation as ReplaceAttributeOperation;
     const currentRecord = cache.getRecordSync(op.record);
-    let record: Record;
+    let record: InitializedRecord;
 
     if (currentRecord) {
       record = clone(currentRecord);
@@ -156,7 +156,7 @@ export const SyncTransformOperators: Dict<SyncTransformOperator> = {
     const op = operation as AddToRelatedRecordsOperation;
     const { relationship, relatedRecord } = op;
     const currentRecord = cache.getRecordSync(op.record);
-    let record: Record;
+    let record: InitializedRecord;
 
     if (currentRecord) {
       record = clone(currentRecord);
@@ -190,7 +190,7 @@ export const SyncTransformOperators: Dict<SyncTransformOperator> = {
     const op = operation as RemoveFromRelatedRecordsOperation;
     const currentRecord = cache.getRecordSync(op.record);
     const { relationship, relatedRecord } = op;
-    let record: Record;
+    let record: InitializedRecord;
 
     if (currentRecord) {
       record = clone(currentRecord);
@@ -231,7 +231,7 @@ export const SyncTransformOperators: Dict<SyncTransformOperator> = {
     const op = operation as ReplaceRelatedRecordsOperation;
     const currentRecord = cache.getRecordSync(op.record);
     const { relationship, relatedRecords } = op;
-    let record: Record;
+    let record: InitializedRecord;
 
     if (currentRecord) {
       record = clone(currentRecord);
@@ -261,7 +261,7 @@ export const SyncTransformOperators: Dict<SyncTransformOperator> = {
     const op = operation as ReplaceRelatedRecordOperation;
     const currentRecord = cache.getRecordSync(op.record);
     const { relationship, relatedRecord } = op;
-    let record: Record;
+    let record: InitializedRecord;
 
     if (currentRecord) {
       record = clone(currentRecord);

--- a/packages/@orbit/record-cache/src/record-accessor.ts
+++ b/packages/@orbit/record-cache/src/record-accessor.ts
@@ -1,6 +1,6 @@
 import {
   RecordKeyMap,
-  Record,
+  InitializedRecord,
   RecordSchema,
   RecordIdentity
 } from '@orbit/records';
@@ -23,7 +23,7 @@ export interface BaseRecordAccessor {
 }
 
 export interface RecordChangeset {
-  setRecords?: Record[];
+  setRecords?: InitializedRecord[];
   removeRecords?: RecordIdentity[];
   addInverseRelationships?: RecordRelationshipIdentity[];
   removeInverseRelationships?: RecordRelationshipIdentity[];
@@ -31,8 +31,10 @@ export interface RecordChangeset {
 
 export interface SyncRecordAccessor extends BaseRecordAccessor {
   // Getters
-  getRecordSync(recordIdentity: RecordIdentity): Record | undefined;
-  getRecordsSync(typeOrIdentities?: string | RecordIdentity[]): Record[];
+  getRecordSync(recordIdentity: RecordIdentity): InitializedRecord | undefined;
+  getRecordsSync(
+    typeOrIdentities?: string | RecordIdentity[]
+  ): InitializedRecord[];
   getRelatedRecordSync(
     identity: RecordIdentity,
     relationship: string
@@ -46,10 +48,12 @@ export interface SyncRecordAccessor extends BaseRecordAccessor {
   ): RecordRelationshipIdentity[];
 
   // Setters
-  setRecordSync(record: Record): void;
-  setRecordsSync(records: Record[]): void;
-  removeRecordSync(recordIdentity: RecordIdentity): Record | undefined;
-  removeRecordsSync(recordIdentities: RecordIdentity[]): Record[];
+  setRecordSync(record: InitializedRecord): void;
+  setRecordsSync(records: InitializedRecord[]): void;
+  removeRecordSync(
+    recordIdentity: RecordIdentity
+  ): InitializedRecord | undefined;
+  removeRecordsSync(recordIdentities: RecordIdentity[]): InitializedRecord[];
   addInverseRelationshipsSync(
     relationships: RecordRelationshipIdentity[]
   ): void;
@@ -61,10 +65,12 @@ export interface SyncRecordAccessor extends BaseRecordAccessor {
 
 export interface AsyncRecordAccessor extends BaseRecordAccessor {
   // Getters
-  getRecordAsync(recordIdentity: RecordIdentity): Promise<Record | undefined>;
+  getRecordAsync(
+    recordIdentity: RecordIdentity
+  ): Promise<InitializedRecord | undefined>;
   getRecordsAsync(
     typeOrIdentities?: string | RecordIdentity[]
-  ): Promise<Record[]>;
+  ): Promise<InitializedRecord[]>;
   getRelatedRecordAsync(
     identity: RecordIdentity,
     relationship: string
@@ -78,12 +84,14 @@ export interface AsyncRecordAccessor extends BaseRecordAccessor {
   ): Promise<RecordRelationshipIdentity[]>;
 
   // Setters
-  setRecordAsync(record: Record): Promise<void>;
-  setRecordsAsync(records: Record[]): Promise<void>;
+  setRecordAsync(record: InitializedRecord): Promise<void>;
+  setRecordsAsync(records: InitializedRecord[]): Promise<void>;
   removeRecordAsync(
     recordIdentity: RecordIdentity
-  ): Promise<Record | undefined>;
-  removeRecordsAsync(recordIdentities: RecordIdentity[]): Promise<Record[]>;
+  ): Promise<InitializedRecord | undefined>;
+  removeRecordsAsync(
+    recordIdentities: RecordIdentity[]
+  ): Promise<InitializedRecord[]>;
   addInverseRelationshipsAsync(
     relationships: RecordRelationshipIdentity[]
   ): Promise<void>;

--- a/packages/@orbit/record-cache/src/record-transform-buffer.ts
+++ b/packages/@orbit/record-cache/src/record-transform-buffer.ts
@@ -1,7 +1,7 @@
 import { objectValues, Dict } from '@orbit/utils';
 import {
   deserializeRecordIdentity,
-  Record,
+  InitializedRecord,
   RecordIdentity,
   serializeRecordIdentity
 } from '@orbit/records';
@@ -22,7 +22,7 @@ function deserializeRecordRelationshipIdentity(
 }
 
 export interface RecordTransformBufferState {
-  records: Dict<Record | null>;
+  records: Dict<InitializedRecord | null>;
   inverseRelationships: Dict<Dict<RecordRelationshipIdentity | null>>;
 }
 
@@ -107,15 +107,17 @@ export class RecordTransformBuffer extends SyncRecordCache {
     return changeset;
   }
 
-  getRecordSync(identity: RecordIdentity): Record | undefined {
+  getRecordSync(identity: RecordIdentity): InitializedRecord | undefined {
     return this._state.records[serializeRecordIdentity(identity)] ?? undefined;
   }
 
-  getRecordsSync(typeOrIdentities?: string | RecordIdentity[]): Record[] {
+  getRecordsSync(
+    typeOrIdentities?: string | RecordIdentity[]
+  ): InitializedRecord[] {
     if (typeof typeOrIdentities === 'string') {
       return objectValues(this._state.records[typeOrIdentities]);
     } else if (Array.isArray(typeOrIdentities)) {
-      const records: Record[] = [];
+      const records: InitializedRecord[] = [];
       const identities: RecordIdentity[] = typeOrIdentities;
       for (let i of identities) {
         let record = this.getRecordSync(i);
@@ -129,18 +131,20 @@ export class RecordTransformBuffer extends SyncRecordCache {
     }
   }
 
-  setRecordSync(record: Record): void {
+  setRecordSync(record: InitializedRecord): void {
     this._state.records[serializeRecordIdentity(record)] = record;
     if (this._delta) {
       this._delta.records[serializeRecordIdentity(record)] = record;
     }
   }
 
-  setRecordsSync(records: Record[]): void {
+  setRecordsSync(records: InitializedRecord[]): void {
     records.forEach((record) => this.setRecordSync(record));
   }
 
-  removeRecordSync(recordIdentity: RecordIdentity): Record | undefined {
+  removeRecordSync(
+    recordIdentity: RecordIdentity
+  ): InitializedRecord | undefined {
     const record = this.getRecordSync(recordIdentity);
     if (record) {
       delete this._state.records[serializeRecordIdentity(record)];
@@ -153,7 +157,7 @@ export class RecordTransformBuffer extends SyncRecordCache {
     }
   }
 
-  removeRecordsSync(recordIdentities: RecordIdentity[]): Record[] {
+  removeRecordsSync(recordIdentities: RecordIdentity[]): InitializedRecord[] {
     const records = [];
     for (let recordIdentity of recordIdentities) {
       let record = this.getRecordSync(recordIdentity);

--- a/packages/@orbit/record-cache/src/sync-record-cache.ts
+++ b/packages/@orbit/record-cache/src/sync-record-cache.ts
@@ -10,7 +10,7 @@ import {
   RequestOptions
 } from '@orbit/data';
 import {
-  Record,
+  InitializedRecord,
   RecordOperation,
   RecordIdentity,
   RecordOperationTerm,
@@ -144,19 +144,25 @@ export abstract class SyncRecordCache<
   }
 
   // Abstract methods for getting records and relationships
-  abstract getRecordSync(recordIdentity: RecordIdentity): Record | undefined;
+  abstract getRecordSync(
+    recordIdentity: RecordIdentity
+  ): InitializedRecord | undefined;
   abstract getRecordsSync(
     typeOrIdentities?: string | RecordIdentity[]
-  ): Record[];
+  ): InitializedRecord[];
   abstract getInverseRelationshipsSync(
     recordIdentityOrIdentities: RecordIdentity | RecordIdentity[]
   ): RecordRelationshipIdentity[];
 
   // Abstract methods for setting records and relationships
-  abstract setRecordSync(record: Record): void;
-  abstract setRecordsSync(records: Record[]): void;
-  abstract removeRecordSync(recordIdentity: RecordIdentity): Record | undefined;
-  abstract removeRecordsSync(recordIdentities: RecordIdentity[]): Record[];
+  abstract setRecordSync(record: InitializedRecord): void;
+  abstract setRecordsSync(records: InitializedRecord[]): void;
+  abstract removeRecordSync(
+    recordIdentity: RecordIdentity
+  ): InitializedRecord | undefined;
+  abstract removeRecordsSync(
+    recordIdentities: RecordIdentity[]
+  ): InitializedRecord[];
   abstract addInverseRelationshipsSync(
     relationships: RecordRelationshipIdentity[]
   ): void;

--- a/packages/@orbit/record-cache/test/async-record-cache-patch-test.ts
+++ b/packages/@orbit/record-cache/test/async-record-cache-patch-test.ts
@@ -1,7 +1,7 @@
 import {
   equalRecordIdentities,
   RecordKeyMap,
-  Record,
+  InitializedRecord,
   RecordIdentity,
   recordsInclude,
   recordsIncludeAll,
@@ -155,13 +155,17 @@ module('AsyncRecordCache - patch', function (hooks) {
   test('#patch updates inverse hasOne relationship when a record with relationships unspecified is added - record added after', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' },
       relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
     };
-    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' } };
+    const io: InitializedRecord = {
+      type: 'moon',
+      id: 'm1',
+      attributes: { name: 'Io' }
+    };
 
     await cache.patch((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
 
@@ -169,13 +173,15 @@ module('AsyncRecordCache - patch', function (hooks) {
       ((await cache.getRecordAsync({
         type: 'planet',
         id: 'p1'
-      })) as Record)?.relationships?.moons.data,
+      })) as InitializedRecord)?.relationships?.moons.data,
       [{ type: 'moon', id: 'm1' }],
       'Io has been assigned to Jupiter'
     );
     assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-        ?.relationships?.planet.data,
+      ((await cache.getRecordAsync({
+        type: 'moon',
+        id: 'm1'
+      })) as InitializedRecord)?.relationships?.planet.data,
       { type: 'planet', id: 'p1' },
       'Jupiter has been assigned to Io'
     );
@@ -184,25 +190,33 @@ module('AsyncRecordCache - patch', function (hooks) {
   test('#patch updates inverse hasOne relationship when a record with relationships unspecified is added - record added before', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' },
       relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
     };
-    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' } };
+    const io: InitializedRecord = {
+      type: 'moon',
+      id: 'm1',
+      attributes: { name: 'Io' }
+    };
 
     await cache.patch((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
 
     assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-        ?.relationships?.moons.data,
+      ((await cache.getRecordAsync({
+        type: 'planet',
+        id: 'p1'
+      })) as InitializedRecord)?.relationships?.moons.data,
       [{ type: 'moon', id: 'm1' }],
       'Io has been assigned to Jupiter'
     );
     assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-        ?.relationships?.planet.data,
+      ((await cache.getRecordAsync({
+        type: 'moon',
+        id: 'm1'
+      })) as InitializedRecord)?.relationships?.planet.data,
       { type: 'planet', id: 'p1' },
       'Jupiter has been assigned to Io'
     );
@@ -211,13 +225,13 @@ module('AsyncRecordCache - patch', function (hooks) {
   test('#patch updates inverse hasMany relationship when a record with relationships unspecified is added - record added after', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const io: Record = {
+    const io: InitializedRecord = {
       type: 'moon',
       id: 'm1',
       attributes: { name: 'Io' },
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' }
@@ -226,14 +240,18 @@ module('AsyncRecordCache - patch', function (hooks) {
     await cache.patch((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
 
     assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-        ?.relationships?.moons.data,
+      ((await cache.getRecordAsync({
+        type: 'planet',
+        id: 'p1'
+      })) as InitializedRecord)?.relationships?.moons.data,
       [{ type: 'moon', id: 'm1' }],
       'Io has been assigned to Jupiter'
     );
     assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-        ?.relationships?.planet.data,
+      ((await cache.getRecordAsync({
+        type: 'moon',
+        id: 'm1'
+      })) as InitializedRecord)?.relationships?.planet.data,
       { type: 'planet', id: 'p1' },
       'Jupiter has been assigned to Io'
     );
@@ -242,13 +260,13 @@ module('AsyncRecordCache - patch', function (hooks) {
   test('#patch updates inverse hasMany relationship when a record with relationships unspecified is added - record added before', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const io: Record = {
+    const io: InitializedRecord = {
       type: 'moon',
       id: 'm1',
       attributes: { name: 'Io' },
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' }
@@ -257,14 +275,18 @@ module('AsyncRecordCache - patch', function (hooks) {
     await cache.patch((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
 
     assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-        ?.relationships?.moons.data,
+      ((await cache.getRecordAsync({
+        type: 'planet',
+        id: 'p1'
+      })) as InitializedRecord)?.relationships?.moons.data,
       [{ type: 'moon', id: 'm1' }],
       'Io has been assigned to Jupiter'
     );
     assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-        ?.relationships?.planet.data,
+      ((await cache.getRecordAsync({
+        type: 'moon',
+        id: 'm1'
+      })) as InitializedRecord)?.relationships?.planet.data,
       { type: 'planet', id: 'p1' },
       'Jupiter has been assigned to Io'
     );
@@ -273,13 +295,13 @@ module('AsyncRecordCache - patch', function (hooks) {
   test('#patch updates inverse hasOne relationship when a record with an empty relationship is added', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const io: Record = {
+    const io: InitializedRecord = {
       type: 'moon',
       id: 'm1',
       attributes: { name: 'Io' },
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' },
@@ -289,14 +311,18 @@ module('AsyncRecordCache - patch', function (hooks) {
     await cache.patch((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
 
     assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-        ?.relationships?.moons.data,
+      ((await cache.getRecordAsync({
+        type: 'planet',
+        id: 'p1'
+      })) as InitializedRecord)?.relationships?.moons.data,
       [],
       'Jupiter has no moons'
     );
     assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-        ?.relationships?.planet.data,
+      ((await cache.getRecordAsync({
+        type: 'moon',
+        id: 'm1'
+      })) as InitializedRecord)?.relationships?.planet.data,
       null,
       'Jupiter has been cleared to Io'
     );
@@ -305,13 +331,13 @@ module('AsyncRecordCache - patch', function (hooks) {
   test('#patch updates inverse hasMany relationship when a record with an empty relationship is added', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' },
       relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
     };
-    const io: Record = {
+    const io: InitializedRecord = {
       type: 'moon',
       id: 'm1',
       attributes: { name: 'Io' },
@@ -321,14 +347,18 @@ module('AsyncRecordCache - patch', function (hooks) {
     await cache.patch((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
 
     assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-        ?.relationships?.moons.data,
+      ((await cache.getRecordAsync({
+        type: 'planet',
+        id: 'p1'
+      })) as InitializedRecord)?.relationships?.moons.data,
       [],
       'Io has been cleared from Jupiter'
     );
     assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-        ?.relationships?.planet.data,
+      ((await cache.getRecordAsync({
+        type: 'moon',
+        id: 'm1'
+      })) as InitializedRecord)?.relationships?.planet.data,
       null,
       'Io has no planet'
     );
@@ -337,7 +367,7 @@ module('AsyncRecordCache - patch', function (hooks) {
   test('#patch updates inverse hasMany polymorphic relationship', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const sun: Record = {
+    const sun: InitializedRecord = {
       type: 'star',
       id: 's1',
       attributes: { name: 'Sun' },
@@ -350,12 +380,16 @@ module('AsyncRecordCache - patch', function (hooks) {
         }
       }
     };
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' }
     };
-    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' } };
+    const io: InitializedRecord = {
+      type: 'moon',
+      id: 'm1',
+      attributes: { name: 'Io' }
+    };
 
     await cache.patch((t) => [
       t.updateRecord(sun),
@@ -364,8 +398,10 @@ module('AsyncRecordCache - patch', function (hooks) {
     ]);
 
     assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'star', id: 's1' })) as Record)
-        ?.relationships?.celestialObjects.data,
+      ((await cache.getRecordAsync({
+        type: 'star',
+        id: 's1'
+      })) as InitializedRecord)?.relationships?.celestialObjects.data,
       [
         { type: 'planet', id: 'p1' },
         { type: 'moon', id: 'm1' }
@@ -373,14 +409,18 @@ module('AsyncRecordCache - patch', function (hooks) {
       'Jupiter and Io has been assigned to Sun'
     );
     assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-        ?.relationships?.star.data,
+      ((await cache.getRecordAsync({
+        type: 'planet',
+        id: 'p1'
+      })) as InitializedRecord)?.relationships?.star.data,
       { type: 'star', id: 's1' },
       'Sun has been assigned to Jupiter'
     );
     assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-        ?.relationships?.star.data,
+      ((await cache.getRecordAsync({
+        type: 'moon',
+        id: 'm1'
+      })) as InitializedRecord)?.relationships?.star.data,
       { type: 'star', id: 's1' },
       'Sun has been assigned to Io'
     );
@@ -389,19 +429,23 @@ module('AsyncRecordCache - patch', function (hooks) {
   test('#patch updates inverse hasOne polymorphic relationship', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' },
       relationships: { star: { data: { type: 'star', id: 's1' } } }
     };
-    const io: Record = {
+    const io: InitializedRecord = {
       type: 'moon',
       id: 'm1',
       attributes: { name: 'Io' },
       relationships: { star: { data: { type: 'star', id: 's1' } } }
     };
-    const sun: Record = { type: 'star', id: 's1', attributes: { name: 'Sun' } };
+    const sun: InitializedRecord = {
+      type: 'star',
+      id: 's1',
+      attributes: { name: 'Sun' }
+    };
 
     await cache.patch((t) => [
       t.updateRecord(jupiter),
@@ -410,8 +454,10 @@ module('AsyncRecordCache - patch', function (hooks) {
     ]);
 
     assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'star', id: 's1' })) as Record)
-        ?.relationships?.celestialObjects.data,
+      ((await cache.getRecordAsync({
+        type: 'star',
+        id: 's1'
+      })) as InitializedRecord)?.relationships?.celestialObjects.data,
       [
         { type: 'planet', id: 'p1' },
         { type: 'moon', id: 'm1' }
@@ -419,14 +465,18 @@ module('AsyncRecordCache - patch', function (hooks) {
       'Jupiter and Io has been assigned to Sun'
     );
     assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-        ?.relationships?.star.data,
+      ((await cache.getRecordAsync({
+        type: 'planet',
+        id: 'p1'
+      })) as InitializedRecord)?.relationships?.star.data,
       { type: 'star', id: 's1' },
       'Sun has been assigned to Jupiter'
     );
     assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-        ?.relationships?.star.data,
+      ((await cache.getRecordAsync({
+        type: 'moon',
+        id: 'm1'
+      })) as InitializedRecord)?.relationships?.star.data,
       { type: 'star', id: 's1' },
       'Sun has been assigned to Io'
     );
@@ -435,19 +485,19 @@ module('AsyncRecordCache - patch', function (hooks) {
   test('#patch tracks refs and clears them from hasOne relationships when a referenced record is removed', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' },
       relationships: { moons: { data: undefined } }
     };
-    const io: Record = {
+    const io: InitializedRecord = {
       type: 'moon',
       id: 'm1',
       attributes: { name: 'Io' },
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
-    const europa: Record = {
+    const europa: InitializedRecord = {
       type: 'moon',
       id: 'm2',
       attributes: { name: 'Europa' },
@@ -461,14 +511,18 @@ module('AsyncRecordCache - patch', function (hooks) {
     ]);
 
     assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-        ?.relationships?.planet.data,
+      ((await cache.getRecordAsync({
+        type: 'moon',
+        id: 'm1'
+      })) as InitializedRecord)?.relationships?.planet.data,
       { type: 'planet', id: 'p1' },
       'Jupiter has been assigned to Io'
     );
     assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm2' })) as Record)
-        ?.relationships?.planet.data,
+      ((await cache.getRecordAsync({
+        type: 'moon',
+        id: 'm2'
+      })) as InitializedRecord)?.relationships?.planet.data,
       { type: 'planet', id: 'p1' },
       'Jupiter has been assigned to Europa'
     );
@@ -482,14 +536,18 @@ module('AsyncRecordCache - patch', function (hooks) {
     );
 
     assert.equal(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-        ?.relationships?.planet.data,
+      ((await cache.getRecordAsync({
+        type: 'moon',
+        id: 'm1'
+      })) as InitializedRecord)?.relationships?.planet.data,
       undefined,
       'Jupiter has been cleared from Io'
     );
     assert.equal(
-      ((await cache.getRecordAsync({ type: 'moon', id: 'm2' })) as Record)
-        ?.relationships?.planet.data,
+      ((await cache.getRecordAsync({
+        type: 'moon',
+        id: 'm2'
+      })) as InitializedRecord)?.relationships?.planet.data,
       undefined,
       'Jupiter has been cleared from Europa'
     );
@@ -498,19 +556,19 @@ module('AsyncRecordCache - patch', function (hooks) {
   test('#patch tracks refs and clears them from hasMany relationships when a referenced record is removed', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const io: Record = {
+    const io: InitializedRecord = {
       type: 'moon',
       id: 'm1',
       attributes: { name: 'Io' },
       relationships: { planet: { data: null } }
     };
-    const europa: Record = {
+    const europa: InitializedRecord = {
       type: 'moon',
       id: 'm2',
       attributes: { name: 'Europa' },
       relationships: { planet: { data: null } }
     };
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' },
@@ -531,8 +589,10 @@ module('AsyncRecordCache - patch', function (hooks) {
     ]);
 
     assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-        ?.relationships?.moons.data,
+      ((await cache.getRecordAsync({
+        type: 'planet',
+        id: 'p1'
+      })) as InitializedRecord)?.relationships?.moons.data,
       [
         { type: 'moon', id: 'm1' },
         { type: 'moon', id: 'm2' }
@@ -597,8 +657,10 @@ module('AsyncRecordCache - patch', function (hooks) {
     );
 
     assert.deepEqual(
-      ((await cache.getRecordAsync({ type: 'planet', id: 'p1' })) as Record)
-        ?.relationships?.moons.data,
+      ((await cache.getRecordAsync({
+        type: 'planet',
+        id: 'p1'
+      })) as InitializedRecord)?.relationships?.moons.data,
       [{ type: 'moon', id: 'm1' }],
       'relationship was added'
     );
@@ -707,7 +769,7 @@ module('AsyncRecordCache - patch', function (hooks) {
 
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'p1',
       type: 'planet',
       attributes: { name: 'Jupiter' },
@@ -732,7 +794,7 @@ module('AsyncRecordCache - patch', function (hooks) {
 
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'p1',
       type: 'planet',
       attributes: { name: 'Jupiter' }
@@ -756,7 +818,7 @@ module('AsyncRecordCache - patch', function (hooks) {
 
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = { id: 'jupiter', type: 'planet' };
+    const jupiter: InitializedRecord = { id: 'jupiter', type: 'planet' };
     await cache.patch((t) => t.addRecord(jupiter));
 
     const callisto = { id: 'callisto', type: 'moon' };
@@ -801,7 +863,7 @@ module('AsyncRecordCache - patch', function (hooks) {
 
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = { id: 'jupiter', type: 'planet' };
+    const jupiter: InitializedRecord = { id: 'jupiter', type: 'planet' };
     await cache.patch((t) => t.addRecord(jupiter));
 
     const callisto = { id: 'callisto', type: 'moon' };
@@ -844,7 +906,7 @@ module('AsyncRecordCache - patch', function (hooks) {
 
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const europa: Record = {
+    const europa: InitializedRecord = {
       id: 'm1',
       type: 'moon',
       attributes: { name: 'Europa' },
@@ -869,7 +931,7 @@ module('AsyncRecordCache - patch', function (hooks) {
 
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const europa: Record = {
+    const europa: InitializedRecord = {
       type: 'moon',
       id: 'm1',
       attributes: { name: 'Europa' },
@@ -927,11 +989,11 @@ module('AsyncRecordCache - patch', function (hooks) {
     const one = (await cache.getRecordAsync({
       type: 'one',
       id: '1'
-    })) as Record;
+    })) as InitializedRecord;
     const two = (await cache.getRecordAsync({
       type: 'two',
       id: '2'
-    })) as Record;
+    })) as InitializedRecord;
     assert.ok(one, 'one exists');
     assert.ok(two, 'two exists');
     assert.deepEqual(
@@ -948,8 +1010,10 @@ module('AsyncRecordCache - patch', function (hooks) {
     await cache.patch((t) => t.removeRecord(two));
 
     assert.equal(
-      ((await cache.getRecordAsync({ type: 'one', id: '1' })) as Record)
-        ?.relationships?.two.data,
+      ((await cache.getRecordAsync({
+        type: 'one',
+        id: '1'
+      })) as InitializedRecord)?.relationships?.two.data,
       null,
       'ones link to two got removed'
     );
@@ -976,18 +1040,18 @@ module('AsyncRecordCache - patch', function (hooks) {
       keyMap
     });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' }
     };
-    const io: Record = {
+    const io: InitializedRecord = {
       type: 'moon',
       id: 'm1',
       attributes: { name: 'Io' },
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
-    const europa: Record = {
+    const europa: InitializedRecord = {
       type: 'moon',
       id: 'm2',
       attributes: { name: 'Europa' },
@@ -1037,18 +1101,18 @@ module('AsyncRecordCache - patch', function (hooks) {
       keyMap
     });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' }
     };
-    const io: Record = {
+    const io: InitializedRecord = {
       type: 'moon',
       id: 'm1',
       attributes: { name: 'Io' },
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
-    const europa: Record = {
+    const europa: InitializedRecord = {
       type: 'moon',
       id: 'm2',
       attributes: { name: 'Europa' },
@@ -1098,18 +1162,18 @@ module('AsyncRecordCache - patch', function (hooks) {
       keyMap
     });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' }
     };
-    const io: Record = {
+    const io: InitializedRecord = {
       type: 'moon',
       id: 'm1',
       attributes: { name: 'Io' },
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
-    const europa: Record = {
+    const europa: InitializedRecord = {
       type: 'moon',
       id: 'm2',
       attributes: { name: 'Europa' },
@@ -1285,14 +1349,14 @@ module('AsyncRecordCache - patch', function (hooks) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: '1',
       attributes: { name: 'Earth' },
       relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
     };
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: '1',
       attributes: { name: 'Jupiter', classification: 'terrestrial' },
@@ -1505,7 +1569,7 @@ module('AsyncRecordCache - patch', function (hooks) {
       type: 'planetarySystem'
     });
     assert.deepEqual(
-      (latestHome?.relationships?.star.data as Record).id,
+      (latestHome?.relationships?.star.data as InitializedRecord).id,
       star1.id,
       'The original related record is in place.'
     );
@@ -1528,7 +1592,7 @@ module('AsyncRecordCache - patch', function (hooks) {
     });
 
     assert.deepEqual(
-      (latestHome?.relationships?.star.data as Record).id,
+      (latestHome?.relationships?.star.data as InitializedRecord).id,
       star2.id,
       'The related record was replaced.'
     );

--- a/packages/@orbit/record-cache/test/async-record-cache-query-test.ts
+++ b/packages/@orbit/record-cache/test/async-record-cache-query-test.ts
@@ -1,6 +1,6 @@
 import {
   RecordKeyMap,
-  Record,
+  InitializedRecord,
   RecordNotFoundException,
   RecordSchema
 } from '@orbit/records';
@@ -21,7 +21,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query can retrieve an individual record', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -31,11 +31,11 @@ module('AsyncRecordCache - query', function (hooks) {
       }
     };
 
-    const updatedRecord = await cache.update<Record>((t) => [
+    const updatedRecord = await cache.update<InitializedRecord>((t) => [
       t.addRecord(jupiter)
     ]);
 
-    const foundRecord = await cache.query<Record>((q) =>
+    const foundRecord = await cache.query<InitializedRecord>((q) =>
       q.findRecord({ type: 'planet', id: 'jupiter' })
     );
 
@@ -46,7 +46,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query can retrieve multiple expressions', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -55,7 +55,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -78,7 +78,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query can find records by type', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -87,7 +87,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -96,7 +96,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -105,7 +105,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -124,7 +124,9 @@ module('AsyncRecordCache - query', function (hooks) {
 
     arrayMembershipMatches(
       assert,
-      (await cache.query((q) => q.findRecords('planet'))) as Record[],
+      (await cache.query((q) =>
+        q.findRecords('planet')
+      )) as InitializedRecord[],
       [jupiter, earth, venus, mercury]
     );
   });
@@ -132,7 +134,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query can find records by identities', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -141,7 +143,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -150,7 +152,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -159,7 +161,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -184,7 +186,7 @@ module('AsyncRecordCache - query', function (hooks) {
           { type: 'planet', id: 'venus' },
           { type: 'planet', id: 'FAKE' }
         ])
-      )) as Record[],
+      )) as InitializedRecord[],
       [jupiter, venus]
     );
   });
@@ -192,7 +194,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query can perform a simple attribute filter by value equality', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -201,7 +203,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -210,7 +212,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -219,7 +221,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -240,7 +242,7 @@ module('AsyncRecordCache - query', function (hooks) {
       assert,
       (await cache.query((q) =>
         q.findRecords('planet').filter({ attribute: 'name', value: 'Jupiter' })
-      )) as Record[],
+      )) as InitializedRecord[],
       [jupiter]
     );
   });
@@ -248,7 +250,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query can perform a simple attribute filter by value comparison (gt, lt, gte & lte)', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -258,7 +260,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -268,7 +270,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -278,7 +280,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -301,7 +303,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRecords('planet')
           .filter({ attribute: 'sequence', value: 2, op: 'gt' })
-      )) as Record[],
+      )) as InitializedRecord[],
       [earth, jupiter]
     );
     arrayMembershipMatches(
@@ -310,7 +312,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRecords('planet')
           .filter({ attribute: 'sequence', value: 2, op: 'gte' })
-      )) as Record[],
+      )) as InitializedRecord[],
       [venus, earth, jupiter]
     );
     arrayMembershipMatches(
@@ -319,7 +321,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRecords('planet')
           .filter({ attribute: 'sequence', value: 2, op: 'lt' })
-      )) as Record[],
+      )) as InitializedRecord[],
       [mercury]
     );
     arrayMembershipMatches(
@@ -328,7 +330,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRecords('planet')
           .filter({ attribute: 'sequence', value: 2, op: 'lte' })
-      )) as Record[],
+      )) as InitializedRecord[],
       [venus, mercury]
     );
     arrayMembershipMatches(
@@ -340,7 +342,7 @@ module('AsyncRecordCache - query', function (hooks) {
             { attribute: 'sequence', value: 2, op: 'gte' },
             { attribute: 'sequence', value: 4, op: 'lt' }
           )
-      )) as Record[],
+      )) as InitializedRecord[],
       [venus, earth]
     );
   });
@@ -348,7 +350,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query can perform relatedRecords filters with operators `equal`, `all`, `some` and `none`', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -367,7 +369,7 @@ module('AsyncRecordCache - query', function (hooks) {
         }
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -378,7 +380,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { moons: { data: [{ type: 'moon', id: 'moon' }] } }
     };
-    const mars: Record = {
+    const mars: InitializedRecord = {
       type: 'planet',
       id: 'mars',
       attributes: {
@@ -396,7 +398,7 @@ module('AsyncRecordCache - query', function (hooks) {
         }
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -406,43 +408,43 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: false
       }
     };
-    const theMoon: Record = {
+    const theMoon: InitializedRecord = {
       id: 'moon',
       type: 'moon',
       attributes: { name: 'The moon' },
       relationships: { planet: { data: { type: 'planet', id: 'earth' } } }
     };
-    const europa: Record = {
+    const europa: InitializedRecord = {
       id: 'europa',
       type: 'moon',
       attributes: { name: 'Europa' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    const ganymede: Record = {
+    const ganymede: InitializedRecord = {
       id: 'ganymede',
       type: 'moon',
       attributes: { name: 'Ganymede' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    const callisto: Record = {
+    const callisto: InitializedRecord = {
       id: 'callisto',
       type: 'moon',
       attributes: { name: 'Callisto' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    const phobos: Record = {
+    const phobos: InitializedRecord = {
       id: 'phobos',
       type: 'moon',
       attributes: { name: 'Phobos' },
       relationships: { planet: { data: { type: 'planet', id: 'mars' } } }
     };
-    const deimos: Record = {
+    const deimos: InitializedRecord = {
       id: 'deimos',
       type: 'moon',
       attributes: { name: 'Deimos' },
       relationships: { planet: { data: { type: 'planet', id: 'mars' } } }
     };
-    const titan: Record = {
+    const titan: InitializedRecord = {
       id: 'titan',
       type: 'moon',
       attributes: { name: 'titan' },
@@ -468,7 +470,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [theMoon], op: 'equal' })
-      )) as Record[],
+      )) as InitializedRecord[],
       [earth]
     );
     arrayMembershipMatches(
@@ -477,7 +479,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [phobos], op: 'equal' })
-      )) as Record[],
+      )) as InitializedRecord[],
       []
     );
     arrayMembershipMatches(
@@ -486,7 +488,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [phobos], op: 'all' })
-      )) as Record[],
+      )) as InitializedRecord[],
       [mars]
     );
     arrayMembershipMatches(
@@ -495,7 +497,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [phobos, callisto], op: 'all' })
-      )) as Record[],
+      )) as InitializedRecord[],
       []
     );
     arrayMembershipMatches(
@@ -506,7 +508,7 @@ module('AsyncRecordCache - query', function (hooks) {
           records: [phobos, callisto],
           op: 'some'
         })
-      )) as Record[],
+      )) as InitializedRecord[],
       [mars, jupiter]
     );
     arrayMembershipMatches(
@@ -515,7 +517,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [titan], op: 'some' })
-      )) as Record[],
+      )) as InitializedRecord[],
       []
     );
     arrayMembershipMatches(
@@ -524,7 +526,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [ganymede], op: 'none' })
-      )) as Record[],
+      )) as InitializedRecord[],
       [earth, mars]
     );
   });
@@ -532,7 +534,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query can perform relatedRecord filters', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -551,7 +553,7 @@ module('AsyncRecordCache - query', function (hooks) {
         }
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -562,7 +564,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { moons: { data: [{ type: 'moon', id: 'moon' }] } }
     };
-    const mars: Record = {
+    const mars: InitializedRecord = {
       type: 'planet',
       id: 'mars',
       attributes: {
@@ -580,7 +582,7 @@ module('AsyncRecordCache - query', function (hooks) {
         }
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -590,43 +592,43 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: false
       }
     };
-    const theMoon: Record = {
+    const theMoon: InitializedRecord = {
       id: 'moon',
       type: 'moon',
       attributes: { name: 'The moon' },
       relationships: { planet: { data: { type: 'planet', id: 'earth' } } }
     };
-    const europa: Record = {
+    const europa: InitializedRecord = {
       id: 'europa',
       type: 'moon',
       attributes: { name: 'Europa' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    const ganymede: Record = {
+    const ganymede: InitializedRecord = {
       id: 'ganymede',
       type: 'moon',
       attributes: { name: 'Ganymede' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    const callisto: Record = {
+    const callisto: InitializedRecord = {
       id: 'callisto',
       type: 'moon',
       attributes: { name: 'Callisto' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    const phobos: Record = {
+    const phobos: InitializedRecord = {
       id: 'phobos',
       type: 'moon',
       attributes: { name: 'Phobos' },
       relationships: { planet: { data: { type: 'planet', id: 'mars' } } }
     };
-    const deimos: Record = {
+    const deimos: InitializedRecord = {
       id: 'deimos',
       type: 'moon',
       attributes: { name: 'Deimos' },
       relationships: { planet: { data: { type: 'planet', id: 'mars' } } }
     };
-    const titan: Record = {
+    const titan: InitializedRecord = {
       id: 'titan',
       type: 'moon',
       attributes: { name: 'titan' },
@@ -650,28 +652,28 @@ module('AsyncRecordCache - query', function (hooks) {
       assert,
       (await cache.query((q) =>
         q.findRecords('moon').filter({ relation: 'planet', record: null })
-      )) as Record[],
+      )) as InitializedRecord[],
       [titan]
     );
     arrayMembershipMatches(
       assert,
       (await cache.query((q) =>
         q.findRecords('moon').filter({ relation: 'planet', record: earth })
-      )) as Record[],
+      )) as InitializedRecord[],
       [theMoon]
     );
     arrayMembershipMatches(
       assert,
       (await cache.query((q) =>
         q.findRecords('moon').filter({ relation: 'planet', record: jupiter })
-      )) as Record[],
+      )) as InitializedRecord[],
       [europa, ganymede, callisto]
     );
     arrayMembershipMatches(
       assert,
       (await cache.query((q) =>
         q.findRecords('moon').filter({ relation: 'planet', record: mercury })
-      )) as Record[],
+      )) as InitializedRecord[],
       []
     );
     arrayMembershipMatches(
@@ -680,7 +682,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRecords('moon')
           .filter({ relation: 'planet', record: [earth, mars] })
-      )) as Record[],
+      )) as InitializedRecord[],
       [theMoon, phobos, deimos]
     );
   });
@@ -688,7 +690,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query can perform a complex attribute filter by value', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -697,7 +699,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -706,7 +708,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -715,7 +717,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -741,7 +743,7 @@ module('AsyncRecordCache - query', function (hooks) {
             { attribute: 'atmosphere', value: true },
             { attribute: 'classification', value: 'terrestrial' }
           )
-      )) as Record[],
+      )) as InitializedRecord[],
       [earth, venus]
     );
   });
@@ -749,8 +751,8 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query can perform a filter on attributes, even when a particular record has none', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = { type: 'planet', id: 'jupiter' };
-    const earth: Record = {
+    const jupiter: InitializedRecord = { type: 'planet', id: 'jupiter' };
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -759,7 +761,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -768,7 +770,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -794,7 +796,7 @@ module('AsyncRecordCache - query', function (hooks) {
             { attribute: 'atmosphere', value: true },
             { attribute: 'classification', value: 'terrestrial' }
           )
-      )) as Record[],
+      )) as InitializedRecord[],
       [earth, venus]
     );
   });
@@ -802,7 +804,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query can sort by an attribute', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -811,7 +813,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -820,7 +822,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -829,7 +831,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -855,8 +857,8 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query can sort by an attribute, even when a particular record has none', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = { type: 'planet', id: 'jupiter' };
-    const earth: Record = {
+    const jupiter: InitializedRecord = { type: 'planet', id: 'jupiter' };
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -865,7 +867,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -874,7 +876,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -900,7 +902,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query can filter and sort by attributes', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -909,7 +911,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -918,7 +920,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -927,7 +929,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -961,7 +963,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query can sort by an attribute in descending order', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -970,7 +972,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -979,7 +981,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -988,7 +990,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -1014,7 +1016,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query can sort by according to multiple criteria', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -1023,7 +1025,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -1032,7 +1034,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -1041,7 +1043,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -1069,7 +1071,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query - findRecord - finds record', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'jupiter',
       type: 'planet',
       attributes: { name: 'Jupiter' },
@@ -1110,7 +1112,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query - findRecords - finds matching records', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'jupiter',
       type: 'planet',
       attributes: { name: 'Jupiter' },
@@ -1135,7 +1137,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query - page - can paginate records by offset and limit', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'jupiter',
       type: 'planet',
       attributes: { name: 'Jupiter' }
@@ -1189,7 +1191,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'jupiter',
       type: 'planet',
       attributes: { name: 'Jupiter' },
@@ -1216,7 +1218,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords - returns empty array if there are no related records', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'jupiter',
       type: 'planet',
       attributes: { name: 'Jupiter' }
@@ -1262,7 +1264,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecord', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'jupiter',
       type: 'planet',
       attributes: { name: 'Jupiter' },
@@ -1289,7 +1291,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecord - return null if no related record is found', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const callisto: Record = {
+    const callisto: InitializedRecord = {
       id: 'callisto',
       type: 'moon',
       attributes: { name: 'Callisto' }
@@ -1335,7 +1337,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords can perform a simple attribute filter by value equality', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const sun: Record = {
+    const sun: InitializedRecord = {
       type: 'star',
       id: 'sun',
       relationships: {
@@ -1350,7 +1352,7 @@ module('AsyncRecordCache - query', function (hooks) {
       }
     };
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -1360,7 +1362,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -1370,7 +1372,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -1380,7 +1382,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -1405,7 +1407,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ attribute: 'name', value: 'Jupiter' })
-      )) as Record[],
+      )) as InitializedRecord[],
       [jupiter]
     );
   });
@@ -1413,7 +1415,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords - can perform a simple attribute filter by value comparison (gt, lt, gte & lte)', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const sun: Record = {
+    const sun: InitializedRecord = {
       type: 'star',
       id: 'sun',
       relationships: {
@@ -1428,7 +1430,7 @@ module('AsyncRecordCache - query', function (hooks) {
       }
     };
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -1439,7 +1441,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -1450,7 +1452,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -1461,7 +1463,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -1486,7 +1488,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ attribute: 'sequence', value: 2, op: 'gt' })
-      )) as Record[],
+      )) as InitializedRecord[],
       [earth, jupiter]
     );
     arrayMembershipMatches(
@@ -1495,7 +1497,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ attribute: 'sequence', value: 2, op: 'gte' })
-      )) as Record[],
+      )) as InitializedRecord[],
       [venus, earth, jupiter]
     );
     arrayMembershipMatches(
@@ -1504,7 +1506,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ attribute: 'sequence', value: 2, op: 'lt' })
-      )) as Record[],
+      )) as InitializedRecord[],
       [mercury]
     );
     arrayMembershipMatches(
@@ -1513,7 +1515,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ attribute: 'sequence', value: 2, op: 'lte' })
-      )) as Record[],
+      )) as InitializedRecord[],
       [venus, mercury]
     );
   });
@@ -1521,7 +1523,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords - can perform relatedRecords filters with operators `equal`, `all`, `some` and `none`', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const sun: Record = {
+    const sun: InitializedRecord = {
       type: 'star',
       id: 'sun',
       relationships: {
@@ -1536,7 +1538,7 @@ module('AsyncRecordCache - query', function (hooks) {
       }
     };
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -1556,7 +1558,7 @@ module('AsyncRecordCache - query', function (hooks) {
         }
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -1570,7 +1572,7 @@ module('AsyncRecordCache - query', function (hooks) {
         moons: { data: [{ type: 'moon', id: 'moon' }] }
       }
     };
-    const mars: Record = {
+    const mars: InitializedRecord = {
       type: 'planet',
       id: 'mars',
       attributes: {
@@ -1589,7 +1591,7 @@ module('AsyncRecordCache - query', function (hooks) {
         }
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -1600,43 +1602,43 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const theMoon: Record = {
+    const theMoon: InitializedRecord = {
       id: 'moon',
       type: 'moon',
       attributes: { name: 'The moon' },
       relationships: { planet: { data: { type: 'planet', id: 'earth' } } }
     };
-    const europa: Record = {
+    const europa: InitializedRecord = {
       id: 'europa',
       type: 'moon',
       attributes: { name: 'Europa' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    const ganymede: Record = {
+    const ganymede: InitializedRecord = {
       id: 'ganymede',
       type: 'moon',
       attributes: { name: 'Ganymede' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    const callisto: Record = {
+    const callisto: InitializedRecord = {
       id: 'callisto',
       type: 'moon',
       attributes: { name: 'Callisto' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    const phobos: Record = {
+    const phobos: InitializedRecord = {
       id: 'phobos',
       type: 'moon',
       attributes: { name: 'Phobos' },
       relationships: { planet: { data: { type: 'planet', id: 'mars' } } }
     };
-    const deimos: Record = {
+    const deimos: InitializedRecord = {
       id: 'deimos',
       type: 'moon',
       attributes: { name: 'Deimos' },
       relationships: { planet: { data: { type: 'planet', id: 'mars' } } }
     };
-    const titan: Record = {
+    const titan: InitializedRecord = {
       id: 'titan',
       type: 'moon',
       attributes: { name: 'titan' },
@@ -1663,7 +1665,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'moons', records: [theMoon], op: 'equal' })
-      )) as Record[],
+      )) as InitializedRecord[],
       [earth]
     );
     arrayMembershipMatches(
@@ -1672,7 +1674,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'moons', records: [phobos], op: 'equal' })
-      )) as Record[],
+      )) as InitializedRecord[],
       []
     );
     arrayMembershipMatches(
@@ -1681,7 +1683,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'moons', records: [phobos], op: 'all' })
-      )) as Record[],
+      )) as InitializedRecord[],
       [mars]
     );
     arrayMembershipMatches(
@@ -1690,7 +1692,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'moons', records: [phobos, callisto], op: 'all' })
-      )) as Record[],
+      )) as InitializedRecord[],
       []
     );
     arrayMembershipMatches(
@@ -1701,7 +1703,7 @@ module('AsyncRecordCache - query', function (hooks) {
           records: [phobos, callisto],
           op: 'some'
         })
-      )) as Record[],
+      )) as InitializedRecord[],
       [mars, jupiter]
     );
     arrayMembershipMatches(
@@ -1710,7 +1712,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'moons', records: [titan], op: 'some' })
-      )) as Record[],
+      )) as InitializedRecord[],
       []
     );
     arrayMembershipMatches(
@@ -1719,7 +1721,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'moons', records: [ganymede], op: 'none' })
-      )) as Record[],
+      )) as InitializedRecord[],
       [earth, mars]
     );
   });
@@ -1727,7 +1729,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords - can perform relatedRecord filters', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const sun: Record = {
+    const sun: InitializedRecord = {
       type: 'star',
       id: 'sun',
       relationships: {
@@ -1748,7 +1750,7 @@ module('AsyncRecordCache - query', function (hooks) {
       }
     };
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -1768,7 +1770,7 @@ module('AsyncRecordCache - query', function (hooks) {
         }
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -1782,7 +1784,7 @@ module('AsyncRecordCache - query', function (hooks) {
         moons: { data: [{ type: 'moon', id: 'moon' }] }
       }
     };
-    const mars: Record = {
+    const mars: InitializedRecord = {
       type: 'planet',
       id: 'mars',
       attributes: {
@@ -1801,7 +1803,7 @@ module('AsyncRecordCache - query', function (hooks) {
         }
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -1812,7 +1814,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const theMoon: Record = {
+    const theMoon: InitializedRecord = {
       id: 'moon',
       type: 'moon',
       attributes: { name: 'The moon' },
@@ -1821,7 +1823,7 @@ module('AsyncRecordCache - query', function (hooks) {
         star: { data: { type: 'star', id: 'sun' } }
       }
     };
-    const europa: Record = {
+    const europa: InitializedRecord = {
       id: 'europa',
       type: 'moon',
       attributes: { name: 'Europa' },
@@ -1830,7 +1832,7 @@ module('AsyncRecordCache - query', function (hooks) {
         star: { data: { type: 'star', id: 'sun' } }
       }
     };
-    const ganymede: Record = {
+    const ganymede: InitializedRecord = {
       id: 'ganymede',
       type: 'moon',
       attributes: { name: 'Ganymede' },
@@ -1839,7 +1841,7 @@ module('AsyncRecordCache - query', function (hooks) {
         star: { data: { type: 'star', id: 'sun' } }
       }
     };
-    const callisto: Record = {
+    const callisto: InitializedRecord = {
       id: 'callisto',
       type: 'moon',
       attributes: { name: 'Callisto' },
@@ -1848,7 +1850,7 @@ module('AsyncRecordCache - query', function (hooks) {
         star: { data: { type: 'star', id: 'sun' } }
       }
     };
-    const phobos: Record = {
+    const phobos: InitializedRecord = {
       id: 'phobos',
       type: 'moon',
       attributes: { name: 'Phobos' },
@@ -1857,7 +1859,7 @@ module('AsyncRecordCache - query', function (hooks) {
         star: { data: { type: 'star', id: 'sun' } }
       }
     };
-    const deimos: Record = {
+    const deimos: InitializedRecord = {
       id: 'deimos',
       type: 'moon',
       attributes: { name: 'Deimos' },
@@ -1866,7 +1868,7 @@ module('AsyncRecordCache - query', function (hooks) {
         star: { data: { type: 'star', id: 'sun' } }
       }
     };
-    const titan: Record = {
+    const titan: InitializedRecord = {
       id: 'titan',
       type: 'moon',
       attributes: { name: 'titan' },
@@ -1896,7 +1898,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'planet', record: null })
-      )) as Record[],
+      )) as InitializedRecord[],
       [titan]
     );
     arrayMembershipMatches(
@@ -1905,7 +1907,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(earth, 'moons')
           .filter({ relation: 'planet', record: earth })
-      )) as Record[],
+      )) as InitializedRecord[],
       [theMoon]
     );
     arrayMembershipMatches(
@@ -1914,7 +1916,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(jupiter, 'moons')
           .filter({ relation: 'planet', record: jupiter })
-      )) as Record[],
+      )) as InitializedRecord[],
       [europa, ganymede, callisto]
     );
     arrayMembershipMatches(
@@ -1923,7 +1925,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(mercury, 'moons')
           .filter({ relation: 'planet', record: mercury })
-      )) as Record[],
+      )) as InitializedRecord[],
       []
     );
     arrayMembershipMatches(
@@ -1932,7 +1934,7 @@ module('AsyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'planet', record: [earth, mars] })
-      )) as Record[],
+      )) as InitializedRecord[],
       [theMoon, phobos, deimos]
     );
   });
@@ -1940,7 +1942,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords - can perform a complex attribute filter by value', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const sun: Record = {
+    const sun: InitializedRecord = {
       type: 'star',
       id: 'sun',
       relationships: {
@@ -1955,7 +1957,7 @@ module('AsyncRecordCache - query', function (hooks) {
       }
     };
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -1965,7 +1967,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -1975,7 +1977,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -1985,7 +1987,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -2013,7 +2015,7 @@ module('AsyncRecordCache - query', function (hooks) {
             { attribute: 'atmosphere', value: true },
             { attribute: 'classification', value: 'terrestrial' }
           )
-      )) as Record[],
+      )) as InitializedRecord[],
       [earth, venus]
     );
   });
@@ -2021,7 +2023,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords - can perform a filter on attributes, even when a particular record has none', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const sun: Record = {
+    const sun: InitializedRecord = {
       type: 'star',
       id: 'sun',
       relationships: {
@@ -2036,12 +2038,12 @@ module('AsyncRecordCache - query', function (hooks) {
       }
     };
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -2051,7 +2053,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -2061,7 +2063,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -2089,7 +2091,7 @@ module('AsyncRecordCache - query', function (hooks) {
             { attribute: 'atmosphere', value: true },
             { attribute: 'classification', value: 'terrestrial' }
           )
-      )) as Record[],
+      )) as InitializedRecord[],
       [earth, venus]
     );
   });
@@ -2097,7 +2099,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords - can sort by an attribute', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const sun: Record = {
+    const sun: InitializedRecord = {
       type: 'star',
       id: 'sun',
       relationships: {
@@ -2112,7 +2114,7 @@ module('AsyncRecordCache - query', function (hooks) {
       }
     };
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -2122,7 +2124,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -2132,7 +2134,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -2142,7 +2144,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -2172,7 +2174,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords - can sort by an attribute, even when a particular record has none', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const sun: Record = {
+    const sun: InitializedRecord = {
       type: 'star',
       id: 'sun',
       relationships: {
@@ -2187,8 +2189,8 @@ module('AsyncRecordCache - query', function (hooks) {
       }
     };
 
-    const jupiter: Record = { type: 'planet', id: 'jupiter' };
-    const earth: Record = {
+    const jupiter: InitializedRecord = { type: 'planet', id: 'jupiter' };
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -2198,7 +2200,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -2208,7 +2210,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -2238,7 +2240,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords - can filter and sort by attributes', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const sun: Record = {
+    const sun: InitializedRecord = {
       type: 'star',
       id: 'sun',
       relationships: {
@@ -2253,7 +2255,7 @@ module('AsyncRecordCache - query', function (hooks) {
       }
     };
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -2263,7 +2265,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -2273,7 +2275,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -2283,7 +2285,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -2319,7 +2321,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords - can sort by an attribute in descending order', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const sun: Record = {
+    const sun: InitializedRecord = {
       type: 'star',
       id: 'sun',
       relationships: {
@@ -2334,7 +2336,7 @@ module('AsyncRecordCache - query', function (hooks) {
       }
     };
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -2344,7 +2346,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -2354,7 +2356,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -2364,7 +2366,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -2394,7 +2396,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords - can sort by according to multiple criteria', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const sun: Record = {
+    const sun: InitializedRecord = {
       type: 'star',
       id: 'sun',
       relationships: {
@@ -2409,7 +2411,7 @@ module('AsyncRecordCache - query', function (hooks) {
       }
     };
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -2419,7 +2421,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -2429,7 +2431,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -2439,7 +2441,7 @@ module('AsyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -2471,7 +2473,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords - page - can paginate records by offset and limit', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const sun: Record = {
+    const sun: InitializedRecord = {
       type: 'star',
       id: 'sun',
       relationships: {
@@ -2486,7 +2488,7 @@ module('AsyncRecordCache - query', function (hooks) {
       }
     };
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'jupiter',
       type: 'planet',
       attributes: { name: 'Jupiter' },
@@ -2553,7 +2555,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#liveQuery', async function (assert) {
     let cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'jupiter',
       type: 'planet',
       attributes: { name: 'Jupiter' }
@@ -2564,7 +2566,7 @@ module('AsyncRecordCache - query', function (hooks) {
       attributes: { name: 'Jupiter 2' }
     };
 
-    const callisto: Record = {
+    const callisto: InitializedRecord = {
       id: 'callisto',
       type: 'moon',
       attributes: { name: 'Callisto' },
@@ -2777,7 +2779,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#liveQuery findRecords (debounce)', async function (assert) {
     let cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const planets: Record[] = [
+    const planets: InitializedRecord[] = [
       {
         id: 'planet1',
         type: 'planet',
@@ -2819,7 +2821,7 @@ module('AsyncRecordCache - query', function (hooks) {
       debounceLiveQueries: false
     });
 
-    const planets: Record[] = [
+    const planets: InitializedRecord[] = [
       {
         id: 'planet1',
         type: 'planet',
@@ -2844,7 +2846,7 @@ module('AsyncRecordCache - query', function (hooks) {
 
     const done = assert.async();
     livePlanets.subscribe(async (update) => {
-      const result = (await update.query()) as Record[];
+      const result = (await update.query()) as InitializedRecord[];
       assert.equal(result.length, i);
 
       if (i === 3) {
@@ -2859,7 +2861,7 @@ module('AsyncRecordCache - query', function (hooks) {
   test('#liveQuery can apply attribute filters', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -2869,7 +2871,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -2879,7 +2881,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -2889,7 +2891,7 @@ module('AsyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -2911,13 +2913,17 @@ module('AsyncRecordCache - query', function (hooks) {
 
     const done = assert.async();
     livePlanets.subscribe(async (update) => {
-      const result = (await update.query()) as Record[];
+      const result = (await update.query()) as InitializedRecord[];
       arrayMembershipMatches(assert, result, [venus, earth]);
       done();
     });
 
     // liveQuery results are initially empty
-    arrayMembershipMatches(assert, (await livePlanets.query()) as Record[], []);
+    arrayMembershipMatches(
+      assert,
+      (await livePlanets.query()) as InitializedRecord[],
+      []
+    );
 
     // adding records should update liveQuery results
     cache.update((t) => [

--- a/packages/@orbit/record-cache/test/async-record-cache-update-test.ts
+++ b/packages/@orbit/record-cache/test/async-record-cache-update-test.ts
@@ -1,7 +1,7 @@
 import {
   equalRecordIdentities,
   RecordKeyMap,
-  Record,
+  InitializedRecord,
   RecordIdentity,
   recordsInclude,
   recordsIncludeAll,
@@ -42,7 +42,7 @@ module('AsyncRecordCache - update', function (hooks) {
         test('#update sets data and #records retrieves it', async function (assert) {
           assert.expect(4);
 
-          const earth: Record = {
+          const earth: InitializedRecord = {
             type: 'planet',
             id: '1',
             attributes: { name: 'Earth' },
@@ -74,7 +74,7 @@ module('AsyncRecordCache - update', function (hooks) {
         test('#update can replace records', async function (assert) {
           assert.expect(5);
 
-          const earth: Record = {
+          const earth: InitializedRecord = {
             type: 'planet',
             id: '1',
             attributes: { name: 'Earth' },
@@ -111,7 +111,7 @@ module('AsyncRecordCache - update', function (hooks) {
         test('#update can replace keys', async function (assert) {
           assert.expect(4);
 
-          const earth: Record = { type: 'planet', id: '1' };
+          const earth: InitializedRecord = { type: 'planet', id: '1' };
 
           cache.on('patch', (operation, data) => {
             assert.deepEqual(operation, {
@@ -191,13 +191,13 @@ module('AsyncRecordCache - update', function (hooks) {
         });
 
         test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added after', async function (assert) {
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: 'p1',
             attributes: { name: 'Jupiter' },
             relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
           };
-          const io: Record = {
+          const io: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Io' }
@@ -212,26 +212,28 @@ module('AsyncRecordCache - update', function (hooks) {
             ((await cache.getRecordAsync({
               type: 'planet',
               id: 'p1'
-            })) as Record)?.relationships?.moons.data,
+            })) as InitializedRecord)?.relationships?.moons.data,
             [{ type: 'moon', id: 'm1' }],
             'Io has been assigned to Jupiter'
           );
           assert.deepEqual(
-            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-              ?.relationships?.planet.data,
+            ((await cache.getRecordAsync({
+              type: 'moon',
+              id: 'm1'
+            })) as InitializedRecord)?.relationships?.planet.data,
             { type: 'planet', id: 'p1' },
             'Jupiter has been assigned to Io'
           );
         });
 
         test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added before', async function (assert) {
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: 'p1',
             attributes: { name: 'Jupiter' },
             relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
           };
-          const io: Record = {
+          const io: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Io' }
@@ -246,26 +248,28 @@ module('AsyncRecordCache - update', function (hooks) {
             ((await cache.getRecordAsync({
               type: 'planet',
               id: 'p1'
-            })) as Record)?.relationships?.moons.data,
+            })) as InitializedRecord)?.relationships?.moons.data,
             [{ type: 'moon', id: 'm1' }],
             'Io has been assigned to Jupiter'
           );
           assert.deepEqual(
-            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-              ?.relationships?.planet.data,
+            ((await cache.getRecordAsync({
+              type: 'moon',
+              id: 'm1'
+            })) as InitializedRecord)?.relationships?.planet.data,
             { type: 'planet', id: 'p1' },
             'Jupiter has been assigned to Io'
           );
         });
 
         test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added after', async function (assert) {
-          const io: Record = {
+          const io: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Io' },
             relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
           };
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: 'p1',
             attributes: { name: 'Jupiter' }
@@ -280,26 +284,28 @@ module('AsyncRecordCache - update', function (hooks) {
             ((await cache.getRecordAsync({
               type: 'planet',
               id: 'p1'
-            })) as Record)?.relationships?.moons.data,
+            })) as InitializedRecord)?.relationships?.moons.data,
             [{ type: 'moon', id: 'm1' }],
             'Io has been assigned to Jupiter'
           );
           assert.deepEqual(
-            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-              ?.relationships?.planet.data,
+            ((await cache.getRecordAsync({
+              type: 'moon',
+              id: 'm1'
+            })) as InitializedRecord)?.relationships?.planet.data,
             { type: 'planet', id: 'p1' },
             'Jupiter has been assigned to Io'
           );
         });
 
         test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added before', async function (assert) {
-          const io: Record = {
+          const io: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Io' },
             relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
           };
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: 'p1',
             attributes: { name: 'Jupiter' }
@@ -314,26 +320,28 @@ module('AsyncRecordCache - update', function (hooks) {
             ((await cache.getRecordAsync({
               type: 'planet',
               id: 'p1'
-            })) as Record)?.relationships?.moons.data,
+            })) as InitializedRecord)?.relationships?.moons.data,
             [{ type: 'moon', id: 'm1' }],
             'Io has been assigned to Jupiter'
           );
           assert.deepEqual(
-            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-              ?.relationships?.planet.data,
+            ((await cache.getRecordAsync({
+              type: 'moon',
+              id: 'm1'
+            })) as InitializedRecord)?.relationships?.planet.data,
             { type: 'planet', id: 'p1' },
             'Jupiter has been assigned to Io'
           );
         });
 
         test('#update updates inverse hasOne relationship when a record with an empty relationship is added', async function (assert) {
-          const io: Record = {
+          const io: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Io' },
             relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
           };
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: 'p1',
             attributes: { name: 'Jupiter' },
@@ -349,26 +357,28 @@ module('AsyncRecordCache - update', function (hooks) {
             ((await cache.getRecordAsync({
               type: 'planet',
               id: 'p1'
-            })) as Record)?.relationships?.moons.data,
+            })) as InitializedRecord)?.relationships?.moons.data,
             [],
             'Jupiter has no moons'
           );
           assert.deepEqual(
-            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-              ?.relationships?.planet.data,
+            ((await cache.getRecordAsync({
+              type: 'moon',
+              id: 'm1'
+            })) as InitializedRecord)?.relationships?.planet.data,
             null,
             'Jupiter has been cleared from Io'
           );
         });
 
         test('#update updates inverse hasMany relationship when a record with an empty relationship is added', async function (assert) {
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: 'p1',
             attributes: { name: 'Jupiter' },
             relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
           };
-          const io: Record = {
+          const io: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Io' },
@@ -384,20 +394,22 @@ module('AsyncRecordCache - update', function (hooks) {
             ((await cache.getRecordAsync({
               type: 'planet',
               id: 'p1'
-            })) as Record)?.relationships?.moons.data,
+            })) as InitializedRecord)?.relationships?.moons.data,
             [],
             'Io has been cleared from Jupiter'
           );
           assert.deepEqual(
-            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-              ?.relationships?.planet.data,
+            ((await cache.getRecordAsync({
+              type: 'moon',
+              id: 'm1'
+            })) as InitializedRecord)?.relationships?.planet.data,
             null,
             'Io has no planet'
           );
         });
 
         test('#update updates inverse hasMany polymorphic relationship', async function (assert) {
-          const sun: Record = {
+          const sun: InitializedRecord = {
             type: 'star',
             id: 's1',
             attributes: { name: 'Sun' },
@@ -410,12 +422,12 @@ module('AsyncRecordCache - update', function (hooks) {
               }
             }
           };
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: 'p1',
             attributes: { name: 'Jupiter' }
           };
-          const io: Record = {
+          const io: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Io' }
@@ -428,8 +440,10 @@ module('AsyncRecordCache - update', function (hooks) {
           ]);
 
           assert.deepEqual(
-            ((await cache.getRecordAsync({ type: 'star', id: 's1' })) as Record)
-              ?.relationships?.celestialObjects.data,
+            ((await cache.getRecordAsync({
+              type: 'star',
+              id: 's1'
+            })) as InitializedRecord)?.relationships?.celestialObjects.data,
             [
               { type: 'planet', id: 'p1' },
               { type: 'moon', id: 'm1' }
@@ -440,32 +454,34 @@ module('AsyncRecordCache - update', function (hooks) {
             ((await cache.getRecordAsync({
               type: 'planet',
               id: 'p1'
-            })) as Record)?.relationships?.star.data,
+            })) as InitializedRecord)?.relationships?.star.data,
             { type: 'star', id: 's1' },
             'Sun has been assigned to Jupiter'
           );
           assert.deepEqual(
-            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-              ?.relationships?.star.data,
+            ((await cache.getRecordAsync({
+              type: 'moon',
+              id: 'm1'
+            })) as InitializedRecord)?.relationships?.star.data,
             { type: 'star', id: 's1' },
             'Sun has been assigned to Io'
           );
         });
 
         test('#update updates inverse hasOne polymorphic relationship', async function (assert) {
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: 'p1',
             attributes: { name: 'Jupiter' },
             relationships: { star: { data: { type: 'star', id: 's1' } } }
           };
-          const io: Record = {
+          const io: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Io' },
             relationships: { star: { data: { type: 'star', id: 's1' } } }
           };
-          const sun: Record = {
+          const sun: InitializedRecord = {
             type: 'star',
             id: 's1',
             attributes: { name: 'Sun' }
@@ -478,8 +494,10 @@ module('AsyncRecordCache - update', function (hooks) {
           ]);
 
           assert.deepEqual(
-            ((await cache.getRecordAsync({ type: 'star', id: 's1' })) as Record)
-              ?.relationships?.celestialObjects.data,
+            ((await cache.getRecordAsync({
+              type: 'star',
+              id: 's1'
+            })) as InitializedRecord)?.relationships?.celestialObjects.data,
             [
               { type: 'planet', id: 'p1' },
               { type: 'moon', id: 'm1' }
@@ -490,32 +508,34 @@ module('AsyncRecordCache - update', function (hooks) {
             ((await cache.getRecordAsync({
               type: 'planet',
               id: 'p1'
-            })) as Record)?.relationships?.star.data,
+            })) as InitializedRecord)?.relationships?.star.data,
             { type: 'star', id: 's1' },
             'Sun has been assigned to Jupiter'
           );
           assert.deepEqual(
-            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-              ?.relationships?.star.data,
+            ((await cache.getRecordAsync({
+              type: 'moon',
+              id: 'm1'
+            })) as InitializedRecord)?.relationships?.star.data,
             { type: 'star', id: 's1' },
             'Sun has been assigned to Io'
           );
         });
 
         test('#update tracks refs and clears them from hasOne relationships when a referenced record is removed', async function (assert) {
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: 'p1',
             attributes: { name: 'Jupiter' },
             relationships: { moons: { data: undefined } }
           };
-          const io: Record = {
+          const io: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Io' },
             relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
           };
-          const europa: Record = {
+          const europa: InitializedRecord = {
             type: 'moon',
             id: 'm2',
             attributes: { name: 'Europa' },
@@ -529,14 +549,18 @@ module('AsyncRecordCache - update', function (hooks) {
           ]);
 
           assert.deepEqual(
-            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-              ?.relationships?.planet.data,
+            ((await cache.getRecordAsync({
+              type: 'moon',
+              id: 'm1'
+            })) as InitializedRecord)?.relationships?.planet.data,
             { type: 'planet', id: 'p1' },
             'Jupiter has been assigned to Io'
           );
           assert.deepEqual(
-            ((await cache.getRecordAsync({ type: 'moon', id: 'm2' })) as Record)
-              ?.relationships?.planet.data,
+            ((await cache.getRecordAsync({
+              type: 'moon',
+              id: 'm2'
+            })) as InitializedRecord)?.relationships?.planet.data,
             { type: 'planet', id: 'p1' },
             'Jupiter has been assigned to Europa'
           );
@@ -550,33 +574,37 @@ module('AsyncRecordCache - update', function (hooks) {
           );
 
           assert.equal(
-            ((await cache.getRecordAsync({ type: 'moon', id: 'm1' })) as Record)
-              ?.relationships?.planet.data,
+            ((await cache.getRecordAsync({
+              type: 'moon',
+              id: 'm1'
+            })) as InitializedRecord)?.relationships?.planet.data,
             undefined,
             'Jupiter has been cleared from Io'
           );
           assert.equal(
-            ((await cache.getRecordAsync({ type: 'moon', id: 'm2' })) as Record)
-              ?.relationships?.planet.data,
+            ((await cache.getRecordAsync({
+              type: 'moon',
+              id: 'm2'
+            })) as InitializedRecord)?.relationships?.planet.data,
             undefined,
             'Jupiter has been cleared from Europa'
           );
         });
 
         test('#update tracks refs and clears them from hasMany relationships when a referenced record is removed', async function (assert) {
-          const io: Record = {
+          const io: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Io' },
             relationships: { planet: { data: null } }
           };
-          const europa: Record = {
+          const europa: InitializedRecord = {
             type: 'moon',
             id: 'm2',
             attributes: { name: 'Europa' },
             relationships: { planet: { data: null } }
           };
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: 'p1',
             attributes: { name: 'Jupiter' },
@@ -600,7 +628,7 @@ module('AsyncRecordCache - update', function (hooks) {
             ((await cache.getRecordAsync({
               type: 'planet',
               id: 'p1'
-            })) as Record)?.relationships?.moons.data,
+            })) as InitializedRecord)?.relationships?.moons.data,
             [
               { type: 'moon', id: 'm1' },
               { type: 'moon', id: 'm2' }
@@ -663,7 +691,7 @@ module('AsyncRecordCache - update', function (hooks) {
             ((await cache.getRecordAsync({
               type: 'planet',
               id: 'p1'
-            })) as Record)?.relationships?.moons.data,
+            })) as InitializedRecord)?.relationships?.moons.data,
             [{ type: 'moon', id: 'm1' }],
             'relationship was added'
           );
@@ -761,7 +789,7 @@ module('AsyncRecordCache - update', function (hooks) {
         test('#update does not add link to hasMany if link already exists', async function (assert) {
           assert.expect(1);
 
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             id: 'p1',
             type: 'planet',
             attributes: { name: 'Jupiter' },
@@ -784,7 +812,7 @@ module('AsyncRecordCache - update', function (hooks) {
         test("#update does not remove relationship from hasMany if relationship doesn't exist", async function (assert) {
           assert.expect(1);
 
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             id: 'p1',
             type: 'planet',
             attributes: { name: 'Jupiter' }
@@ -809,10 +837,10 @@ module('AsyncRecordCache - update', function (hooks) {
         test('#update can add and remove to has-many relationship', async function (assert) {
           assert.expect(2);
 
-          const jupiter: Record = { id: 'jupiter', type: 'planet' };
+          const jupiter: InitializedRecord = { id: 'jupiter', type: 'planet' };
           await cache.update((t) => t.addRecord(jupiter));
 
-          const callisto: Record = { id: 'callisto', type: 'moon' };
+          const callisto: InitializedRecord = { id: 'callisto', type: 'moon' };
           await cache.update((t) => t.addRecord(callisto));
 
           await cache.update((t) =>
@@ -855,10 +883,10 @@ module('AsyncRecordCache - update', function (hooks) {
         test('#update can add and clear has-one relationship', async function (assert) {
           assert.expect(2);
 
-          const jupiter: Record = { id: 'jupiter', type: 'planet' };
+          const jupiter: InitializedRecord = { id: 'jupiter', type: 'planet' };
           await cache.update((t) => t.addRecord(jupiter));
 
-          const callisto: Record = { id: 'callisto', type: 'moon' };
+          const callisto: InitializedRecord = { id: 'callisto', type: 'moon' };
           await cache.update((t) => t.addRecord(callisto));
 
           await cache.update((t) =>
@@ -898,7 +926,7 @@ module('AsyncRecordCache - update', function (hooks) {
         test('does not replace hasOne if relationship already exists', async function (assert) {
           assert.expect(1);
 
-          const europa: Record = {
+          const europa: InitializedRecord = {
             id: 'm1',
             type: 'moon',
             attributes: { name: 'Europa' },
@@ -924,7 +952,7 @@ module('AsyncRecordCache - update', function (hooks) {
         test("does not remove hasOne if relationship doesn't exist", async function (assert) {
           assert.expect(1);
 
-          const europa: Record = {
+          const europa: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Europa' },
@@ -1184,14 +1212,14 @@ module('AsyncRecordCache - update', function (hooks) {
         test('#update merges records when "replacing" and _will_ replace specified attributes and relationships', async function (assert) {
           const tb = cache.transformBuilder;
 
-          const earth: Record = {
+          const earth: InitializedRecord = {
             type: 'planet',
             id: '1',
             attributes: { name: 'Earth' },
             relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
           };
 
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: '1',
             attributes: { name: 'Jupiter', classification: 'terrestrial' },
@@ -1589,7 +1617,7 @@ module('AsyncRecordCache - update', function (hooks) {
             type: 'planetarySystem'
           });
           assert.deepEqual(
-            (latestHome?.relationships?.star.data as Record).id,
+            (latestHome?.relationships?.star.data as InitializedRecord).id,
             star1.id,
             'The original related record is in place.'
           );
@@ -1612,14 +1640,14 @@ module('AsyncRecordCache - update', function (hooks) {
           });
 
           assert.deepEqual(
-            (latestHome?.relationships?.star.data as Record).id,
+            (latestHome?.relationships?.star.data as InitializedRecord).id,
             star2.id,
             'The related record was replaced.'
           );
         });
 
         test("#update - updateRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
-          const earth: Record = {
+          const earth: InitializedRecord = {
             type: 'planet',
             id: '1',
             attributes: { name: 'Earth' },
@@ -1638,7 +1666,7 @@ module('AsyncRecordCache - update', function (hooks) {
         });
 
         test("#update - removeRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
-          const earth: Record = {
+          const earth: InitializedRecord = {
             type: 'planet',
             id: '1'
           };
@@ -1655,7 +1683,7 @@ module('AsyncRecordCache - update', function (hooks) {
         });
 
         test("#update - replaceKey - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
-          const earth: Record = {
+          const earth: InitializedRecord = {
             type: 'planet',
             id: '1',
             attributes: { name: 'Earth' },
@@ -1674,7 +1702,7 @@ module('AsyncRecordCache - update', function (hooks) {
         });
 
         test("#update - replaceAttribute - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", async function (assert) {
-          const earth: Record = {
+          const earth: InitializedRecord = {
             type: 'planet',
             id: '1',
             attributes: { name: 'Earth' },
@@ -1812,11 +1840,11 @@ module('AsyncRecordCache - update', function (hooks) {
           const one = (await cache.getRecordAsync({
             type: 'one',
             id: '1'
-          })) as Record;
+          })) as InitializedRecord;
           const two = (await cache.getRecordAsync({
             type: 'two',
             id: '2'
-          })) as Record;
+          })) as InitializedRecord;
           assert.ok(one, 'one exists');
           assert.ok(two, 'two exists');
           assert.deepEqual(
@@ -1833,8 +1861,10 @@ module('AsyncRecordCache - update', function (hooks) {
           await cache.update((t) => t.removeRecord(two));
 
           assert.equal(
-            ((await cache.getRecordAsync({ type: 'one', id: '1' })) as Record)
-              .relationships?.two.data,
+            ((await cache.getRecordAsync({
+              type: 'one',
+              id: '1'
+            })) as InitializedRecord).relationships?.two.data,
             null,
             'ones link to two got removed'
           );
@@ -1866,18 +1896,18 @@ module('AsyncRecordCache - update', function (hooks) {
             defaultTransformOptions
           });
 
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: 'p1',
             attributes: { name: 'Jupiter' }
           };
-          const io: Record = {
+          const io: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Io' },
             relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
           };
-          const europa: Record = {
+          const europa: InitializedRecord = {
             type: 'moon',
             id: 'm2',
             attributes: { name: 'Europa' },
@@ -1928,18 +1958,18 @@ module('AsyncRecordCache - update', function (hooks) {
             defaultTransformOptions
           });
 
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: 'p1',
             attributes: { name: 'Jupiter' }
           };
-          const io: Record = {
+          const io: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Io' },
             relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
           };
-          const europa: Record = {
+          const europa: InitializedRecord = {
             type: 'moon',
             id: 'm2',
             attributes: { name: 'Europa' },
@@ -1990,18 +2020,18 @@ module('AsyncRecordCache - update', function (hooks) {
             defaultTransformOptions
           });
 
-          const jupiter: Record = {
+          const jupiter: InitializedRecord = {
             type: 'planet',
             id: 'p1',
             attributes: { name: 'Jupiter' }
           };
-          const io: Record = {
+          const io: InitializedRecord = {
             type: 'moon',
             id: 'm1',
             attributes: { name: 'Io' },
             relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
           };
-          const europa: Record = {
+          const europa: InitializedRecord = {
             type: 'moon',
             id: 'm2',
             attributes: { name: 'Europa' },

--- a/packages/@orbit/record-cache/test/operation-processors/schema-consistency-processor-test.ts
+++ b/packages/@orbit/record-cache/test/operation-processors/schema-consistency-processor-test.ts
@@ -3,7 +3,6 @@ import {
   RecordKeyMap,
   RecordSchema,
   RecordSchemaSettings,
-  Record,
   AddToRelatedRecordsOperation,
   ReplaceRelatedRecordOperation,
   ReplaceRelatedRecordsOperation,
@@ -1000,7 +999,7 @@ module('SchemaConsistencyProcessor', function (hooks) {
       processors: [SyncSchemaConsistencyProcessor]
     });
     processor = cache.processors[0] as SyncSchemaConsistencyProcessor;
-    const jupiter: Record = {
+    const jupiter = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -1012,12 +1011,12 @@ module('SchemaConsistencyProcessor', function (hooks) {
         }
       }
     };
-    const io: Record = {
+    const io = {
       type: 'moon',
       id: 'io',
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    const europa: Record = {
+    const europa = {
       type: 'moon',
       id: 'europa',
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
@@ -1090,7 +1089,7 @@ module('SchemaConsistencyProcessor', function (hooks) {
       processors: [SyncSchemaConsistencyProcessor]
     });
     processor = cache.processors[0] as SyncSchemaConsistencyProcessor;
-    const jupiter: Record = {
+    const jupiter = {
       type: 'planet',
       id: 'jupiter',
       relationships: {
@@ -1102,12 +1101,12 @@ module('SchemaConsistencyProcessor', function (hooks) {
         }
       }
     };
-    const io: Record = {
+    const io = {
       type: 'moon',
       id: 'io',
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    const europa: Record = {
+    const europa = {
       type: 'moon',
       id: 'europa',
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }

--- a/packages/@orbit/record-cache/test/support/example-async-record-cache.ts
+++ b/packages/@orbit/record-cache/test/support/example-async-record-cache.ts
@@ -1,6 +1,10 @@
 /* eslint-disable valid-jsdoc */
 import { clone, deepGet, deepSet, Dict, objectValues } from '@orbit/utils';
-import { Record, RecordIdentity, equalRecordIdentities } from '@orbit/records';
+import {
+  InitializedRecord,
+  RecordIdentity,
+  equalRecordIdentities
+} from '@orbit/records';
 import { RecordRelationshipIdentity } from '../../src/record-accessor';
 import {
   AsyncRecordCache,
@@ -11,7 +15,7 @@ import {
  * A minimal implementation of `AsyncRecordCache`.
  */
 export class ExampleAsyncRecordCache extends AsyncRecordCache {
-  protected _records: Dict<Dict<Record>>;
+  protected _records: Dict<Dict<InitializedRecord>>;
   protected _inverseRelationships: Dict<Dict<RecordRelationshipIdentity[]>>;
 
   constructor(settings: AsyncRecordCacheSettings) {
@@ -26,17 +30,19 @@ export class ExampleAsyncRecordCache extends AsyncRecordCache {
     });
   }
 
-  async getRecordAsync(identity: RecordIdentity): Promise<Record | undefined> {
+  async getRecordAsync(
+    identity: RecordIdentity
+  ): Promise<InitializedRecord | undefined> {
     return deepGet(this._records, [identity.type, identity.id]);
   }
 
   async getRecordsAsync(
     typeOrIdentities?: string | RecordIdentity[]
-  ): Promise<Record[]> {
+  ): Promise<InitializedRecord[]> {
     if (typeof typeOrIdentities === 'string') {
       return objectValues(this._records[typeOrIdentities]);
     } else if (Array.isArray(typeOrIdentities)) {
-      const records: Record[] = [];
+      const records: InitializedRecord[] = [];
       const identities: RecordIdentity[] = typeOrIdentities;
       for (let i of identities) {
         let record = await this.getRecordAsync(i);
@@ -50,11 +56,11 @@ export class ExampleAsyncRecordCache extends AsyncRecordCache {
     }
   }
 
-  async setRecordAsync(record: Record): Promise<void> {
+  async setRecordAsync(record: InitializedRecord): Promise<void> {
     deepSet(this._records, [record.type, record.id], record);
   }
 
-  async setRecordsAsync(records: Record[]): Promise<void> {
+  async setRecordsAsync(records: InitializedRecord[]): Promise<void> {
     for (let record of records) {
       deepSet(this._records, [record.type, record.id], record);
     }
@@ -62,7 +68,7 @@ export class ExampleAsyncRecordCache extends AsyncRecordCache {
 
   async removeRecordAsync(
     recordIdentity: RecordIdentity
-  ): Promise<Record | undefined> {
+  ): Promise<InitializedRecord | undefined> {
     const record = await this.getRecordAsync(recordIdentity);
     if (record) {
       delete this._records[recordIdentity.type][recordIdentity.id];
@@ -74,7 +80,7 @@ export class ExampleAsyncRecordCache extends AsyncRecordCache {
 
   async removeRecordsAsync(
     recordIdentities: RecordIdentity[]
-  ): Promise<Record[]> {
+  ): Promise<InitializedRecord[]> {
     const records = [];
     for (let recordIdentity of recordIdentities) {
       let record = await this.getRecordAsync(recordIdentity);

--- a/packages/@orbit/record-cache/test/support/example-sync-record-cache.ts
+++ b/packages/@orbit/record-cache/test/support/example-sync-record-cache.ts
@@ -1,6 +1,10 @@
 /* eslint-disable valid-jsdoc */
 import { clone, deepGet, deepSet, Dict, objectValues } from '@orbit/utils';
-import { Record, RecordIdentity, equalRecordIdentities } from '@orbit/records';
+import {
+  InitializedRecord,
+  RecordIdentity,
+  equalRecordIdentities
+} from '@orbit/records';
 import { RecordRelationshipIdentity } from '../../src/record-accessor';
 import {
   SyncRecordCache,
@@ -11,7 +15,7 @@ import {
  * A minimal implementation of `SyncRecordCache`.
  */
 export class ExampleSyncRecordCache extends SyncRecordCache {
-  protected _records: Dict<Dict<Record>>;
+  protected _records: Dict<Dict<InitializedRecord>>;
   protected _inverseRelationships: Dict<Dict<RecordRelationshipIdentity[]>>;
 
   constructor(settings: SyncRecordCacheSettings) {
@@ -26,15 +30,17 @@ export class ExampleSyncRecordCache extends SyncRecordCache {
     });
   }
 
-  getRecordSync(identity: RecordIdentity): Record | undefined {
+  getRecordSync(identity: RecordIdentity): InitializedRecord | undefined {
     return deepGet(this._records, [identity.type, identity.id]);
   }
 
-  getRecordsSync(typeOrIdentities?: string | RecordIdentity[]): Record[] {
+  getRecordsSync(
+    typeOrIdentities?: string | RecordIdentity[]
+  ): InitializedRecord[] {
     if (typeof typeOrIdentities === 'string') {
       return objectValues(this._records[typeOrIdentities]);
     } else if (Array.isArray(typeOrIdentities)) {
-      const records: Record[] = [];
+      const records: InitializedRecord[] = [];
       const identities: RecordIdentity[] = typeOrIdentities;
       for (let i of identities) {
         let record = this.getRecordSync(i);
@@ -48,17 +54,19 @@ export class ExampleSyncRecordCache extends SyncRecordCache {
     }
   }
 
-  setRecordSync(record: Record): void {
+  setRecordSync(record: InitializedRecord): void {
     deepSet(this._records, [record.type, record.id], record);
   }
 
-  setRecordsSync(records: Record[]): void {
+  setRecordsSync(records: InitializedRecord[]): void {
     for (let record of records) {
       deepSet(this._records, [record.type, record.id], record);
     }
   }
 
-  removeRecordSync(recordIdentity: RecordIdentity): Record | undefined {
+  removeRecordSync(
+    recordIdentity: RecordIdentity
+  ): InitializedRecord | undefined {
     const record = this.getRecordSync(recordIdentity);
     if (record) {
       delete this._records[recordIdentity.type][recordIdentity.id];
@@ -68,7 +76,7 @@ export class ExampleSyncRecordCache extends SyncRecordCache {
     }
   }
 
-  removeRecordsSync(recordIdentities: RecordIdentity[]): Record[] {
+  removeRecordsSync(recordIdentities: RecordIdentity[]): InitializedRecord[] {
     const records = [];
     for (let recordIdentity of recordIdentities) {
       let record = this.getRecordSync(recordIdentity);

--- a/packages/@orbit/record-cache/test/sync-record-cache-patch-test.ts
+++ b/packages/@orbit/record-cache/test/sync-record-cache-patch-test.ts
@@ -1,7 +1,7 @@
 import {
   equalRecordIdentities,
   RecordKeyMap,
-  Record,
+  InitializedRecord,
   RecordIdentity,
   recordsInclude,
   recordsIncludeAll,
@@ -25,7 +25,7 @@ module('SyncRecordCache', function (hooks) {
 
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: '1',
       attributes: { name: 'Earth' },
@@ -59,7 +59,7 @@ module('SyncRecordCache', function (hooks) {
 
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: '1',
       attributes: { name: 'Earth' },
@@ -98,7 +98,7 @@ module('SyncRecordCache', function (hooks) {
 
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const earth: Record = { type: 'planet', id: '1' };
+    const earth: InitializedRecord = { type: 'planet', id: '1' };
 
     cache.on('patch', (operation, data) => {
       assert.deepEqual(operation, {
@@ -152,25 +152,29 @@ module('SyncRecordCache', function (hooks) {
   test('#patch updates inverse hasOne relationship when a record with relationships unspecified is added - record added after', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' },
       relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
     };
-    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' } };
+    const io: InitializedRecord = {
+      type: 'moon',
+      id: 'm1',
+      attributes: { name: 'Io' }
+    };
 
     cache.patch((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
 
     assert.deepEqual(
-      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as InitializedRecord)
         ?.relationships?.moons.data,
       [{ type: 'moon', id: 'm1' }],
       'Io has been assigned to Jupiter'
     );
     assert.deepEqual(
-      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)?.relationships
-        ?.planet.data,
+      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
+        ?.relationships?.planet.data,
       { type: 'planet', id: 'p1' },
       'Jupiter has been assigned to Io'
     );
@@ -179,25 +183,29 @@ module('SyncRecordCache', function (hooks) {
   test('#patch updates inverse hasOne relationship when a record with relationships unspecified is added - record added before', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' },
       relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
     };
-    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' } };
+    const io: InitializedRecord = {
+      type: 'moon',
+      id: 'm1',
+      attributes: { name: 'Io' }
+    };
 
     cache.patch((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
 
     assert.deepEqual(
-      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as InitializedRecord)
         ?.relationships?.moons.data,
       [{ type: 'moon', id: 'm1' }],
       'Io has been assigned to Jupiter'
     );
     assert.deepEqual(
-      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)?.relationships
-        ?.planet.data,
+      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
+        ?.relationships?.planet.data,
       { type: 'planet', id: 'p1' },
       'Jupiter has been assigned to Io'
     );
@@ -206,13 +214,13 @@ module('SyncRecordCache', function (hooks) {
   test('#patch updates inverse hasMany relationship when a record with relationships unspecified is added - record added after', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const io: Record = {
+    const io: InitializedRecord = {
       type: 'moon',
       id: 'm1',
       attributes: { name: 'Io' },
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' }
@@ -221,14 +229,14 @@ module('SyncRecordCache', function (hooks) {
     cache.patch((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
 
     assert.deepEqual(
-      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as InitializedRecord)
         ?.relationships?.moons.data,
       [{ type: 'moon', id: 'm1' }],
       'Io has been assigned to Jupiter'
     );
     assert.deepEqual(
-      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)?.relationships
-        ?.planet.data,
+      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
+        ?.relationships?.planet.data,
       { type: 'planet', id: 'p1' },
       'Jupiter has been assigned to Io'
     );
@@ -237,13 +245,13 @@ module('SyncRecordCache', function (hooks) {
   test('#patch updates inverse hasMany relationship when a record with relationships unspecified is added - record added before', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const io: Record = {
+    const io: InitializedRecord = {
       type: 'moon',
       id: 'm1',
       attributes: { name: 'Io' },
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' }
@@ -252,14 +260,14 @@ module('SyncRecordCache', function (hooks) {
     cache.patch((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
 
     assert.deepEqual(
-      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as InitializedRecord)
         ?.relationships?.moons.data,
       [{ type: 'moon', id: 'm1' }],
       'Io has been assigned to Jupiter'
     );
     assert.deepEqual(
-      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)?.relationships
-        ?.planet.data,
+      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
+        ?.relationships?.planet.data,
       { type: 'planet', id: 'p1' },
       'Jupiter has been assigned to Io'
     );
@@ -268,13 +276,13 @@ module('SyncRecordCache', function (hooks) {
   test('#patch updates inverse hasOne relationship when a record with an empty relationship is added', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const io: Record = {
+    const io: InitializedRecord = {
       type: 'moon',
       id: 'm1',
       attributes: { name: 'Io' },
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' },
@@ -284,14 +292,14 @@ module('SyncRecordCache', function (hooks) {
     cache.patch((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
 
     assert.deepEqual(
-      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as InitializedRecord)
         ?.relationships?.moons.data,
       [],
       'Jupiter has no moons'
     );
     assert.deepEqual(
-      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)?.relationships
-        ?.planet.data,
+      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
+        ?.relationships?.planet.data,
       null,
       'Jupiter has been cleared from Io'
     );
@@ -300,13 +308,13 @@ module('SyncRecordCache', function (hooks) {
   test('#patch updates inverse hasMany relationship when a record with an empty relationship is added', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' },
       relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
     };
-    const io: Record = {
+    const io: InitializedRecord = {
       type: 'moon',
       id: 'm1',
       attributes: { name: 'Io' },
@@ -316,14 +324,14 @@ module('SyncRecordCache', function (hooks) {
     cache.patch((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
 
     assert.deepEqual(
-      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as InitializedRecord)
         ?.relationships?.moons.data,
       [],
       'Io has been cleared from Jupiter'
     );
     assert.deepEqual(
-      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)?.relationships
-        ?.planet.data,
+      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
+        ?.relationships?.planet.data,
       null,
       'Io has no planet'
     );
@@ -332,7 +340,7 @@ module('SyncRecordCache', function (hooks) {
   test('#patch updates inverse hasMany polymorphic relationship', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const sun: Record = {
+    const sun: InitializedRecord = {
       type: 'star',
       id: 's1',
       attributes: { name: 'Sun' },
@@ -345,12 +353,16 @@ module('SyncRecordCache', function (hooks) {
         }
       }
     };
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' }
     };
-    const io: Record = { type: 'moon', id: 'm1', attributes: { name: 'Io' } };
+    const io: InitializedRecord = {
+      type: 'moon',
+      id: 'm1',
+      attributes: { name: 'Io' }
+    };
 
     cache.patch((t) => [
       t.updateRecord(sun),
@@ -359,8 +371,8 @@ module('SyncRecordCache', function (hooks) {
     ]);
 
     assert.deepEqual(
-      (cache.getRecordSync({ type: 'star', id: 's1' }) as Record)?.relationships
-        ?.celestialObjects.data,
+      (cache.getRecordSync({ type: 'star', id: 's1' }) as InitializedRecord)
+        ?.relationships?.celestialObjects.data,
       [
         { type: 'planet', id: 'p1' },
         { type: 'moon', id: 'm1' }
@@ -368,14 +380,14 @@ module('SyncRecordCache', function (hooks) {
       'Jupiter and Io has been assigned to Sun'
     );
     assert.deepEqual(
-      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as InitializedRecord)
         ?.relationships?.star.data,
       { type: 'star', id: 's1' },
       'Sun has been assigned to Jupiter'
     );
     assert.deepEqual(
-      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)?.relationships
-        ?.star.data,
+      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
+        ?.relationships?.star.data,
       { type: 'star', id: 's1' },
       'Sun has been assigned to Io'
     );
@@ -384,19 +396,23 @@ module('SyncRecordCache', function (hooks) {
   test('#patch updates inverse hasOne polymorphic relationship', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' },
       relationships: { star: { data: { type: 'star', id: 's1' } } }
     };
-    const io: Record = {
+    const io: InitializedRecord = {
       type: 'moon',
       id: 'm1',
       attributes: { name: 'Io' },
       relationships: { star: { data: { type: 'star', id: 's1' } } }
     };
-    const sun: Record = { type: 'star', id: 's1', attributes: { name: 'Sun' } };
+    const sun: InitializedRecord = {
+      type: 'star',
+      id: 's1',
+      attributes: { name: 'Sun' }
+    };
 
     cache.patch((t) => [
       t.updateRecord(jupiter),
@@ -405,8 +421,8 @@ module('SyncRecordCache', function (hooks) {
     ]);
 
     assert.deepEqual(
-      (cache.getRecordSync({ type: 'star', id: 's1' }) as Record)?.relationships
-        ?.celestialObjects.data,
+      (cache.getRecordSync({ type: 'star', id: 's1' }) as InitializedRecord)
+        ?.relationships?.celestialObjects.data,
       [
         { type: 'planet', id: 'p1' },
         { type: 'moon', id: 'm1' }
@@ -414,14 +430,14 @@ module('SyncRecordCache', function (hooks) {
       'Jupiter and Io has been assigned to Sun'
     );
     assert.deepEqual(
-      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as InitializedRecord)
         ?.relationships?.star.data,
       { type: 'star', id: 's1' },
       'Sun has been assigned to Jupiter'
     );
     assert.deepEqual(
-      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)?.relationships
-        ?.star.data,
+      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
+        ?.relationships?.star.data,
       { type: 'star', id: 's1' },
       'Sun has been assigned to Io'
     );
@@ -430,19 +446,19 @@ module('SyncRecordCache', function (hooks) {
   test('#patch tracks refs and clears them from hasOne relationships when a referenced record is removed', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' },
       relationships: { moons: { data: undefined } }
     };
-    const io: Record = {
+    const io: InitializedRecord = {
       type: 'moon',
       id: 'm1',
       attributes: { name: 'Io' },
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
-    const europa: Record = {
+    const europa: InitializedRecord = {
       type: 'moon',
       id: 'm2',
       attributes: { name: 'Europa' },
@@ -456,14 +472,14 @@ module('SyncRecordCache', function (hooks) {
     ]);
 
     assert.deepEqual(
-      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)?.relationships
-        ?.planet.data,
+      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
+        ?.relationships?.planet.data,
       { type: 'planet', id: 'p1' },
       'Jupiter has been assigned to Io'
     );
     assert.deepEqual(
-      (cache.getRecordSync({ type: 'moon', id: 'm2' }) as Record)?.relationships
-        ?.planet.data,
+      (cache.getRecordSync({ type: 'moon', id: 'm2' }) as InitializedRecord)
+        ?.relationships?.planet.data,
       { type: 'planet', id: 'p1' },
       'Jupiter has been assigned to Europa'
     );
@@ -477,14 +493,14 @@ module('SyncRecordCache', function (hooks) {
     );
 
     assert.equal(
-      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)?.relationships
-        ?.planet.data,
+      (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
+        ?.relationships?.planet.data,
       undefined,
       'Jupiter has been cleared from Io'
     );
     assert.equal(
-      (cache.getRecordSync({ type: 'moon', id: 'm2' }) as Record)?.relationships
-        ?.planet.data,
+      (cache.getRecordSync({ type: 'moon', id: 'm2' }) as InitializedRecord)
+        ?.relationships?.planet.data,
       undefined,
       'Jupiter has been cleared from Europa'
     );
@@ -493,19 +509,19 @@ module('SyncRecordCache', function (hooks) {
   test('#patch tracks refs and clears them from hasMany relationships when a referenced record is removed', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const io: Record = {
+    const io: InitializedRecord = {
       type: 'moon',
       id: 'm1',
       attributes: { name: 'Io' },
       relationships: { planet: { data: null } }
     };
-    const europa: Record = {
+    const europa: InitializedRecord = {
       type: 'moon',
       id: 'm2',
       attributes: { name: 'Europa' },
       relationships: { planet: { data: null } }
     };
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' },
@@ -526,7 +542,7 @@ module('SyncRecordCache', function (hooks) {
     ]);
 
     assert.deepEqual(
-      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as InitializedRecord)
         ?.relationships?.moons.data,
       [
         { type: 'moon', id: 'm1' },
@@ -586,7 +602,7 @@ module('SyncRecordCache', function (hooks) {
     );
 
     assert.deepEqual(
-      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
+      (cache.getRecordSync({ type: 'planet', id: 'p1' }) as InitializedRecord)
         ?.relationships?.moons.data,
       [{ type: 'moon', id: 'm1' }],
       'relationship was added'
@@ -693,7 +709,7 @@ module('SyncRecordCache', function (hooks) {
 
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'p1',
       type: 'planet',
       attributes: { name: 'Jupiter' },
@@ -718,7 +734,7 @@ module('SyncRecordCache', function (hooks) {
 
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'p1',
       type: 'planet',
       attributes: { name: 'Jupiter' }
@@ -742,10 +758,10 @@ module('SyncRecordCache', function (hooks) {
 
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = { id: 'jupiter', type: 'planet' };
+    const jupiter: InitializedRecord = { id: 'jupiter', type: 'planet' };
     cache.patch((t) => t.addRecord(jupiter));
 
-    const callisto: Record = { id: 'callisto', type: 'moon' };
+    const callisto: InitializedRecord = { id: 'callisto', type: 'moon' };
     cache.patch((t) => t.addRecord(callisto));
 
     cache.patch((t) =>
@@ -781,10 +797,10 @@ module('SyncRecordCache', function (hooks) {
 
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = { id: 'jupiter', type: 'planet' };
+    const jupiter: InitializedRecord = { id: 'jupiter', type: 'planet' };
     cache.patch((t) => t.addRecord(jupiter));
 
-    const callisto: Record = { id: 'callisto', type: 'moon' };
+    const callisto: InitializedRecord = { id: 'callisto', type: 'moon' };
     cache.patch((t) => t.addRecord(callisto));
 
     cache.patch((t) =>
@@ -818,7 +834,7 @@ module('SyncRecordCache', function (hooks) {
 
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const europa: Record = {
+    const europa: InitializedRecord = {
       id: 'm1',
       type: 'moon',
       attributes: { name: 'Europa' },
@@ -843,7 +859,7 @@ module('SyncRecordCache', function (hooks) {
 
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const europa: Record = {
+    const europa: InitializedRecord = {
       type: 'moon',
       id: 'm1',
       attributes: { name: 'Europa' },
@@ -898,8 +914,14 @@ module('SyncRecordCache', function (hooks) {
       })
     ]);
 
-    const one = cache.getRecordSync({ type: 'one', id: '1' }) as Record;
-    const two = cache.getRecordSync({ type: 'two', id: '2' }) as Record;
+    const one = cache.getRecordSync({
+      type: 'one',
+      id: '1'
+    }) as InitializedRecord;
+    const two = cache.getRecordSync({
+      type: 'two',
+      id: '2'
+    }) as InitializedRecord;
     assert.ok(one, 'one exists');
     assert.ok(two, 'two exists');
     assert.deepEqual(
@@ -916,8 +938,8 @@ module('SyncRecordCache', function (hooks) {
     cache.patch((t) => t.removeRecord(two));
 
     assert.equal(
-      (cache.getRecordSync({ type: 'one', id: '1' }) as Record).relationships
-        ?.two.data,
+      (cache.getRecordSync({ type: 'one', id: '1' }) as InitializedRecord)
+        .relationships?.two.data,
       null,
       'ones link to two got removed'
     );
@@ -944,18 +966,18 @@ module('SyncRecordCache', function (hooks) {
       keyMap
     });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' }
     };
-    const io: Record = {
+    const io: InitializedRecord = {
       type: 'moon',
       id: 'm1',
       attributes: { name: 'Io' },
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
-    const europa: Record = {
+    const europa: InitializedRecord = {
       type: 'moon',
       id: 'm2',
       attributes: { name: 'Europa' },
@@ -1005,18 +1027,18 @@ module('SyncRecordCache', function (hooks) {
       keyMap
     });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' }
     };
-    const io: Record = {
+    const io: InitializedRecord = {
       type: 'moon',
       id: 'm1',
       attributes: { name: 'Io' },
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
-    const europa: Record = {
+    const europa: InitializedRecord = {
       type: 'moon',
       id: 'm2',
       attributes: { name: 'Europa' },
@@ -1066,18 +1088,18 @@ module('SyncRecordCache', function (hooks) {
       keyMap
     });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'p1',
       attributes: { name: 'Jupiter' }
     };
-    const io: Record = {
+    const io: InitializedRecord = {
       type: 'moon',
       id: 'm1',
       attributes: { name: 'Io' },
       relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
     };
-    const europa: Record = {
+    const europa: InitializedRecord = {
       type: 'moon',
       id: 'm2',
       attributes: { name: 'Europa' },
@@ -1255,14 +1277,14 @@ module('SyncRecordCache', function (hooks) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
     const tb = cache.transformBuilder;
 
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: '1',
       attributes: { name: 'Earth' },
       relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
     };
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: '1',
       attributes: { name: 'Jupiter', classification: 'terrestrial' },
@@ -1473,7 +1495,7 @@ module('SyncRecordCache', function (hooks) {
       type: 'planetarySystem'
     });
     assert.deepEqual(
-      (latestHome?.relationships?.star.data as Record).id,
+      (latestHome?.relationships?.star.data as InitializedRecord).id,
       star1.id,
       'The original related record is in place.'
     );
@@ -1496,7 +1518,7 @@ module('SyncRecordCache', function (hooks) {
     });
 
     assert.deepEqual(
-      (latestHome?.relationships?.star.data as Record).id,
+      (latestHome?.relationships?.star.data as InitializedRecord).id,
       star2.id,
       'The related record was replaced.'
     );

--- a/packages/@orbit/record-cache/test/sync-record-cache-query-test.ts
+++ b/packages/@orbit/record-cache/test/sync-record-cache-query-test.ts
@@ -1,6 +1,6 @@
 import {
   RecordKeyMap,
-  Record,
+  InitializedRecord,
   RecordNotFoundException,
   RecordSchema
 } from '@orbit/records';
@@ -21,7 +21,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query can retrieve an individual record', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -31,9 +31,11 @@ module('SyncRecordCache - query', function (hooks) {
       }
     };
 
-    const updatedRecord = cache.update<Record>((t) => [t.addRecord(jupiter)]);
+    const updatedRecord = cache.update<InitializedRecord>((t) => [
+      t.addRecord(jupiter)
+    ]);
 
-    const foundRecord = cache.query<Record>((q) =>
+    const foundRecord = cache.query<InitializedRecord>((q) =>
       q.findRecord({ type: 'planet', id: 'jupiter' })
     );
 
@@ -44,7 +46,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query can retrieve multiple expressions', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -53,7 +55,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -76,7 +78,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query can find records by type', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -85,7 +87,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -94,7 +96,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -103,7 +105,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -122,7 +124,7 @@ module('SyncRecordCache - query', function (hooks) {
 
     arrayMembershipMatches(
       assert,
-      cache.query((q) => q.findRecords('planet')) as Record[],
+      cache.query((q) => q.findRecords('planet')) as InitializedRecord[],
       [jupiter, earth, venus, mercury]
     );
   });
@@ -130,7 +132,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query can find records by identities', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -139,7 +141,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -148,7 +150,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -157,7 +159,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -182,7 +184,7 @@ module('SyncRecordCache - query', function (hooks) {
           { type: 'planet', id: 'venus' },
           { type: 'planet', id: 'FAKE' }
         ])
-      ) as Record[],
+      ) as InitializedRecord[],
       [jupiter, venus]
     );
   });
@@ -190,7 +192,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query can perform a simple attribute filter by value equality', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -199,7 +201,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -208,7 +210,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -217,7 +219,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -238,7 +240,7 @@ module('SyncRecordCache - query', function (hooks) {
       assert,
       cache.query((q) =>
         q.findRecords('planet').filter({ attribute: 'name', value: 'Jupiter' })
-      ) as Record[],
+      ) as InitializedRecord[],
       [jupiter]
     );
   });
@@ -246,7 +248,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query can perform a simple attribute filter by value comparison (gt, lt, gte & lte)', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -256,7 +258,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -266,7 +268,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -276,7 +278,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -299,7 +301,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRecords('planet')
           .filter({ attribute: 'sequence', value: 2, op: 'gt' })
-      ) as Record[],
+      ) as InitializedRecord[],
       [earth, jupiter]
     );
     arrayMembershipMatches(
@@ -308,7 +310,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRecords('planet')
           .filter({ attribute: 'sequence', value: 2, op: 'gte' })
-      ) as Record[],
+      ) as InitializedRecord[],
       [venus, earth, jupiter]
     );
     arrayMembershipMatches(
@@ -317,7 +319,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRecords('planet')
           .filter({ attribute: 'sequence', value: 2, op: 'lt' })
-      ) as Record[],
+      ) as InitializedRecord[],
       [mercury]
     );
     arrayMembershipMatches(
@@ -326,7 +328,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRecords('planet')
           .filter({ attribute: 'sequence', value: 2, op: 'lte' })
-      ) as Record[],
+      ) as InitializedRecord[],
       [venus, mercury]
     );
     arrayMembershipMatches(
@@ -338,7 +340,7 @@ module('SyncRecordCache - query', function (hooks) {
             { attribute: 'sequence', value: 2, op: 'gte' },
             { attribute: 'sequence', value: 4, op: 'lt' }
           )
-      ) as Record[],
+      ) as InitializedRecord[],
       [venus, earth]
     );
   });
@@ -346,7 +348,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query can perform relatedRecords filters with operators `equal`, `all`, `some` and `none`', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -365,7 +367,7 @@ module('SyncRecordCache - query', function (hooks) {
         }
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -376,7 +378,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { moons: { data: [{ type: 'moon', id: 'moon' }] } }
     };
-    const mars: Record = {
+    const mars: InitializedRecord = {
       type: 'planet',
       id: 'mars',
       attributes: {
@@ -394,7 +396,7 @@ module('SyncRecordCache - query', function (hooks) {
         }
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -404,43 +406,43 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: false
       }
     };
-    const theMoon: Record = {
+    const theMoon: InitializedRecord = {
       id: 'moon',
       type: 'moon',
       attributes: { name: 'The moon' },
       relationships: { planet: { data: { type: 'planet', id: 'earth' } } }
     };
-    const europa: Record = {
+    const europa: InitializedRecord = {
       id: 'europa',
       type: 'moon',
       attributes: { name: 'Europa' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    const ganymede: Record = {
+    const ganymede: InitializedRecord = {
       id: 'ganymede',
       type: 'moon',
       attributes: { name: 'Ganymede' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    const callisto: Record = {
+    const callisto: InitializedRecord = {
       id: 'callisto',
       type: 'moon',
       attributes: { name: 'Callisto' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    const phobos: Record = {
+    const phobos: InitializedRecord = {
       id: 'phobos',
       type: 'moon',
       attributes: { name: 'Phobos' },
       relationships: { planet: { data: { type: 'planet', id: 'mars' } } }
     };
-    const deimos: Record = {
+    const deimos: InitializedRecord = {
       id: 'deimos',
       type: 'moon',
       attributes: { name: 'Deimos' },
       relationships: { planet: { data: { type: 'planet', id: 'mars' } } }
     };
-    const titan: Record = {
+    const titan: InitializedRecord = {
       id: 'titan',
       type: 'moon',
       attributes: { name: 'titan' },
@@ -466,7 +468,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [theMoon], op: 'equal' })
-      ) as Record[],
+      ) as InitializedRecord[],
       [earth]
     );
     arrayMembershipMatches(
@@ -475,7 +477,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [phobos], op: 'equal' })
-      ) as Record[],
+      ) as InitializedRecord[],
       []
     );
     arrayMembershipMatches(
@@ -484,7 +486,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [phobos], op: 'all' })
-      ) as Record[],
+      ) as InitializedRecord[],
       [mars]
     );
     arrayMembershipMatches(
@@ -493,7 +495,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [phobos, callisto], op: 'all' })
-      ) as Record[],
+      ) as InitializedRecord[],
       []
     );
     arrayMembershipMatches(
@@ -504,7 +506,7 @@ module('SyncRecordCache - query', function (hooks) {
           records: [phobos, callisto],
           op: 'some'
         })
-      ) as Record[],
+      ) as InitializedRecord[],
       [mars, jupiter]
     );
     arrayMembershipMatches(
@@ -513,7 +515,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [titan], op: 'some' })
-      ) as Record[],
+      ) as InitializedRecord[],
       []
     );
     arrayMembershipMatches(
@@ -522,7 +524,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRecords('planet')
           .filter({ relation: 'moons', records: [ganymede], op: 'none' })
-      ) as Record[],
+      ) as InitializedRecord[],
       [earth, mars]
     );
   });
@@ -530,7 +532,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query can perform relatedRecord filters', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -549,7 +551,7 @@ module('SyncRecordCache - query', function (hooks) {
         }
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -560,7 +562,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { moons: { data: [{ type: 'moon', id: 'moon' }] } }
     };
-    const mars: Record = {
+    const mars: InitializedRecord = {
       type: 'planet',
       id: 'mars',
       attributes: {
@@ -578,7 +580,7 @@ module('SyncRecordCache - query', function (hooks) {
         }
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -588,43 +590,43 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: false
       }
     };
-    const theMoon: Record = {
+    const theMoon: InitializedRecord = {
       id: 'moon',
       type: 'moon',
       attributes: { name: 'The moon' },
       relationships: { planet: { data: { type: 'planet', id: 'earth' } } }
     };
-    const europa: Record = {
+    const europa: InitializedRecord = {
       id: 'europa',
       type: 'moon',
       attributes: { name: 'Europa' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    const ganymede: Record = {
+    const ganymede: InitializedRecord = {
       id: 'ganymede',
       type: 'moon',
       attributes: { name: 'Ganymede' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    const callisto: Record = {
+    const callisto: InitializedRecord = {
       id: 'callisto',
       type: 'moon',
       attributes: { name: 'Callisto' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    const phobos: Record = {
+    const phobos: InitializedRecord = {
       id: 'phobos',
       type: 'moon',
       attributes: { name: 'Phobos' },
       relationships: { planet: { data: { type: 'planet', id: 'mars' } } }
     };
-    const deimos: Record = {
+    const deimos: InitializedRecord = {
       id: 'deimos',
       type: 'moon',
       attributes: { name: 'Deimos' },
       relationships: { planet: { data: { type: 'planet', id: 'mars' } } }
     };
-    const titan: Record = {
+    const titan: InitializedRecord = {
       id: 'titan',
       type: 'moon',
       attributes: { name: 'titan' },
@@ -648,28 +650,28 @@ module('SyncRecordCache - query', function (hooks) {
       assert,
       cache.query((q) =>
         q.findRecords('moon').filter({ relation: 'planet', record: null })
-      ) as Record[],
+      ) as InitializedRecord[],
       [titan]
     );
     arrayMembershipMatches(
       assert,
       cache.query((q) =>
         q.findRecords('moon').filter({ relation: 'planet', record: earth })
-      ) as Record[],
+      ) as InitializedRecord[],
       [theMoon]
     );
     arrayMembershipMatches(
       assert,
       cache.query((q) =>
         q.findRecords('moon').filter({ relation: 'planet', record: jupiter })
-      ) as Record[],
+      ) as InitializedRecord[],
       [europa, ganymede, callisto]
     );
     arrayMembershipMatches(
       assert,
       cache.query((q) =>
         q.findRecords('moon').filter({ relation: 'planet', record: mercury })
-      ) as Record[],
+      ) as InitializedRecord[],
       []
     );
     arrayMembershipMatches(
@@ -678,7 +680,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRecords('moon')
           .filter({ relation: 'planet', record: [earth, mars] })
-      ) as Record[],
+      ) as InitializedRecord[],
       [theMoon, phobos, deimos]
     );
   });
@@ -686,7 +688,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query can perform a complex attribute filter by value', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -695,7 +697,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -704,7 +706,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -713,7 +715,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -739,7 +741,7 @@ module('SyncRecordCache - query', function (hooks) {
             { attribute: 'atmosphere', value: true },
             { attribute: 'classification', value: 'terrestrial' }
           )
-      ) as Record[],
+      ) as InitializedRecord[],
       [earth, venus]
     );
   });
@@ -747,8 +749,8 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query can perform a filter on attributes, even when a particular record has none', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = { type: 'planet', id: 'jupiter' };
-    const earth: Record = {
+    const jupiter: InitializedRecord = { type: 'planet', id: 'jupiter' };
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -757,7 +759,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -766,7 +768,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -792,7 +794,7 @@ module('SyncRecordCache - query', function (hooks) {
             { attribute: 'atmosphere', value: true },
             { attribute: 'classification', value: 'terrestrial' }
           )
-      ) as Record[],
+      ) as InitializedRecord[],
       [earth, venus]
     );
   });
@@ -800,7 +802,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query can sort by an attribute', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -809,7 +811,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -818,7 +820,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -827,7 +829,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -853,8 +855,8 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query can sort by an attribute, even when a particular record has none', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = { type: 'planet', id: 'jupiter' };
-    const earth: Record = {
+    const jupiter: InitializedRecord = { type: 'planet', id: 'jupiter' };
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -863,7 +865,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -872,7 +874,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -898,7 +900,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query can filter and sort by attributes', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -907,7 +909,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -916,7 +918,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -925,7 +927,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -959,7 +961,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query can sort by an attribute in descending order', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -968,7 +970,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -977,7 +979,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -986,7 +988,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -1012,7 +1014,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query can sort by according to multiple criteria', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -1021,7 +1023,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -1030,7 +1032,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -1039,7 +1041,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -1067,7 +1069,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query - findRecord - finds record', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'jupiter',
       type: 'planet',
       attributes: { name: 'Jupiter' },
@@ -1108,14 +1110,14 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query - findRecords - finds matching records', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'jupiter',
       type: 'planet',
       attributes: { name: 'Jupiter' },
       relationships: { moons: { data: [{ type: 'moon', id: 'callisto' }] } }
     };
 
-    const callisto: Record = {
+    const callisto: InitializedRecord = {
       id: 'callisto',
       type: 'moon',
       attributes: { name: 'Callisto' },
@@ -1133,25 +1135,25 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query - page - can paginate records by offset and limit', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'jupiter',
       type: 'planet',
       attributes: { name: 'Jupiter' }
     };
 
-    const earth: Record = {
+    const earth: InitializedRecord = {
       id: 'earth',
       type: 'planet',
       attributes: { name: 'Earth' }
     };
 
-    const venus: Record = {
+    const venus: InitializedRecord = {
       id: 'venus',
       type: 'planet',
       attributes: { name: 'Venus' }
     };
 
-    const mars: Record = {
+    const mars: InitializedRecord = {
       id: 'mars',
       type: 'planet',
       attributes: { name: 'Mars' }
@@ -1187,14 +1189,14 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'jupiter',
       type: 'planet',
       attributes: { name: 'Jupiter' },
       relationships: { moons: { data: [{ type: 'moon', id: 'callisto' }] } }
     };
 
-    const callisto: Record = {
+    const callisto: InitializedRecord = {
       id: 'callisto',
       type: 'moon',
       attributes: { name: 'Callisto' },
@@ -1214,7 +1216,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords - returns empty array if there are no related records', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'jupiter',
       type: 'planet',
       attributes: { name: 'Jupiter' }
@@ -1260,14 +1262,14 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecord', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'jupiter',
       type: 'planet',
       attributes: { name: 'Jupiter' },
       relationships: { moons: { data: [{ type: 'moon', id: 'callisto' }] } }
     };
 
-    const callisto: Record = {
+    const callisto: InitializedRecord = {
       id: 'callisto',
       type: 'moon',
       attributes: { name: 'Callisto' },
@@ -1287,7 +1289,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecord - return null if no related record is found', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const callisto: Record = {
+    const callisto: InitializedRecord = {
       id: 'callisto',
       type: 'moon',
       attributes: { name: 'Callisto' }
@@ -1333,7 +1335,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords can perform a simple attribute filter by value equality', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const sun: Record = {
+    const sun: InitializedRecord = {
       type: 'star',
       id: 'sun',
       relationships: {
@@ -1348,7 +1350,7 @@ module('SyncRecordCache - query', function (hooks) {
       }
     };
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -1358,7 +1360,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -1368,7 +1370,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -1378,7 +1380,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -1403,7 +1405,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ attribute: 'name', value: 'Jupiter' })
-      ) as Record[],
+      ) as InitializedRecord[],
       [jupiter]
     );
   });
@@ -1411,7 +1413,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords - can perform a simple attribute filter by value comparison (gt, lt, gte & lte)', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const sun: Record = {
+    const sun: InitializedRecord = {
       type: 'star',
       id: 'sun',
       relationships: {
@@ -1426,7 +1428,7 @@ module('SyncRecordCache - query', function (hooks) {
       }
     };
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -1437,7 +1439,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -1448,7 +1450,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -1459,7 +1461,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -1484,7 +1486,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ attribute: 'sequence', value: 2, op: 'gt' })
-      ) as Record[],
+      ) as InitializedRecord[],
       [earth, jupiter]
     );
     arrayMembershipMatches(
@@ -1493,7 +1495,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ attribute: 'sequence', value: 2, op: 'gte' })
-      ) as Record[],
+      ) as InitializedRecord[],
       [venus, earth, jupiter]
     );
     arrayMembershipMatches(
@@ -1502,7 +1504,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ attribute: 'sequence', value: 2, op: 'lt' })
-      ) as Record[],
+      ) as InitializedRecord[],
       [mercury]
     );
     arrayMembershipMatches(
@@ -1511,7 +1513,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ attribute: 'sequence', value: 2, op: 'lte' })
-      ) as Record[],
+      ) as InitializedRecord[],
       [venus, mercury]
     );
   });
@@ -1519,7 +1521,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords - can perform relatedRecords filters with operators `equal`, `all`, `some` and `none`', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const sun: Record = {
+    const sun: InitializedRecord = {
       type: 'star',
       id: 'sun',
       relationships: {
@@ -1534,7 +1536,7 @@ module('SyncRecordCache - query', function (hooks) {
       }
     };
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -1554,7 +1556,7 @@ module('SyncRecordCache - query', function (hooks) {
         }
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -1568,7 +1570,7 @@ module('SyncRecordCache - query', function (hooks) {
         moons: { data: [{ type: 'moon', id: 'moon' }] }
       }
     };
-    const mars: Record = {
+    const mars: InitializedRecord = {
       type: 'planet',
       id: 'mars',
       attributes: {
@@ -1587,7 +1589,7 @@ module('SyncRecordCache - query', function (hooks) {
         }
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -1598,43 +1600,43 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const theMoon: Record = {
+    const theMoon: InitializedRecord = {
       id: 'moon',
       type: 'moon',
       attributes: { name: 'The moon' },
       relationships: { planet: { data: { type: 'planet', id: 'earth' } } }
     };
-    const europa: Record = {
+    const europa: InitializedRecord = {
       id: 'europa',
       type: 'moon',
       attributes: { name: 'Europa' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    const ganymede: Record = {
+    const ganymede: InitializedRecord = {
       id: 'ganymede',
       type: 'moon',
       attributes: { name: 'Ganymede' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    const callisto: Record = {
+    const callisto: InitializedRecord = {
       id: 'callisto',
       type: 'moon',
       attributes: { name: 'Callisto' },
       relationships: { planet: { data: { type: 'planet', id: 'jupiter' } } }
     };
-    const phobos: Record = {
+    const phobos: InitializedRecord = {
       id: 'phobos',
       type: 'moon',
       attributes: { name: 'Phobos' },
       relationships: { planet: { data: { type: 'planet', id: 'mars' } } }
     };
-    const deimos: Record = {
+    const deimos: InitializedRecord = {
       id: 'deimos',
       type: 'moon',
       attributes: { name: 'Deimos' },
       relationships: { planet: { data: { type: 'planet', id: 'mars' } } }
     };
-    const titan: Record = {
+    const titan: InitializedRecord = {
       id: 'titan',
       type: 'moon',
       attributes: { name: 'titan' },
@@ -1661,7 +1663,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'moons', records: [theMoon], op: 'equal' })
-      ) as Record[],
+      ) as InitializedRecord[],
       [earth]
     );
     arrayMembershipMatches(
@@ -1670,7 +1672,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'moons', records: [phobos], op: 'equal' })
-      ) as Record[],
+      ) as InitializedRecord[],
       []
     );
     arrayMembershipMatches(
@@ -1679,7 +1681,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'moons', records: [phobos], op: 'all' })
-      ) as Record[],
+      ) as InitializedRecord[],
       [mars]
     );
     arrayMembershipMatches(
@@ -1688,7 +1690,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'moons', records: [phobos, callisto], op: 'all' })
-      ) as Record[],
+      ) as InitializedRecord[],
       []
     );
     arrayMembershipMatches(
@@ -1699,7 +1701,7 @@ module('SyncRecordCache - query', function (hooks) {
           records: [phobos, callisto],
           op: 'some'
         })
-      ) as Record[],
+      ) as InitializedRecord[],
       [mars, jupiter]
     );
     arrayMembershipMatches(
@@ -1708,7 +1710,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'moons', records: [titan], op: 'some' })
-      ) as Record[],
+      ) as InitializedRecord[],
       []
     );
     arrayMembershipMatches(
@@ -1717,7 +1719,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'moons', records: [ganymede], op: 'none' })
-      ) as Record[],
+      ) as InitializedRecord[],
       [earth, mars]
     );
   });
@@ -1725,7 +1727,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords - can perform relatedRecord filters', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const sun: Record = {
+    const sun: InitializedRecord = {
       type: 'star',
       id: 'sun',
       relationships: {
@@ -1747,7 +1749,7 @@ module('SyncRecordCache - query', function (hooks) {
       }
     };
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -1767,7 +1769,7 @@ module('SyncRecordCache - query', function (hooks) {
         }
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -1781,7 +1783,7 @@ module('SyncRecordCache - query', function (hooks) {
         moons: { data: [{ type: 'moon', id: 'moon' }] }
       }
     };
-    const mars: Record = {
+    const mars: InitializedRecord = {
       type: 'planet',
       id: 'mars',
       attributes: {
@@ -1800,7 +1802,7 @@ module('SyncRecordCache - query', function (hooks) {
         }
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -1811,7 +1813,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const theMoon: Record = {
+    const theMoon: InitializedRecord = {
       id: 'moon',
       type: 'moon',
       attributes: { name: 'The moon' },
@@ -1820,7 +1822,7 @@ module('SyncRecordCache - query', function (hooks) {
         star: { data: { type: 'star', id: 'sun' } }
       }
     };
-    const europa: Record = {
+    const europa: InitializedRecord = {
       id: 'europa',
       type: 'moon',
       attributes: { name: 'Europa' },
@@ -1829,7 +1831,7 @@ module('SyncRecordCache - query', function (hooks) {
         star: { data: { type: 'star', id: 'sun' } }
       }
     };
-    const ganymede: Record = {
+    const ganymede: InitializedRecord = {
       id: 'ganymede',
       type: 'moon',
       attributes: { name: 'Ganymede' },
@@ -1838,7 +1840,7 @@ module('SyncRecordCache - query', function (hooks) {
         star: { data: { type: 'star', id: 'sun' } }
       }
     };
-    const callisto: Record = {
+    const callisto: InitializedRecord = {
       id: 'callisto',
       type: 'moon',
       attributes: { name: 'Callisto' },
@@ -1847,7 +1849,7 @@ module('SyncRecordCache - query', function (hooks) {
         star: { data: { type: 'star', id: 'sun' } }
       }
     };
-    const phobos: Record = {
+    const phobos: InitializedRecord = {
       id: 'phobos',
       type: 'moon',
       attributes: { name: 'Phobos' },
@@ -1856,7 +1858,7 @@ module('SyncRecordCache - query', function (hooks) {
         star: { data: { type: 'star', id: 'sun' } }
       }
     };
-    const deimos: Record = {
+    const deimos: InitializedRecord = {
       id: 'deimos',
       type: 'moon',
       attributes: { name: 'Deimos' },
@@ -1865,7 +1867,7 @@ module('SyncRecordCache - query', function (hooks) {
         star: { data: { type: 'star', id: 'sun' } }
       }
     };
-    const titan: Record = {
+    const titan: InitializedRecord = {
       id: 'titan',
       type: 'moon',
       attributes: { name: 'titan' },
@@ -1895,7 +1897,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'planet', record: null })
-      ) as Record[],
+      ) as InitializedRecord[],
       [titan]
     );
     arrayMembershipMatches(
@@ -1904,7 +1906,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(earth, 'moons')
           .filter({ relation: 'planet', record: earth })
-      ) as Record[],
+      ) as InitializedRecord[],
       [theMoon]
     );
     arrayMembershipMatches(
@@ -1913,7 +1915,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(jupiter, 'moons')
           .filter({ relation: 'planet', record: jupiter })
-      ) as Record[],
+      ) as InitializedRecord[],
       [europa, ganymede, callisto]
     );
     arrayMembershipMatches(
@@ -1922,7 +1924,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(mercury, 'moons')
           .filter({ relation: 'planet', record: mercury })
-      ) as Record[],
+      ) as InitializedRecord[],
       []
     );
     arrayMembershipMatches(
@@ -1931,7 +1933,7 @@ module('SyncRecordCache - query', function (hooks) {
         q
           .findRelatedRecords(sun, 'celestialObjects')
           .filter({ relation: 'planet', record: [earth, mars] })
-      ) as Record[],
+      ) as InitializedRecord[],
       [theMoon, phobos, deimos]
     );
   });
@@ -1939,7 +1941,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords - can perform a complex attribute filter by value', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const sun: Record = {
+    const sun: InitializedRecord = {
       type: 'star',
       id: 'sun',
       relationships: {
@@ -1954,7 +1956,7 @@ module('SyncRecordCache - query', function (hooks) {
       }
     };
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -1964,7 +1966,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -1974,7 +1976,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -1984,7 +1986,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -2012,7 +2014,7 @@ module('SyncRecordCache - query', function (hooks) {
             { attribute: 'atmosphere', value: true },
             { attribute: 'classification', value: 'terrestrial' }
           )
-      ) as Record[],
+      ) as InitializedRecord[],
       [earth, venus]
     );
   });
@@ -2020,7 +2022,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords - can perform a filter on attributes, even when a particular record has none', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const sun: Record = {
+    const sun: InitializedRecord = {
       type: 'star',
       id: 'sun',
       relationships: {
@@ -2035,12 +2037,12 @@ module('SyncRecordCache - query', function (hooks) {
       }
     };
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -2050,7 +2052,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -2060,7 +2062,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -2088,7 +2090,7 @@ module('SyncRecordCache - query', function (hooks) {
             { attribute: 'atmosphere', value: true },
             { attribute: 'classification', value: 'terrestrial' }
           )
-      ) as Record[],
+      ) as InitializedRecord[],
       [earth, venus]
     );
   });
@@ -2096,7 +2098,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords - can sort by an attribute', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const sun: Record = {
+    const sun: InitializedRecord = {
       type: 'star',
       id: 'sun',
       relationships: {
@@ -2111,7 +2113,7 @@ module('SyncRecordCache - query', function (hooks) {
       }
     };
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -2121,7 +2123,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -2131,7 +2133,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -2141,7 +2143,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -2171,7 +2173,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords - can sort by an attribute, even when a particular record has none', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const sun: Record = {
+    const sun: InitializedRecord = {
       type: 'star',
       id: 'sun',
       relationships: {
@@ -2186,8 +2188,8 @@ module('SyncRecordCache - query', function (hooks) {
       }
     };
 
-    const jupiter: Record = { type: 'planet', id: 'jupiter' };
-    const earth: Record = {
+    const jupiter: InitializedRecord = { type: 'planet', id: 'jupiter' };
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -2197,7 +2199,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -2207,7 +2209,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -2237,7 +2239,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords - can filter and sort by attributes', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const sun: Record = {
+    const sun: InitializedRecord = {
       type: 'star',
       id: 'sun',
       relationships: {
@@ -2252,7 +2254,7 @@ module('SyncRecordCache - query', function (hooks) {
       }
     };
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -2262,7 +2264,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -2272,7 +2274,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -2282,7 +2284,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -2318,7 +2320,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords - can sort by an attribute in descending order', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const sun: Record = {
+    const sun: InitializedRecord = {
       type: 'star',
       id: 'sun',
       relationships: {
@@ -2333,7 +2335,7 @@ module('SyncRecordCache - query', function (hooks) {
       }
     };
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -2343,7 +2345,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -2353,7 +2355,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -2363,7 +2365,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -2393,7 +2395,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords - can sort by according to multiple criteria', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const sun: Record = {
+    const sun: InitializedRecord = {
       type: 'star',
       id: 'sun',
       relationships: {
@@ -2408,7 +2410,7 @@ module('SyncRecordCache - query', function (hooks) {
       }
     };
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -2418,7 +2420,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -2428,7 +2430,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -2438,7 +2440,7 @@ module('SyncRecordCache - query', function (hooks) {
       },
       relationships: { star: { data: { type: 'star', id: 'sun' } } }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -2470,7 +2472,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#query - findRelatedRecords - page - can paginate records by offset and limit', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const sun: Record = {
+    const sun: InitializedRecord = {
       type: 'star',
       id: 'sun',
       relationships: {
@@ -2485,7 +2487,7 @@ module('SyncRecordCache - query', function (hooks) {
       }
     };
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'jupiter',
       type: 'planet',
       attributes: { name: 'Jupiter' },
@@ -2552,7 +2554,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#liveQuery', async function (assert) {
     let cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       id: 'jupiter',
       type: 'planet',
       attributes: { name: 'Jupiter' }
@@ -2563,7 +2565,7 @@ module('SyncRecordCache - query', function (hooks) {
       attributes: { name: 'Jupiter 2' }
     };
 
-    const callisto: Record = {
+    const callisto: InitializedRecord = {
       id: 'callisto',
       type: 'moon',
       attributes: { name: 'Callisto' },
@@ -2769,7 +2771,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#liveQuery findRecords (debounce)', async function (assert) {
     let cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const planets: Record[] = [
+    const planets: InitializedRecord[] = [
       {
         id: 'planet1',
         type: 'planet',
@@ -2811,7 +2813,7 @@ module('SyncRecordCache - query', function (hooks) {
       debounceLiveQueries: false
     });
 
-    const planets: Record[] = [
+    const planets: InitializedRecord[] = [
       {
         id: 'planet1',
         type: 'planet',
@@ -2836,7 +2838,7 @@ module('SyncRecordCache - query', function (hooks) {
 
     const done = assert.async();
     livePlanets.subscribe((update) => {
-      const result = update.query() as Record[];
+      const result = update.query() as InitializedRecord[];
       assert.equal(result.length, i);
 
       if (i === 3) {
@@ -2851,7 +2853,7 @@ module('SyncRecordCache - query', function (hooks) {
   test('#liveQuery can apply attribute filters', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-    const jupiter: Record = {
+    const jupiter: InitializedRecord = {
       type: 'planet',
       id: 'jupiter',
       attributes: {
@@ -2861,7 +2863,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const earth: Record = {
+    const earth: InitializedRecord = {
       type: 'planet',
       id: 'earth',
       attributes: {
@@ -2871,7 +2873,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const venus: Record = {
+    const venus: InitializedRecord = {
       type: 'planet',
       id: 'venus',
       attributes: {
@@ -2881,7 +2883,7 @@ module('SyncRecordCache - query', function (hooks) {
         atmosphere: true
       }
     };
-    const mercury: Record = {
+    const mercury: InitializedRecord = {
       type: 'planet',
       id: 'mercury',
       attributes: {
@@ -2903,13 +2905,17 @@ module('SyncRecordCache - query', function (hooks) {
 
     const done = assert.async();
     livePlanets.subscribe((update) => {
-      const result = update.query() as Record[];
+      const result = update.query() as InitializedRecord[];
       arrayMembershipMatches(assert, result, [venus, earth]);
       done();
     });
 
     // liveQuery results are initially empty
-    arrayMembershipMatches(assert, livePlanets.query() as Record[], []);
+    arrayMembershipMatches(
+      assert,
+      livePlanets.query() as InitializedRecord[],
+      []
+    );
 
     // adding records should update liveQuery results
     cache.update((t) => [

--- a/packages/@orbit/record-cache/test/sync-record-cache-update-test.ts
+++ b/packages/@orbit/record-cache/test/sync-record-cache-update-test.ts
@@ -1,7 +1,7 @@
 import {
   equalRecordIdentities,
   RecordKeyMap,
-  Record,
+  InitializedRecord,
   RecordIdentity,
   recordsInclude,
   recordsIncludeAll,
@@ -37,7 +37,7 @@ module('SyncRecordCache', function (hooks) {
           defaultTransformOptions
         });
 
-        const earth: Record = {
+        const earth: InitializedRecord = {
           type: 'planet',
           id: '1',
           attributes: { name: 'Earth' },
@@ -71,7 +71,7 @@ module('SyncRecordCache', function (hooks) {
 
         const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-        const earth: Record = {
+        const earth: InitializedRecord = {
           type: 'planet',
           id: '1',
           attributes: { name: 'Earth' },
@@ -110,7 +110,7 @@ module('SyncRecordCache', function (hooks) {
 
         const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-        const earth: Record = { type: 'planet', id: '1' };
+        const earth: InitializedRecord = { type: 'planet', id: '1' };
 
         cache.on('patch', (operation, data) => {
           assert.deepEqual(operation, {
@@ -193,13 +193,13 @@ module('SyncRecordCache', function (hooks) {
       test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added after', function (assert) {
         const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' },
           relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' }
@@ -208,13 +208,15 @@ module('SyncRecordCache', function (hooks) {
         cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.moons.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.moons.data,
           [{ type: 'moon', id: 'm1' }],
           'Io has been assigned to Jupiter'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.planet.data,
           { type: 'planet', id: 'p1' },
           'Jupiter has been assigned to Io'
@@ -224,13 +226,13 @@ module('SyncRecordCache', function (hooks) {
       test('#update updates inverse hasOne relationship when a record with relationships unspecified is added - record added before', function (assert) {
         const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' },
           relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' }
@@ -239,13 +241,15 @@ module('SyncRecordCache', function (hooks) {
         cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.moons.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.moons.data,
           [{ type: 'moon', id: 'm1' }],
           'Io has been assigned to Jupiter'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.planet.data,
           { type: 'planet', id: 'p1' },
           'Jupiter has been assigned to Io'
@@ -255,13 +259,13 @@ module('SyncRecordCache', function (hooks) {
       test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added after', function (assert) {
         const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
         };
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' }
@@ -270,13 +274,15 @@ module('SyncRecordCache', function (hooks) {
         cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.moons.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.moons.data,
           [{ type: 'moon', id: 'm1' }],
           'Io has been assigned to Jupiter'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.planet.data,
           { type: 'planet', id: 'p1' },
           'Jupiter has been assigned to Io'
@@ -286,13 +292,13 @@ module('SyncRecordCache', function (hooks) {
       test('#update updates inverse hasMany relationship when a record with relationships unspecified is added - record added before', function (assert) {
         const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
         };
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' }
@@ -301,13 +307,15 @@ module('SyncRecordCache', function (hooks) {
         cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.moons.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.moons.data,
           [{ type: 'moon', id: 'm1' }],
           'Io has been assigned to Jupiter'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.planet.data,
           { type: 'planet', id: 'p1' },
           'Jupiter has been assigned to Io'
@@ -317,13 +325,13 @@ module('SyncRecordCache', function (hooks) {
       test('#update updates inverse hasOne relationship when a record with an empty relationship is added', function (assert) {
         const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
         };
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' },
@@ -333,13 +341,15 @@ module('SyncRecordCache', function (hooks) {
         cache.update((t) => [t.updateRecord(io), t.updateRecord(jupiter)]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.moons.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.moons.data,
           [],
           'Jupiter has no moons'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.planet.data,
           null,
           'Jupiter has been cleared from Io'
@@ -349,13 +359,13 @@ module('SyncRecordCache', function (hooks) {
       test('#update updates inverse hasMany relationship when a record with an empty relationship is added', function (assert) {
         const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' },
           relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
@@ -365,13 +375,15 @@ module('SyncRecordCache', function (hooks) {
         cache.update((t) => [t.updateRecord(jupiter), t.updateRecord(io)]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.moons.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.moons.data,
           [],
           'Io has been cleared from Jupiter'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.planet.data,
           null,
           'Io has no planet'
@@ -381,7 +393,7 @@ module('SyncRecordCache', function (hooks) {
       test('#update updates inverse hasMany polymorphic relationship', function (assert) {
         const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-        const sun: Record = {
+        const sun: InitializedRecord = {
           type: 'star',
           id: 's1',
           attributes: { name: 'Sun' },
@@ -394,12 +406,12 @@ module('SyncRecordCache', function (hooks) {
             }
           }
         };
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' }
@@ -412,7 +424,7 @@ module('SyncRecordCache', function (hooks) {
         ]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'star', id: 's1' }) as Record)
+          (cache.getRecordSync({ type: 'star', id: 's1' }) as InitializedRecord)
             ?.relationships?.celestialObjects.data,
           [
             { type: 'planet', id: 'p1' },
@@ -421,13 +433,15 @@ module('SyncRecordCache', function (hooks) {
           'Jupiter and Io has been assigned to Sun'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.star.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.star.data,
           { type: 'star', id: 's1' },
           'Sun has been assigned to Jupiter'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.star.data,
           { type: 'star', id: 's1' },
           'Sun has been assigned to Io'
@@ -437,19 +451,19 @@ module('SyncRecordCache', function (hooks) {
       test('#update updates inverse hasOne polymorphic relationship', function (assert) {
         const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' },
           relationships: { star: { data: { type: 'star', id: 's1' } } }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { star: { data: { type: 'star', id: 's1' } } }
         };
-        const sun: Record = {
+        const sun: InitializedRecord = {
           type: 'star',
           id: 's1',
           attributes: { name: 'Sun' }
@@ -462,7 +476,7 @@ module('SyncRecordCache', function (hooks) {
         ]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'star', id: 's1' }) as Record)
+          (cache.getRecordSync({ type: 'star', id: 's1' }) as InitializedRecord)
             ?.relationships?.celestialObjects.data,
           [
             { type: 'planet', id: 'p1' },
@@ -471,13 +485,15 @@ module('SyncRecordCache', function (hooks) {
           'Jupiter and Io has been assigned to Sun'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.star.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.star.data,
           { type: 'star', id: 's1' },
           'Sun has been assigned to Jupiter'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.star.data,
           { type: 'star', id: 's1' },
           'Sun has been assigned to Io'
@@ -487,19 +503,19 @@ module('SyncRecordCache', function (hooks) {
       test('#update tracks refs and clears them from hasOne relationships when a referenced record is removed', function (assert) {
         const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' },
           relationships: { moons: { data: undefined } }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
         };
-        const europa: Record = {
+        const europa: InitializedRecord = {
           type: 'moon',
           id: 'm2',
           attributes: { name: 'Europa' },
@@ -513,13 +529,13 @@ module('SyncRecordCache', function (hooks) {
         ]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.planet.data,
           { type: 'planet', id: 'p1' },
           'Jupiter has been assigned to Io'
         );
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'moon', id: 'm2' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm2' }) as InitializedRecord)
             ?.relationships?.planet.data,
           { type: 'planet', id: 'p1' },
           'Jupiter has been assigned to Europa'
@@ -534,13 +550,13 @@ module('SyncRecordCache', function (hooks) {
         );
 
         assert.equal(
-          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm1' }) as InitializedRecord)
             ?.relationships?.planet.data,
           undefined,
           'Jupiter has been cleared from Io'
         );
         assert.equal(
-          (cache.getRecordSync({ type: 'moon', id: 'm2' }) as Record)
+          (cache.getRecordSync({ type: 'moon', id: 'm2' }) as InitializedRecord)
             ?.relationships?.planet.data,
           undefined,
           'Jupiter has been cleared from Europa'
@@ -550,19 +566,19 @@ module('SyncRecordCache', function (hooks) {
       test('#update tracks refs and clears them from hasMany relationships when a referenced record is removed', function (assert) {
         const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { planet: { data: null } }
         };
-        const europa: Record = {
+        const europa: InitializedRecord = {
           type: 'moon',
           id: 'm2',
           attributes: { name: 'Europa' },
           relationships: { planet: { data: null } }
         };
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' },
@@ -583,8 +599,10 @@ module('SyncRecordCache', function (hooks) {
         ]);
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.moons.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.moons.data,
           [
             { type: 'moon', id: 'm1' },
             { type: 'moon', id: 'm2' }
@@ -643,8 +661,10 @@ module('SyncRecordCache', function (hooks) {
         );
 
         assert.deepEqual(
-          (cache.getRecordSync({ type: 'planet', id: 'p1' }) as Record)
-            ?.relationships?.moons.data,
+          (cache.getRecordSync({
+            type: 'planet',
+            id: 'p1'
+          }) as InitializedRecord)?.relationships?.moons.data,
           [{ type: 'moon', id: 'm1' }],
           'relationship was added'
         );
@@ -750,7 +770,7 @@ module('SyncRecordCache', function (hooks) {
 
         const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           id: 'p1',
           type: 'planet',
           attributes: { name: 'Jupiter' },
@@ -775,7 +795,7 @@ module('SyncRecordCache', function (hooks) {
 
         const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           id: 'p1',
           type: 'planet',
           attributes: { name: 'Jupiter' }
@@ -802,10 +822,10 @@ module('SyncRecordCache', function (hooks) {
 
         const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-        const jupiter: Record = { id: 'jupiter', type: 'planet' };
+        const jupiter: InitializedRecord = { id: 'jupiter', type: 'planet' };
         cache.update((t) => t.addRecord(jupiter));
 
-        const callisto: Record = { id: 'callisto', type: 'moon' };
+        const callisto: InitializedRecord = { id: 'callisto', type: 'moon' };
         cache.update((t) => t.addRecord(callisto));
 
         cache.update((t) =>
@@ -844,10 +864,10 @@ module('SyncRecordCache', function (hooks) {
 
         const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-        const jupiter: Record = { id: 'jupiter', type: 'planet' };
+        const jupiter: InitializedRecord = { id: 'jupiter', type: 'planet' };
         cache.update((t) => t.addRecord(jupiter));
 
-        const callisto: Record = { id: 'callisto', type: 'moon' };
+        const callisto: InitializedRecord = { id: 'callisto', type: 'moon' };
         cache.update((t) => t.addRecord(callisto));
 
         cache.update((t) =>
@@ -881,7 +901,7 @@ module('SyncRecordCache', function (hooks) {
 
         const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-        const europa: Record = {
+        const europa: InitializedRecord = {
           id: 'm1',
           type: 'moon',
           attributes: { name: 'Europa' },
@@ -906,7 +926,7 @@ module('SyncRecordCache', function (hooks) {
 
         const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-        const europa: Record = {
+        const europa: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Europa' },
@@ -964,8 +984,14 @@ module('SyncRecordCache', function (hooks) {
           })
         ]);
 
-        const one = cache.getRecordSync({ type: 'one', id: '1' }) as Record;
-        const two = cache.getRecordSync({ type: 'two', id: '2' }) as Record;
+        const one = cache.getRecordSync({
+          type: 'one',
+          id: '1'
+        }) as InitializedRecord;
+        const two = cache.getRecordSync({
+          type: 'two',
+          id: '2'
+        }) as InitializedRecord;
         assert.ok(one, 'one exists');
         assert.ok(two, 'two exists');
         assert.deepEqual(
@@ -982,7 +1008,7 @@ module('SyncRecordCache', function (hooks) {
         cache.update((t) => t.removeRecord(two));
 
         assert.equal(
-          (cache.getRecordSync({ type: 'one', id: '1' }) as Record)
+          (cache.getRecordSync({ type: 'one', id: '1' }) as InitializedRecord)
             .relationships?.two.data,
           null,
           'ones link to two got removed'
@@ -1010,18 +1036,18 @@ module('SyncRecordCache', function (hooks) {
           keyMap
         });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
         };
-        const europa: Record = {
+        const europa: InitializedRecord = {
           type: 'moon',
           id: 'm2',
           attributes: { name: 'Europa' },
@@ -1071,18 +1097,18 @@ module('SyncRecordCache', function (hooks) {
           keyMap
         });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
         };
-        const europa: Record = {
+        const europa: InitializedRecord = {
           type: 'moon',
           id: 'm2',
           attributes: { name: 'Europa' },
@@ -1132,18 +1158,18 @@ module('SyncRecordCache', function (hooks) {
           keyMap
         });
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: 'p1',
           attributes: { name: 'Jupiter' }
         };
-        const io: Record = {
+        const io: InitializedRecord = {
           type: 'moon',
           id: 'm1',
           attributes: { name: 'Io' },
           relationships: { planet: { data: { type: 'planet', id: 'p1' } } }
         };
-        const europa: Record = {
+        const europa: InitializedRecord = {
           type: 'moon',
           id: 'm2',
           attributes: { name: 'Europa' },
@@ -1405,14 +1431,14 @@ module('SyncRecordCache', function (hooks) {
         const cache = new ExampleSyncRecordCache({ schema, keyMap });
         const tb = cache.transformBuilder;
 
-        const earth: Record = {
+        const earth: InitializedRecord = {
           type: 'planet',
           id: '1',
           attributes: { name: 'Earth' },
           relationships: { moons: { data: [{ type: 'moon', id: 'm1' }] } }
         };
 
-        const jupiter: Record = {
+        const jupiter: InitializedRecord = {
           type: 'planet',
           id: '1',
           attributes: { name: 'Jupiter', classification: 'terrestrial' },
@@ -1800,7 +1826,7 @@ module('SyncRecordCache', function (hooks) {
           type: 'planetarySystem'
         });
         assert.deepEqual(
-          (latestHome?.relationships?.star.data as Record).id,
+          (latestHome?.relationships?.star.data as InitializedRecord).id,
           star1.id,
           'The original related record is in place.'
         );
@@ -1823,7 +1849,7 @@ module('SyncRecordCache', function (hooks) {
         });
 
         assert.deepEqual(
-          (latestHome?.relationships?.star.data as Record).id,
+          (latestHome?.relationships?.star.data as InitializedRecord).id,
           star2.id,
           'The related record was replaced.'
         );
@@ -1832,7 +1858,7 @@ module('SyncRecordCache', function (hooks) {
       test("#update - updateRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
         const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-        const earth: Record = {
+        const earth: InitializedRecord = {
           type: 'planet',
           id: '1',
           attributes: { name: 'Earth' },
@@ -1853,7 +1879,7 @@ module('SyncRecordCache', function (hooks) {
       test("#update - removeRecord - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
         const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-        const earth: Record = {
+        const earth: InitializedRecord = {
           type: 'planet',
           id: '1'
         };
@@ -1872,7 +1898,7 @@ module('SyncRecordCache', function (hooks) {
       test("#update - replaceKey - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
         const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-        const earth: Record = {
+        const earth: InitializedRecord = {
           type: 'planet',
           id: '1',
           attributes: { name: 'Earth' },
@@ -1893,7 +1919,7 @@ module('SyncRecordCache', function (hooks) {
       test("#update - replaceAttribute - throws RecordNotFoundException if record doesn't exist with `raiseNotFoundExceptions` option", function (assert) {
         const cache = new ExampleSyncRecordCache({ schema, keyMap });
 
-        const earth: Record = {
+        const earth: InitializedRecord = {
           type: 'planet',
           id: '1',
           attributes: { name: 'Earth' },

--- a/packages/@orbit/records/src/record-key-map.ts
+++ b/packages/@orbit/records/src/record-key-map.ts
@@ -1,5 +1,5 @@
 import { deepGet, deepSet, firstResult, Dict } from '@orbit/utils';
-import { Record, UninitializedRecord } from './record';
+import { InitializedRecord, UninitializedRecord } from './record';
 
 /**
  * Maintains a map between records' ids and keys.
@@ -37,7 +37,7 @@ export class RecordKeyMap {
   /**
    * Store the id and key values of a record in this key map.
    */
-  pushRecord(record: Record | UninitializedRecord): void {
+  pushRecord(record: InitializedRecord | UninitializedRecord): void {
     const { type, id, keys } = record;
 
     if (!keys || !id) {

--- a/packages/@orbit/records/src/record-operation.ts
+++ b/packages/@orbit/records/src/record-operation.ts
@@ -1,7 +1,7 @@
 import { eq, deepGet, deepSet } from '@orbit/utils';
 import { Operation } from '@orbit/data';
 import {
-  Record,
+  InitializedRecord,
   RecordIdentity,
   cloneRecordIdentity,
   equalRecordIdentities,
@@ -14,7 +14,7 @@ import {
  */
 export interface AddRecordOperation extends Operation {
   op: 'addRecord';
-  record: Record;
+  record: InitializedRecord;
 }
 
 /**
@@ -22,7 +22,7 @@ export interface AddRecordOperation extends Operation {
  */
 export interface UpdateRecordOperation extends Operation {
   op: 'updateRecord';
-  record: Record;
+  record: InitializedRecord;
 }
 
 /**
@@ -107,7 +107,7 @@ export type RecordOperation =
   | ReplaceRelatedRecordsOperation
   | ReplaceRelatedRecordOperation;
 
-export type AddRecordOperationResult = Record;
+export type AddRecordOperationResult = InitializedRecord;
 export type UpdateRecordOperationResult = undefined;
 export type RemoveRecordOperationResult = undefined;
 export type ReplaceKeyOperationResult = undefined;
@@ -117,7 +117,7 @@ export type RemoveFromRelatedRecordsOperationResult = undefined;
 export type ReplaceRelatedRecordsOperationResult = undefined;
 export type ReplaceRelatedRecordOperationResult = undefined;
 
-export type RecordOperationResult<T = Record> = T | undefined;
+export type RecordOperationResult<T = InitializedRecord> = T | undefined;
 
 function markOperationToDelete(operation: Operation): void {
   const o: any = operation;
@@ -261,12 +261,8 @@ function mergeOperations(
           superceded.op === 'updateRecord' ||
           (superceded as any).op === 'replaceRecord'
         ) {
-          let record: Record = superceded.record;
-          if (
-            record.relationships &&
-            record.relationships[superceding.relationship] &&
-            record.relationships[superceding.relationship].data
-          ) {
+          let record: InitializedRecord = superceded.record;
+          if (record.relationships?.[superceding.relationship]?.data) {
             updateRecordAddToHasMany(
               superceded.record,
               superceding.relationship,
@@ -291,12 +287,8 @@ function mergeOperations(
           superceded.op === 'updateRecord' ||
           (superceded as any).op === 'replaceRecord'
         ) {
-          let record: Record = superceded.record;
-          if (
-            record.relationships &&
-            record.relationships[superceding.relationship] &&
-            record.relationships[superceding.relationship].data
-          ) {
+          let record: InitializedRecord = superceded.record;
+          if (record.relationships?.[superceding.relationship]?.data) {
             updateRecordRemoveFromHasMany(
               superceded.record,
               superceding.relationship,
@@ -330,7 +322,7 @@ function isReplaceFieldOp(op: string): boolean {
 }
 
 function updateRecordReplaceAttribute(
-  record: Record,
+  record: InitializedRecord,
   attribute: string,
   value: unknown
 ) {
@@ -338,7 +330,7 @@ function updateRecordReplaceAttribute(
 }
 
 function updateRecordReplaceHasOne(
-  record: Record,
+  record: InitializedRecord,
   relationship: string,
   relatedRecord: RecordIdentity | null
 ) {
@@ -350,7 +342,7 @@ function updateRecordReplaceHasOne(
 }
 
 function updateRecordReplaceHasMany(
-  record: Record,
+  record: InitializedRecord,
   relationship: string,
   relatedRecords: RecordIdentity[]
 ) {
@@ -362,7 +354,7 @@ function updateRecordReplaceHasMany(
 }
 
 function updateRecordAddToHasMany(
-  record: Record,
+  record: InitializedRecord,
   relationship: string,
   relatedRecord: RecordIdentity
 ) {
@@ -372,7 +364,7 @@ function updateRecordAddToHasMany(
 }
 
 function updateRecordRemoveFromHasMany(
-  record: Record,
+  record: InitializedRecord,
   relationship: string,
   relatedRecord: RecordIdentity
 ) {
@@ -426,15 +418,15 @@ export function coalesceRecordOperations(
  * of a set of operations.
  */
 export function recordDiffs(
-  record: Record,
-  updatedRecord: Record
+  record: InitializedRecord,
+  updatedRecord: InitializedRecord
 ): RecordOperation[] {
   const ops: RecordOperation[] = [];
 
   if (record && updatedRecord) {
     let fullRecordUpdate = false;
     const recordIdentity = cloneRecordIdentity(record);
-    const diffRecord: Record = { ...recordIdentity };
+    const diffRecord: InitializedRecord = { ...recordIdentity };
 
     for (let member in updatedRecord) {
       if (member !== 'id' && member !== 'type') {

--- a/packages/@orbit/records/src/record-query-expression.ts
+++ b/packages/@orbit/records/src/record-query-expression.ts
@@ -1,5 +1,5 @@
 import { QueryExpression } from '@orbit/data';
-import { RecordIdentity, Record } from './record';
+import { RecordIdentity, InitializedRecord } from './record';
 
 export type SortOrder = 'ascending' | 'descending';
 
@@ -97,12 +97,12 @@ export type RecordQueryExpression =
   | FindRelatedRecords
   | FindRecords;
 
-export type FindRecordResult = Record | undefined;
-export type FindRelatedRecordResult = Record | null | undefined;
-export type FindRelatedRecordsResult = Record[] | undefined;
-export type FindRecordsResult = Record[];
+export type FindRecordResult = InitializedRecord | undefined;
+export type FindRelatedRecordResult = InitializedRecord | null | undefined;
+export type FindRelatedRecordsResult = InitializedRecord[] | undefined;
+export type FindRecordsResult = InitializedRecord[];
 
-export type RecordQueryExpressionResult<T = Record> =
+export type RecordQueryExpressionResult<T = InitializedRecord> =
   | T
   | T[]
   | null

--- a/packages/@orbit/records/src/record-query.ts
+++ b/packages/@orbit/records/src/record-query.ts
@@ -1,5 +1,5 @@
 import { Query, QueryOrExpressions } from '@orbit/data';
-import { Record } from './record';
+import { InitializedRecord } from './record';
 import { RecordQueryBuilder } from './record-query-builder';
 import {
   RecordQueryExpression,
@@ -15,6 +15,6 @@ export type RecordQueryOrExpressions = QueryOrExpressions<
   RecordQueryBuilder
 >;
 
-export type RecordQueryResult<T = Record> =
+export type RecordQueryResult<T = InitializedRecord> =
   | RecordQueryExpressionResult<T>
   | RecordQueryExpressionResult<T>[];

--- a/packages/@orbit/records/src/record-schema.ts
+++ b/packages/@orbit/records/src/record-schema.ts
@@ -3,7 +3,11 @@ import { fulfillAll, Orbit } from '@orbit/core';
 import { ModelNotFound } from './record-exceptions';
 import { Dict } from '@orbit/utils';
 import { evented, Evented } from '@orbit/core';
-import { Record, RecordInitializer, UninitializedRecord } from './record';
+import {
+  InitializedRecord,
+  RecordInitializer,
+  UninitializedRecord
+} from './record';
 
 const { uuid, deprecate } = Orbit;
 
@@ -189,11 +193,11 @@ export class RecordSchema {
     }
   }
 
-  initializeRecord(record: UninitializedRecord): Record {
+  initializeRecord(record: UninitializedRecord): InitializedRecord {
     if (record.id === undefined) {
       record.id = this.generateId(record.type);
     }
-    return record as Record;
+    return record as InitializedRecord;
   }
 
   get models(): Dict<ModelDefinition> {

--- a/packages/@orbit/records/src/record-transform-builder.ts
+++ b/packages/@orbit/records/src/record-transform-builder.ts
@@ -1,7 +1,7 @@
 import { Orbit } from '@orbit/core';
 import { TransformBuilderFunc } from '@orbit/data';
 import {
-  Record,
+  InitializedRecord,
   RecordIdentity,
   RecordInitializer,
   UninitializedRecord
@@ -44,8 +44,8 @@ export class RecordTransformBuilder {
   /**
    * Instantiate a new `addRecord` operation.
    */
-  addRecord(newRecord: Record | UninitializedRecord): AddRecordTerm {
-    let record: Record;
+  addRecord(newRecord: UninitializedRecord): AddRecordTerm {
+    let record: InitializedRecord;
 
     if (this._recordInitializer) {
       record = this._recordInitializer.initializeRecord(newRecord);
@@ -55,10 +55,10 @@ export class RecordTransformBuilder {
           'The `RecordInitializer` assigned to the `TransformBuilder` exhibits deprecated behavior. `initializeRecord` should return a record.'
         );
         // Assume that `initializeRecord` is following its old signature and initializing the passed `record`.
-        record = newRecord as Record;
+        record = newRecord as InitializedRecord;
       }
     } else {
-      record = newRecord as Record;
+      record = newRecord as InitializedRecord;
     }
 
     assert(
@@ -72,7 +72,7 @@ export class RecordTransformBuilder {
   /**
    * Instantiate a new `updateRecord` operation.
    */
-  updateRecord(record: Record): UpdateRecordTerm {
+  updateRecord(record: InitializedRecord): UpdateRecordTerm {
     return new UpdateRecordTerm(record);
   }
 

--- a/packages/@orbit/records/src/record-transform.ts
+++ b/packages/@orbit/records/src/record-transform.ts
@@ -1,5 +1,5 @@
 import { RecordOperation, RecordOperationResult } from './record-operation';
-import { Record } from './record';
+import { InitializedRecord } from './record';
 import { Transform, TransformOrOperations } from '@orbit/data';
 import { RecordTransformBuilder } from './record-transform-builder';
 
@@ -12,6 +12,6 @@ export type RecordTransformOrOperations = TransformOrOperations<
   RecordTransformBuilder
 >;
 
-export type RecordTransformResult<T = Record> =
+export type RecordTransformResult<T = InitializedRecord> =
   | RecordOperationResult<T>
   | RecordOperationResult<T>[];

--- a/packages/@orbit/records/src/record.ts
+++ b/packages/@orbit/records/src/record.ts
@@ -36,7 +36,12 @@ export interface RecordFields {
   meta?: Dict<any>;
 }
 
+/**
+ * @deprecated since v0.17, use alias `InitializedRecord` instead
+ */
 export interface Record extends RecordFields, RecordIdentity {}
+
+export interface InitializedRecord extends RecordFields, RecordIdentity {}
 
 export interface UninitializedRecord extends RecordFields {
   type: string;
@@ -44,7 +49,7 @@ export interface UninitializedRecord extends RecordFields {
 }
 
 export interface RecordInitializer {
-  initializeRecord(record: UninitializedRecord): Record;
+  initializeRecord(record: UninitializedRecord): InitializedRecord;
 }
 
 export function cloneRecordIdentity(identity: RecordIdentity): RecordIdentity {
@@ -134,9 +139,12 @@ export function recordsIncludeAll(
   );
 }
 
-export function mergeRecords(current: Record | null, updates: Record): Record {
+export function mergeRecords(
+  current: InitializedRecord | null,
+  updates: InitializedRecord
+): InitializedRecord {
   if (current) {
-    let record: Record = cloneRecordIdentity(current);
+    let record: InitializedRecord = cloneRecordIdentity(current);
 
     // Merge `meta` and `links`, replacing whole sections rather than merging
     // individual members

--- a/packages/@orbit/records/test/record-transform-builder-test.ts
+++ b/packages/@orbit/records/test/record-transform-builder-test.ts
@@ -1,4 +1,4 @@
-import { Record, UninitializedRecord } from '../src/record';
+import { InitializedRecord, UninitializedRecord } from '../src/record';
 import { RecordTransformBuilder } from '../src/record-transform-builder';
 import {
   AddRecordOperation,
@@ -234,11 +234,11 @@ module('RecordTransformBuilder', function (hooks) {
 
   test('#addRecord - when a recordInitializer has been set', function (assert) {
     const recordInitializer = {
-      initializeRecord(record: UninitializedRecord): Record {
+      initializeRecord(record: UninitializedRecord): InitializedRecord {
         if (record.id === undefined) {
           record.id = 'abc123';
         }
-        return record as Record;
+        return record as InitializedRecord;
       }
     };
 


### PR DESCRIPTION
Orbit's `Record` interface conflicts with the built-in TS `Record`. This is confusing for humans as well our editors, because it makes auto-completion and auto-import a bit annoying.

`Record` is now deprecated in favor of `InitializedRecord`, which pairs nicely with its sibling `UninitializedRecord`.

Closes #816