### PR TITLE
Support use of a transform builder in Syncable

### DIFF
--- a/packages/@orbit/records/src/record-source-interfaces/record-syncable.ts
+++ b/packages/@orbit/records/src/record-source-interfaces/record-syncable.ts
@@ -1,4 +1,5 @@
 import { Syncable } from '@orbit/data';
 import { RecordOperation } from '../record-operation';
+import { RecordTransformBuilder } from '../record-transform-builder';
 
-export type RecordSyncable = Syncable<RecordOperation>;
+export type RecordSyncable = Syncable<RecordOperation, RecordTransformBuilder>;


### PR DESCRIPTION
Adds support for calling `sync` with a function that expects a transform builder argument. Improves ergonomics of using `sync` directly.

Closes #796