### PR TITLE
Add debug setting to `Orbit` global

### DIFF
--- a/packages/@orbit/coordinator/src/strategy.ts
+++ b/packages/@orbit/coordinator/src/strategy.ts
@@ -1,4 +1,4 @@
-import Orbit, { Assertion } from '@orbit/core';
+import { Orbit, Assertion } from '@orbit/core';
 import { Source } from '@orbit/data';
 import { Coordinator, ActivationOptions, LogLevel } from './coordinator';
 

--- a/packages/@orbit/core/src/deprecate.ts
+++ b/packages/@orbit/core/src/deprecate.ts
@@ -1,3 +1,4 @@
+import { Orbit } from './main';
 declare const console: any;
 
 /**
@@ -8,6 +9,8 @@ export function deprecate(
   message: string,
   test?: boolean | (() => boolean)
 ): void {
+  if (!Orbit.debug) return;
+
   if (typeof test === 'function') {
     if (test()) return;
   } else {

--- a/packages/@orbit/core/src/main.ts
+++ b/packages/@orbit/core/src/main.ts
@@ -10,6 +10,7 @@ export interface OrbitGlobal {
   assert: (description: string, test: boolean) => void | never;
   deprecate: (message: string, test?: boolean | (() => boolean)) => void;
   uuid: () => string;
+  debug: boolean;
 }
 
 // Establish the root object, `window` (`self`) in the browser, `global`
@@ -29,6 +30,7 @@ const globals =
 export const Orbit: OrbitGlobal = {
   globals,
   assert,
+  debug: true,
   deprecate,
   uuid
 };

--- a/packages/@orbit/indexeddb-bucket/src/lib/indexeddb.ts
+++ b/packages/@orbit/indexeddb-bucket/src/lib/indexeddb.ts
@@ -1,4 +1,4 @@
-import Orbit from '@orbit/core';
+import { Orbit } from '@orbit/core';
 
 export function supportsIndexedDB(): boolean {
   return !!Orbit.globals.indexedDB;

--- a/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
@@ -1,4 +1,4 @@
-import Orbit from '@orbit/core';
+import { Orbit } from '@orbit/core';
 import {
   ClientError,
   NetworkError,

--- a/packages/@orbit/jsonapi/src/jsonapi-serializer.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-serializer.ts
@@ -1,5 +1,5 @@
 import { deepSet, Dict } from '@orbit/utils';
-import Orbit, { Assertion } from '@orbit/core';
+import { Orbit, Assertion } from '@orbit/core';
 import {
   RecordSchema,
   RecordKeyMap,

--- a/packages/@orbit/jsonapi/src/jsonapi-source.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-source.ts
@@ -1,5 +1,4 @@
-/* eslint-disable valid-jsdoc */
-import Orbit, { Assertion } from '@orbit/core';
+import { Orbit, Assertion } from '@orbit/core';
 import {
   RequestOptions,
   pullable,

--- a/packages/@orbit/jsonapi/src/jsonapi-url-builder.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-url-builder.ts
@@ -1,4 +1,4 @@
-import Orbit from '@orbit/core';
+import { Orbit } from '@orbit/core';
 import { QueryExpressionParseError } from '@orbit/data';
 import {
   AttributeFilterSpecifier,

--- a/packages/@orbit/jsonapi/src/serializers/jsonapi-resource-identity-serializer.ts
+++ b/packages/@orbit/jsonapi/src/serializers/jsonapi-resource-identity-serializer.ts
@@ -1,4 +1,4 @@
-import Orbit, { Assertion } from '@orbit/core';
+import { Orbit, Assertion } from '@orbit/core';
 import { InitializedRecord, RecordSchema, RecordKeyMap } from '@orbit/records';
 import { Dict } from '@orbit/utils';
 import { Resource } from '../resource-document';

--- a/packages/@orbit/record-cache/src/async-record-cache.ts
+++ b/packages/@orbit/record-cache/src/async-record-cache.ts
@@ -113,11 +113,12 @@ export abstract class AsyncRecordCache<
 
     const processors: AsyncOperationProcessorClass[] = settings.processors
       ? settings.processors
-      : [
-          AsyncSchemaValidationProcessor,
-          AsyncSchemaConsistencyProcessor,
-          AsyncCacheIntegrityProcessor
-        ];
+      : [AsyncSchemaConsistencyProcessor, AsyncCacheIntegrityProcessor];
+
+    if (Orbit.debug && settings.processors === undefined) {
+      processors.push(AsyncSchemaValidationProcessor);
+    }
+
     this._processors = processors.map((Processor) => {
       let processor = new Processor(this);
       assert(

--- a/packages/@orbit/record-cache/src/async-record-cache.ts
+++ b/packages/@orbit/record-cache/src/async-record-cache.ts
@@ -1,4 +1,4 @@
-import Orbit from '@orbit/core';
+import { Orbit } from '@orbit/core';
 import { deepGet, Dict } from '@orbit/utils';
 import {
   buildQuery,

--- a/packages/@orbit/record-cache/src/record-cache.ts
+++ b/packages/@orbit/record-cache/src/record-cache.ts
@@ -1,4 +1,4 @@
-import Orbit, { evented, Evented } from '@orbit/core';
+import { Orbit, evented, Evented } from '@orbit/core';
 import {
   DefaultRequestOptions,
   RequestOptions,

--- a/packages/@orbit/record-cache/src/sync-record-cache.ts
+++ b/packages/@orbit/record-cache/src/sync-record-cache.ts
@@ -1,4 +1,4 @@
-import Orbit from '@orbit/core';
+import { Orbit } from '@orbit/core';
 import { deepGet, Dict } from '@orbit/utils';
 import {
   buildQuery,

--- a/packages/@orbit/record-cache/src/sync-record-cache.ts
+++ b/packages/@orbit/record-cache/src/sync-record-cache.ts
@@ -112,11 +112,12 @@ export abstract class SyncRecordCache<
 
     const processors: SyncOperationProcessorClass[] = settings.processors
       ? settings.processors
-      : [
-          SyncSchemaValidationProcessor,
-          SyncSchemaConsistencyProcessor,
-          SyncCacheIntegrityProcessor
-        ];
+      : [SyncSchemaConsistencyProcessor, SyncCacheIntegrityProcessor];
+
+    if (Orbit.debug && settings.processors === undefined) {
+      processors.push(SyncSchemaValidationProcessor);
+    }
+
     this._processors = processors.map((Processor) => {
       let processor = new Processor(this);
       assert(

--- a/packages/@orbit/record-cache/test/async-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/async-record-cache-test.ts
@@ -1,3 +1,4 @@
+import { Orbit } from '@orbit/core';
 import { RecordKeyMap, RecordSchema } from '@orbit/records';
 import { AsyncSchemaValidationProcessor } from '../src/operation-processors/async-schema-validation-processor';
 import { ExampleAsyncRecordCache } from './support/example-async-record-cache';
@@ -15,13 +16,28 @@ module('AsyncRecordCache', function (hooks) {
 
   test('it exists', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema });
-
     assert.ok(cache);
+  });
+
+  test('it is assigned 3 processors by default in debug mode', async function (assert) {
+    const cache = new ExampleAsyncRecordCache({ schema });
+    assert.ok(Orbit.debug);
     assert.equal(
       cache.processors.length,
       3,
       'processors are assigned by default'
     );
+  });
+
+  test('it is assigned only 2 processors by default in non-debug mode', async function (assert) {
+    Orbit.debug = false;
+    const cache = new ExampleAsyncRecordCache({ schema });
+    assert.equal(
+      cache.processors.length,
+      2,
+      'processors are assigned by default'
+    );
+    Orbit.debug = true;
   });
 
   test('it requires a schema', function (assert) {

--- a/packages/@orbit/record-cache/test/sync-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/sync-record-cache-test.ts
@@ -1,3 +1,4 @@
+import { Orbit } from '@orbit/core';
 import { RecordKeyMap, RecordSchema } from '@orbit/records';
 import { SyncSchemaValidationProcessor } from '../src/operation-processors/sync-schema-validation-processor';
 import { ExampleSyncRecordCache } from './support/example-sync-record-cache';
@@ -15,13 +16,28 @@ module('SyncRecordCache', function (hooks) {
 
   test('it exists', function (assert) {
     const cache = new ExampleSyncRecordCache({ schema });
-
     assert.ok(cache);
+  });
+
+  test('it is assigned 3 processors by default in debug mode', async function (assert) {
+    const cache = new ExampleSyncRecordCache({ schema });
+    assert.ok(Orbit.debug);
     assert.equal(
       cache.processors.length,
       3,
       'processors are assigned by default'
     );
+  });
+
+  test('it is assigned only 2 processors by default in non-debug mode', async function (assert) {
+    Orbit.debug = false;
+    const cache = new ExampleSyncRecordCache({ schema });
+    assert.equal(
+      cache.processors.length,
+      2,
+      'processors are assigned by default'
+    );
+    Orbit.debug = true;
   });
 
   test('it requires a schema', function (assert) {

--- a/packages/@orbit/records/src/record-source.ts
+++ b/packages/@orbit/records/src/record-source.ts
@@ -2,7 +2,7 @@ import { RecordKeyMap } from './record-key-map';
 import { RecordSchema } from './record-schema';
 import { RecordQueryBuilder } from './record-query-builder';
 import { RecordTransformBuilder } from './record-transform-builder';
-import Orbit from '@orbit/core';
+import { Orbit } from '@orbit/core';
 import {
   RequestOptions,
   Source,


### PR DESCRIPTION
`Orbit.debug` is set to `true` by default to improve awareness of deprecations and other debugging safeguards.

When `Orbit.debug` is set to `false`:

* Deprecations will be silenced.
* Schema validation processors won't be assigned  by default in record caches.