### PR TITLE
Deprecate Pullable and Pushable interfaces

### DIFF
--- a/packages/@orbit/data/src/source-interfaces/pullable.ts
+++ b/packages/@orbit/data/src/source-interfaces/pullable.ts
@@ -16,7 +16,7 @@ import { Operation } from '../operation';
 import { QueryExpression } from '../query-expression';
 import { Transform } from '../transform';
 
-const { assert } = Orbit;
+const { assert, deprecate } = Orbit;
 
 const PULLABLE = '__pullable__';
 
@@ -30,6 +30,8 @@ export function isPullable(source: Source): boolean {
 /**
  * A source decorated as `@pullable` must also implement the `Pullable`
  * interface.
+ *
+ * @deprecated since v0.17, use `Queryable` instead
  */
 export interface Pullable<
   Data,
@@ -106,6 +108,10 @@ export function pullable(Klass: unknown): void {
     options?: RequestOptions,
     id?: string
   ): Promise<unknown> {
+    deprecate(
+      "'pull' has been deprecated. Please use 'query' instead and create your own transform from the results."
+    );
+
     await this.activated;
     const query = buildQuery(
       queryOrExpressions,

--- a/packages/@orbit/data/src/source-interfaces/pushable.ts
+++ b/packages/@orbit/data/src/source-interfaces/pushable.ts
@@ -14,7 +14,7 @@ import {
 } from '../response';
 import { Operation } from '../operation';
 
-const { assert } = Orbit;
+const { assert, deprecate } = Orbit;
 
 const PUSHABLE = '__pushable__';
 
@@ -28,6 +28,8 @@ export function isPushable(source: Source): boolean {
 /**
  * A source decorated as `@pushable` must also implement the `Pushable`
  * interface.
+ *
+ * @deprecated since v0.17, use `Updatable` instead
  */
 export interface Pushable<
   Data,
@@ -106,6 +108,10 @@ export function pushable(Klass: unknown): void {
     options?: RO,
     id?: string
   ): Promise<unknown> {
+    deprecate(
+      "'push' has been deprecated. Please use 'update' instead and specify '{ fullResponse: true }' to access the resultant 'transforms'."
+    );
+
     await this.activated;
     const transform = buildTransform(
       transformOrOperations,


### PR DESCRIPTION
The Pullable and Pushable interfaces are now redundant with Queryable and Updatable, respectively.

Closes #829