### PR TITLE
Refinement of serialization options

### DIFF
--- a/packages/@orbit/jsonapi/src/jsonapi-serializer.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-serializer.ts
@@ -284,10 +284,19 @@ export class JSONAPISerializer
     }
     const serializer = this.serializerFor(attrOptions.type || 'unknown');
     if (serializer) {
+      const serializationOptions =
+        attrOptions.serialization ?? (attrOptions as any).serializationOptions;
+
+      if ((attrOptions as any).serializationOptions !== undefined) {
+        deprecate(
+          `The attribute '${attr}' for '${record.type}' has been assigned \`serializationOptions\` in the schema. Use \`serialization\` instead.`
+        );
+      }
+
       value =
         value === null
           ? null
-          : serializer.serialize(value, attrOptions.serializationOptions);
+          : serializer.serialize(value, serializationOptions);
     }
     deepSet(
       resource,
@@ -517,12 +526,22 @@ export class JSONAPISerializer
     record.attributes = record.attributes || {};
     if (value !== undefined && value !== null) {
       const attrOptions = model.attributes?.[attr];
+      if (attrOptions === undefined) {
+        return;
+      }
       const serializer = this.serializerFor(attrOptions?.type || 'unknown');
       if (serializer) {
-        value = serializer.deserialize(
-          value,
-          attrOptions?.deserializationOptions
-        );
+        const deserializationOptions =
+          attrOptions.deserialization ??
+          (attrOptions as any).deserializationOptions;
+
+        if ((attrOptions as any).deserializationOptions !== undefined) {
+          deprecate(
+            `The attribute '${attr}' for '${record.type}' has been assigned \`deserializationOptions\` in the schema. Use \`deserialization\` instead.`
+          );
+        }
+
+        value = serializer.deserialize(value, deserializationOptions);
       }
     }
     record.attributes[attr] = value;

--- a/packages/@orbit/jsonapi/src/jsonapi-serializer.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-serializer.ts
@@ -10,7 +10,6 @@ import {
 } from '@orbit/records';
 import {
   Serializer,
-  UnknownSerializer,
   SerializerForFn,
   StringSerializer,
   buildSerializerSettingsFor
@@ -44,7 +43,7 @@ export interface JSONAPISerializationOptions {
 export interface JSONAPISerializerSettings {
   schema: RecordSchema;
   keyMap?: RecordKeyMap;
-  serializers?: Dict<UnknownSerializer>;
+  serializers?: Dict<Serializer>;
 }
 
 /**

--- a/packages/@orbit/jsonapi/src/serializers/jsonapi-resource-field-serializer.ts
+++ b/packages/@orbit/jsonapi/src/serializers/jsonapi-resource-field-serializer.ts
@@ -10,16 +10,16 @@ export interface JSONAPIResourceFieldSerializationOptions
 
 export class JSONAPIResourceFieldSerializer extends StringSerializer {
   serialize(
-    arg: string | null,
+    arg: string,
     customOptions?: JSONAPIResourceFieldSerializationOptions
-  ): string | null {
+  ): string {
     return super.serialize(arg, customOptions as StringSerializationOptions);
   }
 
   deserialize(
-    arg: string | null,
+    arg: string,
     customOptions?: JSONAPIResourceFieldSerializationOptions
-  ): string | null {
+  ): string {
     return super.deserialize(arg, customOptions as StringSerializationOptions);
   }
 }

--- a/packages/@orbit/jsonapi/src/serializers/jsonapi-resource-serializer.ts
+++ b/packages/@orbit/jsonapi/src/serializers/jsonapi-resource-serializer.ts
@@ -80,7 +80,7 @@ export class JSONAPIResourceSerializer extends JSONAPIBaseSerializer<
     if (value === null) {
       resValue = null;
     } else {
-      const type = fieldOptions.type || 'unknown';
+      const type = fieldOptions.type ?? 'unknown';
       const serializer = this.serializerFor(type);
       if (serializer) {
         const serializationOptions =

--- a/packages/@orbit/jsonapi/src/serializers/jsonapi-resource-serializer.ts
+++ b/packages/@orbit/jsonapi/src/serializers/jsonapi-resource-serializer.ts
@@ -1,5 +1,5 @@
 import { deepSet } from '@orbit/utils';
-import { Assertion } from '@orbit/core';
+import { Assertion, Orbit } from '@orbit/core';
 import {
   InitializedRecord,
   RecordIdentity,
@@ -9,6 +9,7 @@ import { Resource, ResourceIdentity } from '../resource-document';
 import { JSONAPIBaseSerializer } from './jsonapi-base-serializer';
 import { JSONAPIResourceIdentityDeserializationOptions } from './jsonapi-resource-identity-serializer';
 
+const { deprecate } = Orbit;
 export class JSONAPIResourceSerializer extends JSONAPIBaseSerializer<
   InitializedRecord,
   Resource,
@@ -75,17 +76,25 @@ export class JSONAPIResourceSerializer extends JSONAPIBaseSerializer<
       return;
     }
 
-    let resValue: any;
+    let resValue: unknown;
     if (value === null) {
       resValue = null;
     } else {
       const type = fieldOptions.type || 'unknown';
       const serializer = this.serializerFor(type);
       if (serializer) {
-        resValue = serializer.serialize(
-          value,
-          fieldOptions.serializationOptions
-        );
+        const serializationOptions =
+          fieldOptions.serialization ??
+          (fieldOptions as any).serializationOptions;
+
+        if ((fieldOptions as any).serializationOptions !== undefined) {
+          // TODO: Remove in v0.18
+          deprecate(
+            `The attribute '${field}' for '${record.type}' has been assigned \`serializationOptions\` in the schema. Use \`serialization\` instead.`
+          );
+        }
+
+        resValue = serializer.serialize(value, serializationOptions);
       } else {
         throw new Assertion(
           `Serializer could not be found for attribute type '${type}'`
@@ -196,17 +205,25 @@ export class JSONAPIResourceSerializer extends JSONAPIBaseSerializer<
       return;
     }
 
-    let value: any;
+    let value: unknown;
     if (resValue === null) {
       value = null;
     } else {
       const type = fieldOptions.type || 'unknown';
       const serializer = this.serializerFor(type);
       if (serializer) {
-        value = serializer.deserialize(
-          resValue,
-          fieldOptions.serializationOptions
-        );
+        const deserializationOptions =
+          fieldOptions.deserialization ??
+          (fieldOptions as any).deserializationOptions;
+
+        if ((fieldOptions as any).deserializationOptions !== undefined) {
+          // TODO: Remove in v0.18
+          deprecate(
+            `The attribute '${field}' for '${record.type}' has been assigned \`deserializationOptions\` in the schema. Use \`deserialization\` instead.`
+          );
+        }
+
+        value = serializer.deserialize(resValue, deserializationOptions);
       } else {
         throw new Assertion(
           `Serializer could not be found for attribute type '${type}'`

--- a/packages/@orbit/jsonapi/src/serializers/jsonapi-serializer-builder.ts
+++ b/packages/@orbit/jsonapi/src/serializers/jsonapi-serializer-builder.ts
@@ -12,7 +12,7 @@ import {
   SerializerForFn,
   SerializerClassForFn,
   SerializerSettingsForFn,
-  UnknownSerializerClass
+  SerializerClass
 } from '@orbit/serializers';
 import { JSONAPIAtomicOperationSerializer } from './jsonapi-atomic-operation-serializer';
 import { JSONAPIResourceSerializer } from './jsonapi-resource-serializer';
@@ -35,20 +35,20 @@ export function buildJSONAPISerializerFor(settings: {
     unknown: NoopSerializer,
     object: NoopSerializer,
     array: NoopSerializer,
-    boolean: BooleanSerializer as UnknownSerializerClass,
-    string: StringSerializer as UnknownSerializerClass,
-    date: DateSerializer as UnknownSerializerClass,
-    datetime: DateTimeSerializer as UnknownSerializerClass,
-    number: NumberSerializer as UnknownSerializerClass,
-    [JSONAPISerializers.Resource as string]: JSONAPIResourceSerializer as UnknownSerializerClass,
-    [JSONAPISerializers.ResourceDocument as string]: JSONAPIDocumentSerializer as UnknownSerializerClass,
-    [JSONAPISerializers.ResourceIdentity as string]: JSONAPIResourceIdentitySerializer as UnknownSerializerClass,
-    [JSONAPISerializers.ResourceAtomicOperation as string]: JSONAPIAtomicOperationSerializer as UnknownSerializerClass,
-    [JSONAPISerializers.ResourceType as string]: StringSerializer as UnknownSerializerClass,
-    [JSONAPISerializers.ResourceTypePath as string]: StringSerializer as UnknownSerializerClass,
-    [JSONAPISerializers.ResourceField as string]: JSONAPIResourceFieldSerializer as UnknownSerializerClass,
-    [JSONAPISerializers.ResourceFieldParam as string]: JSONAPIResourceFieldSerializer as UnknownSerializerClass,
-    [JSONAPISerializers.ResourceFieldPath as string]: JSONAPIResourceFieldSerializer as UnknownSerializerClass
+    boolean: BooleanSerializer as SerializerClass,
+    string: StringSerializer as SerializerClass,
+    date: DateSerializer as SerializerClass,
+    datetime: DateTimeSerializer as SerializerClass,
+    number: NumberSerializer as SerializerClass,
+    [JSONAPISerializers.Resource as string]: JSONAPIResourceSerializer as SerializerClass,
+    [JSONAPISerializers.ResourceDocument as string]: JSONAPIDocumentSerializer as SerializerClass,
+    [JSONAPISerializers.ResourceIdentity as string]: JSONAPIResourceIdentitySerializer as SerializerClass,
+    [JSONAPISerializers.ResourceAtomicOperation as string]: JSONAPIAtomicOperationSerializer as SerializerClass,
+    [JSONAPISerializers.ResourceType as string]: StringSerializer as SerializerClass,
+    [JSONAPISerializers.ResourceTypePath as string]: StringSerializer as SerializerClass,
+    [JSONAPISerializers.ResourceField as string]: JSONAPIResourceFieldSerializer as SerializerClass,
+    [JSONAPISerializers.ResourceFieldParam as string]: JSONAPIResourceFieldSerializer as SerializerClass,
+    [JSONAPISerializers.ResourceFieldPath as string]: JSONAPIResourceFieldSerializer as SerializerClass
   });
   let serializerClassFor: SerializerClassForFn;
   if (settings.serializerClassFor) {

--- a/packages/@orbit/jsonapi/test/jsonapi-serializer-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-serializer-test.ts
@@ -258,8 +258,8 @@ module('JSONAPISerializer', function (hooks) {
             birthtime: { type: 'datetime' },
             height: {
               type: 'distance',
-              serializationOptions: { format: 'cm', digits: 2 },
-              deserializationOptions: { format: 'cm' }
+              serialization: { format: 'cm', digits: 2 },
+              deserialization: { format: 'cm' }
             },
             isAdult: { type: 'boolean' }
           }

--- a/packages/@orbit/jsonapi/test/serializers/jsonapi-atomic-operation-serializer-test.ts
+++ b/packages/@orbit/jsonapi/test/serializers/jsonapi-atomic-operation-serializer-test.ts
@@ -500,8 +500,8 @@ module('JSONAPIOperationSerializer', function (hooks) {
             birthtime: { type: 'datetime' },
             height: {
               type: 'distance',
-              serializationOptions: { format: 'cm', digits: 2 },
-              deserializationOptions: { format: 'cm' }
+              serialization: { format: 'cm', digits: 2 },
+              deserialization: { format: 'cm' }
             },
             isAdult: { type: 'boolean' }
           }

--- a/packages/@orbit/jsonapi/test/serializers/jsonapi-document-serializer-test.ts
+++ b/packages/@orbit/jsonapi/test/serializers/jsonapi-document-serializer-test.ts
@@ -554,8 +554,8 @@ module('JSONAPIDocumentSerializer', function (hooks) {
             birthtime: { type: 'datetime' },
             height: {
               type: 'distance',
-              serializationOptions: { format: 'cm', digits: 2 },
-              deserializationOptions: { format: 'cm' }
+              serialization: { format: 'cm', digits: 2 },
+              deserialization: { format: 'cm' }
             },
             isAdult: { type: 'boolean' }
           }

--- a/packages/@orbit/jsonapi/test/serializers/jsonapi-resource-field-serializer-test.ts
+++ b/packages/@orbit/jsonapi/test/serializers/jsonapi-resource-field-serializer-test.ts
@@ -22,14 +22,6 @@ module('JSONAPIResourceFieldSerializer', function (hooks) {
     test('#deserialize returns arg untouched', function (assert) {
       assert.equal(serializer.deserialize('abc'), 'abc');
     });
-
-    test('#serialize returns nulls', function (assert) {
-      assert.equal(serializer.serialize(null), null);
-    });
-
-    test('#deserialize returns nulls', function (assert) {
-      assert.equal(serializer.deserialize(null), null);
-    });
   });
 
   module(

--- a/packages/@orbit/jsonapi/test/serializers/jsonapi-resource-serializer-test.ts
+++ b/packages/@orbit/jsonapi/test/serializers/jsonapi-resource-serializer-test.ts
@@ -9,7 +9,8 @@ import { JSONAPIResourceSerializer } from '../../src/serializers/jsonapi-resourc
 import {
   Serializer,
   buildSerializerClassFor,
-  buildSerializerSettingsFor
+  buildSerializerSettingsFor,
+  SerializerClass
 } from '@orbit/serializers';
 import { buildJSONAPISerializerFor } from '../../src/serializers/jsonapi-serializer-builder';
 import { JSONAPISerializers } from '../../src/serializers/jsonapi-serializers';
@@ -520,14 +521,14 @@ module('JSONAPIResourceSerializer', function (hooks) {
       }
 
       class MysterySerializer
-        implements Serializer<unknown, SerializedMystery, any, any> {
-        serialize(arg: unknown, options?: any): SerializedMystery {
+        implements Serializer<unknown, SerializedMystery> {
+        serialize(arg: unknown): SerializedMystery {
           return {
             whatDoWeHaveHere: arg
           };
         }
 
-        deserialize(arg: SerializedMystery, options?: any): unknown {
+        deserialize(arg: SerializedMystery): unknown {
           return arg.whatDoWeHaveHere;
         }
       }
@@ -538,7 +539,7 @@ module('JSONAPIResourceSerializer', function (hooks) {
         let schema = new RecordSchema({ models: modelDefinitions });
         const serializerClassFor = buildSerializerClassFor({
           distance: DistanceSerializer,
-          unknown: MysterySerializer
+          unknown: MysterySerializer as SerializerClass
         });
         const serializerSettingsFor = buildSerializerSettingsFor({
           settingsByType: {

--- a/packages/@orbit/jsonapi/test/serializers/jsonapi-resource-serializer-test.ts
+++ b/packages/@orbit/jsonapi/test/serializers/jsonapi-resource-serializer-test.ts
@@ -481,8 +481,8 @@ module('JSONAPIResourceSerializer', function (hooks) {
             birthtime: { type: 'datetime' },
             height: {
               type: 'distance',
-              serializationOptions: { format: 'cm', digits: 2 },
-              deserializationOptions: { format: 'cm' }
+              serialization: { format: 'cm', digits: 2 },
+              deserialization: { format: 'cm' }
             },
             isAdult: { type: 'boolean' },
             mystery: {}

--- a/packages/@orbit/records/src/record-schema.ts
+++ b/packages/@orbit/records/src/record-schema.ts
@@ -12,8 +12,8 @@ const { uuid, deprecate } = Orbit;
 
 export interface AttributeDefinition {
   type?: string;
-  serializationOptions?: Dict<unknown>;
-  deserializationOptions?: Dict<unknown>;
+  serialization?: Dict<unknown>;
+  deserialization?: Dict<unknown>;
   meta?: Dict<unknown>;
 }
 

--- a/packages/@orbit/serializers/src/base-serializer.ts
+++ b/packages/@orbit/serializers/src/base-serializer.ts
@@ -1,15 +1,11 @@
 import { Serializer } from './serializer';
 import { SerializerForFn } from './serializer-builders';
 
-export interface BaseSerializationOptions {
-  disallowNull?: boolean;
-}
-
 export abstract class BaseSerializer<
   From,
   To,
-  SerializationOptions,
-  DeserializationOptions
+  SerializationOptions = unknown,
+  DeserializationOptions = unknown
 > implements
     Serializer<From, To, SerializationOptions, DeserializationOptions> {
   serializerFor?: SerializerForFn;

--- a/packages/@orbit/serializers/src/boolean-serializer.ts
+++ b/packages/@orbit/serializers/src/boolean-serializer.ts
@@ -1,53 +1,11 @@
-import { BaseSerializer, BaseSerializationOptions } from './base-serializer';
+import { BaseSerializer } from './base-serializer';
 
-export interface BooleanSerializerSettings {
-  serializationOptions?: BaseSerializationOptions;
-  deserializationOptions?: BaseSerializationOptions;
-}
-
-export class BooleanSerializer extends BaseSerializer<
-  boolean | null,
-  boolean | null,
-  BaseSerializationOptions,
-  BaseSerializationOptions
-> {
-  constructor(settings?: BooleanSerializerSettings) {
-    super(settings);
-
-    if (
-      this.serializationOptions &&
-      this.deserializationOptions === undefined
-    ) {
-      const { disallowNull } = this.serializationOptions;
-      this.deserializationOptions = {
-        disallowNull
-      };
-    }
+export class BooleanSerializer extends BaseSerializer<boolean, boolean> {
+  serialize(arg: boolean): boolean {
+    return arg ? true : false;
   }
 
-  serialize(
-    arg: boolean | null,
-    customOptions?: BaseSerializationOptions
-  ): boolean | null {
-    const options = this.buildSerializationOptions(customOptions);
-
-    if (arg === null && options.disallowNull) {
-      throw new Error('null values are not allowed');
-    }
-
-    return arg;
-  }
-
-  deserialize(
-    arg: boolean | null,
-    customOptions?: BaseSerializationOptions
-  ): boolean | null {
-    const options = this.buildDeserializationOptions(customOptions);
-
-    if (arg === null && options.disallowNull) {
-      throw new Error('null values are not allowed');
-    }
-
-    return arg;
+  deserialize(arg: boolean): boolean {
+    return arg ? true : false;
   }
 }

--- a/packages/@orbit/serializers/src/date-serializer.ts
+++ b/packages/@orbit/serializers/src/date-serializer.ts
@@ -1,59 +1,11 @@
-import { BaseSerializer, BaseSerializationOptions } from './base-serializer';
+import { BaseSerializer } from './base-serializer';
 
-export interface DateSerializerSettings {
-  serializationOptions?: BaseSerializationOptions;
-  deserializationOptions?: BaseSerializationOptions;
-}
-
-export class DateSerializer extends BaseSerializer<
-  Date | null,
-  string | null,
-  BaseSerializationOptions,
-  BaseSerializationOptions
-> {
-  constructor(settings?: DateSerializerSettings) {
-    super(settings);
-
-    if (
-      this.serializationOptions &&
-      this.deserializationOptions === undefined
-    ) {
-      const { disallowNull } = this.serializationOptions;
-      this.deserializationOptions = {
-        disallowNull
-      };
-    }
-  }
-
-  serialize(
-    arg: Date | null,
-    customOptions?: BaseSerializationOptions
-  ): string | null {
-    const options = this.buildSerializationOptions(customOptions);
-
-    if (arg === null) {
-      if (options.disallowNull) {
-        throw new Error('null values are not allowed');
-      }
-      return null;
-    }
-
+export class DateSerializer extends BaseSerializer<Date, string> {
+  serialize(arg: Date): string {
     return `${arg.getFullYear()}-${arg.getMonth() + 1}-${arg.getDate()}`;
   }
 
-  deserialize(
-    arg: string | null,
-    customOptions?: BaseSerializationOptions
-  ): Date | null {
-    const options = this.buildDeserializationOptions(customOptions);
-
-    if (arg === null) {
-      if (options.disallowNull) {
-        throw new Error('null values are not allowed');
-      }
-      return null;
-    }
-
+  deserialize(arg: string): Date {
     const [year, month, date] = arg.split('-');
     return new Date(parseInt(year), parseInt(month) - 1, parseInt(date));
   }

--- a/packages/@orbit/serializers/src/date-time-serializer.ts
+++ b/packages/@orbit/serializers/src/date-time-serializer.ts
@@ -1,59 +1,11 @@
-import { BaseSerializer, BaseSerializationOptions } from './base-serializer';
+import { BaseSerializer } from './base-serializer';
 
-export interface DateTimeSerializerSettings {
-  serializationOptions?: BaseSerializationOptions;
-  deserializationOptions?: BaseSerializationOptions;
-}
-
-export class DateTimeSerializer extends BaseSerializer<
-  Date | null,
-  string | null,
-  BaseSerializationOptions,
-  BaseSerializationOptions
-> {
-  constructor(settings?: DateTimeSerializerSettings) {
-    super(settings);
-
-    if (
-      this.serializationOptions &&
-      this.deserializationOptions === undefined
-    ) {
-      const { disallowNull } = this.serializationOptions;
-      this.deserializationOptions = {
-        disallowNull
-      };
-    }
-  }
-
-  serialize(
-    arg: Date | null,
-    customOptions?: BaseSerializationOptions
-  ): string | null {
-    const options = this.buildSerializationOptions(customOptions);
-
-    if (arg === null) {
-      if (options.disallowNull) {
-        throw new Error('null values are not allowed');
-      }
-      return null;
-    }
-
+export class DateTimeSerializer extends BaseSerializer<Date, string> {
+  serialize(arg: Date): string {
     return arg.toISOString();
   }
 
-  deserialize(
-    arg: string | null,
-    customOptions?: BaseSerializationOptions
-  ): Date | null {
-    const options = this.buildDeserializationOptions(customOptions);
-
-    if (arg === null) {
-      if (options.disallowNull) {
-        throw new Error('null values are not allowed');
-      }
-      return null;
-    }
-
+  deserialize(arg: string): Date {
     let offset = arg.indexOf('+');
     if (offset !== -1 && arg.length - 5 === offset) {
       offset += 3;

--- a/packages/@orbit/serializers/src/number-serializer.ts
+++ b/packages/@orbit/serializers/src/number-serializer.ts
@@ -1,53 +1,11 @@
-import { BaseSerializer, BaseSerializationOptions } from './base-serializer';
+import { BaseSerializer } from './base-serializer';
 
-export interface NumberSerializerSettings {
-  serializationOptions?: BaseSerializationOptions;
-  deserializationOptions?: BaseSerializationOptions;
-}
-
-export class NumberSerializer extends BaseSerializer<
-  number | null,
-  number | null,
-  BaseSerializationOptions,
-  BaseSerializationOptions
-> {
-  constructor(settings?: NumberSerializerSettings) {
-    super(settings);
-
-    if (
-      this.serializationOptions &&
-      this.deserializationOptions === undefined
-    ) {
-      const { disallowNull } = this.serializationOptions;
-      this.deserializationOptions = {
-        disallowNull
-      };
-    }
-  }
-
-  serialize(
-    arg: number | null,
-    customOptions?: BaseSerializationOptions
-  ): number | null {
-    const options = this.buildSerializationOptions(customOptions);
-
-    if (arg === null && options.disallowNull) {
-      throw new Error('null values are not allowed');
-    }
-
+export class NumberSerializer extends BaseSerializer<number, number> {
+  serialize(arg: number): number {
     return arg;
   }
 
-  deserialize(
-    arg: number | null,
-    customOptions?: BaseSerializationOptions
-  ): number | null {
-    const options = this.buildDeserializationOptions(customOptions);
-
-    if (arg === null && options.disallowNull) {
-      throw new Error('null values are not allowed');
-    }
-
+  deserialize(arg: number): number {
     return arg;
   }
 }

--- a/packages/@orbit/serializers/src/serializer-builders.ts
+++ b/packages/@orbit/serializers/src/serializer-builders.ts
@@ -1,25 +1,25 @@
-import { UnknownSerializer, UnknownSerializerClass } from './serializer';
+import { Serializer, SerializerClass } from './serializer';
 import { Dict } from '@orbit/utils';
 
-export type SerializerForFn = (type: string) => UnknownSerializer | undefined;
+export type SerializerForFn<S = Serializer> = (type: string) => S | undefined;
 
-export function buildSerializerFor(settings: {
-  serializers?: Dict<UnknownSerializer>;
-  serializerClassFor?: SerializerClassForFn;
+export function buildSerializerFor<S = Serializer>(settings: {
+  serializers?: Dict<S>;
+  serializerClassFor?: SerializerClassForFn<S>;
   serializerSettingsFor?: SerializerSettingsForFn;
-}): SerializerForFn {
-  const customSerializers = settings.serializers || {};
+}): SerializerForFn<S> {
+  const customSerializers = settings.serializers ?? {};
   const serializers = {
     ...customSerializers
   };
   const serializerClassFor = settings.serializerClassFor;
   const serializerSettingsFor = settings.serializerSettingsFor;
 
-  function serializerFor(type: string): UnknownSerializer | undefined {
-    return serializers[type] || createSerializer(type);
+  function serializerFor(type: string): S | undefined {
+    return (serializers[type] as S) ?? createSerializer(type);
   }
 
-  function createSerializer(type: string): UnknownSerializer | undefined {
+  function createSerializer(type: string): S | undefined {
     const SerializerClass = serializerClassFor && serializerClassFor(type);
     if (SerializerClass) {
       const settings =
@@ -34,11 +34,13 @@ export function buildSerializerFor(settings: {
   return serializerFor;
 }
 
-export type SerializerClassForFn = (type: string) => UnknownSerializerClass;
+export type SerializerClassForFn<S = Serializer> = (
+  type: string
+) => SerializerClass<S>;
 
-export function buildSerializerClassFor(
-  serializerClasses: Dict<UnknownSerializerClass> = {}
-): SerializerClassForFn {
+export function buildSerializerClassFor<S = Serializer>(
+  serializerClasses: Dict<SerializerClass<S>> = {}
+): SerializerClassForFn<S> {
   return (type: string) => serializerClasses[type];
 }
 

--- a/packages/@orbit/serializers/src/serializer.ts
+++ b/packages/@orbit/serializers/src/serializer.ts
@@ -1,14 +1,11 @@
 export interface Serializer<
-  From,
-  To,
-  SerializationOptions,
-  DeserializationOptions
+  From = unknown,
+  To = unknown,
+  SerializationOptions = unknown,
+  DeserializationOptions = unknown
 > {
   serialize(arg: From, options?: SerializationOptions): To;
   deserialize(arg: To, options?: DeserializationOptions): From;
 }
 
-export type UnknownSerializer = Serializer<unknown, unknown, unknown, unknown>;
-export type UnknownSerializerClass = new (
-  settings?: unknown
-) => UnknownSerializer;
+export type SerializerClass<S = Serializer> = new (settings?: unknown) => S;

--- a/packages/@orbit/serializers/src/string-serializer.ts
+++ b/packages/@orbit/serializers/src/string-serializer.ts
@@ -1,5 +1,5 @@
 import { Dict } from '@orbit/utils';
-import { BaseSerializationOptions, BaseSerializer } from './base-serializer';
+import { BaseSerializer } from './base-serializer';
 import { Inflector } from './inflector';
 import {
   standardInflectors,
@@ -9,7 +9,7 @@ import {
 
 export type InflectorOrName = Inflector | StandardInflectorName;
 
-export interface StringSerializationOptions extends BaseSerializationOptions {
+export interface StringSerializationOptions {
   inflectors?: InflectorOrName[];
 }
 
@@ -21,8 +21,8 @@ export interface StringSerializerSettings {
 }
 
 export class StringSerializer extends BaseSerializer<
-  string | null,
-  string | null,
+  string,
+  string,
   StringSerializationOptions,
   StringSerializationOptions
 > {
@@ -39,27 +39,15 @@ export class StringSerializer extends BaseSerializer<
       this.serializationOptions &&
       this.deserializationOptions === undefined
     ) {
-      const { disallowNull, inflectors } = this.serializationOptions;
+      const { inflectors } = this.serializationOptions;
       this.deserializationOptions = {
-        disallowNull,
         inflectors: this.buildInverseInflectors(inflectors)
       };
     }
   }
 
-  serialize(
-    arg: string | null,
-    customOptions?: StringSerializationOptions
-  ): string | null {
+  serialize(arg: string, customOptions?: StringSerializationOptions): string {
     const options = this.buildSerializationOptions(customOptions);
-
-    if (arg === null) {
-      if (options.disallowNull) {
-        throw new Error('null values are not allowed');
-      }
-      return null;
-    }
-
     const { inflectors } = options;
     let result = arg;
 
@@ -72,19 +60,8 @@ export class StringSerializer extends BaseSerializer<
     return result;
   }
 
-  deserialize(
-    arg: string | null,
-    customOptions?: StringSerializationOptions
-  ): string | null {
+  deserialize(arg: string, customOptions?: StringSerializationOptions): string {
     const options = this.buildDeserializationOptions(customOptions);
-
-    if (arg === null) {
-      if (options.disallowNull) {
-        throw new Error('null values are not allowed');
-      }
-      return null;
-    }
-
     const { inflectors } = options;
     let result = arg;
 

--- a/packages/@orbit/serializers/test/boolean-serializer-test.ts
+++ b/packages/@orbit/serializers/test/boolean-serializer-test.ts
@@ -5,63 +5,17 @@ const { module, test } = QUnit;
 module('BooleanSerializer', function (hooks) {
   let serializer: BooleanSerializer;
 
-  module('with no options', function (hooks) {
-    hooks.beforeEach(function () {
-      serializer = new BooleanSerializer();
-    });
-
-    test('#serialize returns arg untouched', function (assert) {
-      assert.strictEqual(serializer.serialize(true), true);
-      assert.strictEqual(serializer.serialize(false), false);
-    });
-
-    test('#deserialize returns arg untouched', function (assert) {
-      assert.strictEqual(serializer.deserialize(true), true);
-      assert.strictEqual(serializer.deserialize(false), false);
-    });
-
-    test('#serialize returns nulls', function (assert) {
-      assert.equal(serializer.serialize(null), null);
-    });
-
-    test('#deserialize returns nulls', function (assert) {
-      assert.equal(serializer.deserialize(null), null);
-    });
+  hooks.beforeEach(function () {
+    serializer = new BooleanSerializer();
   });
 
-  module('serializationOptions: { disallowNull: false }', function (hooks) {
-    hooks.beforeEach(function () {
-      serializer = new BooleanSerializer({
-        serializationOptions: { disallowNull: false }
-      });
-    });
-
-    test('#serialize returns nulls', function (assert) {
-      assert.equal(serializer.serialize(null), null);
-    });
-
-    test('#deserialize returns nulls', function (assert) {
-      assert.equal(serializer.deserialize(null), null);
-    });
+  test('#serialize returns arg', function (assert) {
+    assert.strictEqual(serializer.serialize(true), true);
+    assert.strictEqual(serializer.serialize(false), false);
   });
 
-  module('serializationOptions: { disallowNull: true }', function (hooks) {
-    hooks.beforeEach(function () {
-      serializer = new BooleanSerializer({
-        serializationOptions: { disallowNull: true }
-      });
-    });
-
-    test('#serialize throws error on null', function (assert) {
-      assert.throws(() => {
-        serializer.serialize(null);
-      }, 'null is not allowed');
-    });
-
-    test('#deserialize throws error on null', function (assert) {
-      assert.throws(() => {
-        serializer.deserialize(null);
-      }, 'null is not allowed');
-    });
+  test('#deserialize returns arg', function (assert) {
+    assert.strictEqual(serializer.deserialize(true), true);
+    assert.strictEqual(serializer.deserialize(false), false);
   });
 });

--- a/packages/@orbit/serializers/test/date-serializer-test.ts
+++ b/packages/@orbit/serializers/test/date-serializer-test.ts
@@ -5,64 +5,18 @@ const { module, test } = QUnit;
 module('DateSerializer', function (hooks) {
   let serializer: DateSerializer;
 
-  module('with no options', function (hooks) {
-    hooks.beforeEach(function () {
-      serializer = new DateSerializer();
-    });
-
-    test('#serialize returns a date in YYYY-MM-DD form', function (assert) {
-      assert.equal(serializer.serialize(new Date(2017, 11, 31)), '2017-12-31');
-    });
-
-    test('#deserialize returns a Date', function (assert) {
-      assert.equal(
-        serializer.deserialize('2017-12-31')?.toISOString(),
-        new Date(2017, 11, 31).toISOString()
-      );
-    });
-
-    test('#serialize returns nulls', function (assert) {
-      assert.equal(serializer.serialize(null), null);
-    });
-
-    test('#deserialize returns nulls', function (assert) {
-      assert.equal(serializer.deserialize(null), null);
-    });
+  hooks.beforeEach(function () {
+    serializer = new DateSerializer();
   });
 
-  module('serializationOptions: { disallowNull: false }', function (hooks) {
-    hooks.beforeEach(function () {
-      serializer = new DateSerializer({
-        serializationOptions: { disallowNull: false }
-      });
-    });
-
-    test('#serialize returns nulls', function (assert) {
-      assert.equal(serializer.serialize(null), null);
-    });
-
-    test('#deserialize returns nulls', function (assert) {
-      assert.equal(serializer.deserialize(null), null);
-    });
+  test('#serialize returns a date in YYYY-MM-DD form', function (assert) {
+    assert.equal(serializer.serialize(new Date(2017, 11, 31)), '2017-12-31');
   });
 
-  module('serializationOptions: { disallowNull: true }', function (hooks) {
-    hooks.beforeEach(function () {
-      serializer = new DateSerializer({
-        serializationOptions: { disallowNull: true }
-      });
-    });
-
-    test('#serialize throws error on null', function (assert) {
-      assert.throws(() => {
-        serializer.serialize(null);
-      }, 'null is not allowed');
-    });
-
-    test('#deserialize throws error on null', function (assert) {
-      assert.throws(() => {
-        serializer.deserialize(null);
-      }, 'null is not allowed');
-    });
+  test('#deserialize returns a Date', function (assert) {
+    assert.equal(
+      serializer.deserialize('2017-12-31')?.toISOString(),
+      new Date(2017, 11, 31).toISOString()
+    );
   });
 });

--- a/packages/@orbit/serializers/test/date-time-serializer-test.ts
+++ b/packages/@orbit/serializers/test/date-time-serializer-test.ts
@@ -8,64 +8,18 @@ module('DateTimeSerializer', function (hooks) {
   let dateString = '2015-01-01T10:00:00.000Z';
   let date = new Date(dateString);
 
-  module('with no options', function (hooks) {
-    hooks.beforeEach(function () {
-      serializer = new DateTimeSerializer();
-    });
-
-    test('#serialize returns a date-time in ISO format', function (assert) {
-      assert.equal(serializer.serialize(date), dateString);
-    });
-
-    test('#deserialize returns a Date, with a time set', function (assert) {
-      assert.equal(
-        serializer.deserialize(dateString)?.toISOString(),
-        date.toISOString()
-      );
-    });
-
-    test('#serialize returns nulls', function (assert) {
-      assert.equal(serializer.serialize(null), null);
-    });
-
-    test('#deserialize returns nulls', function (assert) {
-      assert.equal(serializer.deserialize(null), null);
-    });
+  hooks.beforeEach(function () {
+    serializer = new DateTimeSerializer();
   });
 
-  module('serializationOptions: { disallowNull: false }', function (hooks) {
-    hooks.beforeEach(function () {
-      serializer = new DateTimeSerializer({
-        serializationOptions: { disallowNull: false }
-      });
-    });
-
-    test('#serialize returns nulls', function (assert) {
-      assert.equal(serializer.serialize(null), null);
-    });
-
-    test('#deserialize returns nulls', function (assert) {
-      assert.equal(serializer.deserialize(null), null);
-    });
+  test('#serialize returns a date-time in ISO format', function (assert) {
+    assert.equal(serializer.serialize(date), dateString);
   });
 
-  module('serializationOptions: { disallowNull: true }', function (hooks) {
-    hooks.beforeEach(function () {
-      serializer = new DateTimeSerializer({
-        serializationOptions: { disallowNull: true }
-      });
-    });
-
-    test('#serialize throws error on null', function (assert) {
-      assert.throws(() => {
-        serializer.serialize(null);
-      }, 'null is not allowed');
-    });
-
-    test('#deserialize throws error on null', function (assert) {
-      assert.throws(() => {
-        serializer.deserialize(null);
-      }, 'null is not allowed');
-    });
+  test('#deserialize returns a Date, with a time set', function (assert) {
+    assert.equal(
+      serializer.deserialize(dateString)?.toISOString(),
+      date.toISOString()
+    );
   });
 });

--- a/packages/@orbit/serializers/test/number-serializer-test.ts
+++ b/packages/@orbit/serializers/test/number-serializer-test.ts
@@ -5,63 +5,17 @@ const { module, test } = QUnit;
 module('NumberSerializer', function (hooks) {
   let serializer: NumberSerializer;
 
-  module('with no options', function (hooks) {
-    hooks.beforeEach(function () {
-      serializer = new NumberSerializer();
-    });
-
-    test('#serialize returns arg untouched', function (assert) {
-      assert.strictEqual(serializer.serialize(1), 1);
-      assert.strictEqual(serializer.serialize(2.4), 2.4);
-    });
-
-    test('#deserialize returns arg untouched', function (assert) {
-      assert.strictEqual(serializer.deserialize(1), 1);
-      assert.strictEqual(serializer.deserialize(2.4), 2.4);
-    });
-
-    test('#serialize returns nulls', function (assert) {
-      assert.equal(serializer.serialize(null), null);
-    });
-
-    test('#deserialize returns nulls', function (assert) {
-      assert.equal(serializer.deserialize(null), null);
-    });
+  hooks.beforeEach(function () {
+    serializer = new NumberSerializer();
   });
 
-  module('serializationOptions: { disallowNull: false }', function (hooks) {
-    hooks.beforeEach(function () {
-      serializer = new NumberSerializer({
-        serializationOptions: { disallowNull: false }
-      });
-    });
-
-    test('#serialize returns nulls', function (assert) {
-      assert.equal(serializer.serialize(null), null);
-    });
-
-    test('#deserialize returns nulls', function (assert) {
-      assert.equal(serializer.deserialize(null), null);
-    });
+  test('#serialize returns arg', function (assert) {
+    assert.strictEqual(serializer.serialize(1), 1);
+    assert.strictEqual(serializer.serialize(2.4), 2.4);
   });
 
-  module('serializationOptions: { disallowNull: true }', function (hooks) {
-    hooks.beforeEach(function () {
-      serializer = new NumberSerializer({
-        serializationOptions: { disallowNull: true }
-      });
-    });
-
-    test('#serialize throws error on null', function (assert) {
-      assert.throws(() => {
-        serializer.serialize(null);
-      }, 'null is not allowed');
-    });
-
-    test('#deserialize throws error on null', function (assert) {
-      assert.throws(() => {
-        serializer.deserialize(null);
-      }, 'null is not allowed');
-    });
+  test('#deserialize returns arg', function (assert) {
+    assert.strictEqual(serializer.deserialize(1), 1);
+    assert.strictEqual(serializer.deserialize(2.4), 2.4);
   });
 });

--- a/packages/@orbit/serializers/test/serializer-builders-test.ts
+++ b/packages/@orbit/serializers/test/serializer-builders-test.ts
@@ -1,10 +1,9 @@
 import { NoopSerializer } from '../src/noop-serializer';
-import { BooleanSerializer } from '../src/boolean-serializer';
-import { UnknownSerializerClass } from '../src/serializer';
+import { SerializerClass } from '../src/serializer';
 import {
   buildSerializerClassFor,
-  buildSerializerSettingsFor,
-  buildSerializerFor
+  buildSerializerFor,
+  buildSerializerSettingsFor
 } from '../src/serializer-builders';
 import { StringSerializer } from '../src/string-serializer';
 
@@ -13,13 +12,13 @@ const { module, test } = QUnit;
 module('Serializer builders', function (hooks) {
   test('buildSerializerClassFor returns fn that returns serializer classes', function (assert) {
     const serializerClassFor = buildSerializerClassFor({
-      boolean: BooleanSerializer as UnknownSerializerClass,
+      string: StringSerializer as SerializerClass,
       noop: NoopSerializer
     });
 
     assert.strictEqual(
-      serializerClassFor('boolean'),
-      BooleanSerializer as UnknownSerializerClass
+      serializerClassFor('string'),
+      StringSerializer as SerializerClass
     );
     assert.strictEqual(serializerClassFor('noop'), NoopSerializer);
     assert.strictEqual(serializerClassFor('unrecognized'), undefined);
@@ -31,21 +30,21 @@ module('Serializer builders', function (hooks) {
         foo: 'bar'
       },
       settingsByType: {
-        boolean: {
-          serializationOptions: { disallowNull: true }
+        string: {
+          serializationOptions: { inflectors: ['pluralize'] }
         },
         noop: {
           foo: 'baz',
-          serializationOptions: { disallowNull: false }
+          serializationOptions: { a: 'b' }
         }
       }
     });
 
     assert.deepEqual(
-      serializerSettingsFor('boolean'),
+      serializerSettingsFor('string'),
       {
         foo: 'bar',
-        serializationOptions: { disallowNull: true }
+        serializationOptions: { inflectors: ['pluralize'] }
       },
       'shared settings will be merged with typed settings'
     );
@@ -53,7 +52,7 @@ module('Serializer builders', function (hooks) {
       serializerSettingsFor('noop'),
       {
         foo: 'baz',
-        serializationOptions: { disallowNull: false }
+        serializationOptions: { a: 'b' }
       },
       'shared settings will be overridden by typed settings'
     );
@@ -68,7 +67,7 @@ module('Serializer builders', function (hooks) {
 
   test('buildSerializerFor returns fn that returns serializer', function (assert) {
     const serializerClassFor = buildSerializerClassFor({
-      string: StringSerializer as UnknownSerializerClass,
+      string: StringSerializer as SerializerClass,
       noop: NoopSerializer
     });
 

--- a/packages/@orbit/serializers/test/serializer-builders-test.ts
+++ b/packages/@orbit/serializers/test/serializer-builders-test.ts
@@ -6,6 +6,7 @@ import {
   buildSerializerSettingsFor,
   buildSerializerFor
 } from '../src/serializer-builders';
+import { StringSerializer } from '../src/string-serializer';
 
 const { module, test } = QUnit;
 
@@ -67,7 +68,7 @@ module('Serializer builders', function (hooks) {
 
   test('buildSerializerFor returns fn that returns serializer', function (assert) {
     const serializerClassFor = buildSerializerClassFor({
-      boolean: BooleanSerializer as UnknownSerializerClass,
+      string: StringSerializer as UnknownSerializerClass,
       noop: NoopSerializer
     });
 
@@ -76,12 +77,11 @@ module('Serializer builders', function (hooks) {
         foo: 'bar'
       },
       settingsByType: {
-        boolean: {
-          serializationOptions: { disallowNull: true }
+        string: {
+          serializationOptions: { inflectors: ['pluralize'] }
         },
         noop: {
-          foo: 'baz',
-          serializationOptions: { disallowNull: false }
+          foo: 'baz'
         }
       }
     });
@@ -98,15 +98,16 @@ module('Serializer builders', function (hooks) {
       serializers
     });
 
-    assert.strictEqual(
-      (serializerFor('boolean') as BooleanSerializer).serialize(true),
-      true,
+    assert.ok(
+      serializerFor('string') instanceof StringSerializer,
       'serializerFor returns a serializer created from a provided class'
     );
 
-    assert.throws(() => {
-      (serializerFor('boolean') as BooleanSerializer).serialize(null);
-    }, 'type-specific settings (such as disallowNull) will be passed into the constructor');
+    assert.strictEqual(
+      (serializerFor('string') as StringSerializer).serialize('brownCow'),
+      'brownCows',
+      'type-specific settings are used by the serializer'
+    );
 
     assert.strictEqual(
       serializerFor('noop'),

--- a/packages/@orbit/serializers/test/string-serializer-test.ts
+++ b/packages/@orbit/serializers/test/string-serializer-test.ts
@@ -18,50 +18,6 @@ module('StringSerializer', function (hooks) {
     test('#deserialize returns arg untouched', function (assert) {
       assert.equal(serializer.deserialize('abc'), 'abc');
     });
-
-    test('#serialize returns nulls', function (assert) {
-      assert.equal(serializer.serialize(null), null);
-    });
-
-    test('#deserialize returns nulls', function (assert) {
-      assert.equal(serializer.deserialize(null), null);
-    });
-  });
-
-  module('serializationOptions: { disallowNull: false }', function (hooks) {
-    hooks.beforeEach(function () {
-      serializer = new StringSerializer({
-        serializationOptions: { disallowNull: false }
-      });
-    });
-
-    test('#serialize returns nulls', function (assert) {
-      assert.equal(serializer.serialize(null), null);
-    });
-
-    test('#deserialize returns nulls', function (assert) {
-      assert.equal(serializer.deserialize(null), null);
-    });
-  });
-
-  module('serializationOptions: { disallowNull: true }', function (hooks) {
-    hooks.beforeEach(function () {
-      serializer = new StringSerializer({
-        serializationOptions: { disallowNull: true }
-      });
-    });
-
-    test('#serialize throws error on null', function (assert) {
-      assert.throws(() => {
-        serializer.serialize(null);
-      }, 'null is not allowed');
-    });
-
-    test('#deserialize throws error on null', function (assert) {
-      assert.throws(() => {
-        serializer.deserialize(null);
-      }, 'null is not allowed');
-    });
   });
 
   module(


### PR DESCRIPTION
This PR makes a cleanup pass on a number of issues related to serialization prior to the launch of the new interfaces in v0.17.

First of all, the model definitions used to define a schema now expect `serializationOptions` and `deserializationOptions` to be shortened to simply `serialization` and `deserialization`:

```diff
const person: ModelDefinition = {
  attributes: {
    name: { type: 'string' },
    birthday: { type: 'date' },
    height: {
      type: 'distance',
-      serializationOptions: { format: 'cm', digits: 2 },
-      deserializationOptions: { format: 'cm' }
+      serialization: { format: 'cm', digits: 2 },
+      deserialization: { format: 'cm' }
    }
  }
};
```

The old names are deprecated for now, but won't be supported in v0.18.

This change clears the way for a sibling set of options, `validation`, to be included in a very symmetrical and ergonomic way.

Along the lines of introducing validation concepts, this PR also removes the option `disallowNull` as a base serialization option in favor of encouraging this kind of check in validators instead. IMO this option added unnecessary complexity to every serializer and makes much more sense in a validation layer. Since this option was only supported for a few beta releases, I'm not going to go through the full deprecation process. I want it gone by v0.17 final.

One last change is related to typings for serializers. The `Serializer` and `SerializerClass` interfaces now better use generics and default to unknowns, eliminating the need for the awkward interfaces `UnknownSerializer` and `UnknownSerializerClass`.

Apologies for some of the churn as I try to stabilize serialization concepts and typings before v0.17 final.