### PR TITLE
Fix data-only response from `update` when a transform has already been applied

### DIFF
--- a/packages/@orbit/data/src/source-interfaces/updatable.ts
+++ b/packages/@orbit/data/src/source-interfaces/updatable.ts
@@ -90,9 +90,7 @@ export function updatable(Klass: unknown): void {
     );
 
     if (this.transformLog.contains(transform.id)) {
-      const transforms: Transform<Operation>[] = [];
-      const response = options?.fullResponse ? { transforms } : transforms;
-      return response;
+      return options?.fullResponse ? { transforms: [] } : undefined;
     } else {
       const response = await this._enqueueRequest('update', transform);
       return options?.fullResponse ? response : response.data;


### PR DESCRIPTION
For data-only requests, `update` was mistakenly returning an empty array (`[]`) instead of `undefined` when called with a transform that was previously applied.