### PR TITLE
Fix sharing of validatorFor function between record sources and caches, and memory sources and forks

### DIFF
--- a/packages/@orbit/indexeddb/src/indexeddb-source.ts
+++ b/packages/@orbit/indexeddb/src/indexeddb-source.ts
@@ -121,6 +121,13 @@ export class IndexedDBSource<
     cacheSettings.defaultTransformOptions =
       cacheSettings.defaultTransformOptions ?? settings.defaultTransformOptions;
 
+    if (
+      cacheSettings.validatorFor === undefined &&
+      cacheSettings.validators === undefined
+    ) {
+      cacheSettings.validatorFor = this._validatorFor;
+    }
+
     const cacheClass = settings.cacheClass ?? IndexedDBCache;
     this._cache = new cacheClass(
       cacheSettings as IndexedDBCacheSettings<QO, TO, QB, TB>

--- a/packages/@orbit/indexeddb/test/indexeddb-source-test.ts
+++ b/packages/@orbit/indexeddb/test/indexeddb-source-test.ts
@@ -172,6 +172,19 @@ module('IndexedDBSource', function (hooks) {
     );
   });
 
+  test('shares its `validatorFor` with its cache', function (assert) {
+    const source = new IndexedDBSource({
+      schema,
+      keyMap,
+      autoActivate: false
+    });
+    assert.strictEqual(
+      source.cache.validatorFor,
+      source.validatorFor,
+      'validatorFor is shared'
+    );
+  });
+
   module('activated', function (hooks) {
     hooks.beforeEach(async () => {
       source = new IndexedDBSource({ schema, keyMap });

--- a/packages/@orbit/local-storage/src/local-storage-source.ts
+++ b/packages/@orbit/local-storage/src/local-storage-source.ts
@@ -126,6 +126,13 @@ export class LocalStorageSource<
     cacheSettings.namespace = cacheSettings.namespace ?? settings.namespace;
     cacheSettings.delimiter = cacheSettings.delimiter ?? settings.delimiter;
 
+    if (
+      cacheSettings.validatorFor === undefined &&
+      cacheSettings.validators === undefined
+    ) {
+      cacheSettings.validatorFor = this._validatorFor;
+    }
+
     const cacheClass = settings.cacheClass ?? LocalStorageCache;
     this._cache = new cacheClass(
       cacheSettings as LocalStorageCacheSettings<QO, TO, QB, TB>

--- a/packages/@orbit/local-storage/test/local-storage-source-test.ts
+++ b/packages/@orbit/local-storage/test/local-storage-source-test.ts
@@ -163,6 +163,19 @@ module('LocalStorageSource', function (hooks) {
     );
   });
 
+  test('shares its `validatorFor` with its cache', function (assert) {
+    const source = new LocalStorageSource({
+      schema,
+      keyMap,
+      autoActivate: false
+    });
+    assert.strictEqual(
+      source.cache.validatorFor,
+      source.validatorFor,
+      'validatorFor is shared'
+    );
+  });
+
   test('#getKeyForRecord returns the local storage key that will be used for a record', function (assert) {
     assert.equal(
       source.getKeyForRecord({ type: 'planet', id: 'jupiter' }),

--- a/packages/@orbit/memory/src/memory-source.ts
+++ b/packages/@orbit/memory/src/memory-source.ts
@@ -265,8 +265,9 @@ export class MemorySource<
     settings.schema = schema;
     settings.cacheSettings = settings.cacheSettings || { schema };
     settings.keyMap = this._keyMap;
-    settings.queryBuilder = this.queryBuilder;
-    settings.transformBuilder = this.transformBuilder;
+    settings.queryBuilder = this._queryBuilder;
+    settings.transformBuilder = this._transformBuilder;
+    settings.validatorFor = this._validatorFor;
     settings.base = this;
 
     return new MemorySource<QO, TO, QB, TB, QRD, TRD>(settings);

--- a/packages/@orbit/memory/src/memory-source.ts
+++ b/packages/@orbit/memory/src/memory-source.ts
@@ -116,6 +116,13 @@ export class MemorySource<
     cacheSettings.defaultTransformOptions =
       cacheSettings.defaultTransformOptions ?? settings.defaultTransformOptions;
 
+    if (
+      cacheSettings.validatorFor === undefined &&
+      cacheSettings.validators === undefined
+    ) {
+      cacheSettings.validatorFor = this._validatorFor;
+    }
+
     const { base } = settings;
     if (base) {
       this._base = base;

--- a/packages/@orbit/memory/test/memory-source-test.ts
+++ b/packages/@orbit/memory/test/memory-source-test.ts
@@ -425,17 +425,22 @@ module('MemorySource', function (hooks) {
       jupiter,
       'data in fork matches data in source'
     );
-    assert.strictEqual(source.schema, fork.schema, 'schema matches');
-    assert.strictEqual(source.keyMap, fork.keyMap, 'keyMap matches');
+    assert.strictEqual(fork.schema, source.schema, 'schema matches');
+    assert.strictEqual(fork.keyMap, source.keyMap, 'keyMap matches');
     assert.strictEqual(
-      source.transformBuilder,
       fork.transformBuilder,
+      source.transformBuilder,
       'transformBuilder is shared'
     );
     assert.strictEqual(
-      source.queryBuilder,
       fork.queryBuilder,
+      source.queryBuilder,
       'queryBuilder is shared'
+    );
+    assert.strictEqual(
+      fork.validatorFor,
+      source.validatorFor,
+      'validatorFor is shared'
     );
     assert.strictEqual(
       fork.forkPoint,

--- a/packages/@orbit/memory/test/memory-source-test.ts
+++ b/packages/@orbit/memory/test/memory-source-test.ts
@@ -195,6 +195,15 @@ module('MemorySource', function (hooks) {
     );
   });
 
+  test('shares its `validatorFor` with its cache', function (assert) {
+    const source = new MemorySource({ schema, keyMap });
+    assert.strictEqual(
+      source.cache.validatorFor,
+      source.validatorFor,
+      'validatorFor is shared'
+    );
+  });
+
   test('#sync - appends transform to log', async function (assert) {
     const source = new MemorySource({ schema, keyMap });
     const recordA = {


### PR DESCRIPTION
As [pointed out](https://github.com/orbitjs/orbit/pull/842#issuecomment-856290051) by @SafaAlfulaij, the new `validatorFor` functions have not been automatically shared between record sources and their caches. Furthermore they were not shared between memory sources and their forks (generated via `fork()`). Therefore, validations may have inadvertently been happening at one layer but not the other. This PR resolves this by always passing `validatorFor` settings along unless an alternative was explicitly provided.

Thanks again for bringing this to my attention @SafaAlfulaij!