### PR TITLE
Validate that validator exists for attribute type [records]

### DIFF
--- a/packages/@orbit/records/test/record-validators/record-attribute-validator-test.ts
+++ b/packages/@orbit/records/test/record-validators/record-attribute-validator-test.ts
@@ -18,6 +18,9 @@ module('validateRecordAttribute', function (hooks) {
           name: {
             type: 'string',
             validation: { required: true, notNull: true, minLength: 2 }
+          },
+          description: {
+            type: 'fake' // Validator does not exist for this type
           }
         },
         relationships: {
@@ -251,6 +254,37 @@ module('validateRecordAttribute', function (hooks) {
             }
           ],
           description: `value is invalid`
+        }
+      ]
+    );
+  });
+
+  test('will check if an `attribute` has a validator defined for its `type`', function (assert) {
+    const attributeDef = schema.getAttribute('planet', 'description');
+
+    assert.deepEqual(
+      validateRecordAttribute(
+        {
+          record: { type: 'planet', id: '1' },
+          attribute: 'description',
+          value: 'a'
+        },
+        {
+          attributeDef,
+          validatorFor
+        }
+      ),
+      [
+        {
+          validator: StandardRecordValidators.RecordAttribute,
+          validation: 'type',
+          ref: {
+            record: { type: 'planet', id: '1' },
+            attribute: 'description',
+            value: 'a'
+          },
+          description:
+            "validator has not been provided for attribute 'description' of `type` 'fake'"
         }
       ]
     );


### PR DESCRIPTION
Rather than raising an exception when `validatorFor(type)` returns `undefined` for an attribute's `type` as defined in the schema, a `type` validation issue is returned. This should be a gentler and more informative way to communicate that the `type` does not have a validator defined. 