### PR TITLE
Fill in gaps in @orbit/validators

### DIFF
--- a/packages/@orbit/validators/src/object-validator.ts
+++ b/packages/@orbit/validators/src/object-validator.ts
@@ -1,0 +1,35 @@
+import { ValidationIssue, ValidationOptions, Validator } from './validator';
+
+interface BaseIssue extends ValidationIssue<unknown> {
+  validator: 'object';
+}
+
+interface TypeIssue extends BaseIssue {
+  validation: 'type';
+}
+export type ObjectValidationIssue = TypeIssue;
+
+export type ObjectValidationOptions = ValidationOptions;
+
+export type ObjectValidator = Validator<
+  unknown,
+  ObjectValidationOptions,
+  ObjectValidationIssue
+>;
+
+export const validateObject: ObjectValidator = (
+  input: unknown,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  options?: ObjectValidationOptions
+): undefined | ObjectValidationIssue[] => {
+  if (typeof input !== 'object') {
+    return [
+      {
+        validator: 'object',
+        validation: 'type',
+        description: 'is not an object',
+        ref: input
+      }
+    ];
+  }
+};

--- a/packages/@orbit/validators/src/standard-validators.ts
+++ b/packages/@orbit/validators/src/standard-validators.ts
@@ -3,6 +3,7 @@ import { ArrayValidator, validateArray } from './array-validator';
 import { BooleanValidator, validateBoolean } from './boolean-validator';
 import { DateValidator, validateDate } from './date-validator';
 import { NumberValidator, validateNumber } from './number-validator';
+import { ObjectValidator, validateObject } from './object-validator';
 import { StringValidator, validateString } from './string-validator';
 
 export enum StandardValidators {
@@ -11,6 +12,7 @@ export enum StandardValidators {
   Date = 'date',
   DateTime = 'datetime',
   Number = 'number',
+  Object = 'object',
   String = 'string'
 }
 
@@ -19,6 +21,7 @@ export type StandardValidator =
   | BooleanValidator
   | DateValidator
   | NumberValidator
+  | ObjectValidator
   | StringValidator;
 
 export const standardValidators: Dict<StandardValidator> = {
@@ -27,5 +30,6 @@ export const standardValidators: Dict<StandardValidator> = {
   date: validateDate,
   datetime: validateDate,
   number: validateNumber,
+  object: validateObject,
   string: validateString
 };

--- a/packages/@orbit/validators/src/standard-validators.ts
+++ b/packages/@orbit/validators/src/standard-validators.ts
@@ -9,6 +9,7 @@ export enum StandardValidators {
   Array = 'array',
   Boolean = 'boolean',
   Date = 'date',
+  DateTime = 'datetime',
   Number = 'number',
   String = 'string'
 }
@@ -24,6 +25,7 @@ export const standardValidators: Dict<StandardValidator> = {
   array: validateArray,
   boolean: validateBoolean,
   date: validateDate,
+  datetime: validateDate,
   number: validateNumber,
   string: validateString
 };

--- a/packages/@orbit/validators/src/validator-builder.ts
+++ b/packages/@orbit/validators/src/validator-builder.ts
@@ -9,7 +9,7 @@ export function buildValidatorFor<V = Validator>(settings: {
   const { validators } = settings;
 
   function validatorFor(type: string): V | undefined {
-    return validators[type];
+    return validators[type] ?? validators['unknown'];
   }
 
   return validatorFor;

--- a/packages/@orbit/validators/test/object-validator-test.ts
+++ b/packages/@orbit/validators/test/object-validator-test.ts
@@ -1,0 +1,19 @@
+import { validateObject } from '../src/object-validator';
+
+const { module, test } = QUnit;
+
+///////////////////////////////////////////////////////////////////////////////
+
+module('validateObject', function (hooks) {
+  test('validates type', function (assert) {
+    assert.strictEqual(validateObject({}), undefined);
+    assert.deepEqual(validateObject('not-an-object' as any), [
+      {
+        validator: 'object',
+        validation: 'type',
+        ref: 'not-an-object' as any,
+        description: 'is not an object'
+      }
+    ]);
+  });
+});

--- a/packages/@orbit/validators/test/standard-validator-test.ts
+++ b/packages/@orbit/validators/test/standard-validator-test.ts
@@ -1,0 +1,21 @@
+import { validateArray } from '../src/array-validator';
+import { validateBoolean } from '../src/boolean-validator';
+import { validateDate } from '../src/date-validator';
+import { validateNumber } from '../src/number-validator';
+import { standardValidators } from '../src/standard-validators';
+import { validateString } from '../src/string-validator';
+
+const { module, test } = QUnit;
+
+///////////////////////////////////////////////////////////////////////////////
+
+module('standardValidators', function (hooks) {
+  test('includes a validator for all "standard" types', function (assert) {
+    assert.strictEqual(standardValidators['array'], validateArray);
+    assert.strictEqual(standardValidators['boolean'], validateBoolean);
+    assert.strictEqual(standardValidators['date'], validateDate);
+    assert.strictEqual(standardValidators['datetime'], validateDate);
+    assert.strictEqual(standardValidators['number'], validateNumber);
+    assert.strictEqual(standardValidators['string'], validateString);
+  });
+});

--- a/packages/@orbit/validators/test/standard-validator-test.ts
+++ b/packages/@orbit/validators/test/standard-validator-test.ts
@@ -2,6 +2,7 @@ import { validateArray } from '../src/array-validator';
 import { validateBoolean } from '../src/boolean-validator';
 import { validateDate } from '../src/date-validator';
 import { validateNumber } from '../src/number-validator';
+import { validateObject } from '../src/object-validator';
 import { standardValidators } from '../src/standard-validators';
 import { validateString } from '../src/string-validator';
 
@@ -16,6 +17,7 @@ module('standardValidators', function (hooks) {
     assert.strictEqual(standardValidators['date'], validateDate);
     assert.strictEqual(standardValidators['datetime'], validateDate);
     assert.strictEqual(standardValidators['number'], validateNumber);
+    assert.strictEqual(standardValidators['object'], validateObject);
     assert.strictEqual(standardValidators['string'], validateString);
   });
 });

--- a/packages/@orbit/validators/test/validator-builder-test.ts
+++ b/packages/@orbit/validators/test/validator-builder-test.ts
@@ -17,5 +17,24 @@ module('buildValidatorFor', function (hooks) {
 
     assert.strictEqual(validatorFor('boolean'), validateBoolean);
     assert.strictEqual(validatorFor('string'), validateString);
+    assert.strictEqual(validatorFor('fake'), undefined);
+  });
+
+  test('returns an `unknown` validator for unrecognized types, if one has been registered', function (assert) {
+    const validateUnknown = () => {
+      // perhaps log an error or throw here
+    };
+
+    const validatorFor = buildValidatorFor({
+      validators: {
+        boolean: validateBoolean,
+        string: validateString,
+        unknown: validateUnknown
+      }
+    });
+
+    assert.strictEqual(validatorFor('boolean'), validateBoolean);
+    assert.strictEqual(validatorFor('string'), validateString);
+    assert.strictEqual(validatorFor('fake'), validateUnknown);
   });
 });


### PR DESCRIPTION
Performs the tasks discussed in #857:

* Adds `validateObject` and registers it in `standardValidators` for `object` types
* Registers `validateDate` in `standardValidators` for `datetime` types (it's already registered for `date` types)
* Introduces the concept of an `unknown` validator to allow for a catch-all for validating types that don't have a registered validator (similar to the `unknown` serializer concept). This can be used as a no-op, or to log an error, or even to throw an exception.

Closes #857