### PR TITLE
Explicitly set trailingSlash: false [website]

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -10,6 +10,7 @@ module.exports = {
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',
+  trailingSlash: false,
   organizationName: 'orbitjs',
   projectName: 'orbitjs.com',
   themeConfig: {


### PR DESCRIPTION
When deploying to GitHub Pages, it is better to use an explicit "trailingSlash" site config.
Otherwise, GitHub Pages will add an extra trailing slash to your site urls only on direct-access (not when navigation) with a server redirect.
This behavior can have SEO impacts and create relative link issues.