### PR TITLE
Create CNAME for website

### DIFF
--- a/website/static/CNAME
+++ b/website/static/CNAME
@@ -1,0 +1,1 @@
+orbitjs.com


### PR DESCRIPTION
Persists CNAME file for ghpages so that we don't need to reset this file after every publish.