### PR TITLE
Introduce new fork / merge possibilities in MemorySource and MemoryCache

### DIFF
--- a/packages/@orbit/memory/src/memory-cache.ts
+++ b/packages/@orbit/memory/src/memory-cache.ts
@@ -73,6 +73,7 @@ export class MemoryCache<
   QRD = unknown,
   TRD extends RecordCacheUpdateDetails = RecordCacheUpdateDetails
 > extends SyncRecordCache<QO, TO, QB, TB, QRD, TRD> {
+  protected _base?: MemoryCache<QO, TO, QB, TB, QRD, TRD>;
   protected _records!: Dict<ImmutableMap<string, InitializedRecord>>;
   protected _inverseRelationships!: Dict<
     ImmutableMap<string, RecordRelationshipIdentity[]>
@@ -81,14 +82,24 @@ export class MemoryCache<
   protected _isTrackingUpdateOperations: boolean;
 
   constructor(settings: MemoryCacheSettings<QO, TO, QB, TB, QRD, TRD>) {
+    const { base, trackUpdateOperations } = settings;
+
     super(settings);
+
+    this._base = base;
 
     // Track update operations if explicitly told to do so, or if a `base`
     // cache has been specified.
     this._isTrackingUpdateOperations =
-      settings.trackUpdateOperations ?? settings.base !== undefined;
+      trackUpdateOperations ?? base !== undefined;
 
-    this.reset(settings.base);
+    this.reset(base);
+  }
+
+  get base(): MemoryCache<QO, TO, QB, TB, QRD, TRD> | undefined {
+    return this._base;
+  }
+
   }
 
   getRecordSync(identity: RecordIdentity): InitializedRecord | undefined {

--- a/packages/@orbit/memory/src/memory-source.ts
+++ b/packages/@orbit/memory/src/memory-source.ts
@@ -329,9 +329,9 @@ export class MemorySource<
 
     let transforms: RecordTransform[];
     if (sinceTransformId) {
-      transforms = forkedSource.transformsSince(sinceTransformId);
+      transforms = forkedSource.getTransformsSince(sinceTransformId);
     } else {
-      transforms = forkedSource.allTransforms();
+      transforms = forkedSource.getAllTransforms();
     }
 
     let ops: RecordOperation[] = [];
@@ -378,7 +378,7 @@ export class MemorySource<
     this.cache.reset(base.cache);
 
     // replay all locally made transforms
-    this.allTransforms().forEach((t) => this._applyTransform(t));
+    this.getAllTransforms().forEach((t) => this._applyTransform(t));
 
     // reset the fork point
     this._forkPoint = base.transformLog.head;
@@ -395,19 +395,39 @@ export class MemorySource<
   }
 
   /**
-   * Returns all transforms since a particular `transformId`.
+   * Returns all logged transforms since a particular `transformId`.
    */
-  transformsSince(transformId: string): RecordTransform[] {
+  getTransformsSince(transformId: string): RecordTransform[] {
     return this.transformLog
       .after(transformId)
       .map((id) => this._transforms[id]);
   }
 
   /**
-   * Returns all tracked transforms.
+   * @deprecated since v0.17, call `getTransformsSince` instead
+   */
+  transformsSince(transformId: string): RecordTransform[] {
+    deprecate(
+      'MemorySource#transformsSince has been deprecated. Please call `source.getTransformsSince(tranformId)` instead.'
+    );
+    return this.getTransformsSince(transformId);
+  }
+
+  /**
+   * Returns all logged transforms.
+   */
+  getAllTransforms(): RecordTransform[] {
+    return this.transformLog.entries.map((id) => this._transforms[id]);
+  }
+
+  /**
+   * @deprecated since v0.17, call `getAllTransforms` instead
    */
   allTransforms(): RecordTransform[] {
-    return this.transformLog.entries.map((id) => this._transforms[id]);
+    deprecate(
+      'MemorySource#allTransforms has been deprecated. Please call `source.getAllTransforms()` instead.'
+    );
+    return this.getAllTransforms();
   }
 
   getTransform(transformId: string): RecordTransform {

--- a/packages/@orbit/memory/test/memory-cache-test.ts
+++ b/packages/@orbit/memory/test/memory-cache-test.ts
@@ -71,12 +71,14 @@ module('MemoryCache', function (hooks) {
 
   test('will track update operations by default if a `base` cache is passed', function (assert) {
     let base = new MemoryCache({ schema });
+    assert.strictEqual(base.base, undefined, 'base.base is undefined');
     assert.notOk(
       base.isTrackingUpdateOperations,
       'base is not tracking update ops'
     );
 
     let cache = new MemoryCache({ schema, base });
+    assert.strictEqual(cache.base, base, 'cache.base is defined');
     assert.ok(cache.isTrackingUpdateOperations, 'child is tracking update ops');
   });
 

--- a/packages/@orbit/memory/test/memory-cache-test.ts
+++ b/packages/@orbit/memory/test/memory-cache-test.ts
@@ -212,10 +212,10 @@ module('MemoryCache', function (hooks) {
     let cache1 = new MemoryCache({ schema, keyMap });
     let cache2 = new MemoryCache({ schema, keyMap });
 
-    cache1.patch((t) =>
+    cache1.update((t) =>
       t.addRecord({ type: 'planet', id: '1', attributes: { name: 'Earth' } })
     );
-    cache2.patch((t) =>
+    cache2.update((t) =>
       t.addRecord({ type: 'planet', id: '1', attributes: { name: 'Jupiter' } })
     );
 

--- a/packages/@orbit/memory/test/memory-cache-test.ts
+++ b/packages/@orbit/memory/test/memory-cache-test.ts
@@ -2550,4 +2550,186 @@ module('MemoryCache', function (hooks) {
       jupiter
     );
   });
+
+  test('#fork - creates a new cache that starts with the same schema and keyMap as the base cache', function (assert) {
+    const cache = new MemoryCache({ schema, keyMap });
+
+    const jupiter: InitializedRecord = {
+      type: 'planet',
+      id: 'jupiter',
+      attributes: { name: 'Jupiter', classification: 'gas giant' }
+    };
+
+    cache.update((t) => t.addRecord(jupiter));
+
+    assert.deepEqual(
+      cache.getRecordSync({ type: 'planet', id: 'jupiter' }),
+      jupiter,
+      'verify base data'
+    );
+
+    const fork = cache.fork();
+
+    assert.deepEqual(
+      fork.getRecordSync({ type: 'planet', id: 'jupiter' }),
+      jupiter,
+      'data in fork matches data in source'
+    );
+    assert.strictEqual(fork.schema, cache.schema, 'schema matches');
+    assert.strictEqual(fork.keyMap, cache.keyMap, 'keyMap matches');
+    assert.strictEqual(
+      fork.transformBuilder,
+      cache.transformBuilder,
+      'transformBuilder is shared'
+    );
+    assert.strictEqual(
+      fork.queryBuilder,
+      cache.queryBuilder,
+      'queryBuilder is shared'
+    );
+    assert.strictEqual(
+      fork.validatorFor,
+      cache.validatorFor,
+      'validatorFor is shared'
+    );
+    assert.strictEqual(
+      fork.base,
+      cache,
+      'base cache is set on the forked cache'
+    );
+  });
+
+  test('#merge - merges changes from a forked cache back into a base cache', function (assert) {
+    const cache = new MemoryCache({ schema, keyMap });
+
+    const jupiter: InitializedRecord = {
+      type: 'planet',
+      id: 'jupiter',
+      attributes: { name: 'Jupiter', classification: 'gas giant' }
+    };
+
+    let fork = cache.fork();
+
+    fork.update((t) => t.addRecord(jupiter));
+
+    assert.deepEqual(
+      fork.getRecordSync({ type: 'planet', id: 'jupiter' }),
+      jupiter,
+      'verify fork data'
+    );
+
+    let response = cache.merge(fork);
+
+    assert.deepEqual(response, [jupiter], 'response is array');
+
+    assert.deepEqual(
+      cache.getRecordSync({ type: 'planet', id: 'jupiter' }),
+      jupiter,
+      'data in cache matches data in fork'
+    );
+  });
+
+  test('#rebase - change in base ends up in fork', function (assert) {
+    assert.expect(3);
+
+    const jupiter: InitializedRecord = {
+      type: 'planet',
+      id: 'jupiter',
+      attributes: { name: 'Jupiter', classification: 'gas giant' }
+    };
+
+    const cache = new MemoryCache({ schema, keyMap });
+
+    let fork = cache.fork();
+
+    cache.update((t) => t.addRecord(jupiter));
+
+    assert.deepEqual(
+      cache.getRecordSync({ type: 'planet', id: 'jupiter' }),
+      jupiter,
+      'verify base cache data'
+    );
+    assert.equal(
+      fork.getRecordsSync('planet').length,
+      0,
+      'forked cache is still empty'
+    );
+
+    fork.rebase();
+
+    assert.deepEqual(
+      fork.getRecordSync({ type: 'planet', id: 'jupiter' }),
+      jupiter,
+      'verify data in forked cache'
+    );
+  });
+
+  test('#rebase - changes in fork are replayed after reset', function (assert) {
+    assert.expect(8);
+
+    const jupiter: InitializedRecord = {
+      type: 'planet',
+      id: 'jupiter',
+      attributes: { name: 'Jupiter', classification: 'gas giant' }
+    };
+
+    const earth: InitializedRecord = {
+      type: 'planet',
+      id: 'earth',
+      attributes: { name: 'Earth', classification: 'terrestrial' }
+    };
+
+    const cache = new MemoryCache({ schema, keyMap });
+
+    let fork = cache.fork();
+
+    cache.update((t) => t.addRecord(jupiter));
+    fork.update((t) => t.addRecord(earth));
+
+    assert.deepEqual(
+      cache.getRecordSync({ type: 'planet', id: 'jupiter' }),
+      jupiter,
+      'jupiter is in base'
+    );
+    assert.deepEqual(
+      cache.getRecordSync({ type: 'planet', id: 'earth' }),
+      undefined,
+      'earth is not in base'
+    );
+
+    assert.deepEqual(
+      fork.getRecordSync({ type: 'planet', id: 'jupiter' }),
+      undefined,
+      'jupiter is not in fork'
+    );
+    assert.deepEqual(
+      fork.getRecordSync({ type: 'planet', id: 'earth' }),
+      earth,
+      'earth is in fork'
+    );
+
+    fork.rebase();
+
+    assert.deepEqual(
+      fork.getRecordSync({ type: 'planet', id: 'jupiter' }),
+      jupiter,
+      'after rebase, jupiter is now in fork'
+    );
+    assert.deepEqual(
+      fork.getRecordSync({ type: 'planet', id: 'earth' }),
+      earth,
+      'after rebase, earth is still in fork'
+    );
+
+    assert.deepEqual(
+      cache.getRecordSync({ type: 'planet', id: 'jupiter' }),
+      jupiter,
+      'after rebase, jupiter is still in base'
+    );
+    assert.deepEqual(
+      cache.getRecordSync({ type: 'planet', id: 'earth' }),
+      undefined,
+      'after rebase, earth is still not in base'
+    );
+  });
 });

--- a/packages/@orbit/memory/test/memory-source-queryable-test.ts
+++ b/packages/@orbit/memory/test/memory-source-queryable-test.ts
@@ -78,7 +78,7 @@ module('MemorySource - queryable', function (hooks) {
       attributes: { name: 'Jupiter', classification: 'gas giant' }
     };
 
-    source.cache.patch((t) => t.addRecord(jupiter));
+    source.cache.update((t) => t.addRecord(jupiter));
 
     assert.equal(
       source.cache.getRecordsSync('planet').length,
@@ -108,7 +108,7 @@ module('MemorySource - queryable', function (hooks) {
       hints.data = jupiter2;
     });
 
-    source.cache.patch((t) => t.addRecord(jupiter2));
+    source.cache.update((t) => t.addRecord(jupiter2));
 
     assert.equal(
       source.cache.getRecordsSync('planet').length,
@@ -155,7 +155,7 @@ module('MemorySource - queryable', function (hooks) {
       }
     });
 
-    source.cache.patch((t) => [
+    source.cache.update((t) => [
       t.addRecord(jupiter),
       t.addRecord(earth),
       t.addRecord(uranus)

--- a/packages/@orbit/memory/test/memory-source-test.ts
+++ b/packages/@orbit/memory/test/memory-source-test.ts
@@ -261,7 +261,7 @@ module('MemorySource', function (hooks) {
     ]);
   });
 
-  test('#transformsSince - returns all transforms since a specified transformId', async function (assert) {
+  test('#getTransformsSince - returns all transforms since a specified transformId', async function (assert) {
     const source = new MemorySource({ schema, keyMap });
     const recordA = {
       id: 'jupiter',
@@ -289,13 +289,13 @@ module('MemorySource', function (hooks) {
     await source.sync(addRecordCTransform);
 
     assert.deepEqual(
-      source.transformsSince(addRecordATransform.id),
+      source.getTransformsSince(addRecordATransform.id),
       [addRecordBTransform, addRecordCTransform],
       'returns transforms since the specified transform'
     );
   });
 
-  test('#allTransforms - returns all tracked transforms', async function (assert) {
+  test('#getAllTransforms - returns all tracked transforms', async function (assert) {
     const source = new MemorySource({ schema, keyMap });
     const recordA = {
       id: 'jupiter',
@@ -323,7 +323,7 @@ module('MemorySource', function (hooks) {
     await source.sync(addRecordCTransform);
 
     assert.deepEqual(
-      source.allTransforms(),
+      source.getAllTransforms(),
       [addRecordATransform, addRecordBTransform, addRecordCTransform],
       'tracks transforms in correct order'
     );
@@ -359,7 +359,7 @@ module('MemorySource', function (hooks) {
     await source.transformLog.truncate(addRecordBTransform.id);
 
     assert.deepEqual(
-      source.allTransforms(),
+      source.getAllTransforms(),
       [addRecordBTransform, addRecordCTransform],
       'remaining transforms are in correct order'
     );
@@ -395,7 +395,7 @@ module('MemorySource', function (hooks) {
     await source.transformLog.clear();
 
     assert.deepEqual(
-      source.allTransforms(),
+      source.getAllTransforms(),
       [],
       'no transforms remain in history'
     );
@@ -644,7 +644,7 @@ module('MemorySource', function (hooks) {
 
     fork.rebase();
 
-    assert.deepEqual(fork.allTransforms(), [addRecordD, addRecordE]);
+    assert.deepEqual(fork.getAllTransforms(), [addRecordD, addRecordE]);
 
     assert.deepEqual(fork.cache.getRecordSync(recordA), recordA);
     assert.deepEqual(fork.cache.getRecordSync(recordB), recordB);

--- a/packages/@orbit/memory/test/memory-source-updatable-test.ts
+++ b/packages/@orbit/memory/test/memory-source-updatable-test.ts
@@ -242,7 +242,7 @@ module('MemorySource - updatable', function (hooks) {
       attributes: { name: 'Earth' }
     };
 
-    source.cache.patch((t) => t.addRecord(earth));
+    source.cache.update((t) => t.addRecord(earth));
 
     source.on('beforeUpdate', (transform: RecordTransform, hints: any) => {
       if (transform?.options?.customizeResults) {


### PR DESCRIPTION
The primary use case of `MemorySource` forking is to create an isolated source and cache, which can be modified and then merged back into its base, with all the associated operations coalesced.

Because the forked `MemorySource` is "just" another `Source`, updates to it are still async, which allows for those updates to be logged, interacted with through other sources, etc. through async processes. Until now, there has been no way to synchronously make changes to a fork and then merge those back to the base source, because only updates at the source level have been tracked.

## Optional update tracking in `MemoryCache`

This PR introduces a new optional form of update tracking in the `cache` associated with a source. By default now, this capability will be enabled in forked caches. Any updates applied to the cache will be tracked and used to form the merge transform when `merge` is invoked. This means that synchronous changes could be made to a forked cache directly rather than going through the associated source. Changes could also still be applied via updates to the forked source, since those will internally also invoke `update` on the cache and be tracked.

```typescript
// fork a base source
let fork = source.fork();

// add jupiter synchronously to the forked source's cache
fork.cache.update((t) => t.addRecord(jupiter));

// merge changes from the fork back to its base
await source.merge(fork);

// jupiter should now be in the base source
source.cache.getRecordSync({ type: 'planet', id: 'jupiter' }); // returns jupiter
```

If you want to continue to track changes only at the source-level and have `merge` work only with those changes, pass the following config when you fork a source:

```typescript
let fork = source.fork({ cacheSettings: { trackUpdateOperations: false } });
```

This will prevent update tracking at the cache level and will signal to `merge` that only transforms applied at the source-level should be merged.

## Other new `MemoryCache` capabilities

Along with change tracking at the cache-level, this PR also introduces the following methods to `MemoryCache`:

* `fork` - creates a new cache based on this one.
* `merge` - merges changes from a forked cache back into this cache.
* `rebase` - resets this cache's state to that of its `base` and then replays any update operations.

`MemoryCache` forking / merging / rebasing is a lighter-weight way of "branching" changes, that can ultimately be merged back into a source. Cache-level forking can be paired with source-level forking for a lot of flexibility and power.
