### PR TITLE
JSONAPISource: Allow multiple consecutive removeFromRelatedRecords ops to be coalesced

### DIFF
--- a/packages/@orbit/jsonapi/src/lib/transform-requests.ts
+++ b/packages/@orbit/jsonapi/src/lib/transform-requests.ts
@@ -370,6 +370,16 @@ export function getTransformRequests(
         (prevRequest as AddToRelatedRecordsRequest).relatedRecords.push(
           cloneRecordIdentity(operation.relatedRecord)
         );
+      } else if (
+        prevRequest.op === 'removeFromRelatedRecords' &&
+        operation.op === 'removeFromRelatedRecords' &&
+        (prevRequest as RemoveFromRelatedRecordsRequest).relationship ===
+          operation.relationship
+      ) {
+        newRequestNeeded = false;
+        (prevRequest as RemoveFromRelatedRecordsRequest).relatedRecords.push(
+          cloneRecordIdentity(operation.relatedRecord)
+        );
       }
     }
 


### PR DESCRIPTION
The logic to coalesce multiple consecutive `removeFromRelatedRecords` ops was missing. It follows the same pattern as the corresponding code to coalesce `addToRelatedRecords` ops.