### PR TITLE
[jsonapi] Introduce `partialSet` request option

### DIFF
--- a/packages/@orbit/jsonapi/src/lib/jsonapi-request-options.ts
+++ b/packages/@orbit/jsonapi/src/lib/jsonapi-request-options.ts
@@ -12,6 +12,26 @@ export interface JSONAPIRequestOptions extends RequestOptions {
   sort?: any;
   page?: any;
   include?: any;
+
+  /**
+   * Explicit control over whether the resultset in a successful response should
+   * be interpreted as a partial set of related records. Currently, this option
+   * only applies to requests for related records.
+   *
+   * Example usage: A request is made to a custom relationship `url` and you
+   * want the records returned to be added to the relationship, rather than to
+   * replace all existing members of that relationship.
+   *
+   * If this property is not set, then `data` will be implicitly treated as a
+   * partial set of related records if:
+   *
+   * - a `filter` option is present in the request
+   * - a `page` option is present in the request
+   * - a `prev` or `next` link is present in the response document's top-level
+   *   `links` object.
+   */
+  partialSet?: boolean;
+
   settings?: FetchSettings;
   url?: string;
 }

--- a/packages/@orbit/jsonapi/src/lib/query-requests.ts
+++ b/packages/@orbit/jsonapi/src/lib/query-requests.ts
@@ -295,7 +295,6 @@ export const QueryRequestProcessors: Dict<QueryRequestProcessor> = {
   ): Promise<QueryRequestProcessorResponse> {
     const { record, relationship } = request as FindRelatedRecordsRequest;
     const options = request.options || {};
-    const isFiltered = !!(options.filter || options.sort || options.page);
     const settings = requestProcessor.buildFetchSettings(options);
     const url =
       options.url ||
@@ -318,7 +317,17 @@ export const QueryRequestProcessors: Dict<QueryRequestProcessor> = {
       const operations = requestProcessor.operationsFromDeserializedDocument(
         recordDoc
       );
-      if (isFiltered) {
+
+      const partialSet =
+        options.partialSet ??
+        !!(
+          options.filter ||
+          options.page ||
+          recordDoc.links?.next ||
+          recordDoc.links?.prev
+        );
+
+      if (partialSet) {
         for (let relatedRecord of relatedRecords) {
           operations.push({
             op: 'addToRelatedRecords',

--- a/packages/@orbit/jsonapi/test/jsonapi-source-pullable-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-pullable-test.ts
@@ -1204,9 +1204,7 @@ module('JSONAPISource - pullable', function (hooks) {
           'updateRecord',
           'updateRecord',
           'updateRecord',
-          'addToRelatedRecords',
-          'addToRelatedRecords',
-          'addToRelatedRecords'
+          'replaceRelatedRecords'
         ]
       );
 
@@ -1271,9 +1269,7 @@ module('JSONAPISource - pullable', function (hooks) {
           'updateRecord',
           'updateRecord',
           'updateRecord',
-          'addToRelatedRecords',
-          'addToRelatedRecords',
-          'addToRelatedRecords'
+          'replaceRelatedRecords'
         ]
       );
 
@@ -1354,9 +1350,7 @@ module('JSONAPISource - pullable', function (hooks) {
           'updateRecord',
           'updateRecord',
           'updateRecord',
-          'addToRelatedRecords',
-          'addToRelatedRecords',
-          'addToRelatedRecords'
+          'replaceRelatedRecords'
         ]
       );
 
@@ -1406,7 +1400,16 @@ module('JSONAPISource - pullable', function (hooks) {
             'page[offset]'
           )}=1&${encodeURIComponent('page[limit]')}=10`
         )
-        .returns(jsonapiResponse(200, { data }));
+        .returns(
+          jsonapiResponse(200, {
+            data,
+            links: {
+              next: `/solar-systems/sun/planets?${encodeURIComponent(
+                'page[offset]'
+              )}=2&${encodeURIComponent('page[limit]')}=10`
+            }
+          })
+        );
 
       let transforms = (await source.pull((q) =>
         q

--- a/packages/@orbit/jsonapi/test/jsonapi-source-with-legacy-serializer-settings-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-with-legacy-serializer-settings-test.ts
@@ -3183,9 +3183,7 @@ module('JSONAPISource with legacy serialization settings', function () {
           'updateRecord',
           'updateRecord',
           'updateRecord',
-          'addToRelatedRecords',
-          'addToRelatedRecords',
-          'addToRelatedRecords'
+          'replaceRelatedRecords'
         ]
       );
 
@@ -3250,9 +3248,7 @@ module('JSONAPISource with legacy serialization settings', function () {
           'updateRecord',
           'updateRecord',
           'updateRecord',
-          'addToRelatedRecords',
-          'addToRelatedRecords',
-          'addToRelatedRecords'
+          'replaceRelatedRecords'
         ]
       );
 
@@ -3333,9 +3329,7 @@ module('JSONAPISource with legacy serialization settings', function () {
           'updateRecord',
           'updateRecord',
           'updateRecord',
-          'addToRelatedRecords',
-          'addToRelatedRecords',
-          'addToRelatedRecords'
+          'replaceRelatedRecords'
         ]
       );
 
@@ -3385,7 +3379,16 @@ module('JSONAPISource with legacy serialization settings', function () {
             'page[offset]'
           )}=1&${encodeURIComponent('page[limit]')}=10`
         )
-        .returns(jsonapiResponse(200, { data }));
+        .returns(
+          jsonapiResponse(200, {
+            data,
+            links: {
+              next: `/solar-systems/sun/planets?${encodeURIComponent(
+                'page[offset]'
+              )}=2&${encodeURIComponent('page[limit]')}=10`
+            }
+          })
+        );
 
       let transforms = (await source.pull((q) =>
         q


### PR DESCRIPTION
The `partialSet` request option provides explicit control over whether the resultset in a successful response should be interpreted as a partial set of related records. Currently, this option only applies to requests for related records.

Example usage: A request is made to a custom relationship `url` and you want the records returned to be added to the relationship, rather than to replace all existing members of that relationship.

If this property is not set, then `data` will be implicitly treated as a partial set of related records if:

- a `filter` option is present in the request
- a `page` option is present in the request
- a `prev` or `next` link is present in the response document's top-level `links` object.