### PR TITLE
[Docs] Update "Relationship filtering" section in querying docs

### DIFF
--- a/website/docs/querying-data.md
+++ b/website/docs/querying-data.md
@@ -271,7 +271,7 @@ For attribute filtering, the following comparison operators are available.
 - `gte`: alias for the `>=` operator.
 - `lte`: alias for the `<=` operator.
 
-#### Relationship filtering
+### Relationship filtering
 
 Relationship filtering has two types:
 
@@ -280,7 +280,7 @@ Filtering on a `hasOne` relationship:
 ```typescript
 const moonsOfJupiter = orbit.cache.query((q) => {
   return q.findRecords('moon')
-          .filter({ relationship: 'planet', op: 'equal', record: { type: 'planet', id: 'jupiter' } })
+          .filter({ relationship: 'planet', op: 'equal', records: { type: 'planet', id: 'jupiter' } })
 })
 ```
 

--- a/website/docs/querying-data.md
+++ b/website/docs/querying-data.md
@@ -280,7 +280,7 @@ Filtering on a `hasOne` relationship:
 ```typescript
 const moonsOfJupiter = orbit.cache.query((q) => {
   return q.findRecords('moon')
-          .filter({ relationship: 'planet', op: 'equal', records: { type: 'planet', id: 'jupiter' } })
+          .filter({ relationship: 'planet', op: 'equal', record: { type: 'planet', id: 'jupiter' } })
 })
 ```
 

--- a/website/docs/querying-data.md
+++ b/website/docs/querying-data.md
@@ -247,12 +247,10 @@ const denserThanEarth = orbit.cache.query((q) => {
 3. the right hand value:
    This is a value that will remain constant for the entirety of the filter. This value determines, given the operation, which records will be returned and which will not.
 
-### Comparison operators for filtering
-
 There are two different kinds of filtering. Filtering on attribute values and filtering on relationship values.
 Both have their own comparison operators.
 
-#### Attribute filtering
+### Attribute filtering
 
 Attribute filtering looks like the following:
 


### PR DESCRIPTION
- The header I think should be an H3, otherwise it doesn't show up in the navigation and gets lost.
- In my testing, it looks like the correct key is `records` in the relationship filter object... it's inconsistent between the two examples.