### PR TITLE
Expand validation error descriptions

### DIFF
--- a/packages/@orbit/records/src/record-exceptions.ts
+++ b/packages/@orbit/records/src/record-exceptions.ts
@@ -1,5 +1,8 @@
 import { Exception } from '@orbit/core';
-import { ValidationIssue } from '@orbit/validators';
+import {
+  formatValidationDescription,
+  ValidationIssue
+} from '@orbit/validators';
 
 /**
  * An error occured related to the schema.
@@ -17,12 +20,10 @@ export class SchemaError extends Exception {
  * A validation failed.
  */
 export class ValidationError extends Exception {
-  public description: string;
   public issues?: ValidationIssue[];
 
   constructor(description: string, issues?: ValidationIssue[]) {
-    super(description);
-    this.description = description;
+    super(formatValidationDescription(description, issues));
     this.issues = issues;
   }
 }

--- a/packages/@orbit/records/src/record-validators/record-operation-validator.ts
+++ b/packages/@orbit/records/src/record-validators/record-operation-validator.ts
@@ -1,5 +1,6 @@
 import { Assertion } from '@orbit/core';
 import {
+  formatValidationDescription,
   StandardValidator,
   ValidationIssue,
   Validator,
@@ -159,7 +160,10 @@ export const validateRecordOperation: RecordOperationValidator = (
         validation: 'operationValid',
         ref: operation,
         details: issues,
-        description: 'record operation is invalid'
+        description: formatValidationDescription(
+          'record operation is invalid',
+          issues
+        )
       }
     ];
   }

--- a/packages/@orbit/records/src/record-validators/record-query-expression-validator.ts
+++ b/packages/@orbit/records/src/record-validators/record-query-expression-validator.ts
@@ -1,5 +1,6 @@
 import { Assertion } from '@orbit/core';
 import {
+  formatValidationDescription,
   StandardValidator,
   ValidationIssue,
   Validator,
@@ -242,7 +243,10 @@ export const validateRecordQueryExpression: RecordQueryExpressionValidator = (
         validation: 'queryExpressionValid',
         ref: expression,
         details: issues,
-        description: 'record query expression is invalid'
+        description: formatValidationDescription(
+          'record query expression is invalid',
+          issues
+        )
       }
     ];
   }

--- a/packages/@orbit/records/src/record-validators/record-relationship-validator.ts
+++ b/packages/@orbit/records/src/record-validators/record-relationship-validator.ts
@@ -1,6 +1,7 @@
 import { Assertion } from '@orbit/core';
 import {
   ArrayValidator,
+  formatValidationDescription,
   StandardValidator,
   StandardValidators,
   ValidationIssue,
@@ -217,8 +218,11 @@ export const validateRecordRelationship: RecordRelationshipValidator = (
             data
           },
           validation: 'dataValid',
-          description: 'relationship data is invalid',
-          details: dataIssues
+          details: dataIssues,
+          description: formatValidationDescription(
+            'relationship data is invalid',
+            dataIssues
+          )
         }
       ];
     }

--- a/packages/@orbit/records/src/record-validators/related-record-validator.ts
+++ b/packages/@orbit/records/src/record-validators/related-record-validator.ts
@@ -1,5 +1,6 @@
 import { Assertion } from '@orbit/core';
 import {
+  formatValidationDescription,
   StandardValidator,
   ValidationIssue,
   Validator,
@@ -110,7 +111,10 @@ export const validateRelatedRecord: RelatedRecordValidator = (
           relatedRecord
         },
         details: relatedRecordIssues,
-        description: 'relatedRecord is not a valid record identity'
+        description: formatValidationDescription(
+          'relatedRecord is not a valid record identity',
+          relatedRecordIssues
+        )
       }
     ];
   }

--- a/packages/@orbit/records/test/record-validators/record-operation-validator-test.ts
+++ b/packages/@orbit/records/test/record-validators/record-operation-validator-test.ts
@@ -2,7 +2,16 @@ import { RecordSchema } from '../../src/record-schema';
 import { StandardRecordValidators } from '../../src/record-validators/standard-record-validators';
 import { buildRecordValidatorFor } from '../../src/record-validators/record-validator-builder';
 import { validateRecordOperation } from '../../src/record-validators/record-operation-validator';
-import { RecordOperation } from '../../src';
+import {
+  RecordAttributeValidationIssue,
+  RecordFieldDefinitionIssue,
+  RecordKeyValidationIssue,
+  RecordOperation,
+  RecordRelationshipValidationIssue,
+  RecordTypeValidationIssue,
+  RelatedRecordValidationIssue
+} from '../../src';
+import { formatValidationDescription } from '@orbit/validators';
 
 const { module, test } = QUnit;
 
@@ -105,6 +114,39 @@ module('validateRecordOperation', function (hooks) {
       }
     };
 
+    const issues: RecordFieldDefinitionIssue[] = [
+      {
+        validator: StandardRecordValidators.RecordFieldDefinition,
+        validation: 'fieldDefined',
+        ref: {
+          kind: 'key',
+          type: 'moon',
+          field: 'fakeKey'
+        },
+        description: `key 'fakeKey' for type 'moon' is not defined in schema`
+      },
+      {
+        validator: StandardRecordValidators.RecordFieldDefinition,
+        validation: 'fieldDefined',
+        ref: {
+          kind: 'attribute',
+          type: 'moon',
+          field: 'fakeAttr'
+        },
+        description: `attribute 'fakeAttr' for type 'moon' is not defined in schema`
+      },
+      {
+        validator: StandardRecordValidators.RecordFieldDefinition,
+        validation: 'fieldDefined',
+        ref: {
+          kind: 'relationship',
+          type: 'moon',
+          field: 'fakeRel'
+        },
+        description: `relationship 'fakeRel' for type 'moon' is not defined in schema`
+      }
+    ];
+
     assert.deepEqual(
       validateRecordOperation(
         {
@@ -124,39 +166,11 @@ module('validateRecordOperation', function (hooks) {
             op: 'addRecord',
             record: invalidRecord
           },
-          details: [
-            {
-              validator: StandardRecordValidators.RecordFieldDefinition,
-              validation: 'fieldDefined',
-              ref: {
-                kind: 'key',
-                type: 'moon',
-                field: 'fakeKey'
-              },
-              description: `key 'fakeKey' for type 'moon' is not defined in schema`
-            },
-            {
-              validator: StandardRecordValidators.RecordFieldDefinition,
-              validation: 'fieldDefined',
-              ref: {
-                kind: 'attribute',
-                type: 'moon',
-                field: 'fakeAttr'
-              },
-              description: `attribute 'fakeAttr' for type 'moon' is not defined in schema`
-            },
-            {
-              validator: StandardRecordValidators.RecordFieldDefinition,
-              validation: 'fieldDefined',
-              ref: {
-                kind: 'relationship',
-                type: 'moon',
-                field: 'fakeRel'
-              },
-              description: `relationship 'fakeRel' for type 'moon' is not defined in schema`
-            }
-          ],
-          description: 'record operation is invalid'
+          details: issues,
+          description: formatValidationDescription(
+            'record operation is invalid',
+            issues
+          )
         }
       ],
       'invalid operation'
@@ -194,6 +208,19 @@ module('validateRecordOperation', function (hooks) {
       }
     };
 
+    const issues: RecordFieldDefinitionIssue[] = [
+      {
+        validator: StandardRecordValidators.RecordFieldDefinition,
+        validation: 'fieldDefined',
+        ref: {
+          kind: 'attribute',
+          type: 'moon',
+          field: 'fakeAttr'
+        },
+        description: `attribute 'fakeAttr' for type 'moon' is not defined in schema`
+      }
+    ];
+
     assert.deepEqual(
       validateRecordOperation(
         {
@@ -213,19 +240,11 @@ module('validateRecordOperation', function (hooks) {
             op: 'updateRecord',
             record: invalidUpdate
           },
-          details: [
-            {
-              validator: StandardRecordValidators.RecordFieldDefinition,
-              validation: 'fieldDefined',
-              ref: {
-                kind: 'attribute',
-                type: 'moon',
-                field: 'fakeAttr'
-              },
-              description: `attribute 'fakeAttr' for type 'moon' is not defined in schema`
-            }
-          ],
-          description: 'record operation is invalid'
+          details: issues,
+          description: formatValidationDescription(
+            'record operation is invalid',
+            issues
+          )
         }
       ],
       'invalid operation'
@@ -258,6 +277,15 @@ module('validateRecordOperation', function (hooks) {
       id: '1'
     };
 
+    const issues: RecordTypeValidationIssue[] = [
+      {
+        validator: StandardRecordValidators.RecordType,
+        validation: 'recordTypeDefined',
+        ref: 'fake',
+        description: `Record type 'fake' does not exist in schema`
+      }
+    ];
+
     assert.deepEqual(
       validateRecordOperation(
         {
@@ -277,15 +305,11 @@ module('validateRecordOperation', function (hooks) {
             op: 'removeRecord',
             record: invalidRecord
           },
-          details: [
-            {
-              validator: StandardRecordValidators.RecordType,
-              validation: 'recordTypeDefined',
-              ref: 'fake',
-              description: `Record type 'fake' does not exist in schema`
-            }
-          ],
-          description: 'record operation is invalid'
+          details: issues,
+          description: formatValidationDescription(
+            'record operation is invalid',
+            issues
+          )
         }
       ],
       'invalid operation'
@@ -320,6 +344,19 @@ module('validateRecordOperation', function (hooks) {
       id: '1'
     };
 
+    const issues: RecordKeyValidationIssue[] = [
+      {
+        validator: StandardRecordValidators.RecordFieldDefinition,
+        validation: 'fieldDefined',
+        ref: {
+          kind: 'key',
+          type: 'fake',
+          field: 'remoteId'
+        },
+        description: `key 'remoteId' for type 'fake' is not defined in schema`
+      }
+    ];
+
     assert.deepEqual(
       validateRecordOperation(
         {
@@ -343,19 +380,11 @@ module('validateRecordOperation', function (hooks) {
             key: 'remoteId',
             value: 'a'
           },
-          details: [
-            {
-              validator: StandardRecordValidators.RecordFieldDefinition,
-              validation: 'fieldDefined',
-              ref: {
-                kind: 'key',
-                type: 'fake',
-                field: 'remoteId'
-              },
-              description: `key 'remoteId' for type 'fake' is not defined in schema`
-            }
-          ],
-          description: 'record operation is invalid'
+          details: issues,
+          description: formatValidationDescription(
+            'record operation is invalid',
+            issues
+          )
         }
       ],
       'invalid operation'
@@ -390,6 +419,19 @@ module('validateRecordOperation', function (hooks) {
       id: '1'
     };
 
+    const issues: RecordAttributeValidationIssue[] = [
+      {
+        validator: StandardRecordValidators.RecordFieldDefinition,
+        validation: 'fieldDefined',
+        ref: {
+          kind: 'attribute',
+          type: 'fake',
+          field: 'name'
+        },
+        description: `attribute 'name' for type 'fake' is not defined in schema`
+      }
+    ];
+
     assert.deepEqual(
       validateRecordOperation(
         {
@@ -413,19 +455,11 @@ module('validateRecordOperation', function (hooks) {
             attribute: 'name',
             value: 'a'
           },
-          details: [
-            {
-              validator: StandardRecordValidators.RecordFieldDefinition,
-              validation: 'fieldDefined',
-              ref: {
-                kind: 'attribute',
-                type: 'fake',
-                field: 'name'
-              },
-              description: `attribute 'name' for type 'fake' is not defined in schema`
-            }
-          ],
-          description: 'record operation is invalid'
+          details: issues,
+          description: formatValidationDescription(
+            'record operation is invalid',
+            issues
+          )
         }
       ],
       'invalid operation'
@@ -469,6 +503,23 @@ module('validateRecordOperation', function (hooks) {
       }
     };
 
+    const issues: RelatedRecordValidationIssue[] = [
+      {
+        validator: StandardRecordValidators.RelatedRecord,
+        validation: 'relatedRecordType',
+        ref: {
+          record: { type: 'planet', id: '1' },
+          relationship: 'moons',
+          relatedRecord: { type: 'planet', id: '1' }
+        },
+        details: {
+          allowedTypes: ['moon']
+        },
+        description:
+          "relatedRecord has a type 'planet' which is not an allowed type for this relationship"
+      }
+    ];
+
     assert.deepEqual(
       validateRecordOperation(invalidOperation, {
         schema,
@@ -479,23 +530,11 @@ module('validateRecordOperation', function (hooks) {
           validator: StandardRecordValidators.RecordOperation,
           validation: 'operationValid',
           ref: invalidOperation,
-          details: [
-            {
-              validator: StandardRecordValidators.RelatedRecord,
-              validation: 'relatedRecordType',
-              ref: {
-                record: { type: 'planet', id: '1' },
-                relationship: 'moons',
-                relatedRecord: { type: 'planet', id: '1' }
-              },
-              details: {
-                allowedTypes: ['moon']
-              },
-              description:
-                "relatedRecord has a type 'planet' which is not an allowed type for this relationship"
-            }
-          ],
-          description: 'record operation is invalid'
+          details: issues,
+          description: formatValidationDescription(
+            'record operation is invalid',
+            issues
+          )
         }
       ],
       'invalid operation'
@@ -539,6 +578,23 @@ module('validateRecordOperation', function (hooks) {
       }
     };
 
+    const issues: RelatedRecordValidationIssue[] = [
+      {
+        validator: StandardRecordValidators.RelatedRecord,
+        validation: 'relatedRecordType',
+        ref: {
+          record: { type: 'planet', id: '1' },
+          relationship: 'moons',
+          relatedRecord: { type: 'planet', id: '1' }
+        },
+        details: {
+          allowedTypes: ['moon']
+        },
+        description:
+          "relatedRecord has a type 'planet' which is not an allowed type for this relationship"
+      }
+    ];
+
     assert.deepEqual(
       validateRecordOperation(invalidOperation, {
         schema,
@@ -549,23 +605,11 @@ module('validateRecordOperation', function (hooks) {
           validator: StandardRecordValidators.RecordOperation,
           validation: 'operationValid',
           ref: invalidOperation,
-          details: [
-            {
-              validator: StandardRecordValidators.RelatedRecord,
-              validation: 'relatedRecordType',
-              ref: {
-                record: { type: 'planet', id: '1' },
-                relationship: 'moons',
-                relatedRecord: { type: 'planet', id: '1' }
-              },
-              details: {
-                allowedTypes: ['moon']
-              },
-              description:
-                "relatedRecord has a type 'planet' which is not an allowed type for this relationship"
-            }
-          ],
-          description: 'record operation is invalid'
+          details: issues,
+          description: formatValidationDescription(
+            'record operation is invalid',
+            issues
+          )
         }
       ],
       'invalid operation'
@@ -613,6 +657,40 @@ module('validateRecordOperation', function (hooks) {
       ]
     };
 
+    const relationshipDataIssues: RelatedRecordValidationIssue[] = [
+      {
+        validator: StandardRecordValidators.RelatedRecord,
+        validation: 'relatedRecordType',
+        ref: {
+          record: { type: 'planet', id: '1' },
+          relationship: 'moons',
+          relatedRecord: { type: 'planet', id: '1' }
+        },
+        details: {
+          allowedTypes: ['moon']
+        },
+        description:
+          "relatedRecord has a type 'planet' which is not an allowed type for this relationship"
+      }
+    ];
+
+    const issues: RecordRelationshipValidationIssue[] = [
+      {
+        validator: StandardRecordValidators.RecordRelationship,
+        validation: 'dataValid',
+        ref: {
+          record: { type: 'planet', id: '1' },
+          relationship: 'moons',
+          data: [{ type: 'planet', id: '1' }]
+        },
+        details: relationshipDataIssues,
+        description: formatValidationDescription(
+          'relationship data is invalid',
+          relationshipDataIssues
+        )
+      }
+    ];
+
     assert.deepEqual(
       validateRecordOperation(invalidOperation, {
         schema,
@@ -623,35 +701,11 @@ module('validateRecordOperation', function (hooks) {
           validator: StandardRecordValidators.RecordOperation,
           validation: 'operationValid',
           ref: invalidOperation,
-          details: [
-            {
-              validator: StandardRecordValidators.RecordRelationship,
-              validation: 'dataValid',
-              ref: {
-                record: { type: 'planet', id: '1' },
-                relationship: 'moons',
-                data: [{ type: 'planet', id: '1' }]
-              },
-              description: 'relationship data is invalid',
-              details: [
-                {
-                  validator: StandardRecordValidators.RelatedRecord,
-                  validation: 'relatedRecordType',
-                  ref: {
-                    record: { type: 'planet', id: '1' },
-                    relationship: 'moons',
-                    relatedRecord: { type: 'planet', id: '1' }
-                  },
-                  details: {
-                    allowedTypes: ['moon']
-                  },
-                  description:
-                    "relatedRecord has a type 'planet' which is not an allowed type for this relationship"
-                }
-              ]
-            }
-          ],
-          description: 'record operation is invalid'
+          details: issues,
+          description: formatValidationDescription(
+            'record operation is invalid',
+            issues
+          )
         }
       ],
       'invalid operation'
@@ -695,6 +749,40 @@ module('validateRecordOperation', function (hooks) {
       }
     };
 
+    const relationshipDataIssues: RelatedRecordValidationIssue[] = [
+      {
+        validator: StandardRecordValidators.RelatedRecord,
+        validation: 'relatedRecordType',
+        ref: {
+          record: { type: 'moon', id: '1' },
+          relationship: 'planet',
+          relatedRecord: { type: 'moon', id: '1' }
+        },
+        details: {
+          allowedTypes: ['planet']
+        },
+        description:
+          "relatedRecord has a type 'moon' which is not an allowed type for this relationship"
+      }
+    ];
+
+    const issues: RecordRelationshipValidationIssue[] = [
+      {
+        validator: StandardRecordValidators.RecordRelationship,
+        validation: 'dataValid',
+        ref: {
+          record: { type: 'moon', id: '1' },
+          relationship: 'planet',
+          data: { type: 'moon', id: '1' }
+        },
+        details: relationshipDataIssues,
+        description: formatValidationDescription(
+          'relationship data is invalid',
+          relationshipDataIssues
+        )
+      }
+    ];
+
     assert.deepEqual(
       validateRecordOperation(invalidOperation, {
         schema,
@@ -705,35 +793,11 @@ module('validateRecordOperation', function (hooks) {
           validator: StandardRecordValidators.RecordOperation,
           validation: 'operationValid',
           ref: invalidOperation,
-          details: [
-            {
-              validator: StandardRecordValidators.RecordRelationship,
-              validation: 'dataValid',
-              ref: {
-                record: { type: 'moon', id: '1' },
-                relationship: 'planet',
-                data: { type: 'moon', id: '1' }
-              },
-              description: 'relationship data is invalid',
-              details: [
-                {
-                  validator: StandardRecordValidators.RelatedRecord,
-                  validation: 'relatedRecordType',
-                  ref: {
-                    record: { type: 'moon', id: '1' },
-                    relationship: 'planet',
-                    relatedRecord: { type: 'moon', id: '1' }
-                  },
-                  details: {
-                    allowedTypes: ['planet']
-                  },
-                  description:
-                    "relatedRecord has a type 'moon' which is not an allowed type for this relationship"
-                }
-              ]
-            }
-          ],
-          description: 'record operation is invalid'
+          details: issues,
+          description: formatValidationDescription(
+            'record operation is invalid',
+            issues
+          )
         }
       ],
       'invalid operation'

--- a/packages/@orbit/records/test/record-validators/record-query-expression-validator-test.ts
+++ b/packages/@orbit/records/test/record-validators/record-query-expression-validator-test.ts
@@ -3,6 +3,7 @@ import { StandardRecordValidators } from '../../src/record-validators/standard-r
 import { buildRecordValidatorFor } from '../../src/record-validators/record-validator-builder';
 import { validateRecordQueryExpression } from '../../src/record-validators/record-query-expression-validator';
 import { RecordQueryExpression } from '../../src';
+import { formatValidationDescription } from '@orbit/validators';
 
 const { module, test } = QUnit;
 
@@ -90,6 +91,15 @@ module('validateRecordQueryExpression', function (hooks) {
       id: '1'
     };
 
+    const issues = [
+      {
+        validator: StandardRecordValidators.RecordType,
+        validation: 'recordTypeDefined',
+        ref: 'unknown',
+        description: `Record type 'unknown' does not exist in schema`
+      }
+    ];
+
     assert.deepEqual(
       validateRecordQueryExpression(
         {
@@ -109,15 +119,11 @@ module('validateRecordQueryExpression', function (hooks) {
             op: 'findRecord',
             record: invalidRecord
           },
-          details: [
-            {
-              validator: StandardRecordValidators.RecordType,
-              validation: 'recordTypeDefined',
-              ref: 'unknown',
-              description: `Record type 'unknown' does not exist in schema`
-            }
-          ],
-          description: 'record query expression is invalid'
+          details: issues,
+          description: formatValidationDescription(
+            'record query expression is invalid',
+            issues
+          )
         }
       ],
       'invalid query expression'
@@ -151,6 +157,25 @@ module('validateRecordQueryExpression', function (hooks) {
       id: '1'
     };
 
+    const issues = [
+      {
+        validator: StandardRecordValidators.RecordType,
+        validation: 'recordTypeDefined',
+        ref: 'unknown',
+        description: `Record type 'unknown' does not exist in schema`
+      },
+      {
+        validator: StandardRecordValidators.RecordFieldDefinition,
+        validation: 'fieldDefined',
+        ref: {
+          field: 'planet',
+          kind: 'relationship',
+          type: 'unknown'
+        },
+        description: `relationship 'planet' for type 'unknown' is not defined in schema`
+      }
+    ];
+
     assert.deepEqual(
       validateRecordQueryExpression(
         {
@@ -172,25 +197,11 @@ module('validateRecordQueryExpression', function (hooks) {
             record: invalidRecord,
             relationship: 'planet'
           },
-          details: [
-            {
-              validator: StandardRecordValidators.RecordType,
-              validation: 'recordTypeDefined',
-              ref: 'unknown',
-              description: `Record type 'unknown' does not exist in schema`
-            },
-            {
-              validator: StandardRecordValidators.RecordFieldDefinition,
-              validation: 'fieldDefined',
-              ref: {
-                field: 'planet',
-                kind: 'relationship',
-                type: 'unknown'
-              },
-              description: `relationship 'planet' for type 'unknown' is not defined in schema`
-            }
-          ],
-          description: 'record query expression is invalid'
+          details: issues,
+          description: formatValidationDescription(
+            'record query expression is invalid',
+            issues
+          )
         }
       ],
       'invalid query expression'
@@ -224,6 +235,25 @@ module('validateRecordQueryExpression', function (hooks) {
       id: '1'
     };
 
+    const issues = [
+      {
+        validator: StandardRecordValidators.RecordType,
+        validation: 'recordTypeDefined',
+        ref: 'unknown',
+        description: `Record type 'unknown' does not exist in schema`
+      },
+      {
+        validator: StandardRecordValidators.RecordFieldDefinition,
+        validation: 'fieldDefined',
+        ref: {
+          field: 'moons',
+          kind: 'relationship',
+          type: 'unknown'
+        },
+        description: `relationship 'moons' for type 'unknown' is not defined in schema`
+      }
+    ];
+
     assert.deepEqual(
       validateRecordQueryExpression(
         {
@@ -245,25 +275,11 @@ module('validateRecordQueryExpression', function (hooks) {
             record: invalidRecord,
             relationship: 'moons'
           },
-          details: [
-            {
-              validator: StandardRecordValidators.RecordType,
-              validation: 'recordTypeDefined',
-              ref: 'unknown',
-              description: `Record type 'unknown' does not exist in schema`
-            },
-            {
-              validator: StandardRecordValidators.RecordFieldDefinition,
-              validation: 'fieldDefined',
-              ref: {
-                field: 'moons',
-                kind: 'relationship',
-                type: 'unknown'
-              },
-              description: `relationship 'moons' for type 'unknown' is not defined in schema`
-            }
-          ],
-          description: 'record query expression is invalid'
+          details: issues,
+          description: formatValidationDescription(
+            'record query expression is invalid',
+            issues
+          )
         }
       ],
       'invalid query expression'
@@ -286,6 +302,15 @@ module('validateRecordQueryExpression', function (hooks) {
       'valid query expression'
     );
 
+    const issues = [
+      {
+        validator: StandardRecordValidators.RecordType,
+        validation: 'recordTypeDefined',
+        ref: 'unknown',
+        description: `Record type 'unknown' does not exist in schema`
+      }
+    ];
+
     assert.deepEqual(
       validateRecordQueryExpression(
         {
@@ -305,15 +330,11 @@ module('validateRecordQueryExpression', function (hooks) {
             op: 'findRecords',
             type: 'unknown'
           },
-          details: [
-            {
-              validator: StandardRecordValidators.RecordType,
-              validation: 'recordTypeDefined',
-              ref: 'unknown',
-              description: `Record type 'unknown' does not exist in schema`
-            }
-          ],
-          description: 'record query expression is invalid'
+          details: issues,
+          description: formatValidationDescription(
+            'record query expression is invalid',
+            issues
+          )
         }
       ],
       'invalid query expression'
@@ -346,6 +367,15 @@ module('validateRecordQueryExpression', function (hooks) {
       id: '1'
     };
 
+    const issues = [
+      {
+        validator: StandardRecordValidators.RecordType,
+        validation: 'recordTypeDefined',
+        ref: 'unknown',
+        description: `Record type 'unknown' does not exist in schema`
+      }
+    ];
+
     assert.deepEqual(
       validateRecordQueryExpression(
         {
@@ -365,15 +395,11 @@ module('validateRecordQueryExpression', function (hooks) {
             op: 'findRecords',
             records: [invalidRecord]
           },
-          details: [
-            {
-              validator: StandardRecordValidators.RecordType,
-              validation: 'recordTypeDefined',
-              ref: 'unknown',
-              description: `Record type 'unknown' does not exist in schema`
-            }
-          ],
-          description: 'record query expression is invalid'
+          details: issues,
+          description: formatValidationDescription(
+            'record query expression is invalid',
+            issues
+          )
         }
       ],
       'invalid query expression'

--- a/packages/@orbit/records/test/record-validators/related-record-validator-test.ts
+++ b/packages/@orbit/records/test/record-validators/related-record-validator-test.ts
@@ -2,6 +2,7 @@ import { RecordSchema } from '../../src/record-schema';
 import { StandardRecordValidators } from '../../src/record-validators/standard-record-validators';
 import { buildRecordValidatorFor } from '../../src/record-validators/record-validator-builder';
 import { validateRelatedRecord } from '../../src/record-validators/related-record-validator';
+import { formatValidationDescription } from '@orbit/validators';
 
 const { module, test } = QUnit;
 
@@ -160,6 +161,15 @@ module('validateRelatedRecord', function (hooks) {
   test('will check if relatedRecord is a valid record identity', function (assert) {
     const relationshipDef = schema.getRelationship('moon', 'planet');
 
+    const issues = [
+      {
+        description: "Record type 'fake' does not exist in schema",
+        ref: 'fake',
+        validation: 'recordTypeDefined',
+        validator: 'recordType'
+      }
+    ];
+
     assert.deepEqual(
       validateRelatedRecord(
         {
@@ -182,15 +192,11 @@ module('validateRelatedRecord', function (hooks) {
             relationship: 'planet',
             relatedRecord: { type: 'fake', id: 'p1' }
           },
-          details: [
-            {
-              description: "Record type 'fake' does not exist in schema",
-              ref: 'fake',
-              validation: 'recordTypeDefined',
-              validator: 'recordType'
-            }
-          ],
-          description: 'relatedRecord is not a valid record identity'
+          description: formatValidationDescription(
+            'relatedRecord is not a valid record identity',
+            issues
+          ),
+          details: issues
         }
       ]
     );

--- a/packages/@orbit/validators/src/validator.ts
+++ b/packages/@orbit/validators/src/validator.ts
@@ -40,3 +40,16 @@ export type Validator<
   Options = ValidationOptions,
   Issue = ValidationIssue<Input>
 > = (input: Input, options?: Options) => undefined | Issue[];
+
+export function formatValidationDescription(
+  summary: string,
+  issues?: ValidationIssue[]
+): string {
+  if (issues && issues.length > 0) {
+    return `${summary}\n${issues
+      .map((i) => `- ${i.description.replace(/\n/g, '\n  ')}`)
+      .join('\n')}`;
+  } else {
+    return summary;
+  }
+}

--- a/packages/@orbit/validators/test/validator-test.ts
+++ b/packages/@orbit/validators/test/validator-test.ts
@@ -1,0 +1,57 @@
+import { formatValidationDescription } from '../src/validator';
+
+const { module, test } = QUnit;
+
+///////////////////////////////////////////////////////////////////////////////
+
+module('formatValidationDescription', function (hooks) {
+  test('includes summary only if no issues are included', function (assert) {
+    assert.strictEqual(formatValidationDescription('summary', []), 'summary');
+  });
+
+  test('includes summary followed by issue descriptions', function (assert) {
+    assert.strictEqual(
+      formatValidationDescription('summary', [
+        {
+          validator: 'v1',
+          validation: 'v1-a',
+          description: 'a'
+        },
+        {
+          validator: 'v2',
+          validation: 'v2-a',
+          description: 'b'
+        },
+        {
+          validator: 'v3',
+          validation: 'v3-a',
+          description: 'c'
+        }
+      ]),
+      `summary\n- a\n- b\n- c`
+    );
+  });
+
+  test('nests any new lines in issue descriptions', function (assert) {
+    assert.strictEqual(
+      formatValidationDescription('summary', [
+        {
+          validator: 'v1',
+          validation: 'v1-a',
+          description: 'a\n- a1\n- a2'
+        },
+        {
+          validator: 'v2',
+          validation: 'v2-a',
+          description: 'b'
+        },
+        {
+          validator: 'v3',
+          validation: 'v3-a',
+          description: 'c'
+        }
+      ]),
+      `summary\n- a\n  - a1\n  - a2\n- b\n- c`
+    );
+  });
+});


### PR DESCRIPTION
The description for validation errors will now include all the descriptions of associated validation issues, which may in turn contain descriptions for nested validation issues.

For instance, instead of the generic description `record operation is invalid`, an expanded description such as the following will be used:

```
record operation is invalid
- relationship data is invalid
  - relatedRecord has a type 'person' which is not an allowed type for this relationship
```

Closes #890