### PR TITLE
Exception refactoring

### DIFF
--- a/packages/@orbit/coordinator/test/strategies/sync-strategy-test.ts
+++ b/packages/@orbit/coordinator/test/strategies/sync-strategy-test.ts
@@ -169,7 +169,7 @@ module('SyncStrategy', function (hooks) {
       source: 's1',
       target: 's2',
       blocking: true,
-      catch(e: Exception, transform: Transform<RecordOperation>) {
+      catch(e: Error, transform: Transform<RecordOperation>) {
         assert.equal(e.message, ':(', 'error matches');
         assert.strictEqual(
           transform,
@@ -210,7 +210,7 @@ module('SyncStrategy', function (hooks) {
       source: 's1',
       target: 's2',
       blocking: true,
-      catch(e: Exception, transform: Transform<RecordOperation>) {
+      catch(e: Error, transform: Transform<RecordOperation>) {
         assert.equal(e.message, ':(', 'error matches');
         assert.strictEqual(
           transform,

--- a/packages/@orbit/core/src/exception.ts
+++ b/packages/@orbit/core/src/exception.ts
@@ -1,7 +1,21 @@
+import { deprecate } from './deprecate';
+
 /**
  * Base exception class.
  */
-export class Exception extends Error {}
+export class Exception extends Error {
+  /**
+   * A synonym for message.
+   *
+   * @deprecated since v0.17, access `message` instead
+   */
+  public get description(): string {
+    deprecate(
+      "'Exception#description' has been deprecated. Please access 'message' instead."
+    );
+    return this.message;
+  }
+}
 
 /**
  * Exception raised when an item does not exist in a log.

--- a/packages/@orbit/data/src/exception.ts
+++ b/packages/@orbit/data/src/exception.ts
@@ -5,43 +5,6 @@ import { QueryExpression } from './query-expression';
 import { Transform } from './transform';
 
 /**
- * An client-side error occurred while communicating with a remote server.
- */
-export class ClientError extends Exception {
-  public description: string;
-
-  constructor(description: string) {
-    super(`Client error: ${description}`);
-    this.description = description;
-  }
-}
-
-/**
- * A server-side error occurred while communicating with a remote server.
- */
-export class ServerError extends Exception {
-  public description: string;
-
-  constructor(description: string) {
-    super(`Server error: ${description}`);
-    this.description = description;
-  }
-}
-
-/**
- * A networking error occurred while attempting to communicate with a remote
- * server.
- */
-export class NetworkError extends Exception {
-  public description: string;
-
-  constructor(description: string) {
-    super(`Network error: ${description}`);
-    this.description = description;
-  }
-}
-
-/**
  * A query expression could not be parsed.
  */
 export class QueryExpressionParseError extends Exception {

--- a/packages/@orbit/data/src/exception.ts
+++ b/packages/@orbit/data/src/exception.ts
@@ -8,12 +8,10 @@ import { Transform } from './transform';
  * A query expression could not be parsed.
  */
 export class QueryExpressionParseError extends Exception {
-  public description: string;
   public expression?: QueryExpression;
 
   constructor(description: string, expression?: QueryExpression) {
     super(`Query expression parse error: ${description}`);
-    this.description = description;
     this.expression = expression;
   }
 }
@@ -22,12 +20,10 @@ export class QueryExpressionParseError extends Exception {
  * A query is invalid for a particular source.
  */
 export class QueryNotAllowed extends Exception {
-  public description: string;
   public query: Query<QueryExpression>;
 
   constructor(description: string, query: Query<QueryExpression>) {
     super(`Query not allowed: ${description}`);
-    this.description = description;
     this.query = query;
   }
 }
@@ -36,12 +32,10 @@ export class QueryNotAllowed extends Exception {
  * A transform is invalid for a particular source.
  */
 export class TransformNotAllowed extends Exception {
-  public description: string;
   public transform: Transform<Operation>;
 
   constructor(description: string, transform: Transform<Operation>) {
     super(`Transform not allowed: ${description}`);
-    this.description = description;
     this.transform = transform;
   }
 }

--- a/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
@@ -1,10 +1,5 @@
 import { Orbit } from '@orbit/core';
-import {
-  ClientError,
-  NetworkError,
-  requestOptionsForSource,
-  ServerError
-} from '@orbit/data';
+import { requestOptionsForSource } from '@orbit/data';
 import {
   RecordKeyMap,
   InitializedRecord,
@@ -14,7 +9,12 @@ import {
   RecordQuery
 } from '@orbit/records';
 import { Dict } from '@orbit/utils';
-import { InvalidServerResponse } from './lib/exceptions';
+import {
+  NetworkError,
+  InvalidServerResponse,
+  ClientError,
+  ServerError
+} from './lib/exceptions';
 import { RecordTransformRequest } from './lib/transform-requests';
 import { RecordQueryRequest } from './lib/query-requests';
 import { deepMerge, toArray } from '@orbit/utils';

--- a/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
+++ b/packages/@orbit/jsonapi/src/jsonapi-request-processor.ts
@@ -267,10 +267,6 @@ export class JSONAPIRequestProcessor {
   /* eslint-enable @typescript-eslint/no-unused-vars */
 
   protected responseHasContent(response: Response): boolean {
-    if (response.status === 204) {
-      return false;
-    }
-
     let contentType = response.headers.get('Content-Type');
     if (contentType) {
       for (let allowedContentType of this.allowedContentTypes) {
@@ -278,6 +274,11 @@ export class JSONAPIRequestProcessor {
           return true;
         }
       }
+      throw new InvalidServerResponse(
+        `The server responded with the content type '${contentType}', which is not allowed. Allowed content types include: '${this.allowedContentTypes.join(
+          "', '"
+        )}'.`
+      );
     }
     return false;
   }
@@ -304,20 +305,8 @@ export class JSONAPIRequestProcessor {
     const responseDetail: JSONAPIResponse = {
       response
     };
-    if (response.status === 201) {
-      if (this.responseHasContent(response)) {
-        responseDetail.document = await response.json();
-      } else {
-        throw new InvalidServerResponse(
-          `Server responses with a ${
-            response.status
-          } status should return content with one of the following content types: ${this.allowedContentTypes.join(
-            ', '
-          )}.`
-        );
-      }
-    } else if (response.status >= 200 && response.status < 300) {
-      if (this.responseHasContent(response)) {
+    if (response.status >= 200 && response.status < 300) {
+      if (response.status !== 204 && this.responseHasContent(response)) {
         responseDetail.document = await response.json();
       }
     } else if (response.status !== 304 && response.status !== 404) {

--- a/packages/@orbit/jsonapi/src/lib/exceptions.ts
+++ b/packages/@orbit/jsonapi/src/lib/exceptions.ts
@@ -1,5 +1,37 @@
 import { Exception } from '@orbit/core';
 
+/**
+ * A client-side error occurred while communicating with a remote server.
+ */
+export class ClientError extends Exception {
+  public data?: unknown;
+
+  constructor(description: string) {
+    super(`Client error: ${description}`);
+  }
+}
+
+/**
+ * A server-side error occurred while communicating with a remote server.
+ */
+export class ServerError extends Exception {
+  public data?: unknown;
+
+  constructor(description: string) {
+    super(`Server error: ${description}`);
+  }
+}
+
+/**
+ * A network error occurred while attempting to communicate with a remote
+ * server.
+ */
+export class NetworkError extends Exception {
+  constructor(description: string) {
+    super(`Network error: ${description}`);
+  }
+}
+
 export class InvalidServerResponse extends Exception {
   public response: string;
 

--- a/packages/@orbit/jsonapi/test/jsonapi-request-processor-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-request-processor-test.ts
@@ -10,6 +10,7 @@ import { JSONAPIRequestProcessor } from '../src/jsonapi-request-processor';
 import { jsonapiResponse } from './support/jsonapi';
 import { SinonStub } from 'sinon';
 import * as sinon from 'sinon';
+import { InvalidServerResponse } from '../src/lib/exceptions';
 
 const { module, test } = QUnit;
 

--- a/packages/@orbit/jsonapi/test/jsonapi-source-pullable-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-pullable-test.ts
@@ -154,7 +154,10 @@ module('JSONAPISource - pullable', function (hooks) {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof NetworkError, 'Network error raised');
-        assert.equal(e.description, 'No fetch response within 10ms.');
+        assert.equal(
+          (e as NetworkError).message,
+          'Network error: No fetch response within 10ms.'
+        );
       }
     });
 
@@ -195,7 +198,10 @@ module('JSONAPISource - pullable', function (hooks) {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof NetworkError, 'Network error raised');
-        assert.equal(e.description, 'No fetch response within 10ms.');
+        assert.equal(
+          (e as NetworkError).message,
+          'Network error: No fetch response within 10ms.'
+        );
       }
     });
 
@@ -216,7 +222,7 @@ module('JSONAPISource - pullable', function (hooks) {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof NetworkError, 'Network error raised');
-        assert.equal(e.description, ':(');
+        assert.equal((e as NetworkError).message, 'Network error: :(');
       }
     });
 

--- a/packages/@orbit/jsonapi/test/jsonapi-source-pullable-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-pullable-test.ts
@@ -1,4 +1,3 @@
-import { NetworkError } from '@orbit/data';
 import {
   RecordKeyMap,
   InitializedRecord,
@@ -18,6 +17,7 @@ import {
   JSONAPIResourceSerializer,
   Resource
 } from '../src';
+import { NetworkError } from '../src/lib/exceptions';
 import { JSONAPISource } from '../src/jsonapi-source';
 import { JSONAPISerializers } from '../src/serializers/jsonapi-serializers';
 import { jsonapiResponse } from './support/jsonapi';

--- a/packages/@orbit/jsonapi/test/jsonapi-source-pushable-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-pushable-test.ts
@@ -880,7 +880,10 @@ module('JSONAPISource - pushable', function (hooks) {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof NetworkError, 'Network error raised');
-        assert.equal(e.description, 'No fetch response within 10ms.');
+        assert.equal(
+          (e as NetworkError).message,
+          'Network error: No fetch response within 10ms.'
+        );
       }
     });
 
@@ -918,7 +921,10 @@ module('JSONAPISource - pushable', function (hooks) {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof NetworkError, 'Network error raised');
-        assert.equal(e.description, 'No fetch response within 10ms.');
+        assert.equal(
+          (e as NetworkError).message,
+          'Network error: No fetch response within 10ms.'
+        );
       }
     });
 
@@ -943,7 +949,7 @@ module('JSONAPISource - pushable', function (hooks) {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof NetworkError, 'Network error raised');
-        assert.equal(e.description, ':(');
+        assert.equal((e as NetworkError).message, 'Network error: :(');
       }
     });
 
@@ -977,8 +983,15 @@ module('JSONAPISource - pushable', function (hooks) {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof ClientError, 'Client error raised');
-        assert.equal(e.description, 'Unprocessable Entity');
-        assert.deepEqual(e.data, { errors }, 'Error data included');
+        assert.equal(
+          (e as ClientError).message,
+          'Client error: Unprocessable Entity'
+        );
+        assert.deepEqual(
+          (e as ClientError).data,
+          { errors },
+          'Error data included'
+        );
       }
     });
   });

--- a/packages/@orbit/jsonapi/test/jsonapi-source-pushable-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-pushable-test.ts
@@ -1,17 +1,12 @@
-import {
-  buildTransform,
-  ClientError,
-  NetworkError,
-  TransformNotAllowed
-} from '@orbit/data';
+import { buildTransform, TransformNotAllowed } from '@orbit/data';
 import {
   AddRecordOperation,
-  RecordKeyMap,
   InitializedRecord,
+  RecordKeyMap,
   RecordOperation,
-  ReplaceKeyOperation,
   RecordSchema,
   RecordTransform,
+  ReplaceKeyOperation,
   UpdateRecordOperation
 } from '@orbit/records';
 import { toArray } from '@orbit/utils';
@@ -19,6 +14,7 @@ import * as sinon from 'sinon';
 import { SinonStub } from 'sinon';
 import { JSONAPIResourceSerializer } from '../src';
 import { JSONAPISource } from '../src/jsonapi-source';
+import { ClientError, NetworkError } from '../src/lib/exceptions';
 import { JSONAPISerializers } from '../src/serializers/jsonapi-serializers';
 import { jsonapiResponse } from './support/jsonapi';
 import {

--- a/packages/@orbit/jsonapi/test/jsonapi-source-queryable-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-queryable-test.ts
@@ -383,7 +383,10 @@ module('JSONAPISource - queryable', function (hooks) {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof NetworkError, 'Network error raised');
-        assert.equal(e.description, 'No fetch response within 10ms.');
+        assert.equal(
+          (e as NetworkError).message,
+          'Network error: No fetch response within 10ms.'
+        );
       }
     });
 
@@ -424,7 +427,10 @@ module('JSONAPISource - queryable', function (hooks) {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof NetworkError, 'Network error raised');
-        assert.equal(e.description, 'No fetch response within 10ms.');
+        assert.equal(
+          (e as NetworkError).message,
+          'Network error: No fetch response within 10ms.'
+        );
       }
     });
 
@@ -445,7 +451,7 @@ module('JSONAPISource - queryable', function (hooks) {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof NetworkError, 'Network error raised');
-        assert.equal(e.description, ':(');
+        assert.equal((e as NetworkError).message, 'Network error: :(');
       }
     });
 

--- a/packages/@orbit/jsonapi/test/jsonapi-source-queryable-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-queryable-test.ts
@@ -1,4 +1,4 @@
-import { NetworkError, QueryNotAllowed } from '@orbit/data';
+import { QueryNotAllowed } from '@orbit/data';
 import {
   RecordKeyMap,
   InitializedRecord,
@@ -13,6 +13,7 @@ import {
   JSONAPIResourceIdentitySerializer,
   JSONAPIResourceSerializer
 } from '../src';
+import { NetworkError } from '../src/lib/exceptions';
 import { JSONAPISource } from '../src/jsonapi-source';
 import { Resource, ResourceDocument } from '../src/resource-document';
 import { JSONAPISerializers } from '../src/serializers/jsonapi-serializers';

--- a/packages/@orbit/jsonapi/test/jsonapi-source-updatable-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-updatable-test.ts
@@ -961,7 +961,10 @@ module('JSONAPISource - updatable', function (hooks) {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof NetworkError, 'Network error raised');
-        assert.equal(e.description, 'No fetch response within 10ms.');
+        assert.equal(
+          (e as NetworkError).message,
+          'Network error: No fetch response within 10ms.'
+        );
       }
     });
 
@@ -999,7 +1002,10 @@ module('JSONAPISource - updatable', function (hooks) {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof NetworkError, 'Network error raised');
-        assert.equal(e.description, 'No fetch response within 10ms.');
+        assert.equal(
+          (e as NetworkError).message,
+          'Network error: No fetch response within 10ms.'
+        );
       }
     });
 
@@ -1024,7 +1030,7 @@ module('JSONAPISource - updatable', function (hooks) {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof NetworkError, 'Network error raised');
-        assert.equal(e.description, ':(');
+        assert.equal((e as NetworkError).message, 'Network error: :(');
       }
     });
 
@@ -1058,8 +1064,15 @@ module('JSONAPISource - updatable', function (hooks) {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof ClientError, 'Client error raised');
-        assert.equal(e.description, 'Unprocessable Entity');
-        assert.deepEqual(e.data, { errors }, 'Error data included');
+        assert.equal(
+          (e as ClientError).message,
+          'Client error: Unprocessable Entity'
+        );
+        assert.deepEqual(
+          (e as ClientError).data,
+          { errors },
+          'Error data included'
+        );
       }
     });
   });

--- a/packages/@orbit/jsonapi/test/jsonapi-source-updatable-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-updatable-test.ts
@@ -1,4 +1,4 @@
-import { ClientError, NetworkError, TransformNotAllowed } from '@orbit/data';
+import { TransformNotAllowed } from '@orbit/data';
 import {
   RecordKeyMap,
   InitializedRecord,
@@ -13,6 +13,7 @@ import { toArray } from '@orbit/utils';
 import * as sinon from 'sinon';
 import { SinonStub } from 'sinon';
 import { JSONAPIResourceSerializer } from '../src';
+import { ClientError, NetworkError } from '../src/lib/exceptions';
 import { JSONAPISource } from '../src/jsonapi-source';
 import { JSONAPISerializers } from '../src/serializers/jsonapi-serializers';
 import { jsonapiResponse } from './support/jsonapi';

--- a/packages/@orbit/jsonapi/test/jsonapi-source-with-legacy-serializer-settings-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-with-legacy-serializer-settings-test.ts
@@ -1,9 +1,4 @@
-import {
-  buildTransform,
-  ClientError,
-  NetworkError,
-  TransformNotAllowed
-} from '@orbit/data';
+import { buildTransform, TransformNotAllowed } from '@orbit/data';
 import {
   AddRecordOperation,
   RecordKeyMap,
@@ -29,6 +24,7 @@ import { JSONAPISerializers } from '../src/serializers/jsonapi-serializers';
 import { buildSerializerSettingsFor } from '@orbit/serializers';
 import { JSONAPIResourceSerializer } from '../src/serializers/jsonapi-resource-serializer';
 import { JSONAPIResourceIdentitySerializer } from '../src/serializers/jsonapi-resource-identity-serializer';
+import { ClientError, NetworkError } from '../src/lib/exceptions';
 
 const { module, test } = QUnit;
 

--- a/packages/@orbit/jsonapi/test/jsonapi-source-with-legacy-serializer-settings-test.ts
+++ b/packages/@orbit/jsonapi/test/jsonapi-source-with-legacy-serializer-settings-test.ts
@@ -1042,7 +1042,10 @@ module('JSONAPISource with legacy serialization settings', function () {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof NetworkError, 'Network error raised');
-        assert.equal(e.description, 'No fetch response within 10ms.');
+        assert.equal(
+          (e as NetworkError).message,
+          'Network error: No fetch response within 10ms.'
+        );
       }
     });
 
@@ -1080,7 +1083,10 @@ module('JSONAPISource with legacy serialization settings', function () {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof NetworkError, 'Network error raised');
-        assert.equal(e.description, 'No fetch response within 10ms.');
+        assert.equal(
+          (e as NetworkError).message,
+          'Network error: No fetch response within 10ms.'
+        );
       }
     });
 
@@ -1105,7 +1111,7 @@ module('JSONAPISource with legacy serialization settings', function () {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof NetworkError, 'Network error raised');
-        assert.equal(e.description, ':(');
+        assert.equal((e as NetworkError).message, 'Network error: :(');
       }
     });
 
@@ -1139,8 +1145,15 @@ module('JSONAPISource with legacy serialization settings', function () {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof ClientError, 'Client error raised');
-        assert.equal(e.description, 'Unprocessable Entity');
-        assert.deepEqual(e.data, { errors }, 'Error data included');
+        assert.equal(
+          (e as ClientError).message,
+          'Client error: Unprocessable Entity'
+        );
+        assert.deepEqual(
+          (e as ClientError).data,
+          { errors },
+          'Error data included'
+        );
       }
     });
 
@@ -1929,7 +1942,10 @@ module('JSONAPISource with legacy serialization settings', function () {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof NetworkError, 'Network error raised');
-        assert.equal(e.description, 'No fetch response within 10ms.');
+        assert.equal(
+          (e as NetworkError).message,
+          'Network error: No fetch response within 10ms.'
+        );
       }
     });
 
@@ -1967,7 +1983,10 @@ module('JSONAPISource with legacy serialization settings', function () {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof NetworkError, 'Network error raised');
-        assert.equal(e.description, 'No fetch response within 10ms.');
+        assert.equal(
+          (e as NetworkError).message,
+          'Network error: No fetch response within 10ms.'
+        );
       }
     });
 
@@ -1992,7 +2011,7 @@ module('JSONAPISource with legacy serialization settings', function () {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof NetworkError, 'Network error raised');
-        assert.equal(e.description, ':(');
+        assert.equal((e as NetworkError).message, 'Network error: :(');
       }
     });
 
@@ -2026,8 +2045,15 @@ module('JSONAPISource with legacy serialization settings', function () {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof ClientError, 'Client error raised');
-        assert.equal(e.description, 'Unprocessable Entity');
-        assert.deepEqual(e.data, { errors }, 'Error data included');
+        assert.equal(
+          (e as ClientError).message,
+          'Client error: Unprocessable Entity'
+        );
+        assert.deepEqual(
+          (e as ClientError).data,
+          { errors },
+          'Error data included'
+        );
       }
     });
 
@@ -2129,7 +2155,10 @@ module('JSONAPISource with legacy serialization settings', function () {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof NetworkError, 'Network error raised');
-        assert.equal(e.description, 'No fetch response within 10ms.');
+        assert.equal(
+          (e as NetworkError).message,
+          'Network error: No fetch response within 10ms.'
+        );
       }
     });
 
@@ -2170,7 +2199,10 @@ module('JSONAPISource with legacy serialization settings', function () {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof NetworkError, 'Network error raised');
-        assert.equal(e.description, 'No fetch response within 10ms.');
+        assert.equal(
+          (e as NetworkError).message,
+          'Network error: No fetch response within 10ms.'
+        );
       }
     });
 
@@ -2191,7 +2223,7 @@ module('JSONAPISource with legacy serialization settings', function () {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof NetworkError, 'Network error raised');
-        assert.equal(e.description, ':(');
+        assert.equal((e as NetworkError).message, 'Network error: :(');
       }
     });
 
@@ -3819,7 +3851,10 @@ module('JSONAPISource with legacy serialization settings', function () {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof NetworkError, 'Network error raised');
-        assert.equal(e.description, 'No fetch response within 10ms.');
+        assert.equal(
+          (e as NetworkError).message,
+          'Network error: No fetch response within 10ms.'
+        );
       }
     });
 
@@ -3860,7 +3895,10 @@ module('JSONAPISource with legacy serialization settings', function () {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof NetworkError, 'Network error raised');
-        assert.equal(e.description, 'No fetch response within 10ms.');
+        assert.equal(
+          (e as NetworkError).message,
+          'Network error: No fetch response within 10ms.'
+        );
       }
     });
 
@@ -3881,7 +3919,7 @@ module('JSONAPISource with legacy serialization settings', function () {
         assert.ok(false, 'should not be reached');
       } catch (e) {
         assert.ok(e instanceof NetworkError, 'Network error raised');
-        assert.equal(e.description, ':(');
+        assert.equal((e as NetworkError).message, 'Network error: :(');
       }
     });
 

--- a/packages/@orbit/records/src/record-exceptions.ts
+++ b/packages/@orbit/records/src/record-exceptions.ts
@@ -8,11 +8,8 @@ import {
  * An error occured related to the schema.
  */
 export class SchemaError extends Exception {
-  public description: string;
-
   constructor(description: string) {
     super(`Schema: ${description}`);
-    this.description = description;
   }
 }
 
@@ -68,7 +65,6 @@ export class RelationshipNotDefined extends SchemaError {
  * An error occurred related to a particular record.
  */
 export abstract class RecordException extends Exception {
-  public description: string;
   public type: string;
   public id: string;
   public field?: string;
@@ -80,11 +76,8 @@ export abstract class RecordException extends Exception {
       specifier = `${specifier}/${field}`;
     }
 
-    let message = `${description}: ${specifier}`;
+    super(`${description}: ${specifier}`);
 
-    super(message);
-
-    this.description = description;
     this.type = type;
     this.id = id;
     this.field = field;


### PR DESCRIPTION
Performs some minor refactoring of exceptions:

* **BREAKING**:`ClientError`, `ServerError`, and `NetworkError` have been moved from `@orbit/data` to `@orbit/jsonapi`, the only package in which they are used.
* `Exception#description` has been deprecated in favor of the standard `message` property.
* Content-type checks in `JSONAPIRequestProcessor` have been refactored and streamlined.