### PR TITLE
Use crypto.randomUUID by default for Orbit.uuid

### DIFF
--- a/packages/@orbit/core/src/main.ts
+++ b/packages/@orbit/core/src/main.ts
@@ -1,6 +1,6 @@
 import { assert } from './assert';
 import { deprecate } from './deprecate';
-import { uuid } from '@orbit/utils';
+import { uuid as customRandomUUID } from '@orbit/utils';
 
 declare const self: any;
 declare const global: any;
@@ -26,6 +26,11 @@ const globals =
   (typeof self == 'object' && self.self === self && self) ||
   (typeof global == 'object' && global) ||
   {};
+
+const uuid =
+  globals.crypto?.randomUUID !== undefined
+    ? () => globals.crypto.randomUUID()
+    : customRandomUUID;
 
 export const Orbit: OrbitGlobal = {
   globals,


### PR DESCRIPTION
A browser's built-in Crypto interface should provide the fastest and most secure UUID v4 implementation. Only default to the custom `uuid` function from `@orbit/utils` if `crypto.randomUUID` is not available.

Closes #902