### PR TITLE
Introduce autoValidate setting for RecordCache and RecordSource

### DIFF
--- a/packages/@orbit/record-cache/src/async-record-cache.ts
+++ b/packages/@orbit/record-cache/src/async-record-cache.ts
@@ -114,7 +114,7 @@ export abstract class AsyncRecordCache<
       ? settings.processors
       : [AsyncSchemaConsistencyProcessor, AsyncCacheIntegrityProcessor];
 
-    if (Orbit.debug && settings.processors === undefined) {
+    if (settings.autoValidate !== false && settings.processors === undefined) {
       processors.push(AsyncSchemaValidationProcessor);
     }
 

--- a/packages/@orbit/record-cache/src/sync-record-cache.ts
+++ b/packages/@orbit/record-cache/src/sync-record-cache.ts
@@ -114,7 +114,7 @@ export abstract class SyncRecordCache<
       ? settings.processors
       : [SyncSchemaConsistencyProcessor, SyncCacheIntegrityProcessor];
 
-    if (Orbit.debug && settings.processors === undefined) {
+    if (settings.autoValidate !== false && settings.processors === undefined) {
       processors.push(SyncSchemaValidationProcessor);
     }
 

--- a/packages/@orbit/record-cache/test/async-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/async-record-cache-test.ts
@@ -1,5 +1,8 @@
-import { Orbit } from '@orbit/core';
-import { RecordKeyMap, RecordSchema } from '@orbit/records';
+import {
+  RecordKeyMap,
+  RecordSchema,
+  StandardRecordNormalizer
+} from '@orbit/records';
 import { AsyncSchemaValidationProcessor } from '../src/operation-processors/async-schema-validation-processor';
 import { ExampleAsyncRecordCache } from './support/example-async-record-cache';
 import { createSchemaWithRemoteKey } from './support/setup';
@@ -19,25 +22,54 @@ module('AsyncRecordCache', function (hooks) {
     assert.ok(cache);
   });
 
-  test('it is assigned 3 processors by default in debug mode', async function (assert) {
+  test('it is assigned 3 processors, a validatorFor, transformBuilder, and queryBuilder by default', async function (assert) {
     const cache = new ExampleAsyncRecordCache({ schema });
-    assert.ok(Orbit.debug);
+
     assert.equal(
       cache.processors.length,
       3,
       'processors are assigned by default'
     );
+    assert.ok(cache.validatorFor, 'validatorFor has been created');
+    assert.ok(cache.queryBuilder, 'queryBuilder has been created');
+
+    const normalizer = cache.queryBuilder
+      .$normalizer as StandardRecordNormalizer;
+
+    assert.ok(normalizer, 'normalizer has been created for queryBuilder');
+    assert.ok(normalizer.validateInputs, 'normalizer will validate inputs');
+    assert.ok(cache.transformBuilder, 'transformBuilder has been created');
+    assert.strictEqual(
+      cache.queryBuilder.$normalizer,
+      cache.transformBuilder.$normalizer,
+      'normalizer is the same for transformBuilder'
+    );
   });
 
-  test('it is assigned only 2 processors by default in non-debug mode', async function (assert) {
-    Orbit.debug = false;
-    const cache = new ExampleAsyncRecordCache({ schema });
+  test('it is assigned only 2 processors and will NOT be assigned a validatorFor function if autoValidate: false is specified', async function (assert) {
+    const cache = new ExampleAsyncRecordCache({ schema, autoValidate: false });
     assert.equal(
       cache.processors.length,
       2,
       'processors are assigned by default'
     );
-    Orbit.debug = true;
+    assert.notOk(cache.validatorFor, 'validatorFor has NOT been created');
+    assert.ok(cache.queryBuilder, 'queryBuilder has been created');
+
+    const normalizer = cache.queryBuilder
+      .$normalizer as StandardRecordNormalizer;
+
+    assert.ok(normalizer, 'normalizer has been created for queryBuilder');
+    assert.notOk(
+      normalizer.validateInputs,
+      'normalizer will NOT validate inputs'
+    );
+    assert.ok(cache.transformBuilder, 'transformBuilder has been created');
+    assert.strictEqual(
+      cache.queryBuilder.$normalizer,
+      cache.transformBuilder.$normalizer,
+      'normalizer is the same for transformBuilder'
+    );
   });
 
   test('it requires a schema', function (assert) {

--- a/packages/@orbit/record-cache/test/sync-record-cache-test.ts
+++ b/packages/@orbit/record-cache/test/sync-record-cache-test.ts
@@ -1,5 +1,8 @@
-import { Orbit } from '@orbit/core';
-import { RecordKeyMap, RecordSchema } from '@orbit/records';
+import {
+  RecordKeyMap,
+  RecordSchema,
+  StandardRecordNormalizer
+} from '@orbit/records';
 import { SyncSchemaValidationProcessor } from '../src/operation-processors/sync-schema-validation-processor';
 import { ExampleSyncRecordCache } from './support/example-sync-record-cache';
 import { createSchemaWithRemoteKey } from './support/setup';
@@ -19,25 +22,54 @@ module('SyncRecordCache', function (hooks) {
     assert.ok(cache);
   });
 
-  test('it is assigned 3 processors by default in debug mode', async function (assert) {
+  test('it is assigned 3 processors, a validatorFor, transformBuilder, and queryBuilder by default', async function (assert) {
     const cache = new ExampleSyncRecordCache({ schema });
-    assert.ok(Orbit.debug);
+
     assert.equal(
       cache.processors.length,
       3,
       'processors are assigned by default'
     );
+    assert.ok(cache.validatorFor, 'validatorFor has been created');
+    assert.ok(cache.queryBuilder, 'queryBuilder has been created');
+
+    const normalizer = cache.queryBuilder
+      .$normalizer as StandardRecordNormalizer;
+
+    assert.ok(normalizer, 'normalizer has been created for queryBuilder');
+    assert.ok(normalizer.validateInputs, 'normalizer will validate inputs');
+    assert.ok(cache.transformBuilder, 'transformBuilder has been created');
+    assert.strictEqual(
+      cache.queryBuilder.$normalizer,
+      cache.transformBuilder.$normalizer,
+      'normalizer is the same for transformBuilder'
+    );
   });
 
-  test('it is assigned only 2 processors by default in non-debug mode', async function (assert) {
-    Orbit.debug = false;
-    const cache = new ExampleSyncRecordCache({ schema });
+  test('it is assigned only 2 processors and will NOT be assigned a validatorFor function if autoValidate: false is specified', async function (assert) {
+    const cache = new ExampleSyncRecordCache({ schema, autoValidate: false });
     assert.equal(
       cache.processors.length,
       2,
       'processors are assigned by default'
     );
-    Orbit.debug = true;
+    assert.notOk(cache.validatorFor, 'validatorFor has NOT been created');
+    assert.ok(cache.queryBuilder, 'queryBuilder has been created');
+
+    const normalizer = cache.queryBuilder
+      .$normalizer as StandardRecordNormalizer;
+
+    assert.ok(normalizer, 'normalizer has been created for queryBuilder');
+    assert.notOk(
+      normalizer.validateInputs,
+      'normalizer will NOT validate inputs'
+    );
+    assert.ok(cache.transformBuilder, 'transformBuilder has been created');
+    assert.strictEqual(
+      cache.queryBuilder.$normalizer,
+      cache.transformBuilder.$normalizer,
+      'normalizer is the same for transformBuilder'
+    );
   });
 
   test('it requires a schema', function (assert) {

--- a/packages/@orbit/records/src/record-validators/record-validator-builder.ts
+++ b/packages/@orbit/records/src/record-validators/record-validator-builder.ts
@@ -8,20 +8,14 @@ import {
 import { StandardRecordValidator } from './standard-record-validators';
 import { standardRecordValidators } from './standard-record-validator-dict';
 
-export function buildRecordValidatorFor<
-  V = StandardValidator | StandardRecordValidator
->(settings?: { validators?: Dict<V> }): ValidatorForFn<V> {
-  const validators: Dict<V> = {};
-
-  Object.assign(validators, standardValidators);
-  Object.assign(validators, standardRecordValidators);
-
-  const customValidators = settings?.validators;
-  if (customValidators) {
-    Object.assign(validators, customValidators);
-  }
-
-  return buildValidatorFor<V>({
-    validators
+export function buildRecordValidatorFor(settings?: {
+  validators?: Dict<StandardValidator | StandardRecordValidator>;
+}): ValidatorForFn<StandardValidator | StandardRecordValidator> {
+  return buildValidatorFor<StandardValidator | StandardRecordValidator>({
+    validators: {
+      ...standardValidators,
+      ...standardRecordValidators,
+      ...settings?.validators
+    }
   });
 }

--- a/packages/@orbit/records/src/standard-record-normalizer.ts
+++ b/packages/@orbit/records/src/standard-record-normalizer.ts
@@ -45,11 +45,7 @@ export class StandardRecordNormalizer
     this.schema = schema;
     this.keyMap = keyMap;
     this.cloneInputs = cloneInputs;
-    if (validateInputs === undefined) {
-      this.validateInputs = Orbit.debug ? true : false;
-    } else {
-      this.validateInputs = validateInputs;
-    }
+    this.validateInputs = validateInputs;
   }
 
   normalizeRecordType(type: string): string {

--- a/packages/@orbit/records/test/record-source-test.ts
+++ b/packages/@orbit/records/test/record-source-test.ts
@@ -36,14 +36,7 @@ module('Source', function (hooks) {
     assert.ok(true, 'after upgrade');
   });
 
-  test('it will be assigned a transformBuilder and queryBuilder by default', async function (assert) {
-    source = new MySource({ schema });
-
-    assert.ok(source.queryBuilder, 'queryBuilder has been created');
-    assert.ok(source.transformBuilder, 'transformBuilder has been created');
-  });
-
-  test('it will not be auto-upgraded if autoUpgrade: false option is specified', function (assert) {
+  test('it will not be auto-upgraded if autoUpgrade: false setting is specified', function (assert) {
     assert.expect(1);
 
     class MyDynamicSource extends RecordSource {
@@ -55,6 +48,48 @@ module('Source', function (hooks) {
     source = new MyDynamicSource({ schema, autoUpgrade: false });
     schema.upgrade({});
     assert.ok(true, 'after upgrade');
+  });
+
+  test('it will create a validatorFor, transformBuilder, and queryBuilder by default', async function (assert) {
+    source = new MySource({ schema });
+
+    assert.ok(source.validatorFor, 'validatorFor has been created');
+    assert.ok(source.queryBuilder, 'queryBuilder has been created');
+    assert.ok(
+      source.queryBuilder.$normalizer,
+      'normalizer has been created for queryBuilder'
+    );
+    assert.ok(
+      source.queryBuilder.$normalizer.validateInputs,
+      'normalizer will validate inputs'
+    );
+    assert.ok(source.transformBuilder, 'transformBuilder has been created');
+    assert.strictEqual(
+      source.queryBuilder.$normalizer,
+      source.transformBuilder.$normalizer,
+      'normalizer is the same for transformBuilder'
+    );
+  });
+
+  test('it will NOT be assigned a validatorFor function if autoValidate: false is specified', async function (assert) {
+    source = new MySource({ schema, autoValidate: false });
+
+    assert.notOk(source.validatorFor, 'validatorFor has NOT been created');
+    assert.ok(source.queryBuilder, 'queryBuilder has been created');
+    assert.ok(
+      source.queryBuilder.$normalizer,
+      'normalizer has been created for queryBuilder'
+    );
+    assert.notOk(
+      source.queryBuilder.$normalizer.validateInputs,
+      'normalizer will NOT validate inputs'
+    );
+    assert.ok(source.transformBuilder, 'transformBuilder has been created');
+    assert.strictEqual(
+      source.queryBuilder.$normalizer,
+      source.transformBuilder.$normalizer,
+      'normalizer is the same for transformBuilder'
+    );
   });
 
   test('creates a `transformLog`, `requestQueue`, and `syncQueue`, and assigns each the same bucket as the Source', function (assert) {

--- a/packages/@orbit/records/test/standard-record-normalizer-test.ts
+++ b/packages/@orbit/records/test/standard-record-normalizer-test.ts
@@ -62,24 +62,10 @@ module('StandardRecordNormalizer', function (hooks) {
     assert.ok(normalizer);
   });
 
-  test('has default settings, some dependent on debug mode', function (assert) {
-    assert.ok(Orbit.debug, 'debug mode');
+  test('has default settings', function (assert) {
     normalizer = new StandardRecordNormalizer({ schema });
-    assert.ok(normalizer.validateInputs, 'validateInputs = true in debug mode');
-    assert.notOk(normalizer.cloneInputs, 'cloneInputs = false by default');
-
-    // temporarily change debug mode
-    Orbit.debug = false;
-
-    normalizer = new StandardRecordNormalizer({ schema });
-    assert.notOk(
-      normalizer.validateInputs,
-      'validateInputs = false when not in debug mode'
-    );
-    assert.notOk(normalizer.cloneInputs, 'cloneInputs = false by default');
-
-    // reset global debug mode
-    Orbit.debug = true;
+    assert.notOk(normalizer.validateInputs, 'validateInputs defaults to false');
+    assert.notOk(normalizer.cloneInputs, 'cloneInputs defaults to false');
   });
 
   test('#normalizeRecordType will return a string unmodified by default', function (assert) {


### PR DESCRIPTION
This setting mirrors `autoUpgrade` and `autoActivate` in that if it is left `undefined` it should be treated as `true`.

`RecordCache` and `RecordSource` use this to determine whether to build validators if none are provided.

`SyncRecordCache` and `AsyncRecordCache` also use this option to control whether a schema validation processor is included by default.

This will provide more fine-tuned control over whether validators are built and used by a source / cache than checking `Orbit.debug`.

Closes #903

**Note: This is considered a breaking change because `Orbit.debug` is no longer used to implicitly set `autoValidate`.**