### PR TITLE
Ensure that validator settings are properly transferred to caches and forks

### DIFF
--- a/packages/@orbit/indexeddb/src/indexeddb-source.ts
+++ b/packages/@orbit/indexeddb/src/indexeddb-source.ts
@@ -116,8 +116,10 @@ export class IndexedDBSource<
     cacheSettings.defaultQueryOptions ??= settings.defaultQueryOptions;
     cacheSettings.defaultTransformOptions ??= settings.defaultTransformOptions;
     cacheSettings.namespace ??= settings.namespace;
+    cacheSettings.autoValidate ??= settings.autoValidate;
 
     if (
+      cacheSettings.autoValidate !== false &&
       cacheSettings.validatorFor === undefined &&
       cacheSettings.validators === undefined
     ) {

--- a/packages/@orbit/indexeddb/test/indexeddb-source-test.ts
+++ b/packages/@orbit/indexeddb/test/indexeddb-source-test.ts
@@ -185,6 +185,25 @@ module('IndexedDBSource', function (hooks) {
     );
   });
 
+  test('will not create a `validatorFor` fn if `autoValidate: false`', function (assert) {
+    const source = new IndexedDBSource({
+      schema,
+      keyMap,
+      autoActivate: false,
+      autoValidate: false
+    });
+    assert.strictEqual(
+      source.validatorFor,
+      undefined,
+      'validatorFor is undefined'
+    );
+    assert.strictEqual(
+      source.cache.validatorFor,
+      undefined,
+      'cache.validatorFor is undefined'
+    );
+  });
+
   module('activated', function (hooks) {
     hooks.beforeEach(async () => {
       source = new IndexedDBSource({ schema, keyMap });

--- a/packages/@orbit/local-storage/src/local-storage-source.ts
+++ b/packages/@orbit/local-storage/src/local-storage-source.ts
@@ -121,8 +121,10 @@ export class LocalStorageSource<
     cacheSettings.defaultTransformOptions ??= settings.defaultTransformOptions;
     cacheSettings.namespace ??= settings.namespace;
     cacheSettings.delimiter ??= settings.delimiter;
+    cacheSettings.autoValidate ??= settings.autoValidate;
 
     if (
+      cacheSettings.autoValidate !== false &&
       cacheSettings.validatorFor === undefined &&
       cacheSettings.validators === undefined
     ) {

--- a/packages/@orbit/local-storage/test/local-storage-source-test.ts
+++ b/packages/@orbit/local-storage/test/local-storage-source-test.ts
@@ -176,6 +176,25 @@ module('LocalStorageSource', function (hooks) {
     );
   });
 
+  test('will not create a `validatorFor` fn if `autoValidate: false`', function (assert) {
+    const source = new LocalStorageSource({
+      schema,
+      keyMap,
+      autoActivate: false,
+      autoValidate: false
+    });
+    assert.strictEqual(
+      source.validatorFor,
+      undefined,
+      'validatorFor is undefined'
+    );
+    assert.strictEqual(
+      source.cache.validatorFor,
+      undefined,
+      'cache.validatorFor is undefined'
+    );
+  });
+
   test('#getKeyForRecord returns the local storage key that will be used for a record', function (assert) {
     assert.equal(
       source.getKeyForRecord({ type: 'planet', id: 'jupiter' }),

--- a/packages/@orbit/memory/src/memory-cache.ts
+++ b/packages/@orbit/memory/src/memory-cache.ts
@@ -126,9 +126,15 @@ export class MemoryCache<
     // customizable settings
     settings.queryBuilder ??= this._queryBuilder;
     settings.transformBuilder ??= this._transformBuilder;
-    settings.validatorFor ??= this._validatorFor;
     settings.defaultQueryOptions ??= this._defaultQueryOptions;
     settings.defaultTransformOptions ??= this._defaultTransformOptions;
+    settings.validatorFor ??= this._validatorFor;
+    if (
+      settings.autoValidate === undefined &&
+      settings.validatorFor === undefined
+    ) {
+      settings.autoValidate = false;
+    }
 
     return new MemoryCache(
       settings as MemoryCacheSettings<QO, TO, QB, TB, QRD, TRD>

--- a/packages/@orbit/memory/src/memory-source.ts
+++ b/packages/@orbit/memory/src/memory-source.ts
@@ -122,8 +122,10 @@ export class MemorySource<
     cacheSettings.transformBuilder ??= this.transformBuilder;
     cacheSettings.defaultQueryOptions ??= this.defaultQueryOptions;
     cacheSettings.defaultTransformOptions ??= this.defaultTransformOptions;
+    cacheSettings.autoValidate ??= settings.autoValidate;
 
     if (
+      cacheSettings.autoValidate !== false &&
       cacheSettings.validatorFor === undefined &&
       cacheSettings.validators === undefined
     ) {
@@ -278,9 +280,15 @@ export class MemorySource<
     // customizable settings
     settings.queryBuilder ??= this._queryBuilder;
     settings.transformBuilder ??= this._transformBuilder;
-    settings.validatorFor ??= this._validatorFor;
     settings.defaultQueryOptions ??= this._defaultQueryOptions;
     settings.defaultTransformOptions ??= this._defaultTransformOptions;
+    settings.validatorFor ??= this._validatorFor;
+    if (
+      settings.autoValidate === undefined &&
+      settings.validatorFor === undefined
+    ) {
+      settings.autoValidate = false;
+    }
 
     return new MemorySource<QO, TO, QB, TB, QRD, TRD>(
       settings as MemorySourceSettings<QO, TO, QB, TB, QRD, TRD>

--- a/packages/@orbit/memory/test/memory-cache-test.ts
+++ b/packages/@orbit/memory/test/memory-cache-test.ts
@@ -69,6 +69,15 @@ module('MemoryCache', function (hooks) {
     assert.ok(cache.transformBuilder, 'transformBuilder has been instantiated');
   });
 
+  test('will not create a `validatorFor` fn if `autoValidate: false`', function (assert) {
+    let cache = new MemoryCache({ schema, autoValidate: false });
+    assert.strictEqual(
+      cache.validatorFor,
+      undefined,
+      'cache.validatorFor is undefined'
+    );
+  });
+
   test('will track update operations by default if a `base` cache is passed', function (assert) {
     let base = new MemoryCache({ schema });
     assert.strictEqual(base.base, undefined, 'base.base is undefined');
@@ -2617,6 +2626,24 @@ module('MemoryCache', function (hooks) {
       fork.base,
       cache,
       'base cache is set on the forked cache'
+    );
+  });
+
+  test('#fork - skips creating validatorFor if none is set for the base source', async function (assert) {
+    const cache = new MemoryCache({ schema, keyMap, autoValidate: false });
+
+    assert.strictEqual(
+      cache.validatorFor,
+      undefined,
+      'cache.validatorFor is undefined'
+    );
+
+    const fork = cache.fork();
+
+    assert.strictEqual(
+      fork.validatorFor,
+      undefined,
+      'fork.validatorFor is undefined'
     );
   });
 

--- a/packages/@orbit/memory/test/memory-source-test.ts
+++ b/packages/@orbit/memory/test/memory-source-test.ts
@@ -204,6 +204,20 @@ module('MemorySource', function (hooks) {
     );
   });
 
+  test('will not create a `validatorFor` fn if `autoValidate: false`', function (assert) {
+    const source = new MemorySource({ schema, keyMap, autoValidate: false });
+    assert.strictEqual(
+      source.validatorFor,
+      undefined,
+      'validatorFor is undefined'
+    );
+    assert.strictEqual(
+      source.cache.validatorFor,
+      undefined,
+      'cache.validatorFor is undefined'
+    );
+  });
+
   test('#sync - appends transform to log', async function (assert) {
     const source = new MemorySource({ schema, keyMap });
     const recordA = {
@@ -499,6 +513,34 @@ module('MemorySource', function (hooks) {
       fork.base,
       source,
       'base source is set on the forked source'
+    );
+  });
+
+  test('#fork - skips creating validatorFor if none is set for the base source', async function (assert) {
+    const source = new MemorySource({ schema, keyMap, autoValidate: false });
+
+    assert.strictEqual(
+      source.validatorFor,
+      undefined,
+      'source.validatorFor is undefined'
+    );
+    assert.strictEqual(
+      source.cache.validatorFor,
+      undefined,
+      'source.cache.validatorFor is undefined'
+    );
+
+    const fork = source.fork();
+
+    assert.strictEqual(
+      fork.validatorFor,
+      undefined,
+      'fork.validatorFor is undefined'
+    );
+    assert.strictEqual(
+      fork.cache.validatorFor,
+      undefined,
+      'fork.cache.validatorFor is undefined'
     );
   });
 


### PR DESCRIPTION
When a source is created with `autoValidate: false`, any associated forks and / or caches created from that source should also be created with the same setting.