### PR TITLE
IndexedDBCache: Fix handling of empty operations array

### DIFF
--- a/packages/@orbit/indexeddb/src/indexeddb-cache.ts
+++ b/packages/@orbit/indexeddb/src/indexeddb-cache.ts
@@ -503,29 +503,33 @@ export class IndexedDBCache<
         : [recordIdentityOrIdentities];
 
       const len = identities.length;
-      let completed = 0;
-      for (let i = 0; i < len; i++) {
-        const identity = identities[i];
-        const keyRange = Orbit.globals.IDBKeyRange.only(
-          serializeRecordIdentity(identity)
-        );
-        const request = index.openCursor(keyRange);
+      if (len === 0) {
+        resolve([]);
+      } else {
+        let completed = 0;
+        for (let i = 0; i < len; i++) {
+          const identity = identities[i];
+          const keyRange = Orbit.globals.IDBKeyRange.only(
+            serializeRecordIdentity(identity)
+          );
+          const request = index.openCursor(keyRange);
 
-        request.onsuccess = (event: any) => {
-          const cursor = event.target.result;
-          if (cursor) {
-            let result = this._fromInverseRelationshipForIDB(cursor.value);
-            results.push(result);
-            cursor.continue();
-          } else {
-            completed += 1;
-            if (completed === len) {
-              resolve(results);
+          request.onsuccess = (event: any) => {
+            const cursor = event.target.result;
+            if (cursor) {
+              let result = this._fromInverseRelationshipForIDB(cursor.value);
+              results.push(result);
+              cursor.continue();
+            } else {
+              completed += 1;
+              if (completed === len) {
+                resolve(results);
+              }
             }
-          }
-        };
+          };
 
-        request.onerror = () => reject(request.error);
+          request.onerror = () => reject(request.error);
+        }
       }
     });
   }

--- a/packages/@orbit/indexeddb/test/indexeddb-cache-update-test.ts
+++ b/packages/@orbit/indexeddb/test/indexeddb-cache-update-test.ts
@@ -167,6 +167,12 @@ module('IndexedDBCache - update', function (hooks) {
           );
         });
 
+        test('#update can handle an empty array of operations', async function (assert) {
+          const result = await cache.update(() => []);
+
+          assert.deepEqual(result, [], 'response includes just primary data');
+        });
+
         test('#update updates the cache and returns a full response if requested', async function (assert) {
           let p1 = { type: 'planet', id: '1', attributes: { name: 'Earth' } };
           let p2 = { type: 'planet', id: '2' };


### PR DESCRIPTION
Provide special handling in `getInverseRelationshipsAsync` for an empty array of identities.