### PR TITLE
Provide type for Orbit.fetch

### DIFF
--- a/packages/@orbit/core/src/main.ts
+++ b/packages/@orbit/core/src/main.ts
@@ -11,6 +11,7 @@ export interface OrbitGlobal {
   deprecate: (message: string, test?: boolean | (() => boolean)) => void;
   uuid: () => string;
   debug: boolean;
+  fetch: typeof fetch;
 }
 
 // Establish the root object, `window` (`self`) in the browser, `global`


### PR DESCRIPTION
I was converting some code over to TypeScript and found there's no type for `fetch` on the global `Orbit` object. This property was added at https://github.com/orbitjs/orbit/pull/523/files