### PR TITLE
Include meta in resource linkage interface

### DIFF
--- a/packages/@orbit/records/src/record.ts
+++ b/packages/@orbit/records/src/record.ts
@@ -12,14 +12,18 @@ export interface RecordIdentity {
   id: string;
 }
 
+export interface ResourceLinkage extends RecordIdentity {
+  meta?: Dict<unknown>;
+}
+
 export interface RecordHasOneRelationship {
-  data?: RecordIdentity | null;
+  data?: ResourceLinkage | null;
   links?: Dict<Link>;
   meta?: Dict<unknown>;
 }
 
 export interface RecordHasManyRelationship {
-  data?: RecordIdentity[];
+  data?: ResourceLinkage[];
   links?: Dict<Link>;
   meta?: Dict<unknown>;
 }


### PR DESCRIPTION
Resource identifiers in resource linkages include an optional `meta` member.