### PR TITLE
Allow deepGet to error on missing members

### DIFF
--- a/packages/@orbit/utils/src/objects.ts
+++ b/packages/@orbit/utils/src/objects.ts
@@ -182,7 +182,7 @@ export function deepGet(obj: any, path: string[]): any {
   let result = obj;
 
   while (++index < path.length) {
-    result = result[path[index]];
+    result = result?.[path[index]];
     if (!result) {
       return result;
     }


### PR DESCRIPTION
I'm using `deepGet()` in some userland code and it would be helpful if this used optional chaining to error out on non-existent keys. I don't think this should regress anything in Orbit and better matches the stated goal/operation of the function, anyway?