### PR TITLE
Add "sideEffects": false

### DIFF
--- a/packages/@orbit/coordinator/package.json
+++ b/packages/@orbit/coordinator/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",
+  "sideEffects": false,
   "types": "dist/modules/index.d.ts",
   "scripts": {
     "build": "rm -rf ./dist && yarn build:modules && yarn build:commonjs",

--- a/packages/@orbit/core/package.json
+++ b/packages/@orbit/core/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",
+  "sideEffects": false,
   "types": "dist/modules/index.d.ts",
   "scripts": {
     "build": "rm -rf ./dist && yarn build:modules && yarn build:commonjs",

--- a/packages/@orbit/data/package.json
+++ b/packages/@orbit/data/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",
+  "sideEffects": false,
   "types": "dist/modules/index.d.ts",
   "scripts": {
     "build": "rm -rf ./dist && yarn build:modules && yarn build:commonjs",

--- a/packages/@orbit/identity-map/package.json
+++ b/packages/@orbit/identity-map/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",
+  "sideEffects": false,
   "types": "dist/modules/index.d.ts",
   "scripts": {
     "build": "rm -rf ./dist && yarn build:modules && yarn build:commonjs",

--- a/packages/@orbit/immutable/package.json
+++ b/packages/@orbit/immutable/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",
+  "sideEffects": false,
   "types": "dist/modules/index.d.ts",
   "scripts": {
     "build": "rm -rf ./dist && yarn build:modules && yarn build:commonjs",

--- a/packages/@orbit/indexeddb-bucket/package.json
+++ b/packages/@orbit/indexeddb-bucket/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",
+  "sideEffects": false,
   "types": "dist/modules/index.d.ts",
   "scripts": {
     "build": "rm -rf ./dist && yarn build:modules && yarn build:commonjs",

--- a/packages/@orbit/indexeddb/package.json
+++ b/packages/@orbit/indexeddb/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",
+  "sideEffects": false,
   "types": "dist/modules/index.d.ts",
   "scripts": {
     "build": "rm -rf ./dist && yarn build:modules && yarn build:commonjs",

--- a/packages/@orbit/jsonapi/package.json
+++ b/packages/@orbit/jsonapi/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",
+  "sideEffects": false,
   "types": "dist/modules/index.d.ts",
   "scripts": {
     "build": "rm -rf ./dist && yarn build:modules && yarn build:commonjs",

--- a/packages/@orbit/local-storage-bucket/package.json
+++ b/packages/@orbit/local-storage-bucket/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",
+  "sideEffects": false,
   "types": "dist/modules/index.d.ts",
   "scripts": {
     "build": "rm -rf ./dist && yarn build:modules && yarn build:commonjs",

--- a/packages/@orbit/local-storage/package.json
+++ b/packages/@orbit/local-storage/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",
+  "sideEffects": false,
   "types": "dist/modules/index.d.ts",
   "scripts": {
     "build": "rm -rf ./dist && yarn build:modules && yarn build:commonjs",

--- a/packages/@orbit/memory/package.json
+++ b/packages/@orbit/memory/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",
+  "sideEffects": false,
   "types": "dist/modules/index.d.ts",
   "scripts": {
     "build": "rm -rf ./dist && yarn build:modules && yarn build:commonjs",

--- a/packages/@orbit/record-cache/package.json
+++ b/packages/@orbit/record-cache/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",
+  "sideEffects": false,
   "types": "dist/modules/index.d.ts",
   "scripts": {
     "build": "rm -rf ./dist && yarn build:modules && yarn build:commonjs",

--- a/packages/@orbit/records/package.json
+++ b/packages/@orbit/records/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",
+  "sideEffects": false,
   "types": "dist/modules/index.d.ts",
   "scripts": {
     "build": "rm -rf ./dist && yarn build:modules && yarn build:commonjs",

--- a/packages/@orbit/serializers/package.json
+++ b/packages/@orbit/serializers/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",
+  "sideEffects": false,
   "types": "dist/modules/index.d.ts",
   "scripts": {
     "build": "rm -rf ./dist && yarn build:modules && yarn build:commonjs",

--- a/packages/@orbit/utils/package.json
+++ b/packages/@orbit/utils/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",
+  "sideEffects": false,
   "types": "dist/modules/index.d.ts",
   "scripts": {
     "build": "rm -rf ./dist && yarn build:modules && yarn build:commonjs",

--- a/packages/@orbit/validators/package.json
+++ b/packages/@orbit/validators/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",
+  "sideEffects": false,
   "types": "dist/modules/index.d.ts",
   "scripts": {
     "build": "rm -rf ./dist && yarn build:modules && yarn build:commonjs",


### PR DESCRIPTION
Addresses #969.

I added `"sideEffects": false` to the `package.json` of every non-private package — in other words, to all packages, except
- the root package,
- `orbit-website`,
- `@orbit/build`,
- and `@orbit/integration-tests`.

I think it's safe to say that the public packages are side-effect-free, or at least the benefit of flagging them as such outweigh the small probability that there may exist scenarios where one or several of the packages cannot be considered 100% side-effect-free. For the private packages, I don't think it's worthwhile spending time thinking about whether they are side-effect-free or not, as they never need to be tree-shaken by bundlers.