### PR TITLE
Iterate more correctly over localStorage keys

### DIFF
--- a/packages/@orbit/local-storage/src/local-storage-cache.ts
+++ b/packages/@orbit/local-storage/src/local-storage-cache.ts
@@ -114,8 +114,9 @@ export class LocalStorageCache<
       typeof typeOrIdentities === 'string'
     ) {
       const type: string | undefined = typeOrIdentities;
-      for (let key in Orbit.globals.localStorage) {
-        if (key.indexOf(this.namespace + this.delimiter) === 0) {
+      const prefix: string = this.namespace + this.delimiter;
+      for (let [key, value] of Orbit.globals.localStorage) {
+        if (key.startsWith(prefix) && !key.startsWith(prefix + 'inverseRels')) {
           let typesMatch = type === undefined;
 
           if (!typesMatch) {
@@ -127,7 +128,7 @@ export class LocalStorageCache<
           }
 
           if (typesMatch) {
-            let record = JSON.parse(Orbit.globals.localStorage.getItem(key));
+            let record = JSON.parse(value);
 
             if (this.keyMap) {
               this.keyMap.pushRecord(record);

--- a/packages/@orbit/local-storage/test/support/local-storage.ts
+++ b/packages/@orbit/local-storage/test/support/local-storage.ts
@@ -15,7 +15,7 @@ export function getRecordFromLocalStorage(
 
 export function isLocalStorageEmpty(source: LocalStorageSource): boolean {
   let isEmpty = true;
-  for (let key in Orbit.globals.localStorage) {
+  for (let [key, _] of Orbit.globals.localStorage) {
     if (key.indexOf(source.namespace + source.delimiter) === 0) {
       isEmpty = false;
       break;


### PR DESCRIPTION
Check for "inverseRels" keys when iterating over localStorage. This means we won't accidentally end up with inverse relationship data as part of the records we return from a call to `findRecords()` without a type argument. This was causing normalization errors when trying to restore all records from a localStorage backup.

Also switches from `for...in` to `for...of` as this allows polyfills to control iteration via the `Symbol.iterator` property on the localStorage object.