### PR TITLE
Add "validatorFor" to RecordTransformBuffer

### DIFF
--- a/packages/@orbit/indexeddb/src/indexeddb-cache.ts
+++ b/packages/@orbit/indexeddb/src/indexeddb-cache.ts
@@ -601,10 +601,11 @@ export class IndexedDBCache<
    */
   protected _getTransformBuffer(): RecordTransformBuffer {
     if (this._transformBuffer === undefined) {
-      const { schema, keyMap } = this;
+      const { schema, keyMap, validatorFor } = this;
       this._transformBuffer = new SimpleRecordTransformBuffer({
         schema,
-        keyMap
+        keyMap,
+        validatorFor
       });
     }
     return this._transformBuffer;


### PR DESCRIPTION
As otherwise it will ignore custom validators.

---

I also tried passing in a custom `transformBuffer` to the indexeddb source settings as mentioned in https://github.com/orbitjs/orbit/pull/868 - but it is not passed forward to the indexeddb cache settings....