### PR TITLE
fix: check whether tick has been removed before execution of function

### DIFF
--- a/packages/@orbit/record-cache/src/live-query/live-query.ts
+++ b/packages/@orbit/record-cache/src/live-query/live-query.ts
@@ -171,8 +171,11 @@ function onceTick(fn: () => void) {
     if (!ticks.has(tick)) {
       ticks.add(tick);
       nextTick(() => {
-        fn();
-        cancelTick(tick);
+        // Might have been cancelled
+        if (ticks.has(tick)) {
+          fn();
+          cancelTick(tick);
+        }
       });
     }
   };


### PR DESCRIPTION
There might be a problem with the timing of unsubscription and the execution of the debounced function. If the unsubscribe function is called at a moment when the debounced function has already been scheduled to be executed but hasn't yet executed, it won't stop the function from executing.

This is due to the fact that the execute function is only canceled by cancelTick which is removing it from ticks, but it doesn't actually stop it if it's already been scheduled.

I've added a condition to account for this.