### PR TITLE
ArrayBuffers in attributes are not preserved

### DIFF
--- a/packages/@orbit/memory/test/memory-source-updatable-test.ts
+++ b/packages/@orbit/memory/test/memory-source-updatable-test.ts
@@ -15,6 +15,12 @@ const { module, test } = QUnit;
 module('MemorySource - updatable', function (hooks) {
   const schemaDefinition: RecordSchemaSettings = {
     models: {
+      thingy: {
+        attributes: {
+          ab: { type: 'object' },
+          other: { type: 'object' },
+        },
+      },
       star: {
         attributes: {
           name: { type: 'string' }
@@ -68,6 +74,25 @@ module('MemorySource - updatable', function (hooks) {
   hooks.beforeEach(function () {
     schema = new RecordSchema(schemaDefinition);
     keyMap = new RecordKeyMap();
+  });
+
+  test("#update - works with array buffers", async function(assert) {
+    const source = new MemorySource({schema, keyMap});
+    const ident = {type: 'thingy', id: 'a'};
+
+    const record = {...ident, attributes: {
+      ab: new ArrayBuffer(32),
+      other: {x: 10, y: 10},
+    }};
+
+    await source.update(t => t.addRecord(record));
+
+    await source.update(t =>
+      t.replaceAttribute(ident, 'other', {x: 2, y: 2})
+    );
+
+    let result = await source.query(q => q.findRecord(ident));
+    assert.ok(result.attributes.ab instanceof ArrayBuffer);
   });
 
   test("#update - transforms the source's cache", async function (assert) {


### PR DESCRIPTION
When fetching a record with an ArrayBuffer attribute, it is sometimes preserved, and other times becomes an empty object.

If I had to guess, it might be deep cloning the object with `JSON.parse(JSON.stringify(record))` which doesn't preserve ArrayBuffers.

Maybe there is a way I'm supposed to be handling this with serializers, but the fact that updating an unrelated attribute causes the issue seems like a bug for sure.

Maybe this test belongs further down, but I was having trouble following all the abstractions.